### PR TITLE
remove new_size and implement cast_and_scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,13 +123,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let image_f32: Image<f32, 3> = image.cast_and_scale::<f32>(1.0 / 255.0)?;
 
     // convert the image to grayscale
+    let mut gray = Image::<f32, 1>::from_size_val(image_f32.size(), 0.0)?;
+    imgproc::color::gray_from_rgb(&image_f32, &mut gray)?;
+
+    // resize the image
     let new_size = ImageSize {
         width: 128,
         height: 128,
     };
-
-    let mut gray = Image::<f32, 1>::from_size_val(new_size, 0.0)?;
-    imgproc::color::gray_from_rgb(&image_f32, &mut gray)?;
 
     let mut gray_resized = Image::<f32, 1>::from_size_val(new_size, 0.0)?;
     imgproc::resize::resize_native(

--- a/README.md
+++ b/README.md
@@ -123,18 +123,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let image_f32: Image<f32, 3> = image.cast_and_scale::<f32>(1.0 / 255.0)?;
 
     // convert the image to grayscale
-    let gray: Image<f32, 1> = imgproc::color::gray_from_rgb(&image_f32)?;
+    let new_size = ImageSize {
+        width: 128,
+        height: 128,
+    };
 
-    let gray_resize: Image<f32, 1> = imgproc::resize::resize_native(
-        &gray,
-        ImageSize {
-            width: 128,
-            height: 128,
-        },
+    let mut gray = Image::<f32, 1>::from_size_val(new_size, 0.0)?;
+    imgproc::color::gray_from_rgb(&image_f32, &mut gray)?;
+
+    let mut gray_resized = Image::<f32, 1>::from_size_val(new_size, 0.0)?;
+    imgproc::resize::resize_native(
+        &gray, &mut gray_resized,
         imgproc::resize::InterpolationMode::Bilinear,
     )?;
 
-    println!("gray_resize: {:?}", gray_resize.size());
+    println!("gray_resize: {:?}", gray_resized.size());
 
     // create a Rerun recording stream
     let rec = rerun::RecordingStreamBuilder::new("Kornia App").connect()?;
@@ -142,7 +145,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // log the images
     let _ = rec.log("image", &rerun::Image::try_from(image_viz.data)?);
     let _ = rec.log("gray", &rerun::Image::try_from(gray.data)?);
-    let _ = rec.log("gray_resize", &rerun::Image::try_from(gray_resize.data)?);
+    let _ = rec.log("gray_resize", &rerun::Image::try_from(gray_resized.data)?);
 
     Ok(())
 }

--- a/crates/kornia-image/src/image.rs
+++ b/crates/kornia-image/src/image.rs
@@ -559,9 +559,63 @@ impl<T, const CHANNELS: usize> Image<T, CHANNELS> {
     }
 }
 
