### PR TITLE
support async closure in the stream camera

### DIFF
--- a/crates/kornia-core/Cargo.toml
+++ b/crates/kornia-core/Cargo.toml
@@ -13,7 +13,7 @@ version.workspace = true
 [dependencies]
 
 # external
-arrow-buffer = "52.2.0"
+arrow-buffer = "53.0.0"
 num-traits = "0.2"
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"


### PR DESCRIPTION
- updates arrow-buffer to 53.0.0
- allow `StreamCapture::run_with_termination` to pass an awaitable closure
- update camera examples