### PR TITLE
TensorStorage improvements

### DIFF
--- a/crates/kornia-core/Cargo.toml
+++ b/crates/kornia-core/Cargo.toml
@@ -13,7 +13,7 @@ version.workspace = true
 [dependencies]
 
 # external
-arrow-buffer = "52.0.0"
+arrow-buffer = "52.2.0"
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
 

--- a/crates/kornia-core/src/lib.rs
+++ b/crates/kornia-core/src/lib.rs
@@ -14,7 +14,8 @@ pub mod serde;
 pub mod storage;
 
 pub use crate::allocator::{CpuAllocator, TensorAllocator};
-pub use crate::tensor::{SafeTensorType, Tensor, TensorError};
+pub use crate::storage::SafeTensorType;
+pub use crate::tensor::{Tensor, TensorError};
 
 /// Type alias for a 1-dimensional tensor.
 pub type Tensor1<T> = Tensor<T, 1>;

--- a/crates/kornia-core/src/lib.rs
+++ b/crates/kornia-core/src/lib.rs
@@ -14,7 +14,7 @@ pub mod serde;
 pub mod storage;
 
 pub use crate::allocator::{CpuAllocator, TensorAllocator};
-pub use crate::tensor::{Tensor, TensorError};
+pub use crate::tensor::{SafeTensorType, Tensor, TensorError};
 
 /// Type alias for a 1-dimensional tensor.
 pub type Tensor1<T> = Tensor<T, 1>;

--- a/crates/kornia-core/src/serde.rs
+++ b/crates/kornia-core/src/serde.rs
@@ -1,11 +1,16 @@
-use crate::{allocator::TensorAllocator, storage::TensorStorage, Tensor};
+use crate::{
+    allocator::TensorAllocator,
+    storage::{SafeTensorType, TensorStorage},
+    Tensor,
+};
 
 use serde::ser::SerializeStruct;
 use serde::Deserialize;
 
 impl<T, const N: usize, A: TensorAllocator> serde::Serialize for Tensor<T, N, A>
 where
-    T: serde::Serialize + arrow_buffer::ArrowNativeType + std::panic::RefUnwindSafe,
+    //T: serde::Serialize + arrow_buffer::ArrowNativeType + std::panic::RefUnwindSafe,
+    T: serde::Serialize + SafeTensorType,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -22,7 +27,8 @@ where
 impl<'de, T, const N: usize, A: TensorAllocator + Default> serde::Deserialize<'de>
     for Tensor<T, N, A>
 where
-    T: serde::Deserialize<'de> + arrow_buffer::ArrowNativeType + std::panic::RefUnwindSafe,
+    //T: serde::Deserialize<'de> + arrow_buffer::ArrowNativeType + std::panic::RefUnwindSafe,
+    T: serde::Deserialize<'de> + SafeTensorType,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/crates/kornia-core/src/serde.rs
+++ b/crates/kornia-core/src/serde.rs
@@ -9,7 +9,6 @@ use serde::Deserialize;
 
 impl<T, const N: usize, A: TensorAllocator> serde::Serialize for Tensor<T, N, A>
 where
-    //T: serde::Serialize + arrow_buffer::ArrowNativeType + std::panic::RefUnwindSafe,
     T: serde::Serialize + SafeTensorType,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -27,7 +26,6 @@ where
 impl<'de, T, const N: usize, A: TensorAllocator + Default> serde::Deserialize<'de>
     for Tensor<T, N, A>
 where
-    //T: serde::Deserialize<'de> + arrow_buffer::ArrowNativeType + std::panic::RefUnwindSafe,
     T: serde::Deserialize<'de> + SafeTensorType,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/crates/kornia-core/src/storage.rs
+++ b/crates/kornia-core/src/storage.rs
@@ -19,7 +19,7 @@ use std::{alloc::Layout, ptr::NonNull};
 /// * `marker` - The marker type for the tensor storage.
 pub struct TensorStorage<T: ArrowNativeType, A: TensorAllocator> {
     /// The buffer containing the tensor storage.
-    pub data: Buffer,
+    data: Buffer,
     alloc: A,
     marker: PhantomData<T>,
 }
@@ -93,6 +93,24 @@ where
     /// Returns the allocator used to allocate the tensor storage.
     pub fn alloc(&self) -> &A {
         &self.alloc
+    }
+
+    /// Returns the length of the tensor storage.
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Return the data pointer as a slice.
+    pub fn as_slice(&self) -> &[T] {
+        self.data.typed_data::<T>()
+    }
+
+    /// Return the data pointer as a mutable slice.
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
+        let slice = self.as_slice();
+
+        // SAFETY: the buffer is mutable
+        unsafe { std::slice::from_raw_parts_mut(slice.as_ptr() as *mut T, slice.len()) }
     }
 }
 