+/// Cast the pixel data of an image to a different type.
+///
+/// # Arguments
+///
+/// * `src` - The source image.
+/// * `dst` - The destination image.
+/// * `scale` - The scale to multiply the pixel data with.
+///
+/// Example:
+///
+/// ```
+/// use kornia::image::{Image, ImageSize};
+
+// TODO: in future move to kornia_core
+pub fn cast_and_scale<T, U, const CHANNELS: usize>(
+    src: &Image<T, CHANNELS>,
+    dst: &mut Image<U, CHANNELS>,
+    scale: U,
+) -> Result<(), ImageError>
+where
+    T: Copy + num_traits::NumCast,
+    U: Copy + num_traits::NumCast + std::ops::Mul<U, Output = U>,
+{
+    if src.size() != dst.size() {
+        return Err(ImageError::InvalidImageSize(
+            src.width(),
+            src.height(),
+            dst.width(),
+            dst.height(),
+        ));
+    }
+
+    let src_data = src
+        .data
+        .as_slice()
+        .ok_or(ImageError::ImageDataNotContiguous)?;
+
+    let dst_data = dst
+        .data
+        .as_slice_mut()
+        .ok_or(ImageError::ImageDataNotContiguous)?;
+
+    dst_data
+        .iter_mut()
+        .zip(src_data.iter())
+        .try_for_each(|(out, &inp)| {
+            let x = U::from(inp).ok_or(ImageError::CastError)?;
+            *out = x * scale;
+            Ok::<(), ImageError>(())
+        })?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::image::{Image, ImageError, ImageSize};
+    use crate::image::{self, Image, ImageError, ImageSize};
 
     #[test]
     fn image_size() {
@@ -694,6 +748,27 @@ mod tests {
         let tensor_nhwc = image.to_tensor_nhwc();
         assert_eq!(tensor_nhwc.shape(), &[1, 2, 1, 3]);
         assert_eq!(tensor_nhwc[[0, 1, 0, 2]], 5.0f32);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_cast_and_scale() -> Result<(), ImageError> {
+        let image = Image::<u8, 3>::new(
+            ImageSize {
+                height: 2,
+                width: 1,
+            },
+            vec![0u8, 0, 255, 0, 0, 255],
+        )?;
+
+        let mut image_f64: Image<f64, 3> = Image::from_size_val(image.size(), 0.0)?;
+
+        image::cast_and_scale(&image, &mut image_f64, 1. / 255.0)?;
+
+        let expected = vec![0.0, 0.0, 1.0, 0.0, 0.0, 1.0];
+
+        assert_eq!(image_f64.data.into_raw_vec(), expected);
 
         Ok(())
     }

--- a/crates/kornia-image/src/image.rs
+++ b/crates/kornia-image/src/image.rs
@@ -571,6 +571,23 @@ impl<T, const CHANNELS: usize> Image<T, CHANNELS> {
 ///
 /// ```
 /// use kornia::image::{Image, ImageSize};
+/// use kornia::image::cast_and_scale;
+///
+/// let image = Image::<u8, 1>::new(
+///  ImageSize {
+///   width: 2,
+///  height: 1,
+/// },
+/// vec![0u8, 255],
+/// ).unwrap();
+///
+/// let mut image_f32 = Image::from_size_val(image.size(), 0.0f32).unwrap();
+///
+/// cast_and_scale(&image, &mut image_f32, 1. / 255.0).unwrap();
+///
+/// assert_eq!(image_f32.get_pixel(0, 0, 0).unwrap(), 0.0f32);
+/// assert_eq!(image_f32.get_pixel(1, 0, 0).unwrap(), 1.0f32);
+/// ```
 
 // TODO: in future move to kornia_core
 pub fn cast_and_scale<T, U, const CHANNELS: usize>(

--- a/crates/kornia-image/src/lib.rs
+++ b/crates/kornia-image/src/lib.rs
@@ -8,4 +8,5 @@ pub mod image;
 pub mod error;
 
 pub use crate::error::ImageError;
+pub use crate::image::cast_and_scale;
 pub use crate::image::{Image, ImageDtype, ImageSize};

--- a/crates/kornia-imgproc/benches/bench_resize.rs
+++ b/crates/kornia-imgproc/benches/bench_resize.rs
@@ -45,7 +45,6 @@ fn bench_resize(c: &mut Criterion) {
                 resize::resize_native(
                     black_box(i),
                     black_box(&mut out_f32),
-                    new_size,
                     InterpolationMode::Nearest,
                 )
             })
@@ -58,7 +57,6 @@ fn bench_resize(c: &mut Criterion) {
                 resize::resize_fast(
                     black_box(i),
                     black_box(&mut out_u8),
-                    new_size,
                     InterpolationMode::Nearest,
                 )
             })

--- a/crates/kornia-imgproc/src/warp/perspective.rs
+++ b/crates/kornia-imgproc/src/warp/perspective.rs
@@ -291,7 +291,6 @@ mod tests {
         crate::resize::resize_native(
             &image,
             &mut image_resized,
-            new_size,
             super::InterpolationMode::Bilinear,
         )?;
 

--- a/examples/imgproc/src/main.rs
+++ b/examples/imgproc/src/main.rs
@@ -29,11 +29,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         width: 128,
         height: 128,
     };
+
     let mut gray_resize = Image::<f32, 1>::from_size_val(new_size, 0.0)?;
     imgproc::resize::resize_native(
         &gray,
         &mut gray_resize,
-        new_size,
         imgproc::interpolation::InterpolationMode::Bilinear,
     )?;
 

--- a/examples/normalize_ii/src/main.rs
+++ b/examples/normalize_ii/src/main.rs
@@ -17,7 +17,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let image: Image<u8, 3> = F::read_image_any(&args.image_path)?;
 
     // cast the image to floating point
-    let image_f32: Image<f32, 3> = image.clone().cast_and_scale::<f32>(1.0 / 255.0)?;
+    let image_f32: Image<f32, 3> = image.cast_and_scale::<f32>(1.0 / 255.0)?;
 
     // convert to grayscale
     let mut gray = Image::<f32, 1>::from_size_val(image_f32.size(), 0.0)?;

--- a/examples/webcam/src/main.rs
+++ b/examples/webcam/src/main.rs
@@ -5,7 +5,7 @@ use std::sync::{
 };
 
 use kornia::{
-    image::{Image, ImageSize},
+    image::{image, Image, ImageSize},
     imgproc,
     io::{
         fps_counter::FpsCounter,
@@ -76,6 +76,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let mut img_resized = Image::from_size_val(new_size, 0u8)?;
+    let mut img_f32 = Image::from_size_val(new_size, 0f32)?;
     let mut gray = Image::from_size_val(new_size, 0f32)?;
     let mut bin = Image::from_size_val(new_size, 0f32)?;
 
@@ -91,15 +92,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             imgproc::resize::resize_fast(
                 &img,
                 &mut img_resized,
-                new_size,
                 imgproc::interpolation::InterpolationMode::Bilinear,
             )?;
 
             // convert the image to f32 and normalize before processing
-            let img = img_resized.clone().cast_and_scale::<f32>(1. / 255.)?;
+            image::cast_and_scale(&img_resized, &mut img_f32, 1. / 255.)?;
 
             // convert the image to grayscale and binarize
-            imgproc::color::gray_from_rgb(&img, &mut gray)?;
+            imgproc::color::gray_from_rgb(&img_f32, &mut gray)?;
             imgproc::threshold::threshold_binary(&gray, &mut bin, 0.35, 0.65)?;
 
             // update the fps counter

--- a/kornia-py/src/resize.rs
+++ b/kornia-py/src/resize.rs
@@ -29,7 +29,7 @@ pub fn resize(image: PyImage, new_size: (usize, usize), interpolation: &str) -> 
     let mut image_resized = Image::from_size_val(new_size, 0u8)
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
 
-    resize_fast(&image, &mut image_resized, new_size, interpolation)
+    resize_fast(&image, &mut image_resized, interpolation)
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
 
     Ok(image_resized.to_pyimage())


### PR DESCRIPTION
- remove `new_size` from `resize_native` / `resize_fast` and infer from dst image
- implement `cast_and_scale` into `image` module to receive mutable images