### PR TITLE
Build MacOS ARM64 binaries with GHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,35 @@ jobs:
           name: wheels
           path: dist
 
+  macos-aarch64:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+    steps:
+      - uses: ilammy/setup-nasm@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: aarch64-apple-darwin
+          override: true
+      - uses: messense/maturin-action@v1
+        with:
+          maturin-version: latest
+          command: build
+          args: --target aarch64-apple-darwin --release --out dist -i python${{ matrix.python-version }}
+      - name: Upload wheels
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: dist
+
   windows:
     runs-on: windows-latest
     strategy:
@@ -100,7 +129,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [macos, windows, linux]
+    needs: [macos, macos-aarch64, windows, linux]
     steps:
       - uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+  push:
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   release:
     types: [published]
   workflow_dispatch:
-  push:
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        target: [x86_64-apple-darwin, aarch64-apple-darwin]
     steps:
       - uses: ilammy/setup-nasm@v1
       - uses: actions/checkout@v3
@@ -56,41 +57,13 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
+          target: ${{ matrix.target }}
           override: true
       - uses: messense/maturin-action@v1
         with:
           maturin-version: latest
           command: build
-          args: --release --out dist -i python${{ matrix.python-version }}
-      - name: Upload wheels
-        uses: actions/upload-artifact@v2
-        with:
-          name: wheels
-          path: dist
-
-  macos-aarch64:
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-    steps:
-      - uses: ilammy/setup-nasm@v1
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-          architecture: x64
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          target: aarch64-apple-darwin
-          override: true
-      - uses: messense/maturin-action@v1
-        with:
-          maturin-version: latest
-          command: build
-          args: --target aarch64-apple-darwin --release --out dist -i python${{ matrix.python-version }}
+          args: --target ${{ matrix.target }} --release --out dist -i python${{ matrix.python-version }}
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -129,7 +102,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [macos, macos-aarch64, windows, linux]
+    needs: [macos, windows, linux]
     steps:
       - uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-        target: [x86_64-apple-darwin, aarch64-apple-darwin]
+        target: [x86_64, aarch64]
     steps:
       - uses: ilammy/setup-nasm@v1
       - uses: actions/checkout@v3
@@ -57,13 +57,13 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-          target: ${{ matrix.target }}
+          target: ${{ matrix.target }}-apple-darwin
           override: true
       - uses: messense/maturin-action@v1
         with:
           maturin-version: latest
           command: build
-          args: --target ${{ matrix.target }} --release --out dist -i python${{ matrix.python-version }}
+          args: --target ${{ matrix.target }}-apple-darwin --release --out dist -i python${{ matrix.python-version }}
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
As communicated on Slack, I added workflow to build MacOS ARM64 binaries to support Apple Silicon. I downloaded the wheels and tested on my local M1. Installation worked fine and all pytest tests passed. I only tested Python 3.8-3.11, since there is no Python 3.7 MacOS ARM64 from conda. (I think no one builds Python 3.7 for MacOS ARM64? Anyway, Python 3.7 is reaching end-of-life this June so perhaps we can even stop building for Python 3.7).

This is the workflow run in my fork: https://github.com/gau-nernst/kornia-rs/actions/runs/4263731867

The Linux builds are failing because I don't have access to the Docker images.

Also, this closes #20