### PR TITLE
Add installation instruction to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,22 @@ This project provides low level functionality for Computer Vision written in [Ru
 - We package with support for Linux [amd64/arm64], Macos and WIndows.
 - Supported Python versions are 3.7/3.8/3.9/3.10/3.11
 
+## Installation
+
+From pip:
+
+```bash
+pip install kornia-rs
+```
+
+From source:
+
+```bash
+pip install maturin
+maturin build --release --out dist -i $(which python3)
+pip install dist/*.whl
+```
+
 ## Basic Usage
 
 Load an image, that is converted to `cv::Tensor` wich is a centric structure to the DLPack protocol to share tensor data across frameworks with a zero-copy cost.


### PR DESCRIPTION
As communicated on slack, I added installation instruction to README, specifically for install from source. This will help users when their binary wheels are not available on PyPI e.g. MacOS ARM64 Python3.10+.

Let me know if you want any modifications @edgarriba 