### PR TITLE
Implement H264 VideoWritter with gstreamer

### DIFF
--- a/crates/kornia-imgproc/benches/bench_flip.rs
+++ b/crates/kornia-imgproc/benches/bench_flip.rs
@@ -86,8 +86,11 @@ fn bench_flip(c: &mut Criterion) {
             BenchmarkId::new("par_par_slicecopy", &parameter_string),
             &(&image_f32, &output),
             |b, i| {
-                let (src, mut dst) = (i.0.clone(), i.1.clone());
-                b.iter(|| black_box(par_par_slicecopy(&src, &mut dst)))
+                let (src, mut dst) = (i.0, i.1.clone());
+                b.iter(|| {
+                    par_par_slicecopy(black_box(src), black_box(&mut dst));
+                    black_box(())
+                })
             },
         );
 
@@ -95,8 +98,11 @@ fn bench_flip(c: &mut Criterion) {
             BenchmarkId::new("par_loop_loop", &parameter_string),
             &(&image_f32, &output),
             |b, i| {
-                let (src, mut dst) = (i.0.clone(), i.1.clone());
-                b.iter(|| black_box(par_loop_loop(&src, &mut dst)))
+                let (src, mut dst) = (i.0, i.1.clone());
+                b.iter(|| {
+                    par_loop_loop(black_box(src), black_box(&mut dst));
+                    black_box(())
+                })
             },
         );
 
@@ -104,8 +110,11 @@ fn bench_flip(c: &mut Criterion) {
             BenchmarkId::new("par_loop_slicecopy", &parameter_string),
             &(&image_f32, &output),
             |b, i| {
-                let (src, mut dst) = (i.0.clone(), i.1.clone());
-                b.iter(|| black_box(par_loop_slicecopy(&src, &mut dst)))
+                let (src, mut dst) = (i.0, i.1.clone());
+                b.iter(|| {
+                    par_loop_slicecopy(black_box(src), black_box(&mut dst));
+                    black_box(())
+                })
             },
         );
 
@@ -113,8 +122,11 @@ fn bench_flip(c: &mut Criterion) {
             BenchmarkId::new("par_seq_slicecopy", &parameter_string),
             &(&image_f32, &output),
             |b, i| {
-                let (src, mut dst) = (i.0.clone(), i.1.clone());
-                b.iter(|| black_box(par_seq_slicecopy(&src, &mut dst)))
+                let (src, mut dst) = (i.0, i.1.clone());
+                b.iter(|| {
+                    par_seq_slicecopy(black_box(src), black_box(&mut dst));
+                    black_box(())
+                })
             },
         );
 
@@ -123,7 +135,7 @@ fn bench_flip(c: &mut Criterion) {
             &(&image_f32, &output),
             |b, i| {
                 let (src, mut dst) = (i.0, i.1.clone());
-                b.iter(|| black_box(flip::horizontal_flip(src, &mut dst)))
+                b.iter(|| flip::horizontal_flip(black_box(src), black_box(&mut dst)))
             },
         );
     }

--- a/crates/kornia-io/Cargo.toml
+++ b/crates/kornia-io/Cargo.toml
@@ -26,6 +26,7 @@ thiserror = "1"
 futures = { version = "0.3.1", optional = true }
 gst = { version = "0.23.0", package = "gstreamer", optional = true }
 gst-app = { version = "0.23.0", package = "gstreamer-app", optional = true }
+gst-video = { version = "0.23.0", package = "gstreamer-video", optional = true }
 memmap2 = "0.9.4"
 tokio = { version = "1", features = ["full"], optional = true }
 turbojpeg = { version = "1.0.0", optional = true }
@@ -36,7 +37,7 @@ tempfile = "3.10"
 kornia = { workspace = true, features = ["jpegturbo"] }
 
 [features]
-gstreamer = ["futures", "gst", "gst-app", "tokio"]
+gstreamer = ["futures", "gst", "gst-app", "tokio", "gst-video"]
 jpegturbo = ["turbojpeg"]
 
 [[bench]]

