### PR TITLE
Simplify handling paths by using `impl AsRef<Path>` for JPEG functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ use kornia::io::functional as F;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // read the image
-    let image_path = std::path::Path::new("tests/data/dog.jpeg");
-    let image: Image<u8, 3> = F::read_image_any(image_path)?;
+    let image: Image<u8, 3> = F::read_image_any("tests/data/dog.jpeg")?;
 
     println!("Hello, world! 🦀");
     println!("Loaded Image size: {:?}", image.size());
@@ -116,8 +115,7 @@ use kornia::io::functional as F;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // read the image
-    let image_path = std::path::Path::new("tests/data/dog.jpeg");
-    let image: Image<u8, 3> = F::read_image_any(image_path)?;
+    let image: Image<u8, 3> = F::read_image_any("tests/data/dog.jpeg")?;
     let image_viz = image.clone();
 
     let image_f32: Image<f32, 3> = image.cast_and_scale::<f32>(1.0 / 255.0)?;

--- a/crates/kornia-imgproc/src/color/gray.rs
+++ b/crates/kornia-imgproc/src/color/gray.rs
@@ -85,8 +85,7 @@ mod tests {
 
     #[test]
     fn gray_from_rgb() -> Result<(), Box<dyn std::error::Error>> {
-        let image_path = std::path::Path::new("../../tests/data/dog.jpeg");
-        let image = F::read_image_any(image_path)?;
+        let image = F::read_image_any("../../tests/data/dog.jpeg")?;
         let image_norm = image.cast_and_scale::<f32>(1. / 255.0)?;
 
         let mut gray = Image::<f32, 1>::from_size_val(image_norm.size(), 0.0)?;

--- a/crates/kornia-io/benches/bench_io.rs
+++ b/crates/kornia-io/benches/bench_io.rs
@@ -1,4 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::path::Path;
 
 struct JpegReader {
     decoder: kornia::io::jpeg::ImageDecoder,
@@ -11,14 +12,16 @@ impl JpegReader {
         }
     }
 
-    fn read(&mut self, file_path: &std::path::Path) -> kornia_image::Image<u8, 3> {
+    fn read(&mut self, file_path: impl AsRef<Path>) -> kornia_image::Image<u8, 3> {
+        let file_path = file_path.as_ref().to_owned();
         let file = std::fs::File::open(file_path).unwrap();
         let mmap = unsafe { memmap2::Mmap::map(&file).unwrap() };
         self.decoder.decode(&mmap).unwrap()
     }
 }
 
-fn read_no_mmap(file_path: &std::path::Path) -> kornia_image::Image<u8, 3> {
+fn read_no_mmap(file_path: impl AsRef<Path>) -> kornia_image::Image<u8, 3> {
+    let file_path = file_path.as_ref().to_owned();
     let file = std::fs::read(file_path).unwrap();
     kornia::io::jpeg::ImageDecoder::new()
         .unwrap()
@@ -29,7 +32,7 @@ fn read_no_mmap(file_path: &std::path::Path) -> kornia_image::Image<u8, 3> {
 fn bench_read_jpeg(c: &mut Criterion) {
     let mut group = c.benchmark_group("read_jpeg");
 
-    let img_path = std::path::Path::new("tests/data/dog.jpeg");
+    let img_path = "tests/data/dog.jpeg";
 
     // NOTE: this is the fastest method
     group.bench_function("jpegturbo", |b| {

--- a/crates/kornia-io/src/functional.rs
+++ b/crates/kornia-io/src/functional.rs
@@ -26,14 +26,14 @@ use super::jpeg::{ImageDecoder, ImageEncoder};
 /// use kornia::image::Image;
 /// use kornia::io::functional as F;
 ///
-/// let image_path = std::path::Path::new("../../tests/data/dog.jpeg");
-/// let image: Image<u8, 3> = F::read_image_jpeg(image_path).unwrap();
+/// let image: Image<u8, 3> = F::read_image_jpeg("../../tests/data/dog.jpeg").unwrap();
 ///
 /// assert_eq!(image.size().width, 258);
 /// assert_eq!(image.size().height, 195);
 /// assert_eq!(image.num_channels(), 3);
 /// ```
-pub fn read_image_jpeg(file_path: &Path) -> Result<Image<u8, 3>, IoError> {
+pub fn read_image_jpeg(file_path: impl AsRef<Path>) -> Result<Image<u8, 3>, IoError> {
+    let file_path = file_path.as_ref().to_owned();
     // verify the file exists and is a JPEG
     if !file_path.exists() {
         return Err(IoError::FileDoesNotExist(file_path.to_path_buf()));
@@ -65,7 +65,9 @@ pub fn read_image_jpeg(file_path: &Path) -> Result<Image<u8, 3>, IoError> {
 ///
 /// * `file_path` - The path to the JPEG image.
 /// * `image` - The tensor containing the JPEG image data.
-pub fn write_image_jpeg(file_path: &Path, image: &Image<u8, 3>) -> Result<(), IoError> {
+pub fn write_image_jpeg(file_path: impl AsRef<Path>, image: &Image<u8, 3>) -> Result<(), IoError> {
+    let file_path = file_path.as_ref().to_owned();
+
     // compress the image
     let jpeg_data = ImageEncoder::new()?.encode(image)?;
 
@@ -93,14 +95,15 @@ pub fn write_image_jpeg(file_path: &Path, image: &Image<u8, 3>) -> Result<(), Io
 /// use kornia::image::Image;
 /// use kornia::io::functional as F;
 ///
-/// let image_path = std::path::Path::new("../../tests/data/dog.jpeg");
-/// let image: Image<u8, 3> = F::read_image_any(image_path).unwrap();
+/// let image: Image<u8, 3> = F::read_image_any("../../tests/data/dog.jpeg").unwrap();
 ///
 /// assert_eq!(image.size().width, 258);
 /// assert_eq!(image.size().height, 195);
 /// assert_eq!(image.num_channels(), 3);
 /// ```
-pub fn read_image_any(file_path: &Path) -> Result<Image<u8, 3>, IoError> {
+pub fn read_image_any(file_path: impl AsRef<Path>) -> Result<Image<u8, 3>, IoError> {
+    let file_path = file_path.as_ref().to_owned();
+
     // verify the file exists
     if !file_path.exists() {
         return Err(IoError::FileDoesNotExist(file_path.to_path_buf()));
@@ -132,8 +135,6 @@ pub fn read_image_any(file_path: &Path) -> Result<Image<u8, 3>, IoError> {
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
-
     use crate::error::IoError;
     use crate::functional::read_image_any;
 
@@ -142,8 +143,7 @@ mod tests {
 
     #[test]
     fn read_any() -> Result<(), IoError> {
-        let image_path = Path::new("../../tests/data/dog.jpeg");
-        let image = read_image_any(image_path)?;
+        let image = read_image_any("../../tests/data/dog.jpeg")?;
         assert_eq!(image.size().width, 258);
         assert_eq!(image.size().height, 195);
         Ok(())
@@ -152,8 +152,7 @@ mod tests {
     #[test]
     #[cfg(feature = "jpegturbo")]
     fn read_jpeg() -> Result<(), IoError> {
-        let image_path = Path::new("../../tests/data/dog.jpeg");
-        let image = read_image_jpeg(image_path)?;
+        let image = read_image_jpeg("../../tests/data/dog.jpeg")?;
         assert_eq!(image.size().width, 258);
         assert_eq!(image.size().height, 195);
         Ok(())
@@ -162,12 +161,11 @@ mod tests {
     #[test]
     #[cfg(feature = "jpegturbo")]
     fn read_write_jpeg() -> Result<(), IoError> {
-        let image_path_read = Path::new("../../tests/data/dog.jpeg");
         let tmp_dir = tempfile::tempdir()?;
         std::fs::create_dir_all(tmp_dir.path())?;
 
         let file_path = tmp_dir.path().join("dog.jpeg");
-        let image_data = read_image_jpeg(image_path_read)?;
+        let image_data = read_image_jpeg("../../tests/data/dog.jpeg")?;
         write_image_jpeg(&file_path, &image_data)?;
 
         let image_data_back = read_image_jpeg(&file_path)?;

--- a/kornia-py/src/io/functional.rs
+++ b/kornia-py/src/io/functional.rs
@@ -6,7 +6,7 @@ use kornia::{image::Image, io::functional as F};
 
 #[pyfunction]
 pub fn read_image_jpeg(file_path: &str) -> PyResult<PyImage> {
-    let image = F::read_image_jpeg(Path::new(file_path))
+    let image = F::read_image_jpeg(file_path)
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyFileExistsError, _>(format!("{}", e)))?;
     Ok(image.to_pyimage())
 }
@@ -15,14 +15,14 @@ pub fn read_image_jpeg(file_path: &str) -> PyResult<PyImage> {
 pub fn write_image_jpeg(file_path: &str, image: PyImage) -> PyResult<()> {
     let image = Image::from_pyimage(image)
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
-    F::write_image_jpeg(Path::new(file_path), &image)
+    F::write_image_jpeg(file_path, &image)
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
     Ok(())
 }
 
 #[pyfunction]
 pub fn read_image_any(file_path: &str) -> PyResult<PyImage> {
-    let image = F::read_image_any(Path::new(&file_path))
+    let image = F::read_image_any(file_path)
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyFileExistsError, _>(format!("{}", e)))?;
     Ok(image.to_pyimage())
 }


### PR DESCRIPTION
This is common in other libraries and allows `Path`, `PathBuf`, `&str` and `String` to be passed into the function and automatically converted to a `Path`.