### PR TITLE
add Image to tensor built in utils

### DIFF
--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -2,17 +2,10 @@ name: Python Test
 
 on:
   pull_request:
-    paths:
-      - Cargo.lock
-      - kornia-py/**
-      - .github/workflows/test-python.yml
+    - main
   push:
     branches:
       - main
-    paths:
-      - Cargo.lock
-      - kornia-py/**
-      - .github/workflows/test-python.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -2,7 +2,8 @@ name: Python Test
 
 on:
   pull_request:
-    - main
+    branches:
+      - main
   push:
     branches:
       - main

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .vscode/
-.venv/
+**venv/
 target/
 docker/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ rayon = "1.10.0"
 rerun = "0.14.1"
 walkdir = "2.5.0"
 
+
 [features]
 candle = ["candle-core"]
 

--- a/examples/binarize.rs
+++ b/examples/binarize.rs
@@ -22,9 +22,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // create a Rerun recording stream
     let rec = rerun::RecordingStreamBuilder::new("Kornia App").connect()?;
 
-    let _ = rec.log("image", &rerun::Image::try_from(image_f32.data)?);
-    let _ = rec.log("gray", &rerun::Image::try_from(gray_f32.data)?);
-    let _ = rec.log("gray_bin", &rerun::Image::try_from(gray_bin.data)?);
+    let _ = rec.log("image", &rerun::Image::try_from(image_f32.data())?);
+    let _ = rec.log("gray", &rerun::Image::try_from(gray_f32.data())?);
+    let _ = rec.log("gray_bin", &rerun::Image::try_from(gray_bin.data())?);
 
     Ok(())
 }

--- a/examples/binarize.rs
+++ b/examples/binarize.rs
@@ -20,11 +20,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let gray_bin: Image<f32, 1> = kornia_rs::threshold::threshold_binary(&gray_f32, 0.5, 1.0)?;
 
     // create a Rerun recording stream
-    let rec = rerun::RecordingStreamBuilder::new("Kornia App").connect()?;
+    let rec = rerun::RecordingStreamBuilder::new("Kornia App").spawn()?;
 
-    let _ = rec.log("image", &rerun::Image::try_from(image_f32.data())?);
-    let _ = rec.log("gray", &rerun::Image::try_from(gray_f32.data())?);
-    let _ = rec.log("gray_bin", &rerun::Image::try_from(gray_bin.data())?);
+    rec.log("image", &rerun::Image::try_from(image_f32.data())?)?;
+    rec.log("gray", &rerun::Image::try_from(gray_f32.data())?)?;
+    rec.log("gray_bin", &rerun::Image::try_from(gray_bin.data())?)?;
 
     Ok(())
 }

--- a/examples/binarize.rs
+++ b/examples/binarize.rs
@@ -22,9 +22,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // create a Rerun recording stream
     let rec = rerun::RecordingStreamBuilder::new("Kornia App").spawn()?;
 
-    rec.log("image", &rerun::Image::try_from(image_f32.data())?)?;
-    rec.log("gray", &rerun::Image::try_from(gray_f32.data())?)?;
-    rec.log("gray_bin", &rerun::Image::try_from(gray_bin.data())?)?;
+    rec.log("image", &rerun::Image::try_from(image_f32.data)?)?;
+    rec.log("gray", &rerun::Image::try_from(gray_f32.data)?)?;
+    rec.log("gray_bin", &rerun::Image::try_from(gray_bin.data)?)?;
 
     Ok(())
 }

--- a/examples/histogram.rs
+++ b/examples/histogram.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // log the image and the histogram
     rec.set_time_sequence("step", 0);
-    rec.log("image", &rerun::Image::try_from(image.clone().data)?)?;
+    rec.log("image", &rerun::Image::try_from(image.clone().data())?)?;
 
     // show the image and the histogram
     rec.log_timeless(

--- a/examples/histogram.rs
+++ b/examples/histogram.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // log the image and the histogram
     rec.set_time_sequence("step", 0);
-    rec.log("image", &rerun::Image::try_from(image.clone().data())?)?;
+    rec.log("image", &rerun::Image::try_from(image.clone().data)?)?;
 
     // show the image and the histogram
     rec.log_timeless(

--- a/examples/imgproc.rs
+++ b/examples/imgproc.rs
@@ -26,9 +26,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("Kornia App").spawn()?;
 
     // log the images
-    rec.log("image", &rerun::Image::try_from(image_f32.data())?)?;
-    rec.log("gray", &rerun::Image::try_from(gray.data())?)?;
-    rec.log("gray_resize", &rerun::Image::try_from(gray_resize.data())?)?;
+    rec.log("image", &rerun::Image::try_from(image_f32.data)?)?;
+    rec.log("gray", &rerun::Image::try_from(gray.data)?)?;
+    rec.log("gray_resize", &rerun::Image::try_from(gray_resize.data)?)?;
 
     Ok(())
 }

--- a/examples/imgproc.rs
+++ b/examples/imgproc.rs
@@ -26,9 +26,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("Kornia App").connect()?;
 
     // log the images
-    let _ = rec.log("image", &rerun::Image::try_from(image_f32.data)?);
-    let _ = rec.log("gray", &rerun::Image::try_from(gray.data)?);
-    let _ = rec.log("gray_resize", &rerun::Image::try_from(gray_resize.data)?);
+    let _ = rec.log("image", &rerun::Image::try_from(image_f32.data())?);
+    let _ = rec.log("gray", &rerun::Image::try_from(gray.data())?);
+    let _ = rec.log("gray_resize", &rerun::Image::try_from(gray_resize.data())?);
 
     Ok(())
 }

--- a/examples/imgproc.rs
+++ b/examples/imgproc.rs
@@ -23,12 +23,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("gray_resize: {:?}", gray_resize.size());
 
     // create a Rerun recording stream
-    let rec = rerun::RecordingStreamBuilder::new("Kornia App").connect()?;
+    let rec = rerun::RecordingStreamBuilder::new("Kornia App").spawn()?;
 
     // log the images
-    let _ = rec.log("image", &rerun::Image::try_from(image_f32.data())?);
-    let _ = rec.log("gray", &rerun::Image::try_from(gray.data())?);
-    let _ = rec.log("gray_resize", &rerun::Image::try_from(gray_resize.data())?);
+    rec.log("image", &rerun::Image::try_from(image_f32.data())?)?;
+    rec.log("gray", &rerun::Image::try_from(gray.data())?)?;
+    rec.log("gray_resize", &rerun::Image::try_from(gray_resize.data())?)?;
 
     Ok(())
 }

--- a/examples/metrics.rs
+++ b/examples/metrics.rs
@@ -28,9 +28,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("Kornia App").connect()?;
 
     // log the images
-    let _ = rec.log("image", &rerun::Image::try_from(image.data)?);
-    let _ = rec.log("flip", &rerun::Image::try_from(image_dirty.data)?);
-    let _ = rec.log("mse_map", &rerun::Image::try_from(mse_map.data)?);
+    let _ = rec.log("image", &rerun::Image::try_from(image.data())?);
+    let _ = rec.log("flip", &rerun::Image::try_from(image_dirty.data())?);
+    let _ = rec.log("mse_map", &rerun::Image::try_from(mse_map.data())?);
 
     Ok(())
 }

--- a/examples/metrics.rs
+++ b/examples/metrics.rs
@@ -28,9 +28,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("Kornia App").spawn()?;
 
     // log the images
-    rec.log("image", &rerun::Image::try_from(image.data())?)?;
-    rec.log("flip", &rerun::Image::try_from(image_dirty.data())?)?;
-    rec.log("mse_map", &rerun::Image::try_from(mse_map.data())?)?;
+    rec.log("image", &rerun::Image::try_from(image.data)?)?;
+    rec.log("flip", &rerun::Image::try_from(image_dirty.data)?)?;
+    rec.log("mse_map", &rerun::Image::try_from(mse_map.data)?)?;
 
     Ok(())
 }

--- a/examples/metrics.rs
+++ b/examples/metrics.rs
@@ -25,12 +25,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // let mse_ii = mse_map_ii.mean();
 
     // create a Rerun recording stream
-    let rec = rerun::RecordingStreamBuilder::new("Kornia App").connect()?;
+    let rec = rerun::RecordingStreamBuilder::new("Kornia App").spawn()?;
 
     // log the images
-    let _ = rec.log("image", &rerun::Image::try_from(image.data())?);
-    let _ = rec.log("flip", &rerun::Image::try_from(image_dirty.data())?);
-    let _ = rec.log("mse_map", &rerun::Image::try_from(mse_map.data())?);
+    rec.log("image", &rerun::Image::try_from(image.data())?)?;
+    rec.log("flip", &rerun::Image::try_from(image_dirty.data())?)?;
+    rec.log("mse_map", &rerun::Image::try_from(mse_map.data())?)?;
 
     Ok(())
 }

--- a/examples/rerun_viz.rs
+++ b/examples/rerun_viz.rs
@@ -10,7 +10,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("Kornia App").spawn()?;
 
     // log the image
-    rec.log("image", &rerun::Image::try_from(image.data())?)?;
+    rec.log("image", &rerun::Image::try_from(image.data)?)?;
 
     Ok(())
 }

--- a/examples/rerun_viz.rs
+++ b/examples/rerun_viz.rs
@@ -10,7 +10,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("Kornia App").spawn()?;
 
     // log the image
-    let _ = rec.log("image", &rerun::Image::try_from(image.data())?);
+    rec.log("image", &rerun::Image::try_from(image.data())?)?;
 
     Ok(())
 }

--- a/examples/rerun_viz.rs
+++ b/examples/rerun_viz.rs
@@ -7,10 +7,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let image: Image<u8, 3> = F::read_image_jpeg(image_path)?;
 
     // create a Rerun recording stream
-    let rec = rerun::RecordingStreamBuilder::new("Kornia App").connect()?;
+    let rec = rerun::RecordingStreamBuilder::new("Kornia App").spawn()?;
 
     // log the image
-    let _ = rec.log("image", &rerun::Image::try_from(image.data)?);
+    let _ = rec.log("image", &rerun::Image::try_from(image.data())?);
 
     Ok(())
 }

--- a/kornia-py/benchmark/bench_io.py
+++ b/kornia-py/benchmark/bench_io.py
@@ -21,6 +21,7 @@ def read_image_pillow(image_path: str) -> None:
 def read_image_kornia(image_path: str) -> None:
     return kornia_rs.read_image_jpeg(image_path)
 
+
 def read_image_tensorflow(image_path: str) -> None:
     return tf.keras.utils.load_img(image_path)
 

--- a/kornia-py/src/image.rs
+++ b/kornia-py/src/image.rs
@@ -14,7 +14,7 @@ pub trait ToPyImage {
 
 impl<const CHANNELS: usize> ToPyImage for kornia_rs::image::Image<u8, CHANNELS> {
     fn to_pyimage(self) -> PyImage {
-        Python::with_gil(|py| self.data().to_pyarray(py).to_owned())
+        Python::with_gil(|py| self.data.to_pyarray(py).to_owned())
     }
 }
 

--- a/kornia-py/src/image.rs
+++ b/kornia-py/src/image.rs
@@ -9,12 +9,12 @@ pub type PyImage = Py<PyArray3<u8>>;
 
 /// Trait to convert an image to a PyImage (3D numpy array of u8)
 pub trait ToPyImage {
-    fn to_pyimage(&self) -> PyImage;
+    fn to_pyimage(self) -> PyImage;
 }
 
 impl<const CHANNELS: usize> ToPyImage for kornia_rs::image::Image<u8, CHANNELS> {
-    fn to_pyimage(&self) -> PyImage {
-        Python::with_gil(|py| self.data.to_pyarray(py).to_owned())
+    fn to_pyimage(self) -> PyImage {
+        Python::with_gil(|py| self.data().to_pyarray(py).to_owned())
     }
 }
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -387,6 +387,10 @@ impl<T, const CHANNELS: usize> Image<T, CHANNELS> {
         CHANNELS
     }
 
+    /// Get the pixel data of the image as a 4D tensor in NCHW format.
+    ///
+    /// Internally, the image is stored in HWC format, and the function gives
+    /// away ownership of the pixel data.
     pub fn to_tensor_nchw(self) -> ndarray::Array4<T> {
         // add batch axis 1xHxWxC
         let data = self.data.insert_axis(ndarray::Axis(0));
@@ -395,6 +399,10 @@ impl<T, const CHANNELS: usize> Image<T, CHANNELS> {
         data.permuted_axes([0, 3, 1, 2])
     }
 
+    /// Get the pixel data of the image as a 4D tensor in NHWC format.
+    ///
+    /// Internally, the image is stored in HWC format, and the function gives
+    /// away ownership of the pixel data.
     pub fn to_tensor_nhwc(self) -> ndarray::Array4<T> {
         // add batch axis 1xHxWxC
         let data = self.data.insert_axis(ndarray::Axis(0));
@@ -402,6 +410,9 @@ impl<T, const CHANNELS: usize> Image<T, CHANNELS> {
         data
     }
 
+    /// Get the pixel data of the image.
+    ///
+    /// The function gives away ownership of the pixel data.
     pub fn data(self) -> ndarray::Array3<T> {
         self.data
     }
@@ -522,6 +533,27 @@ mod tests {
         assert_eq!(channels[0].data.get((1, 0, 0)).unwrap(), &3.0f32);
         assert_eq!(channels[1].data.get((1, 0, 0)).unwrap(), &4.0f32);
         assert_eq!(channels[2].data.get((1, 0, 0)).unwrap(), &5.0f32);
+
+        Ok(())
+    }
+
+    #[test]
+    fn convert_to_tensor() -> Result<()> {
+        let image = Image::<f32, 3>::new(
+            ImageSize {
+                height: 2,
+                width: 1,
+            },
+            vec![0., 1., 2., 3., 4., 5.],
+        )?;
+
+        let tensor_nchw = image.clone().to_tensor_nchw();
+        assert_eq!(tensor_nchw.shape(), &[1, 3, 2, 1]);
+        assert_eq!(tensor_nchw[[0, 2, 1, 0]], 5.0f32);
+
+        let tensor_nhwc = image.to_tensor_nhwc();
+        assert_eq!(tensor_nhwc.shape(), &[1, 2, 1, 3]);
+        assert_eq!(tensor_nhwc[[0, 1, 0, 2]], 5.0f32);
 
         Ok(())
     }


### PR DESCRIPTION
- add `.to_tensor_nchw()` and `.to_tensor_nhwc()` to the `Image` struct to easily convert images e.g to feed to onnxruntime
- make `Image.data()` pub (crate) to avoid leaks from user perspective
- some tweaks in the rerun examples logs api