--- a/crates/kornia-io/Cargo.toml
+++ b/crates/kornia-io/Cargo.toml
@@ -26,7 +26,6 @@ thiserror = "1"
 futures = { version = "0.3.1", optional = true }
 gst = { version = "0.23.0", package = "gstreamer", optional = true }
 gst-app = { version = "0.23.0", package = "gstreamer-app", optional = true }
-gst-video = { version = "0.23.0", package = "gstreamer-video", optional = true }
 memmap2 = "0.9.4"
 tokio = { version = "1", features = ["full"], optional = true }
 turbojpeg = { version = "1.0.0", optional = true }
@@ -37,7 +36,7 @@ tempfile = "3.10"
 kornia = { workspace = true, features = ["jpegturbo"] }
 
 [features]
-gstreamer = ["futures", "gst", "gst-app", "tokio", "gst-video"]
+gstreamer = ["futures", "gst", "gst-app", "tokio"]
 jpegturbo = ["turbojpeg"]
 
 [[bench]]

--- a/crates/kornia-io/src/stream/capture.rs
+++ b/crates/kornia-io/src/stream/capture.rs
@@ -161,7 +161,7 @@ impl StreamCapture {
     fn get_appsink(&self) -> Result<gst_app::AppSink, StreamCaptureError> {
         self.pipeline
             .by_name("sink")
-            .ok_or_else(|| StreamCaptureError::DowncastAppSinkError)?
+            .ok_or_else(|| StreamCaptureError::GetElementByNameError)?
             .dynamic_cast::<gst_app::AppSink>()
             .map_err(StreamCaptureError::DowncastPipelineError)
     }

--- a/crates/kornia-io/src/stream/error.rs
+++ b/crates/kornia-io/src/stream/error.rs
@@ -10,8 +10,8 @@ pub enum StreamCaptureError {
     DowncastPipelineError(gst::Element),
 
     /// An error occurred during GStreamer downcast of appsink.
-    #[error("Failed to downcast appsink")]
-    DowncastAppSinkError,
+    #[error("Failed to get an element by name")]
+    GetElementByNameError,
 
     /// An error occurred during GStreamer to get the bus.
     #[error("Failed to get the bus")]
@@ -67,4 +67,8 @@ pub enum StreamCaptureError {
     /// An error for an invalid configuration.
     #[error("Invalid configuration: {0}")]
     InvalidConfig(String),
+
+    /// An error occurred during GStreamer to send end of stream event.
+    #[error("Error ocurred in the gstreamer flow")]
+    GstreamerFlowError(#[from] gst::FlowError),
 }

--- a/crates/kornia-io/src/stream/mod.rs
+++ b/crates/kornia-io/src/stream/mod.rs
@@ -13,8 +13,12 @@ pub mod rtsp;
 /// A module for capturing video streams from v4l2 cameras.
 pub mod v4l2;
 
+/// A module for capturing video streams from video files.
+pub mod video;
+
 pub use crate::stream::camera::{CameraCapture, CameraCaptureConfig};
 pub use crate::stream::capture::StreamCapture;
 pub use crate::stream::error::StreamCaptureError;
 pub use crate::stream::rtsp::RTSPCameraConfig;
 pub use crate::stream::v4l2::V4L2CameraConfig;
+pub use crate::stream::video::VideoWriter;

--- a/crates/kornia-io/src/stream/video.rs
+++ b/crates/kornia-io/src/stream/video.rs
@@ -185,3 +185,33 @@ impl Drop for VideoWriter {
         });
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{VideoWriter, VideoWriterCodec};
+    use kornia_image::{Image, ImageSize};
+
+    #[test]
+    #[ignore = "TODO: fix this test as there's a race condition in the gstreamer flow"]
+    fn video_writer() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp_dir = tempfile::tempdir()?;
+        std::fs::create_dir_all(tmp_dir.path())?;
+
+        let file_path = tmp_dir.path().join("test.mp4");
+
+        let size = ImageSize {
+            width: 6,
+            height: 4,
+        };
+        let mut writer = VideoWriter::new(&file_path, VideoWriterCodec::H264, 30, size)?;
+        writer.start()?;
+
+        let img = Image::new(size, vec![0; size.width * size.height * 3])?;
+        writer.write(&img)?;
+        writer.stop()?;
+
+        assert!(file_path.exists(), "File does not exist: {:?}", file_path);
+
+        Ok(())
+    }
+}

