### PR TITLE
[prototype] `ImageDtype` trait to implement resize for various dtypes

### DIFF
--- a/src/resize.rs
+++ b/src/resize.rs
@@ -269,19 +269,31 @@ pub fn resize_fast(
     new_size: ImageSize,
     interpolation: InterpolationMode,
 ) -> Result<Image<u8, 3>> {
-    let src_width = NonZeroU32::new(image.width() as u32).unwrap();
-    let src_height = NonZeroU32::new(image.height() as u32).unwrap();
+    let src_width = NonZeroU32::new(image.width() as u32).ok_or(anyhow::anyhow!(
+        "The width of the input image must be greater than zero."
+    ))?;
+    let src_height = NonZeroU32::new(image.height() as u32).ok_or(anyhow::anyhow!(
+        "The height of the input image must be greater than zero."
+    ))?;
 
-    // TODO: pass as slice
+    // get the image data as a contiguous slice
+    let image_data = image.data.as_slice().ok_or(anyhow::anyhow!(
+        "The image data must be contiguous and not empty."
+    ))?;
+
     let src_image = fr::Image::from_vec_u8(
         src_width,
         src_height,
-        image.data.as_slice().unwrap().to_vec(),
+        image_data.to_vec(),
         fr::PixelType::U8x3,
     )?;
 
-    let dst_width = NonZeroU32::new(new_size.width as u32).unwrap();
-    let dst_height = NonZeroU32::new(new_size.height as u32).unwrap();
+    let dst_width = NonZeroU32::new(new_size.width as u32).ok_or(anyhow::anyhow!(
+        "The width of the output image must be greater than zero."
+    ))?;
+    let dst_height = NonZeroU32::new(new_size.height as u32).ok_or(anyhow::anyhow!(
+        "The height of the output image must be greater than zero."
+    ))?;
 
     let mut dst_image = fr::Image::new(dst_width, dst_height, src_image.pixel_type());
     let mut dst_view = dst_image.view_mut();

--- a/src/resize.rs
+++ b/src/resize.rs
@@ -302,9 +302,10 @@ pub fn resize_fast(
 
 #[cfg(test)]
 mod tests {
+    use anyhow::Result;
 
     #[test]
-    fn resize_smoke_ch3() {
+    fn resize_smoke_ch3() -> Result<()> {
         use crate::image::{Image, ImageSize};
         let image = Image::<_, 3>::new(
             ImageSize {
@@ -312,8 +313,7 @@ mod tests {
                 height: 5,
             },
             vec![0f32; 4 * 5 * 3],
-        )
-        .unwrap();
+        )?;
         let image_resized = super::resize_native(
             &image,
             ImageSize {
@@ -321,24 +321,24 @@ mod tests {
                 height: 3,
             },
             super::InterpolationMode::Bilinear,
-        )
-        .unwrap();
+        )?;
+
         assert_eq!(image_resized.num_channels(), 3);
         assert_eq!(image_resized.size().width, 2);
         assert_eq!(image_resized.size().height, 3);
+        Ok(())
     }
 
     #[test]
-    fn resize_smoke_ch1() {
+    fn resize_smoke_ch1() -> Result<()> {
         use crate::image::{Image, ImageSize};
         let image = Image::<_, 1>::new(
             ImageSize {
                 width: 4,
                 height: 5,
             },
-            vec![0f32; 4 * 5],
-        )
-        .unwrap();
+            vec![0; 4 * 5],
+        )?;
         let image_resized = super::resize_native(
             &image,
             ImageSize {
@@ -346,11 +346,11 @@ mod tests {
                 height: 3,
             },
             super::InterpolationMode::Nearest,
-        )
-        .unwrap();
+        )?;
         assert_eq!(image_resized.num_channels(), 1);
         assert_eq!(image_resized.size().width, 2);
         assert_eq!(image_resized.size().height, 3);
+        Ok(())
     }
 
     #[test]
@@ -367,7 +367,7 @@ mod tests {
     }
 
     #[test]
-    fn resize_fast() {
+    fn resize_fast() -> Result<()> {
         use crate::image::{Image, ImageSize};
         let image = Image::<_, 3>::new(
             ImageSize {
@@ -375,8 +375,7 @@ mod tests {
                 height: 5,
             },
             vec![0u8; 4 * 5 * 3],
-        )
-        .unwrap();
+        )?;
         let image_resized = super::resize_fast(
             &image,
             ImageSize {
@@ -384,10 +383,10 @@ mod tests {
                 height: 3,
             },
             super::InterpolationMode::Nearest,
-        )
-        .unwrap();
+        )?;
         assert_eq!(image_resized.num_channels(), 3);
         assert_eq!(image_resized.size().width, 2);
         assert_eq!(image_resized.size().height, 3);
+        Ok(())
     }
 }

--- a/src/resize.rs
+++ b/src/resize.rs
@@ -123,7 +123,7 @@ fn bilinear_interpolation<T: ImageDtype>(image: &Array3<T>, u: f32, v: f32, c: u
 /// # Returns
 ///
 /// The interpolated pixel value.
-fn nearest_neighbor_interpolation<T: Copy>(image: &Array3<T>, u: f32, v: f32, c: usize) -> T {
+fn nearest_neighbor_interpolation<T: ImageDtype>(image: &Array3<T>, u: f32, v: f32, c: usize) -> T {
     let (height, width, _) = image.dim();
 
     let iu = u.round() as usize;

--- a/src/resize.rs
+++ b/src/resize.rs
@@ -40,26 +40,19 @@ pub fn meshgrid(x: &Array2<f32>, y: &Array2<f32>) -> (Array2<f32>, Array2<f32>) 
 }
 
 // Send and Sync is required for ndarray::Zip::par_for_each
-pub trait ImageDtype: Copy + Default + Send + Sync {
-    fn to_f32(&self) -> f32;
+pub trait ImageDtype: Copy + Default + Into<f32> + Send + Sync {
     fn from_f32(x: f32) -> Self;
 }
 
 impl ImageDtype for f32 {
-    fn to_f32(&self) -> f32 {
-        *self
-    }
     fn from_f32(x: f32) -> Self {
         x
     }
 }
 
 impl ImageDtype for u8 {
-    fn to_f32(&self) -> f32 {
-        *self as f32
-    }
     fn from_f32(x: f32) -> Self {
-        x.clamp(0.0, 255.0) as u8
+        x.round().clamp(0.0, 255.0) as u8
     }
 }
 
@@ -83,19 +76,19 @@ fn bilinear_interpolation<T: ImageDtype>(image: &Array3<T>, u: f32, v: f32, c: u
 
     let frac_u = u.fract();
     let frac_v = v.fract();
-    let val00 = image[[iv, iu, c]].to_f32();
-    let val01 = if iu + 1 < width {
-        image[[iv, iu + 1, c]].to_f32()
+    let val00: f32 = image[[iv, iu, c]].into();
+    let val01: f32 = if iu + 1 < width {
+        image[[iv, iu + 1, c]].into()
     } else {
         val00
     };
-    let val10 = if iv + 1 < height {
-        image[[iv + 1, iu, c]].to_f32()
+    let val10: f32 = if iv + 1 < height {
+        image[[iv + 1, iu, c]].into()
     } else {
         val00
     };
-    let val11 = if iu + 1 < width && iv + 1 < height {
-        image[[iv + 1, iu + 1, c]].to_f32()
+    let val11: f32 = if iu + 1 < width && iv + 1 < height {
+        image[[iv + 1, iu + 1, c]].into()
     } else {
         val00
     };

--- a/src/resize.rs
+++ b/src/resize.rs
@@ -39,7 +39,8 @@ pub fn meshgrid(x: &Array2<f32>, y: &Array2<f32>) -> (Array2<f32>, Array2<f32>) 
     (xx, yy)
 }
 
-trait ImageDtype {
+// Send and Sync is required for ndarray::Zip::par_for_each
+pub trait ImageDtype: Copy + Default + Send + Sync {
     fn to_f32(&self) -> f32;
     fn from_f32(x: f32) -> Self;
 }
@@ -181,13 +182,13 @@ pub enum InterpolationMode {
 /// assert_eq!(image_resized.size().width, 2);
 /// assert_eq!(image_resized.size().height, 3);
 /// ```
-pub fn resize_native<const CHANNELS: usize>(
-    image: &Image<f32, CHANNELS>,
+pub fn resize_native<T: ImageDtype, const CHANNELS: usize>(
+    image: &Image<T, CHANNELS>,
     new_size: ImageSize,
     interpolation: InterpolationMode,
-) -> Result<Image<f32, CHANNELS>> {
+) -> Result<Image<T, CHANNELS>> {
     // create the output image
-    let mut output = Image::from_size_val(new_size, 0.0)?;
+    let mut output = Image::from_size_val(new_size, T::default())?;
 
     // create a grid of x and y coordinates for the output image
     // and interpolate the values from the input image.


### PR DESCRIPTION
This is my prototype to support resize with different dtypes. Justifications for trait

- `Copy` trait: to get the value out of `ndarray::Array<T, _>`
- `Default` trait: to get 0 value
- `Into<f32>` trait: to convert to f32 for internal computation i.e. bilinear/bicubic
- `Send` and `Sync` trait: required for `ndarray::Zip::par_for_each()`
- `from_f32()` function: convert from internal computation dtype f32 back to original dtype. We can't use `From<f32>` since it is undefined-behavior with underflow and overflow values i.e. we need to clamp the value by ourselves.

I think `ImageDtype` trait can be moved to `image.rs` and data within `Image` must implement `ImageDtype` trait i.e. these are the dtype that we support -> `pub struct Image<T: ImageDtype, const CHANNELS: usize>`