### PR TITLE
Implement TensorView

### DIFF
--- a/crates/kornia-core/Cargo.toml
+++ b/crates/kornia-core/Cargo.toml
@@ -16,7 +16,6 @@ version.workspace = true
 arrow-buffer = "52.2.0"
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
-ndarray = "0.15.4"
 
 
 [dev-dependencies]

--- a/crates/kornia-core/Cargo.toml
+++ b/crates/kornia-core/Cargo.toml
@@ -16,6 +16,7 @@ version.workspace = true
 arrow-buffer = "52.2.0"
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
+ndarray = "0.15.4"
 
 
 [dev-dependencies]

--- a/crates/kornia-core/src/lib.rs
+++ b/crates/kornia-core/src/lib.rs
@@ -13,6 +13,9 @@ pub mod serde;
 /// storage module containing the storage implementations.
 pub mod storage;
 
+/// view module containing the view implementations.
+pub mod view;
+
 pub use crate::allocator::{CpuAllocator, TensorAllocator};
 pub use crate::tensor::{Tensor, TensorError};
 

--- a/crates/kornia-core/src/storage.rs
+++ b/crates/kornia-core/src/storage.rs
@@ -104,18 +104,27 @@ where
     }
 
     /// Returns the allocator used to allocate the tensor storage.
+    #[inline]
     pub fn alloc(&self) -> &A {
         &self.alloc
     }
 
     /// Returns the length of the tensor storage.
+    #[inline]
     pub fn len(&self) -> usize {
         self.data.len()
     }
 
     /// Returns whether the tensor storage is empty.
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.data.is_empty()
+    }
+
+    /// Returns the data pointer
+    #[inline]
+    pub fn as_ptr(&self) -> *const T {
+        self.data.as_ptr()
     }
 
     /// Return the data pointer as a slice.

--- a/crates/kornia-core/src/view.rs
+++ b/crates/kornia-core/src/view.rs
@@ -1,5 +1,50 @@
-use crate::TensorAllocator;
+use crate::{storage::TensorStorage, SafeTensorType, TensorAllocator};
 
-pub struct TensorView<T, const N: usize, A: TensorAllocator> {
-    pub storage: A::Storage,
+/// A view into a tensor.
+pub struct TensorView<'a, T: SafeTensorType, const N: usize, A: TensorAllocator> {
+    /// Reference to the storage held by the another tensor.
+    pub storage: &'a TensorStorage<T, A>,
+
+    /// The shape of the tensor.
+    pub shape: [usize; N],
+
+    /// The strides of the tensor.
+    pub strides: [usize; N],
+}
+
+impl<'a, T: SafeTensorType, const N: usize, A: TensorAllocator> TensorView<'a, T, N, A> {
+    /// Returns the data slice of the tensor.
+    #[inline]
+    pub fn as_slice(&self) -> &[T] {
+        self.storage.as_slice()
+    }
+
+    /// Returns the data pointer of the tensor.
+    #[inline]
+    pub fn as_ptr(&self) -> *const T {
+        self.storage.as_ptr()
+    }
+
+    /// Returns the length of the tensor.
+    #[inline]
+    pub fn numel(&self) -> usize {
+        self.storage.len()
+    }
+
+    /// Get the element at the given index.
+    ///
+    /// # Returns
+    ///
+    /// A reference to the element at the given index.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the index is within the bounds of the tensor.
+    pub fn get_unchecked(&self, index: [usize; N]) -> &T {
+        let offset = index
+            .iter()
+            .zip(self.strides.iter())
+            .fold(0, |acc, (i, s)| acc + i * s);
+        &self.as_slice()[offset]
+    }
 }

--- a/crates/kornia-core/src/view.rs
+++ b/crates/kornia-core/src/view.rs
@@ -1,0 +1,5 @@
+use crate::TensorAllocator;
+
+pub struct TensorView<T, const N: usize, A: TensorAllocator> {
+    pub storage: A::Storage,
+}


### PR DESCRIPTION
- implement a `TensorView` struct to leverage axes permutations
- implement `as_ptr` /  `get` / `get_unchecked`  in `TensorStorage`
- expose `as_ptr` in `Tensor`
- return `TensorView` in `Tensor::reshape`
- implement `Tensor::permute_axes` and return `TensorView`
- implement `Tensor::view` to return `TensorView`
- `Tensor::get` now returns `Option` to align with Arrow and ndarray
- added some of tests