--- a/crates/kornia-io/src/stream/video.rs
+++ b/crates/kornia-io/src/stream/video.rs
@@ -32,7 +32,7 @@ impl VideoWriter {
     /// * `fps` - The frames per second of the video.
     /// * `size` - The size of the video.
     pub fn new(
-        path: &Path,
+        path: impl AsRef<Path>,
         codec: VideoWriterCodec,
         fps: i32,
         size: ImageSize,
@@ -49,6 +49,8 @@ impl VideoWriter {
                 ))
             }
         };
+
+        let path = path.as_ref().to_owned();
 
         let pipeline_str = format!(
             "appsrc name=src ! \

--- a/examples/video_write tasks/Cargo.toml
+++ b/examples/video_write tasks/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "video_write_tasks"
+version = "0.1.0"
+authors = ["Edgar Riba <edgar.riba@gmail.com>"]
+license = "Apache-2.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+clap = { version = "4.5.4", features = ["derive"] }
+ctrlc = "3.4.4"
+kornia = { workspace = true, features = ["gstreamer"] }
+rerun = "0.18"
+tokio = { version = "1" }

--- a/examples/video_write tasks/README.md
+++ b/examples/video_write tasks/README.md
@@ -1,0 +1,21 @@
+An example showing how to use the webcam with the `kornia::io` module with the ability to cancel the feed after a certain amount of time. This example will display the webcam feed in a [`rerun`](https://github.com/rerun-io/rerun) window.
+
+NOTE: This example requires the gstremer backend to be enabled. To enable the gstreamer backend, use the `gstreamer` feature flag when building the `kornia` crate and its dependencies.
+
+```bash
+Usage: webcam [OPTIONS]
+
+Options:
+  -c, --camera-id <CAMERA_ID>  [default: 0]
+  -f, --fps <FPS>              [default: 30]
+  -d, --duration <DURATION>
+  -h, --help                   Print help
+```
+
+Example:
+
+```bash
+cargo run --bin webcam --release -- --camera-id 0 --duration 5 --fps 30
+```
+
+![Screenshot from 2024-08-28 18-33-56](https://github.com/user-attachments/assets/783619e4-4867-48bc-b7d2-d32a133e4f5a)

--- a/examples/video_write tasks/README.md
+++ b/examples/video_write tasks/README.md
@@ -1,21 +1,20 @@
-An example showing how to use the webcam with the `kornia::io` module with the ability to cancel the feed after a certain amount of time. This example will display the webcam feed in a [`rerun`](https://github.com/rerun-io/rerun) window.
+Example showing how to write a video using different background tasks.
 
 NOTE: This example requires the gstremer backend to be enabled. To enable the gstreamer backend, use the `gstreamer` feature flag when building the `kornia` crate and its dependencies.
 
 ```bash
-Usage: webcam [OPTIONS]
+Usage: video_write_tasks [OPTIONS] --output <OUTPUT>
 
 Options:
+  -o, --output <OUTPUT>
   -c, --camera-id <CAMERA_ID>  [default: 0]
   -f, --fps <FPS>              [default: 30]
   -d, --duration <DURATION>
-  -h, --help                   Print help
+  -h, --help                   Print help              Print help
 ```
 
 Example:
 
 ```bash
-cargo run --bin webcam --release -- --camera-id 0 --duration 5 --fps 30
+cargo run --bin video_write_tasks --release -- --output output.mp4
 ```
-
-![Screenshot from 2024-08-28 18-33-56](https://github.com/user-attachments/assets/783619e4-4867-48bc-b7d2-d32a133e4f5a)

--- a/examples/video_write tasks/src/main.rs
+++ b/examples/video_write tasks/src/main.rs
@@ -1,0 +1,127 @@
+use clap::Parser;
+use std::{path::Path, sync::Arc};
+use tokio::signal;
+use tokio::sync::Mutex;
+
+use kornia::{
+    image::{Image, ImageSize},
+    io::stream::{video::VideoWriterCodec, V4L2CameraConfig, VideoWriter},
+};
+
+#[derive(Parser)]
+struct Args {
+    #[arg(short, long, default_value = "0")]
+    camera_id: u32,
+
+    #[arg(short, long, default_value = "30")]
+    fps: i32,
+
+    #[arg(short, long)]
+    duration: Option<u64>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+
+    // start the recording stream
+    let rec = rerun::RecordingStreamBuilder::new("Kornia Video Write App").spawn()?;
+
+    // allocate the image buffers
+    let frame_size = ImageSize {
+        width: 640,
+        height: 480,
+    };
+
+    // create a webcam capture object with camera id 0
+    // and force the image size to 640x480
+    let webcam = V4L2CameraConfig::new()
+        .with_camera_id(args.camera_id)
+        .with_fps(args.fps as u32)
+        .with_size(frame_size)
+        .build()?;
+
+    // start the video writer
+    let video_writer = VideoWriter::new(
+        Path::new("output.mp4"),
+        VideoWriterCodec::H264,
+        args.fps,
+        frame_size,
+    )?;
+    let video_writer = Arc::new(Mutex::new(video_writer));
+    video_writer.lock().await.start()?;
+
+    // Create a channel to send frames to the video writer
+    let (tx, rx) = tokio::sync::mpsc::channel::<Arc<Mutex<Image<u8, 3>>>>(32);
+    let rx = Arc::new(Mutex::new(rx));
+
+    // Spawn a task to read frames from the camera and send them to the video writer
+    let video_writer_task = tokio::spawn({
+        let rx = rx.clone();
+        let video_writer = video_writer.clone();
+        async move {
+            while let Some(img) = rx.lock().await.recv().await {
+                // lock the image and write it to the video writer
+                let img = img.lock().await;
+                video_writer
+                    .lock()
+                    .await
+                    .write(&img)
+                    .expect("Failed to write image to video writer");
+            }
+            Ok::<_, Box<dyn std::error::Error + Send + Sync>>(())
+        }
+    });
+
+    // Visualization thread
+    let visualization_task = tokio::spawn({
+        let rec = rec.clone();
+        let rx = rx.clone();
+        async move {
+            while let Some(img) = rx.lock().await.recv().await {
+                // lock the image and log it
+                let img = img.lock().await;
+                rec.log_static(
+                    "image",
+                    &rerun::Image::from_elements(
+                        img.as_slice(),
+                        img.size().into(),
+                        rerun::ColorModel::RGB,
+                    ),
+                )?;
+            }
+            Ok::<_, Box<dyn std::error::Error + Send + Sync>>(())
+        }
+    });
+
+    // start grabbing frames from the camera
+    let capture = webcam.run_with_termination(
+        |img| {
+            let tx = tx.clone();
+            async move {
+                // send the image to the video writer and the visualization
+                tx.send(Arc::new(Mutex::new(img))).await?;
+                Ok(())
+            }
+        },
+        async {
+            signal::ctrl_c().await.expect("Failed to listen for Ctrl+C");
+            println!("👋 Finished recording. Closing app.");
+        },
+    );
+
+    tokio::select! {
+        _ = capture => (),
+        _ = video_writer_task => (),
+        _ = visualization_task => (),
+        _ = signal::ctrl_c() => (),
+    }
+
+    video_writer
+        .lock()
+        .await
+        .stop()
+        .expect("Failed to stop video writer");
+
+    Ok(())
+}

--- a/examples/video_write/Cargo.toml
+++ b/examples/video_write/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "video_write"
+version = "0.1.0"
+authors = ["Edgar Riba <edgar.riba@gmail.com>"]
+license = "Apache-2.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+clap = { version = "4.5.4", features = ["derive"] }
+ctrlc = "3.4.4"
+kornia = { workspace = true, features = ["gstreamer"] }
+rerun = "0.18"
+tokio = { version = "1" }

--- a/examples/video_write/README.md
+++ b/examples/video_write/README.md
@@ -1,21 +1,21 @@
-An example showing how to use the webcam with the `kornia::io` module with the ability to cancel the feed after a certain amount of time. This example will display the webcam feed in a [`rerun`](https://github.com/rerun-io/rerun) window.
+An example showing how to write a video file using the `kornia::io` module along with the webcam capture example. Visualizes the webcam feed in a [`rerun`](https://github.com/rerun-io/rerun) window.
 
 NOTE: This example requires the gstremer backend to be enabled. To enable the gstreamer backend, use the `gstreamer` feature flag when building the `kornia` crate and its dependencies.
 
 ```bash
-Usage: webcam [OPTIONS]
+Usage: video_write [OPTIONS] --output <OUTPUT>
 
 Options:
+  -o, --output <OUTPUT>
   -c, --camera-id <CAMERA_ID>  [default: 0]
   -f, --fps <FPS>              [default: 30]
-  -d, --duration <DURATION>
   -h, --help                   Print help
 ```
 
 Example:
 
 ```bash
-cargo run --bin webcam --release -- --camera-id 0 --duration 5 --fps 30
+cargo run --bin video_write --release -- --output ~/output.mp4
 ```
 
 ![Screenshot from 2024-08-28 18-33-56](https://github.com/user-attachments/assets/783619e4-4867-48bc-b7d2-d32a133e4f5a)

--- a/examples/video_write/README.md
+++ b/examples/video_write/README.md
@@ -17,5 +17,3 @@ Example:
 ```bash
 cargo run --bin video_write --release -- --output ~/output.mp4
 ```
-
-![Screenshot from 2024-08-28 18-33-56](https://github.com/user-attachments/assets/783619e4-4867-48bc-b7d2-d32a133e4f5a)

--- a/examples/video_write/README.md
+++ b/examples/video_write/README.md
@@ -1,0 +1,21 @@
+An example showing how to use the webcam with the `kornia::io` module with the ability to cancel the feed after a certain amount of time. This example will display the webcam feed in a [`rerun`](https://github.com/rerun-io/rerun) window.
+
+NOTE: This example requires the gstremer backend to be enabled. To enable the gstreamer backend, use the `gstreamer` feature flag when building the `kornia` crate and its dependencies.
+
+```bash
+Usage: webcam [OPTIONS]
+
+Options:
+  -c, --camera-id <CAMERA_ID>  [default: 0]
+  -f, --fps <FPS>              [default: 30]
+  -d, --duration <DURATION>
+  -h, --help                   Print help
+```
+
+Example:
+
+```bash
+cargo run --bin webcam --release -- --camera-id 0 --duration 5 --fps 30
+```
+
+![Screenshot from 2024-08-28 18-33-56](https://github.com/user-attachments/assets/783619e4-4867-48bc-b7d2-d32a133e4f5a)

--- a/examples/video_write/src/main.rs
+++ b/examples/video_write/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use std::{path::Path, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 use tokio::signal;
 use tokio::sync::Mutex;
 
@@ -10,19 +10,24 @@ use kornia::{
 
 #[derive(Parser)]
 struct Args {
+    #[arg(short, long)]
+    output: PathBuf,
+
     #[arg(short, long, default_value = "0")]
     camera_id: u32,
 
     #[arg(short, long, default_value = "30")]
     fps: i32,
-
-    #[arg(short, long)]
-    duration: Option<u64>,
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
+
+    // Ensure the output path ends with .mp4
+    if args.output.extension().and_then(|ext| ext.to_str()) != Some("mp4") {
+        return Err("Output file must have a .mp4 extension".into());
+    }
 
     // start the recording stream
     let rec = rerun::RecordingStreamBuilder::new("Kornia Video Write App").spawn()?;
@@ -42,12 +47,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build()?;
 
     // start the video writer
-    let video_writer = VideoWriter::new(
-        Path::new("output.mp4"),
-        VideoWriterCodec::H264,
-        args.fps,
-        frame_size,
-    )?;
+    let video_writer = VideoWriter::new(args.output, VideoWriterCodec::H264, args.fps, frame_size)?;
     let video_writer = Arc::new(Mutex::new(video_writer));
     video_writer.lock().await.start()?;
 

--- a/examples/video_write/src/main.rs
+++ b/examples/video_write/src/main.rs
@@ -1,0 +1,94 @@
+use clap::Parser;
+use std::{
+    path::Path,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
+};
+use tokio::signal;
+
+use kornia::{
+    image::{ops, Image, ImageSize},
+    imgproc,
+    io::{
+        fps_counter::FpsCounter,
+        stream::{StreamCaptureError, V4L2CameraConfig, VideoWriter},
+    },
+};
+
+#[derive(Parser)]
+struct Args {
+    #[arg(short, long, default_value = "0")]
+    camera_id: u32,
+
+    #[arg(short, long, default_value = "30")]
+    fps: u32,
+
+    #[arg(short, long)]
+    duration: Option<u64>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+
+    // start the recording stream
+    let rec = rerun::RecordingStreamBuilder::new("Kornia Webcapture App").spawn()?;
+
+    // allocate the image buffers
+    let frame_size = ImageSize {
+        width: 640,
+        height: 480,
+    };
+
+    // create a webcam capture object with camera id 0
+    // and force the image size to 640x480
+    let webcam = V4L2CameraConfig::new()
+        .with_camera_id(args.camera_id)
+        .with_fps(args.fps)
+        .with_size(frame_size)
+        .build()?;
+
+    // start the video writer
+    let mut video_writer = VideoWriter::new(Path::new("output.mp4"), args.fps as f32, frame_size)?;
+    video_writer.start()?;
+
+    let video_writer = Arc::new(Mutex::new(video_writer));
+
+    // start grabbing frames from the camera
+    webcam
+        .run_with_termination(
+            |img| {
+                let rec = rec.clone();
+                let video_writer = video_writer.clone();
+                async move {
+                    // write the image to the video writer
+                    video_writer.lock().unwrap().write(img)?;
+                    //println!("Wrote frame");
+
+                    // log the image
+                    //rec.log_static(
+                    //    "image",
+                    //    &rerun::Image::from_elements(
+                    //        img.as_slice(),
+                    //        img.size().into(),
+                    //        rerun::ColorModel::RGB,
+                    //    ),
+                    //)?;
+
+                    Ok(())
+                }
+            },
+            async {
+                signal::ctrl_c().await.expect("Failed to listen for Ctrl+C");
+                println!("👋 Finished recording. Closing app.");
+            },
+        )
+        .await?;
+
+    // stop the video writer
+    video_writer.lock().unwrap().stop()?;
+
+    Ok(())
+}


### PR DESCRIPTION
part of #113 

- create a `video.rs` in `kornia-io`
- implement `VideoWritter` and `VideoWriterCodec` to record h264/rgb videos
- added a new gstreamer error GstreamerFlowError and replaced DowncastAppSinkError by GetElementByNameError.
- create a couple of examples: `video_write` and `video_write_tasks`
- clippy fixes in the benchmarks

Output example:

https://github.com/user-attachments/assets/a51e01c5-4b4d-4209-89f8-ff7862fa251f

