### PR TITLE
[wip] benchmark zune-jpeg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3044,6 +3044,7 @@ dependencies = [
  "tempfile",
  "turbojpeg",
  "walkdir",
+ "zune-jpeg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ tempfile = "3.9.0"
 rayon = "1.10.0"
 rerun = "0.14.1"
 walkdir = "2.5.0"
+zune-jpeg = "0.4.11"
 
 
 [features]

--- a/benches/bench_io.rs
+++ b/benches/bench_io.rs
@@ -1,29 +1,27 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
-struct JpegReader {
-    decoder: kornia_rs::io::jpeg::ImageDecoder,
-}
-
-impl JpegReader {
-    fn new() -> Self {
-        Self {
-            decoder: kornia_rs::io::jpeg::ImageDecoder::new().unwrap(),
-        }
-    }
-
-    fn read(&mut self, file_path: &std::path::Path) -> kornia_rs::image::Image<u8, 3> {
-        let file = std::fs::File::open(file_path).unwrap();
-        let mmap = unsafe { memmap2::Mmap::map(&file).unwrap() };
-        self.decoder.decode(&mmap).unwrap()
-    }
-}
-
-fn read_no_mmap(file_path: &std::path::Path) -> kornia_rs::image::Image<u8, 3> {
+fn read_turbo_no_mmap(file_path: &std::path::Path) -> kornia_rs::image::Image<u8, 3> {
     let file = std::fs::read(file_path).unwrap();
     kornia_rs::io::jpeg::ImageDecoder::new()
         .unwrap()
         .decode(&file)
         .unwrap()
+}
+
+fn read_zune_jpeg(file_path: &std::path::Path) -> kornia_rs::image::Image<u8, 3> {
+    let data = std::fs::read(file_path).unwrap();
+    let mut decoder = zune_jpeg::JpegDecoder::new(&data);
+    decoder.decode_headers().unwrap();
+    let image_info = decoder.info().unwrap();
+    let image_data = decoder.decode().unwrap();
+    kornia_rs::image::Image::new(
+        kornia_rs::image::ImageSize {
+            width: image_info.width as usize,
+            height: image_info.height as usize,
+        },
+        image_data,
+    )
+    .unwrap()
 }
 
 fn bench_read_jpeg(c: &mut Criterion) {
@@ -36,16 +34,17 @@ fn bench_read_jpeg(c: &mut Criterion) {
         b.iter(|| kornia_rs::io::functional::read_image_jpeg(black_box(img_path)).unwrap())
     });
 
-    group.bench_function("image", |b| {
+    group.bench_function("image_any", |b| {
         b.iter(|| kornia_rs::io::functional::read_image_any(black_box(img_path)).unwrap())
     });
 
-    // NOTE: similar to the functional::read_image_jpeg
-    group.bench_function("jpeg_reader", |b| {
-        b.iter(|| JpegReader::new().read(black_box(img_path)))
+    group.bench_function("turbo_no_mmap", |b| {
+        b.iter(|| read_turbo_no_mmap(black_box(img_path)))
     });
 
-    group.bench_function("no_mmap", |b| b.iter(|| read_no_mmap(black_box(img_path))));
+    group.bench_function("zune_jpeg", |b| {
+        b.iter(|| read_zune_jpeg(black_box(img_path)))
+    });
 
     group.finish();
 }


### PR DESCRIPTION
to reproduce: ```RUSTFLAGS="-C target-cpu=native" cargo bench read_jpeg```

image size HxWx3 -- 258x195 ; not big not small similar to what you might target to load large ml dataset in prod

![image](https://github.com/kornia/kornia-rs/assets/5157099/38842e63-2f19-4e77-90be-ded374c4e775)
