### PR TITLE
add kornia_rs::metrics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,14 @@ criterion = { version = "0.5.1", features = ["html_reports"] }
 [features]
 candle = ["candle-core"]
 
-
 [[bench]]
 name = "color_benchmark"
 harness = false
 
 [[bench]]
 name = "resize_benchmark"
+harness = false
+
+[[bench]]
+name = "metrics_benchmark"
 harness = false

--- a/benches/metrics_benchmark.rs
+++ b/benches/metrics_benchmark.rs
@@ -1,0 +1,33 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+
+use kornia_rs::image::{Image, ImageSize};
+
+// TODO: figure how to auto select a function backend based on the input size
+fn mse_zip(image1: &Image<f32, 3>, image2: &Image<f32, 3>) -> f32 {
+    ndarray::Zip::from(&image1.data)
+        .and(&image2.data)
+        .fold(0f32, |acc, &a, &b| acc + (a - b).powi(2))
+        / (image1.data.len() as f32)
+}
+
+fn bench_mse(c: &mut Criterion) {
+    let mut group = c.benchmark_group("mse");
+    let image_sizes = vec![(256, 224), (512, 448), (1024, 896)];
+
+    for (width, height) in image_sizes {
+        let image_size = ImageSize { width, height };
+        let id = format!("{}x{}", width, height);
+        let image = Image::<u8, 3>::new(image_size, vec![0u8; width * height * 3]).unwrap();
+        let image_f32 = image.cast::<f32>().unwrap();
+        group.bench_with_input(BenchmarkId::new("mapv", &id), &image_f32, |b, i| {
+            b.iter(|| kornia_rs::metrics::mse(black_box(i), black_box(i)))
+        });
+        group.bench_with_input(BenchmarkId::new("zip", &id), &image_f32, |b, i| {
+            b.iter(|| mse_zip(black_box(i), black_box(i)))
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_mse);
+criterion_main!(benches);

--- a/examples/binarize.rs
+++ b/examples/binarize.rs
@@ -5,7 +5,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // read the image
     let image_path = std::path::Path::new("tests/data/dog.jpeg");
     let image: Image<u8, 3> = F::read_image_jpeg(image_path)?;
-    let image_viz = image.clone();
 
     // binarize the image as u8
     let _image_bin: Image<u8, 3> =
@@ -16,7 +15,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // convert to grayscale as floating point
     let gray_f32: Image<f32, 1> = kornia_rs::color::gray_from_rgb(&image_f32)?;
-    let gray_viz = gray_f32.clone();
 
     // binarize the gray image as floating point
     let gray_bin: Image<f32, 1> = kornia_rs::threshold::threshold_binary(&gray_f32, 0.5, 1.0)?;
@@ -24,8 +22,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // create a Rerun recording stream
     let rec = rerun::RecordingStreamBuilder::new("Kornia App").connect()?;
 
-    let _ = rec.log("image", &rerun::Image::try_from(image_viz.data)?);
-    let _ = rec.log("gray", &rerun::Image::try_from(gray_viz.data)?);
+    let _ = rec.log("image", &rerun::Image::try_from(image_f32.data)?);
+    let _ = rec.log("gray", &rerun::Image::try_from(gray_f32.data)?);
     let _ = rec.log("gray_bin", &rerun::Image::try_from(gray_bin.data)?);
 
     Ok(())

--- a/examples/imgproc.rs
+++ b/examples/imgproc.rs
@@ -5,7 +5,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // read the image
     let image_path = std::path::Path::new("tests/data/dog.jpeg");
     let image: Image<u8, 3> = F::read_image_jpeg(image_path)?;
-    let image_viz = image.clone();
 
     let image_f32: Image<f32, 3> = image.cast_and_scale::<f32>(1.0 / 255.0)?;
 
@@ -27,7 +26,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("Kornia App").connect()?;
 
     // log the images
-    let _ = rec.log("image", &rerun::Image::try_from(image_viz.data)?);
+    let _ = rec.log("image", &rerun::Image::try_from(image_f32.data)?);
     let _ = rec.log("gray", &rerun::Image::try_from(gray.data)?);
     let _ = rec.log("gray_resize", &rerun::Image::try_from(gray_resize.data)?);
 

--- a/examples/metrics.rs
+++ b/examples/metrics.rs
@@ -1,0 +1,36 @@
+use kornia_rs::image::Image;
+use kornia_rs::io::functional as F;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // read the image
+    let image_path = std::path::Path::new("tests/data/dog.jpeg");
+    let image: Image<u8, 3> = F::read_image_jpeg(image_path)?;
+    let image_viz = image.clone();
+
+    // convert the image to f32 and scale it
+    let image: Image<f32, 3> = image.cast_and_scale::<f32>(1.0 / 255.0)?;
+
+    // modify the image to see the changes
+    let image_dirty = kornia_rs::flip::horizontal_flip(&image)?;
+
+    // compute the mean squared error (mse) between the original and the modified image
+    let mse = kornia_rs::metrics::mse(&image, &image_dirty);
+    let psnr = kornia_rs::metrics::psnr(&image, &image_dirty, 1.0);
+
+    // print the mse error
+    println!("MSE error: {:?}", mse);
+    println!("PSNR error: {:?}", psnr);
+
+    // compute the mse map
+    let mse_map = kornia_rs::metrics::mse_map(&image, &image_dirty);
+
+    // create a Rerun recording stream
+    let rec = rerun::RecordingStreamBuilder::new("Kornia App").connect()?;
+
+    // log the images
+    let _ = rec.log("image", &rerun::Image::try_from(image_viz.data)?);
+    let _ = rec.log("flip", &rerun::Image::try_from(image_dirty.data)?);
+    let _ = rec.log("mse_map", &rerun::Image::try_from(mse_map.data)?);
+
+    Ok(())
+}

--- a/examples/metrics.rs
+++ b/examples/metrics.rs
@@ -20,11 +20,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("MSE error: {:?}", mse);
     println!("PSNR error: {:?}", psnr);
 
-    // compute the mse map
-    let mse_map = kornia_rs::metrics::mse_map(&image, &image_dirty);
-
     // or, alternatively, compute the mse using the built-in functions
-    // let mse_map_ii = image.sub(&image_dirty).powi(2);
+    let mse_map = image.sub(&image_dirty).powi(2);
     // let mse_ii = mse_map_ii.mean();
 
     // create a Rerun recording stream

--- a/examples/metrics.rs
+++ b/examples/metrics.rs
@@ -5,7 +5,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // read the image
     let image_path = std::path::Path::new("tests/data/dog.jpeg");
     let image: Image<u8, 3> = F::read_image_jpeg(image_path)?;
-    let image_viz = image.clone();
 
     // convert the image to f32 and scale it
     let image: Image<f32, 3> = image.cast_and_scale::<f32>(1.0 / 255.0)?;
@@ -24,11 +23,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // compute the mse map
     let mse_map = kornia_rs::metrics::mse_map(&image, &image_dirty);
 
+    // or, alternatively, compute the mse using the built-in functions
+    // let mse_map_ii = image.sub(&image_dirty).powi(2);
+    // let mse_ii = mse_map_ii.mean();
+
     // create a Rerun recording stream
     let rec = rerun::RecordingStreamBuilder::new("Kornia App").connect()?;
 
     // log the images
-    let _ = rec.log("image", &rerun::Image::try_from(image_viz.data)?);
+    let _ = rec.log("image", &rerun::Image::try_from(image.data)?);
     let _ = rec.log("flip", &rerun::Image::try_from(image_dirty.data)?);
     let _ = rec.log("mse_map", &rerun::Image::try_from(mse_map.data)?);
 

--- a/src/flip.rs
+++ b/src/flip.rs
@@ -25,8 +25,8 @@ use anyhow::Result;
 /// )
 /// .unwrap();
 /// let flipped: Image<f32, 3> = kornia_rs::flip::horizontal_flip(&image).unwrap();
-/// assert_eq!(flipped.size().width, 2);
-/// assert_eq!(flipped.size().height, 3);
+/// assert_eq!(flipped.image_size().width, 2);
+/// assert_eq!(flipped.image_size().height, 3);
 /// ```
 pub fn horizontal_flip<T, const CHANNELS: usize>(
     image: &Image<T, CHANNELS>,
@@ -34,13 +34,20 @@ pub fn horizontal_flip<T, const CHANNELS: usize>(
 where
     T: Copy,
 {
-    // NOTE: verify that this is efficient
     let mut img = image.clone();
 
     img.data
         .axis_iter_mut(ndarray::Axis(0))
         .for_each(|mut row| {
-            row.as_slice_mut().unwrap().reverse();
+            let mut i = 0;
+            let mut j = image.width() - 1;
+            while i < j {
+                for c in 0..CHANNELS {
+                    row.swap((i, c), (j, c));
+                }
+                i += 1;
+                j -= 1;
+            }
         });
 
     Ok(img)
@@ -70,8 +77,8 @@ where
 /// )
 /// .unwrap();
 /// let flipped: Image<f32, 3> = kornia_rs::flip::vertical_flip(&image).unwrap();
-/// assert_eq!(flipped.size().width, 2);
-/// assert_eq!(flipped.size().height, 3);
+/// assert_eq!(flipped.image_size().width, 2);
+/// assert_eq!(flipped.image_size().height, 3);
 /// ```
 pub fn vertical_flip<T, const CHANNELS: usize>(
     image: &Image<T, CHANNELS>,

--- a/src/flip.rs
+++ b/src/flip.rs
@@ -25,8 +25,8 @@ use anyhow::Result;
 /// )
 /// .unwrap();
 /// let flipped: Image<f32, 3> = kornia_rs::flip::horizontal_flip(&image).unwrap();
-/// assert_eq!(flipped.image_size().width, 2);
-/// assert_eq!(flipped.image_size().height, 3);
+/// assert_eq!(flipped.size().width, 2);
+/// assert_eq!(flipped.size().height, 3);
 /// ```
 pub fn horizontal_flip<T, const CHANNELS: usize>(
     image: &Image<T, CHANNELS>,
@@ -77,8 +77,8 @@ where
 /// )
 /// .unwrap();
 /// let flipped: Image<f32, 3> = kornia_rs::flip::vertical_flip(&image).unwrap();
-/// assert_eq!(flipped.image_size().width, 2);
-/// assert_eq!(flipped.image_size().height, 3);
+/// assert_eq!(flipped.size().width, 2);
+/// assert_eq!(flipped.size().height, 3);
 /// ```
 pub fn vertical_flip<T, const CHANNELS: usize>(
     image: &Image<T, CHANNELS>,

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,5 +1,6 @@
 //use crate::io;
 use anyhow::Result;
+use num_traits::Float;
 
 /// Image size in pixels
 ///
@@ -17,7 +18,7 @@ use anyhow::Result;
 /// assert_eq!(image_size.width, 10);
 /// assert_eq!(image_size.height, 20);
 /// ```
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ImageSize {
     /// Width of the image in pixels
     pub width: usize,
@@ -37,6 +38,9 @@ impl std::fmt::Display for ImageSize {
 
 #[derive(Clone)]
 /// Represents an image with pixel data.
+///
+/// The image is represented as a 3D array with shape (H, W, C), where H is the height of the image,
+/// The ownership of the pixel data is mutable so that we can manipulate the image from the outside.
 pub struct Image<T, const CHANNELS: usize> {
     /// The pixel data of the image. Is mutable so that we can manipulate the image
     /// from the outside.
@@ -251,6 +255,22 @@ impl<T, const CHANNELS: usize> Image<T, CHANNELS> {
     {
         let scaled_data = self.data.map(|&x| x / scale);
         Image { data: scaled_data }
+    }
+
+    pub fn sub(&self, other: &Self) -> Self
+    where
+        T: Copy + std::ops::Sub<Output = T>,
+    {
+        let diff = &self.data - &other.data;
+        Image { data: diff }
+    }
+
+    pub fn powi(&self, n: i32) -> Self
+    where
+        T: Copy + Float,
+    {
+        let powered_data = self.data.map(|&x| x.powi(n));
+        Image { data: powered_data }
     }
 
     /// Get the size of the image in pixels.

--- a/src/image.rs
+++ b/src/image.rs
@@ -283,6 +283,14 @@ impl<T, const CHANNELS: usize> Image<T, CHANNELS> {
         self.data.fold(T::zero(), |acc, &x| acc + x) / T::from(self.data.len()).unwrap()
     }
 
+    pub fn abs(&self) -> Self
+    where
+        T: Copy + Float,
+    {
+        let abs_data = self.data.map(|&x| x.abs());
+        Image { data: abs_data }
+    }
+
     /// Get the size of the image in pixels.
     #[deprecated(since = "0.1.2", note = "Use `image.size()` instead")]
     pub fn image_size(&self) -> ImageSize {

--- a/src/image.rs
+++ b/src/image.rs
@@ -280,8 +280,7 @@ impl<T, const CHANNELS: usize> Image<T, CHANNELS> {
     where
         T: Copy + Float,
     {
-        let mean = self.data.fold(T::zero(), |acc, &x| acc + x) / T::from(self.data.len()).unwrap();
-        mean
+        self.data.fold(T::zero(), |acc, &x| acc + x) / T::from(self.data.len()).unwrap()
     }
 
     /// Get the size of the image in pixels.

--- a/src/image.rs
+++ b/src/image.rs
@@ -257,6 +257,7 @@ impl<T, const CHANNELS: usize> Image<T, CHANNELS> {
         Image { data: scaled_data }
     }
 
+    // TODO: optimize this
     pub fn sub(&self, other: &Self) -> Self
     where
         T: Copy + std::ops::Sub<Output = T>,
@@ -265,12 +266,22 @@ impl<T, const CHANNELS: usize> Image<T, CHANNELS> {
         Image { data: diff }
     }
 
+    // TODO: optimize this
     pub fn powi(&self, n: i32) -> Self
     where
         T: Copy + Float,
     {
         let powered_data = self.data.map(|&x| x.powi(n));
         Image { data: powered_data }
+    }
+
+    // TODO: optimize this
+    pub fn mean(&self) -> T
+    where
+        T: Copy + Float,
+    {
+        let mean = self.data.fold(T::zero(), |acc, &x| acc + x) / T::from(self.data.len()).unwrap();
+        mean
     }
 
     /// Get the size of the image in pixels.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod color;
 pub mod flip;
 pub mod image;
 pub mod io;
+pub mod metrics;
 pub mod normalize;
 pub mod resize;
 pub mod tensor;

--- a/src/metrics/huber.rs
+++ b/src/metrics/huber.rs
@@ -1,0 +1,102 @@
+use crate::image::Image;
+
+/// Compute the Huber loss between two images.
+///
+/// The Huber loss is a robust loss function that is less sensitive to outliers in data than the squared error loss.
+///
+/// The Huber loss is defined as:
+///
+/// $ L_{\delta}(a, b) = \begin{cases} \frac{1}{2}(a - b)^2 & \text{if } |a - b| \leq \delta \\ \delta(|a - b| - \frac{1}{2}\delta) & \text{otherwise} \end{cases} $
+///
+/// where `a` and `b` are the two images and `delta` is the threshold.
+///
+/// # Arguments
+///
+/// * `image1` - The first input image with shape (H, W, C).
+/// * `image2` - The second input image with shape (H, W, C).
+/// * `delta` - The threshold value.
+///
+/// # Returns
+///
+/// The Huber loss between the two images.
+///
+/// # Example
+///
+/// ```
+/// use kornia_rs::image::{Image, ImageSize};
+///
+/// let image1 = Image::<f32, 1>::new(
+///    ImageSize {
+///       width: 2,
+///      height: 3,
+/// },
+/// vec![0f32, 1f32, 2f32, 3f32, 4f32, 5f32],
+/// )
+/// .unwrap();
+///
+/// let image2 = Image::<f32, 1>::new(
+///   ImageSize {
+///     width: 2,
+///   height: 3,
+/// },
+/// vec![5f32, 4f32, 3f32, 2f32, 1f32, 0f32],
+/// )
+/// .unwrap();
+///
+/// let huber = kornia_rs::metrics::huber(&image1, &image2, 1.0);
+/// assert_eq!(huber, 2.5);
+/// ```
+///
+/// # Panics
+///
+/// Panics if the two images have different shapes.
+///
+/// # References
+///
+/// [Wikipedia - Huber loss](https://en.wikipedia.org/wiki/Huber_loss)
+pub fn huber<const CHANNELS: usize>(
+    image1: &Image<f32, CHANNELS>,
+    image2: &Image<f32, CHANNELS>,
+    delta: f32,
+) -> f32 {
+    assert_eq!(image1.size(), image2.size());
+
+    ndarray::Zip::from(&image1.data)
+        .and(&image2.data)
+        .fold(0f32, |acc, &a, &b| {
+            let diff = a - b;
+            if diff.abs() <= delta {
+                acc + 0.5 * diff.powi(2)
+            } else {
+                acc + delta * (diff.abs() - 0.5 * delta)
+            }
+        })
+        / (image1.data.len() as f32)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::image::{Image, ImageSize};
+
+    #[test]
+    fn test_huber() {
+        let image1 = Image::<_, 1>::new(
+            ImageSize {
+                width: 2,
+                height: 3,
+            },
+            vec![0f32, 1f32, 2f32, 3f32, 4f32, 5f32],
+        )
+        .unwrap();
+        let image2 = Image::<_, 1>::new(
+            ImageSize {
+                width: 2,
+                height: 3,
+            },
+            vec![5f32, 4f32, 3f32, 2f32, 1f32, 0f32],
+        )
+        .unwrap();
+        let huber = super::huber(&image1, &image2, 1.0);
+        assert_eq!(huber, 2.5);
+    }
+}

--- a/src/metrics/l1.rs
+++ b/src/metrics/l1.rs
@@ -1,0 +1,95 @@
+use crate::image::Image;
+
+/// Compute the L1 loss between two images.
+///
+/// The L1 loss is defined as the sum of the absolute differences between the two images.
+///
+/// The L1 loss is defined as:
+///
+/// $ L1(a, b) = \frac{1}{N} \sum_{i=1}^{N} |a_i - b_i| $
+///
+/// where `a` and `b` are the two images and `N` is the number of pixels.
+///
+/// # Arguments
+///
+/// * `image1` - The first input image with shape (H, W, C).
+/// * `image2` - The second input image with shape (H, W, C).
+///
+/// # Returns
+///
+/// The L1 loss between the two images.
+///
+/// # Example
+///
+/// ```
+/// use kornia_rs::image::{Image, ImageSize};
+///
+/// let image1 = Image::<f32, 1>::new(
+///   ImageSize {
+///    width: 2,
+///   height: 3,
+/// },
+/// vec![0f32, 1f32, 2f32, 3f32, 4f32, 5f32],
+/// )
+/// .unwrap();
+///
+/// let image2 = Image::<f32, 1>::new(
+///  ImageSize {
+///   width: 2,
+/// height: 3,
+/// },
+/// vec![5f32, 4f32, 3f32, 2f32, 1f32, 0f32],
+/// )
+/// .unwrap();
+///
+/// let l1_loss = kornia_rs::metrics::l1_loss(&image1, &image2);
+/// assert_eq!(l1_loss, 3.0);
+/// ```
+///
+/// # Panics
+///
+/// Panics if the two images have different shapes.
+///
+/// # References
+///
+/// [Wikipedia - L1 loss](https://en.wikipedia.org/wiki/Huber_loss)
+pub fn l1_loss<const CHANNELS: usize>(
+    image1: &Image<f32, CHANNELS>,
+    image2: &Image<f32, CHANNELS>,
+) -> f32 {
+    assert_eq!(image1.size(), image2.size());
+
+    ndarray::Zip::from(&image1.data)
+        .and(&image2.data)
+        .fold(0f32, |acc, &a, &b| acc + (a - b).abs())
+        / (image1.data.len() as f32)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::image::{Image, ImageSize};
+
+    #[test]
+    fn test_l1_loss() {
+        let image1 = Image::<_, 1>::new(
+            ImageSize {
+                width: 2,
+                height: 3,
+            },
+            vec![0f32, 1f32, 2f32, 3f32, 4f32, 5f32],
+        )
+        .unwrap();
+
+        let image2 = Image::<_, 1>::new(
+            ImageSize {
+                width: 2,
+                height: 3,
+            },
+            vec![5f32, 4f32, 3f32, 2f32, 1f32, 0f32],
+        )
+        .unwrap();
+
+        let l1_loss = crate::metrics::l1_loss(&image1, &image2);
+        assert_eq!(l1_loss, 3.0);
+    }
+}

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -1,3 +1,5 @@
+mod huber;
 mod mse;
 
+pub use huber::huber;
 pub use mse::{mse, mse_map, psnr};

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -1,5 +1,7 @@
 mod huber;
+mod l1;
 mod mse;
 
 pub use huber::huber;
-pub use mse::{mse, mse_map, psnr};
+pub use l1::l1_loss;
+pub use mse::{mse, psnr};

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -1,0 +1,3 @@
+mod mse;
+
+pub use mse::{mse, mse_map, psnr};

--- a/src/metrics/mse.rs
+++ b/src/metrics/mse.rs
@@ -56,63 +56,6 @@ pub fn mse<const CHANNELS: usize>(
     diff.mapv(|x| x.powi(2)).sum() / (image1.data.len() as f32)
 }
 
-/// Compute the mean squared error (MSE) map between two images.
-///
-/// The MSE map is defined as:
-///
-/// $ MSE_{map} = (I_1 - I_2)^2 $
-///
-/// where `I_1` and `I_2` are the two images.
-///
-/// # Arguments
-///
-/// * `image1` - The first input image with shape (H, W, C).
-/// * `image2` - The second input image with shape (H, W, C).
-///
-/// # Returns
-///
-/// The mean squared error map between the two images.
-///
-/// # Example
-///
-/// ```
-/// use kornia_rs::image::{Image, ImageSize};
-///
-/// let image1 = Image::<f32, 1>::new(
-///   ImageSize {
-///     width: 2,
-///    height: 2,
-/// },
-/// vec![0f32, 1f32, 2f32, 3f32],
-/// )
-/// .unwrap();
-///
-/// let image2 = Image::<f32, 1>::new(
-///   ImageSize {
-///    width: 2,
-///  height: 2,
-/// },
-/// vec![0f32, 3f32, 2f32, 3f32],
-/// )
-/// .unwrap();
-///
-/// let mse_map = kornia_rs::metrics::mse_map(&image1, &image2);
-/// assert_eq!(mse_map.size(), image1.size());
-/// ```
-///
-/// # Panics
-///
-/// Panics if the two images have different shapes.
-pub fn mse_map<const CHANNELS: usize>(
-    image1: &Image<f32, CHANNELS>,
-    image2: &Image<f32, CHANNELS>,
-) -> Image<f32, CHANNELS> {
-    assert_eq!(image1.size(), image2.size());
-    let diff = &image1.data - &image2.data;
-    let mse_map = diff.map(|x| x.powi(2));
-    Image { data: mse_map }
-}
-
 /// Compute the peak signal-to-noise ratio (PSNR) between two images.
 ///
 /// The PSNR is defined as:
@@ -227,28 +170,6 @@ mod tests {
         .unwrap();
         let mse = crate::metrics::mse(&image1, &image2);
         assert_eq!(mse, 1.0);
-    }
-
-    #[test]
-    fn test_mse_map() {
-        let image1 = Image::<_, 1>::new(
-            ImageSize {
-                width: 2,
-                height: 2,
-            },
-            vec![0f32, 1f32, 2f32, 3f32],
-        )
-        .unwrap();
-        let image2 = Image::<_, 1>::new(
-            ImageSize {
-                width: 2,
-                height: 2,
-            },
-            vec![0f32, 3f32, 2f32, 3f32],
-        )
-        .unwrap();
-        let mse_map = crate::metrics::mse_map(&image1, &image2);
-        assert_eq!(mse_map.size(), image1.size());
     }
 
     #[test]

--- a/src/metrics/mse.rs
+++ b/src/metrics/mse.rs
@@ -1,0 +1,275 @@
+use crate::image::Image;
+
+/// Compute the mean squared error (MSE) between two images.
+///
+/// The MSE is defined as:
+///
+/// $ MSE = \frac{1}{n} \sum_{i=1}^{n} (I_1 - I_2)^2 $
+///
+/// where `I_1` and `I_2` are the two images and `n` is the number of pixels.
+///
+/// # Arguments
+///
+/// * `image1` - The first input image with shape (H, W, C).
+/// * `image2` - The second input image with shape (H, W, C).
+///
+/// # Returns
+///
+/// The mean squared error between the two images.
+///
+/// # Example
+///
+/// ```
+/// use kornia_rs::image::{Image, ImageSize};
+///
+/// let image1 = Image::<f32, 1>::new(
+///    ImageSize {
+///       width: 2,
+///      height: 3,
+/// },
+/// vec![0f32, 1f32, 2f32, 3f32, 4f32, 5f32],
+/// )
+/// .unwrap();
+///
+/// let image2 = Image::<f32, 1>::new(
+///    ImageSize {
+///      width: 2,
+///     height: 3,
+/// },
+/// vec![0f32, 1f32, 2f32, 3f32, 4f32, 5f32],
+/// )
+/// .unwrap();
+///
+/// let mse = kornia_rs::metrics::mse(&image1, &image2);
+/// assert_eq!(mse, 0f32);
+/// ```
+///
+/// # Panics
+///
+/// Panics if the two images have different shapes.
+pub fn mse<const CHANNELS: usize>(
+    image1: &Image<f32, CHANNELS>,
+    image2: &Image<f32, CHANNELS>,
+) -> f32 {
+    assert_eq!(image1.size(), image2.size());
+    let diff = &image1.data - &image2.data;
+    diff.mapv(|x| x.powi(2)).sum() / (image1.data.len() as f32)
+}
+
+/// Compute the mean squared error (MSE) map between two images.
+///
+/// The MSE map is defined as:
+///
+/// $ MSE_{map} = (I_1 - I_2)^2 $
+///
+/// where `I_1` and `I_2` are the two images.
+///
+/// # Arguments
+///
+/// * `image1` - The first input image with shape (H, W, C).
+/// * `image2` - The second input image with shape (H, W, C).
+///
+/// # Returns
+///
+/// The mean squared error map between the two images.
+///
+/// # Example
+///
+/// ```
+/// use kornia_rs::image::{Image, ImageSize};
+///
+/// let image1 = Image::<f32, 1>::new(
+///   ImageSize {
+///     width: 2,
+///    height: 2,
+/// },
+/// vec![0f32, 1f32, 2f32, 3f32],
+/// )
+/// .unwrap();
+///
+/// let image2 = Image::<f32, 1>::new(
+///   ImageSize {
+///    width: 2,
+///  height: 2,
+/// },
+/// vec![0f32, 3f32, 2f32, 3f32],
+/// )
+/// .unwrap();
+///
+/// let mse_map = kornia_rs::metrics::mse_map(&image1, &image2);
+/// assert_eq!(mse_map.size(), image1.size());
+/// ```
+///
+/// # Panics
+///
+/// Panics if the two images have different shapes.
+pub fn mse_map<const CHANNELS: usize>(
+    image1: &Image<f32, CHANNELS>,
+    image2: &Image<f32, CHANNELS>,
+) -> Image<f32, CHANNELS> {
+    assert_eq!(image1.size(), image2.size());
+    let diff = &image1.data - &image2.data;
+    let mse_map = diff.map(|x| x.powi(2));
+    Image { data: mse_map }
+}
+
+/// Compute the peak signal-to-noise ratio (PSNR) between two images.
+///
+/// The PSNR is defined as:
+///
+/// $ PSNR = 20 \log_{10} \left( \frac{MAX}{\sqrt{MSE}} \right) $
+///
+/// where `MAX` is the maximum possible pixel value and `MSE` is the mean squared error.
+///
+/// # Arguments
+///
+/// * `image1` - The first input image with shape (H, W, C).
+/// * `image2` - The second input image with shape (H, W, C).
+/// * `max_value` - The maximum possible pixel value.
+///
+/// # Returns
+///
+/// The peak signal-to-noise ratio between the two images.
+///
+/// # Example
+/// ```
+/// use kornia_rs::image::{Image, ImageSize};
+///
+/// let image1 = Image::<f32, 3>::new(
+///   ImageSize {
+///     width: 1,
+///    height: 2,
+/// },
+/// vec![0f32, 1f32, 2f32, 3f32, 4f32, 5f32],
+/// )
+/// .unwrap();
+///
+/// let image2 = Image::<f32, 3>::new(
+///   ImageSize {
+///    width: 1,
+///  height: 2,
+/// },
+/// vec![1f32, 3f32, 2f32, 4f32, 5f32, 6f32],
+/// )
+/// .unwrap();
+///
+/// let psnr = kornia_rs::metrics::psnr(&image1, &image2, 1.0);
+/// assert_eq!(psnr, 320.15698);
+/// ```
+///
+/// # Panics
+///
+/// Panics if the two images have different shapes.
+///
+/// # Note
+///
+/// The PSNR is expressed in decibels (dB).
+///
+/// The PSNR is used to measure the quality of a reconstructed image. The higher the PSNR, the better the quality of the reconstructed image.
+/// The PSNR is widely used in image and video compression.
+/// Underneath, the PSNR is based on the mean squared error [mse].
+pub fn psnr<const CHANNELS: usize>(
+    image1: &Image<f32, CHANNELS>,
+    image2: &Image<f32, CHANNELS>,
+    max_value: f32,
+) -> f32 {
+    assert_eq!(image1.size(), image2.size());
+    let mse = mse(image1, image2);
+    if mse == 0f32 {
+        return f32::INFINITY;
+    }
+    20f32 * (max_value / mse.sqrt().log10())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::image::{Image, ImageSize};
+
+    #[test]
+    fn test_equal() {
+        let image1 = Image::<_, 1>::new(
+            ImageSize {
+                width: 2,
+                height: 3,
+            },
+            vec![0f32, 1f32, 2f32, 3f32, 4f32, 5f32],
+        )
+        .unwrap();
+        let image2 = Image::<_, 1>::new(
+            ImageSize {
+                width: 2,
+                height: 3,
+            },
+            vec![0f32, 1f32, 2f32, 3f32, 4f32, 5f32],
+        )
+        .unwrap();
+        let mse = crate::metrics::mse(&image1, &image2);
+        assert_eq!(mse, 0f32);
+    }
+
+    #[test]
+    fn test_not_equal() {
+        let image1 = Image::<_, 1>::new(
+            ImageSize {
+                width: 2,
+                height: 2,
+            },
+            vec![0f32, 1f32, 2f32, 3f32],
+        )
+        .unwrap();
+        let image2 = Image::<_, 1>::new(
+            ImageSize {
+                width: 2,
+                height: 2,
+            },
+            vec![0f32, 3f32, 2f32, 3f32],
+        )
+        .unwrap();
+        let mse = crate::metrics::mse(&image1, &image2);
+        assert_eq!(mse, 1.0);
+    }
+
+    #[test]
+    fn test_mse_map() {
+        let image1 = Image::<_, 1>::new(
+            ImageSize {
+                width: 2,
+                height: 2,
+            },
+            vec![0f32, 1f32, 2f32, 3f32],
+        )
+        .unwrap();
+        let image2 = Image::<_, 1>::new(
+            ImageSize {
+                width: 2,
+                height: 2,
+            },
+            vec![0f32, 3f32, 2f32, 3f32],
+        )
+        .unwrap();
+        let mse_map = crate::metrics::mse_map(&image1, &image2);
+        assert_eq!(mse_map.size(), image1.size());
+    }
+
+    #[test]
+    fn test_psnr() {
+        let image1 = Image::<_, 3>::new(
+            ImageSize {
+                width: 1,
+                height: 2,
+            },
+            vec![0f32, 1f32, 2f32, 3f32, 4f32, 5f32],
+        )
+        .unwrap();
+        let image2 = Image::<_, 3>::new(
+            ImageSize {
+                width: 1,
+                height: 2,
+            },
+            vec![1f32, 3f32, 2f32, 4f32, 5f32, 6f32],
+        )
+        .unwrap();
+        let psnr = crate::metrics::psnr(&image1, &image2, 1.0);
+        assert_eq!(psnr, 320.15698);
+    }
+}


### PR DESCRIPTION
- add the kornia_rs::metrics module
- implement metrics: mse, l1_loss, psnr, huber
- implement image builtins: sub, powi, mean, abs
- fixes implementation of horizontal flip
- add metrics bench and example

![image](https://github.com/kornia/kornia-rs/assets/5157099/3f4cf631-7c6d-4ad3-bfe0-f18d795a8ada)
