### PR TITLE
implement tensorview as_contiguous

### DIFF
--- a/crates/kornia-core/src/lib.rs
+++ b/crates/kornia-core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod view;
 
 pub use crate::allocator::{CpuAllocator, TensorAllocator};
 pub use crate::storage::SafeTensorType;
+pub(crate) use crate::tensor::get_strides_from_shape;
 pub use crate::tensor::{Tensor, TensorError};
 
 /// Type alias for a 1-dimensional tensor.

--- a/crates/kornia-core/src/view.rs
+++ b/crates/kornia-core/src/view.rs
@@ -55,16 +55,12 @@ impl<'a, T: SafeTensorType, const N: usize, A: TensorAllocator> TensorView<'a, T
     /// # Returns
     ///
     /// A new `Tensor` instance with contiguous memory.
-    pub fn as_contiguous(&self) -> Tensor<T, N, A>
-    where
-        T: Clone,
-        A: Clone,
-    {
+    pub fn as_contiguous(&self) -> Tensor<T, N, A> {
         let mut data = Vec::with_capacity(self.numel());
         let mut index = [0; N];
 
         loop {
-            data.push(self.get_unchecked(index).clone());
+            data.push(*self.get_unchecked(index));
 
             // Increment index
             let mut i = N - 1;

--- a/crates/kornia-core/src/view.rs
+++ b/crates/kornia-core/src/view.rs
@@ -1,4 +1,6 @@
-use crate::{storage::TensorStorage, SafeTensorType, TensorAllocator};
+use crate::{
+    get_strides_from_shape, storage::TensorStorage, SafeTensorType, Tensor, TensorAllocator,
+};
 
 /// A view into a tensor.
 pub struct TensorView<'a, T: SafeTensorType, const N: usize, A: TensorAllocator> {
@@ -46,6 +48,43 @@ impl<'a, T: SafeTensorType, const N: usize, A: TensorAllocator> TensorView<'a, T
             .zip(self.strides.iter())
             .fold(0, |acc, (i, s)| acc + i * s);
         self.storage.get_unchecked(offset)
+    }
+
+    /// Convert the view an owned tensor with contiguous memory.
+    ///
+    /// # Returns
+    ///
+    /// A new `Tensor` instance with contiguous memory.
+    pub fn as_contiguous(&self) -> Tensor<T, N, A>
+    where
+        T: Clone,
+        A: Clone,
+    {
+        let mut data = Vec::with_capacity(self.numel());
+        let mut index = [0; N];
+
+        loop {
+            data.push(self.get_unchecked(index).clone());
+
+            // Increment index
+            let mut i = N - 1;
+            while i > 0 && index[i] == self.shape[i] - 1 {
+                index[i] = 0;
+                i -= 1;
+            }
+            if i == 0 && index[0] == self.shape[0] - 1 {
+                break;
+            }
+            index[i] += 1;
+        }
+
+        let strides = get_strides_from_shape(self.shape);
+
+        Tensor {
+            storage: TensorStorage::from_vec(data, self.storage.alloc().clone()),
+            shape: self.shape,
+            strides,
+        }
     }
 }
 


### PR DESCRIPTION
- implement `as_contiguous` in `TensorView` to assure contiguous memory
- add some `#[inline]` methods in `Tensor`
- add tests