--- a/crates/kornia-core/src/storage.rs
+++ b/crates/kornia-core/src/storage.rs
@@ -1,12 +1,26 @@
 use super::allocator::{TensorAllocator, TensorAllocatorError};
-use arrow_buffer::{ArrowNativeType, Buffer};
-use std::marker::PhantomData;
+use arrow_buffer::{Buffer, ScalarBuffer};
 use std::sync::Arc;
 use std::{alloc::Layout, ptr::NonNull};
 
+/// A trait to define the types that can be used in a tensor.
+pub trait SafeTensorType: arrow_buffer::ArrowNativeType + std::panic::RefUnwindSafe {}
+
+/// Implement the `SafeTensorType` trait for the supported types.
+impl SafeTensorType for u8 {}
+impl SafeTensorType for u16 {}
+impl SafeTensorType for u32 {}
+impl SafeTensorType for u64 {}
+impl SafeTensorType for i8 {}
+impl SafeTensorType for i16 {}
+impl SafeTensorType for i32 {}
+impl SafeTensorType for i64 {}
+impl SafeTensorType for f32 {}
+impl SafeTensorType for f64 {}
+
 /// represents a contiguous memory region that can be shared with other buffers and across thread boundaries.
 ///
-/// NOTE: https://docs.rs/arrow/latest/arrow/buffer/struct.Buffer.html
+/// NOTE: https://docs.rs/arrow-buffer/latest/arrow_buffer/buffer/struct.ScalarBuffer.html
 ///
 /// # Safety
 ///
@@ -16,18 +30,19 @@ use std::{alloc::Layout, ptr::NonNull};
 ///
 /// * `data` - The buffer containing the tensor storage.
 /// * `alloc` - The allocator used to allocate the tensor storage.
-/// * `marker` - The marker type for the tensor storage.
-pub struct TensorStorage<T: ArrowNativeType, A: TensorAllocator> {
+pub struct TensorStorage<T, A: TensorAllocator>
+where
+    T: SafeTensorType,
+{
     /// The buffer containing the tensor storage.
-    data: Buffer,
+    data: ScalarBuffer<T>,
     alloc: A,
-    marker: PhantomData<T>,
 }
 
 /// Implement the `TensorStorage` struct.
 impl<T, A: TensorAllocator> TensorStorage<T, A>
 where
-    T: ArrowNativeType + std::panic::RefUnwindSafe,
+    T: SafeTensorType,
 {
     /// Creates a new tensor storage with the given length and allocator.
     ///
@@ -54,9 +69,8 @@ where
         };
 
         Ok(Self {
-            data: buffer,
+            data: buffer.into(),
             alloc,
-            marker: PhantomData,
         })
     }
 
@@ -82,9 +96,8 @@ where
 
         // create tensor storage
         let storage = Self {
-            data: buffer,
+            data: buffer.into(),
             alloc,
-            marker: PhantomData,
         };
 
         Ok(storage)
@@ -100,17 +113,19 @@ where
         self.data.len()
     }
 
+    /// Returns whether the tensor storage is empty.
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
     /// Return the data pointer as a slice.
     pub fn as_slice(&self) -> &[T] {
-        self.data.typed_data::<T>()
+        unsafe { std::slice::from_raw_parts(self.data.as_ptr(), self.len()) }
     }
 
     /// Return the data pointer as a mutable slice.
     pub fn as_mut_slice(&mut self) -> &mut [T] {
-        let slice = self.as_slice();
-
-        // SAFETY: the buffer is mutable
-        unsafe { std::slice::from_raw_parts_mut(slice.as_ptr() as *mut T, slice.len()) }
+        unsafe { std::slice::from_raw_parts_mut(self.data.as_ptr() as *mut T, self.len()) }
     }
 }
 


### PR DESCRIPTION
- implement `SafeTensorType` to support tuple structs out of Tensor
- bump  arrow-buffer to 52.2.0
- use strongly typed `arrow::ScalarBuffer<T>` over `arrow::Buffer`
  - https://docs.rs/arrow-buffer/latest/arrow_buffer/buffer/struct.ScalarBuffer.html
- make data buffer private in TensorStorage
- expose `len()` / `is_empty()` / `as_slice()` / `as_mut_slice()` in storage 