### PR TITLE
Release cargo packages

### DIFF
--- a/.github/workflows/rust_release.yml
+++ b/.github/workflows/rust_release.yml
@@ -26,8 +26,8 @@ jobs:
           args: ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }}
       - name: Publish packages into crates.io
         run: |
-          cargo publish -p kornia-core --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }}
-          cargo publish -p kornia-image --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }}
-          cargo publish -p kornia-io --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --all-features
-          cargo publish -p kornia-imgproc --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }}
-          cargo publish -p kornia --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --all-features
+          cargo publish -p kornia-core --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
+          cargo publish -p kornia-image --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
+          cargo publish -p kornia-io --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --all-features --dry-run
+          cargo publish -p kornia-imgproc --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
+          cargo publish -p kornia --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --all-features --dry-run

--- a/.github/workflows/rust_release.yml
+++ b/.github/workflows/rust_release.yml
@@ -30,9 +30,28 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y cmake nasm libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev pkg-config libssl-dev
       - name: Publish packages into crates.io
-        run: |
-          publish -p kornia-core --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
-          publish -p kornia-image --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
-          publish -p kornia-io --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --all-features --dry-run
-          publish -p kornia-imgproc --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
-          publish -p kornia --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --all-features --dry-run
+        uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: -p kornia-core --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
+          use-cross: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: -p kornia-image --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
+          use-cross: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: -p kornia-io --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --all-features --dry-run
+          use-cross: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: -p kornia-imgproc --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
+          use-cross: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: -p kornia --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --all-features --dry-run
+          use-cross: true

--- a/.github/workflows/rust_release.yml
+++ b/.github/workflows/rust_release.yml
@@ -25,10 +25,15 @@ jobs:
           command: login
           args: ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }}
           use-cross: true
-      - name: Publish packages into crates.io
-        run: |
-          cross publish -p kornia-core --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
-          cargo publish -p kornia-image --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
-          cargo publish -p kornia-io --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --all-features --dry-run
-          cargo publish -p kornia-imgproc --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
-          cargo publish -p kornia --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --all-features --dry-run
+      - uses: actions-rs/cargo@v1
+        with:
+          command: release
+          args: publish --workspace --all-features
+          use-cross: true
+      #- name: Publish packages into crates.io
+      #  run: |
+      #    cross publish -p kornia-core --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
+      #    cargo publish -p kornia-image --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
+      #    cargo publish -p kornia-io --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --all-features --dry-run
+      #    cargo publish -p kornia-imgproc --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
+      #    cargo publish -p kornia --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --all-features --dry-run

--- a/.github/workflows/rust_release.yml
+++ b/.github/workflows/rust_release.yml
@@ -12,7 +12,6 @@ jobs:
           - x86_64-unknown-linux-gnu
     runs-on: ubuntu-latest
     steps:
-      #- uses: ilammy/setup-nasm@v1
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
@@ -24,12 +23,10 @@ jobs:
         with:
           command: login
           args: ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }}
-      - name: Install cross
-        run: cargo install cross
       - name: Publish packages into crates.io
         run: |
-          cross publish -p kornia-core --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
-          cross publish -p kornia-image --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
-          cross publish -p kornia-io --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --all-features --dry-run
-          cross publish -p kornia-imgproc --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
-          cross publish -p kornia --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --all-features --dry-run
+          cargo publish -p kornia-core --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }}
+          cargo publish -p kornia-image --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }}
+          cargo publish -p kornia-io --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --all-features
+          cargo publish -p kornia-imgproc --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }}
+          cargo publish -p kornia --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --all-features

--- a/.github/workflows/rust_release.yml
+++ b/.github/workflows/rust_release.yml
@@ -27,7 +27,7 @@ jobs:
           use-cross: true
       - name: Publish packages into crates.io
         run: |
-          cargo publish -p kornia-core --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
+          cross publish -p kornia-core --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
           cargo publish -p kornia-image --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
           cargo publish -p kornia-io --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --all-features --dry-run
           cargo publish -p kornia-imgproc --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run

--- a/.github/workflows/rust_release.yml
+++ b/.github/workflows/rust_release.yml
@@ -30,3 +30,4 @@ jobs:
           cargo publish -p kornia-image --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }}
           cargo publish -p kornia-imgproc --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }}
           cargo publish -p kornia-io --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --all-features
+          cargo publish -p kornia --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --all-features

--- a/.github/workflows/rust_release.yml
+++ b/.github/workflows/rust_release.yml
@@ -24,9 +24,9 @@ jobs:
         with:
           command: login
           args: ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }}
-      - name: Cargo Publish
-        uses: actions-rs/cargo@v1
-        with:
-          command: publish
-          args: --verbose --target ${{ matrix.target }} --all-features
-          use-cross: true
+      - name: Publish packages into crates.io
+        run: |
+          cargo publish -p kornia-core --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }}
+          cargo publish -p kornia-image --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }}
+          cargo publish -p kornia-imgproc --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }}
+          cargo publish -p kornia-io --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --all-features

--- a/.github/workflows/rust_release.yml
+++ b/.github/workflows/rust_release.yml
@@ -24,30 +24,12 @@ jobs:
         with:
           command: login
           args: ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }}
-          use-cross: true
+      - name: Install cross
+        run: cargo install cross
       - name: Publish packages into crates.io
-        uses: actions-rs/cargo@v1
-        with:
-          command: publish
-          args: -p kornia-core --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
-          use-cross: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: publish
-          args: -p kornia-image --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
-          use-cross: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: publish
-          args: -p kornia-io --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --all-features --dry-run
-          use-cross: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: publish
-          args: -p kornia-imgproc --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
-          use-cross: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: publish
-          args: -p kornia --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --all-features --dry-run
-          use-cross: true
+        run: |
+          cross publish -p kornia-core --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
+          cross publish -p kornia-image --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
+          cross publish -p kornia-io --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --all-features --dry-run
+          cross publish -p kornia-imgproc --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
+          cross publish -p kornia --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --all-features --dry-run

--- a/.github/workflows/rust_release.yml
+++ b/.github/workflows/rust_release.yml
@@ -28,6 +28,6 @@ jobs:
         run: |
           cargo publish -p kornia-core --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }}
           cargo publish -p kornia-image --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }}
-          cargo publish -p kornia-imgproc --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }}
           cargo publish -p kornia-io --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --all-features
+          cargo publish -p kornia-imgproc --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }}
           cargo publish -p kornia --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --all-features

--- a/.github/workflows/rust_release.yml
+++ b/.github/workflows/rust_release.yml
@@ -25,10 +25,6 @@ jobs:
           command: login
           args: ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }}
           use-cross: true
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake nasm libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev pkg-config libssl-dev
       - name: Publish packages into crates.io
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rust_release.yml
+++ b/.github/workflows/rust_release.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           command: login
           args: ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }}
+          use-cross: true
       - name: Publish packages into crates.io
         run: |
           cargo publish -p kornia-core --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run

--- a/.github/workflows/rust_release.yml
+++ b/.github/workflows/rust_release.yml
@@ -12,7 +12,7 @@ jobs:
           - x86_64-unknown-linux-gnu
     runs-on: ubuntu-latest
     steps:
-      - uses: ilammy/setup-nasm@v1
+      #- uses: ilammy/setup-nasm@v1
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
@@ -25,15 +25,14 @@ jobs:
           command: login
           args: ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }}
           use-cross: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: release
-          args: publish --workspace --all-features
-          use-cross: true
-      #- name: Publish packages into crates.io
-      #  run: |
-      #    cross publish -p kornia-core --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
-      #    cargo publish -p kornia-image --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
-      #    cargo publish -p kornia-io --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --all-features --dry-run
-      #    cargo publish -p kornia-imgproc --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
-      #    cargo publish -p kornia --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --all-features --dry-run
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake nasm libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev pkg-config libssl-dev
+      - name: Publish packages into crates.io
+        run: |
+          publish -p kornia-core --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
+          publish -p kornia-image --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
+          publish -p kornia-io --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --all-features --dry-run
+          publish -p kornia-imgproc --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --dry-run
+          publish -p kornia --token ${{ secrets.CARGO_REGISTRY_TOKEN_KORNIA }} --all-features --dry-run

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,11 @@ license-file = "LICENSE"
 readme = "README.md"
 repository = "https://github.com/kornia/kornia-rs"
 rust-version = "1.76"
-version = "0.1.6+dev"
+version = "0.1.6-rc.4"
 
 [workspace.dependencies]
-kornia-core = { path = "crates/kornia-core", version = "0.1.6+dev" }
-kornia-image = { path = "crates/kornia-image", version = "0.1.6+dev" }
-kornia-io = { path = "crates/kornia-io", version = "0.1.6+dev" }
-kornia-imgproc = { path = "crates/kornia-imgproc", version = "0.1.6+dev" }
-kornia = { path = "crates/kornia", version = "0.1.6+dev" }
+kornia-core = { path = "crates/kornia-core", version = "0.1.6-rc.4" }
+kornia-image = { path = "crates/kornia-image", version = "0.1.6-rc.4" }
+kornia-io = { path = "crates/kornia-io", version = "0.1.6-rc.4" }
+kornia-imgproc = { path = "crates/kornia-imgproc", version = "0.1.6-rc.4" }
+kornia = { path = "crates/kornia", version = "0.1.6-rc.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,12 @@ license-file = "LICENSE"
 readme = "README.md"
 repository = "https://github.com/kornia/kornia-rs"
 rust-version = "1.76"
-version = "0.1.6-rc.4"
+version = "0.1.6-rc.5"
 
 [workspace.dependencies]
-kornia-core = { path = "crates/kornia-core", version = "0.1.6-rc.4" }
-kornia-image = { path = "crates/kornia-image", version = "0.1.6-rc.4" }
-kornia-io = { path = "crates/kornia-io", version = "0.1.6-rc.4" }
-kornia-imgproc = { path = "crates/kornia-imgproc", version = "0.1.6-rc.4" }
-kornia = { path = "crates/kornia", version = "0.1.6-rc.4" }
+# NOTE: remember to update the kornia-py package version in `kornia-py/Cargo.toml` when updating the Rust package version
+kornia-core = { path = "crates/kornia-core", version = "0.1.6-rc.5" }
+kornia-image = { path = "crates/kornia-image", version = "0.1.6-rc.5" }
+kornia-io = { path = "crates/kornia-io", version = "0.1.6-rc.5" }
+kornia-imgproc = { path = "crates/kornia-imgproc", version = "0.1.6-rc.5" }
+kornia = { path = "crates/kornia", version = "0.1.6-rc.5" }

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Use the library to perform image I/O, visualisation and other low level operatio
 `cargo run --bin hello_world`
 
 ```rust
-use kornia::image::Image;
-use kornia::io::functional as F;
+use kornia_image::Image;
+use kornia_io::functional as F;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // read the image
@@ -111,7 +111,7 @@ Checkout all the examples in the [`examples`](https://github.com/kornia/kornia-r
 
 ```rust
 use kornia::{image::{Image, ImageSize}, imgproc};
-use kornia::io::functional as F;
+use kornia_io::functional as F;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // read the image

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Use the library to perform image I/O, visualisation and other low level operatio
 `cargo run --bin hello_world`
 
 ```rust
-use kornia_image::Image;
-use kornia_io::functional as F;
+use kornia::image::Image;
+use kornia::io::functional as F;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // read the image
@@ -111,7 +111,7 @@ Checkout all the examples in the [`examples`](https://github.com/kornia/kornia-r
 
 ```rust
 use kornia::{image::{Image, ImageSize}, imgproc};
-use kornia_io::functional as F;
+use kornia::io::functional as F;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // read the image

--- a/crates/kornia-core/Cargo.toml
+++ b/crates/kornia-core/Cargo.toml
@@ -17,7 +17,3 @@ arrow-buffer = "53.0.0"
 num-traits = "0.2"
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
-
-
-[dev-dependencies]
-kornia.workspace = true

--- a/crates/kornia-core/src/tensor.rs
+++ b/crates/kornia-core/src/tensor.rs
@@ -68,7 +68,7 @@ pub(crate) fn get_strides_from_shape<const N: usize>(shape: [usize; N]) -> [usiz
 /// # Example
 ///
 /// ```
-/// use kornia::core::{Tensor, CpuAllocator};
+/// use kornia_core::{Tensor, CpuAllocator};
 ///
 /// let data: Vec<u8> = vec![1, 2, 3, 4];
 /// let t = Tensor::<u8, 2>::new_uninitialized([2, 2], CpuAllocator).unwrap();
@@ -186,7 +186,7 @@ where
     /// # Example
     ///
     /// ```
-    /// use kornia::core::{Tensor, CpuAllocator};
+    /// use kornia_core::{Tensor, CpuAllocator};
     ///
     /// let data: Vec<u8> = vec![1, 2, 3, 4];
     /// let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data, CpuAllocator).unwrap();
@@ -225,7 +225,7 @@ where
     /// # Example
     ///
     /// ```
-    /// use kornia::core::{Tensor, CpuAllocator};
+    /// use kornia_core::{Tensor, CpuAllocator};
     ///
     /// let data: [u8; 4] = [1, 2, 3, 4];
     /// let t = Tensor::<u8, 2>::from_shape_slice([2, 2], &data, CpuAllocator).unwrap();
@@ -261,7 +261,7 @@ where
     /// # Example
     ///
     /// ```
-    /// use kornia::core::{Tensor, CpuAllocator};
+    /// use kornia_core::{Tensor, CpuAllocator};
     ///
     /// let t = Tensor::<u8, 1>::from_shape_val([4], 0, CpuAllocator);
     /// assert_eq!(t.as_slice(), vec![0, 0, 0, 0]);
@@ -301,7 +301,7 @@ where
     /// # Example
     ///
     /// ```
-    /// use kornia::core::{Tensor, CpuAllocator};
+    /// use kornia_core::{Tensor, CpuAllocator};
     ///
     /// let t = Tensor::<u8, 1>::from_shape_fn([4], |[i]| i as u8, CpuAllocator);
     /// assert_eq!(t.as_slice(), vec![0, 1, 2, 3]);
@@ -374,7 +374,7 @@ where
     /// # Example
     ///
     /// ```
-    /// use kornia::core::{Tensor, CpuAllocator};
+    /// use kornia_core::{Tensor, CpuAllocator};
     ///
     /// let data: Vec<u8> = vec![1, 2, 3, 4];
     ///
@@ -406,7 +406,7 @@ where
     /// # Example
     ///
     /// ```
-    /// use kornia::core::{Tensor, CpuAllocator};
+    /// use kornia_core::{Tensor, CpuAllocator};
     ///
     /// let data: Vec<u8> = vec![1, 2, 3, 4];
     ///
@@ -441,7 +441,7 @@ where
     /// # Example
     ///
     /// ```
-    /// use kornia::core::{Tensor, CpuAllocator};
+    /// use kornia_core::{Tensor, CpuAllocator};
     ///
     /// let data: Vec<u8> = vec![1, 2, 3, 4];
     ///
@@ -543,7 +543,7 @@ where
     /// # Example
     ///
     /// ```
-    /// use kornia::core::{Tensor, CpuAllocator};
+    /// use kornia_core::{Tensor, CpuAllocator};
     ///
     /// let data: Vec<u8> = vec![1, 2, 3, 4];
     /// let t = Tensor::<u8, 1>::from_shape_vec([4], data, CpuAllocator).unwrap();
@@ -628,7 +628,7 @@ where
     /// # Example
     ///
     /// ```
-    /// use kornia::core::{Tensor, CpuAllocator};
+    /// use kornia_core::{Tensor, CpuAllocator};
     ///
     /// let data: Vec<u8> = vec![1, 2, 3, 4];
     /// let t = Tensor::<u8, 1>::from_shape_vec([4], data, CpuAllocator).unwrap();
@@ -667,7 +667,7 @@ where
     /// # Example
     ///
     /// ```
-    /// use kornia::core::{Tensor, CpuAllocator};
+    /// use kornia_core::{Tensor, CpuAllocator};
     ///
     /// let data1: Vec<u8> = vec![1, 2, 3, 4];
     /// let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1, CpuAllocator).unwrap();
@@ -732,7 +732,7 @@ where
     /// # Example
     ///
     /// ```
-    /// use kornia::core::{Tensor, CpuAllocator};
+    /// use kornia_core::{Tensor, CpuAllocator};
     ///
     /// let data1: Vec<u8> = vec![1, 2, 3, 4];
     /// let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1, CpuAllocator).unwrap();
@@ -765,7 +765,7 @@ where
     /// # Example
     ///
     /// ```
-    /// use kornia::core::{Tensor, CpuAllocator};
+    /// use kornia_core::{Tensor, CpuAllocator};
     ///
     /// let data1: Vec<u8> = vec![1, 2, 3, 4];
     /// let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1, CpuAllocator).unwrap();
@@ -798,7 +798,7 @@ where
     /// # Example
     ///
     /// ```
-    /// use kornia::core::{Tensor, CpuAllocator};
+    /// use kornia_core::{Tensor, CpuAllocator};
     ///
     /// let data1: Vec<u8> = vec![1, 2, 3, 4];
     /// let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1, CpuAllocator).unwrap();
@@ -831,7 +831,7 @@ where
     /// # Example
     ///
     /// ```
-    /// use kornia::core::{Tensor, CpuAllocator};
+    /// use kornia_core::{Tensor, CpuAllocator};
     ///
     /// let data1: Vec<u8> = vec![1, 2, 3, 4];
     /// let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1, CpuAllocator).unwrap();

--- a/crates/kornia-image/Cargo.toml
+++ b/crates/kornia-image/Cargo.toml
@@ -14,9 +14,5 @@ version.workspace = true
 kornia-core.workspace = true
 
 # external
-ndarray = { version = "0.15", features = ["rayon"] }
 num-traits = "0.2"
 thiserror = "1"
-
-[dev-dependencies]
-kornia.workspace = true

--- a/crates/kornia-image/src/error.rs
+++ b/crates/kornia-image/src/error.rs
@@ -13,10 +13,6 @@ pub enum ImageError {
     #[error("Image data is not contiguous")]
     ImageDataNotContiguous,
 
-    /// Error when shape is not valid.
-    #[error("Invalid shape")]
-    InvalidShape(#[from] ndarray::ShapeError),
-
     /// Error when the image shape is not valid.
     #[error("Invalid image shape")]
     InvalidImageShape(#[from] kornia_core::TensorError),

--- a/crates/kornia-image/src/image.rs
+++ b/crates/kornia-image/src/image.rs
@@ -9,7 +9,7 @@ use crate::error::ImageError;
 /// # Examples
 ///
 /// ```
-/// use kornia::image::ImageSize;
+/// use kornia_image::ImageSize;
 ///
 /// let image_size = ImageSize {
 ///   width: 10,
@@ -106,7 +106,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use kornia::image::{Image, ImageSize};
+    /// use kornia_image::{Image, ImageSize};
     ///
     /// let image = Image::<u8, 3>::new(
     ///    ImageSize {
@@ -155,7 +155,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use kornia::image::{Image, ImageSize};
+    /// use kornia_image::{Image, ImageSize};
     ///
     /// let image = Image::<u8, 3>::from_size_val(
     ///   ImageSize {
@@ -240,7 +240,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use kornia::image::{Image, ImageSize};
+    /// use kornia_image::{Image, ImageSize};
     ///
     /// let image = Image::<f32, 2>::from_size_val(
     ///   ImageSize {
@@ -315,7 +315,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use kornia::image::{Image, ImageSize};
+    /// use kornia_image::{Image, ImageSize};
     ///
     /// let data = vec![0u8, 0, 255, 0, 0, 255];
     ///

--- a/crates/kornia-image/src/ops.rs
+++ b/crates/kornia-image/src/ops.rs
@@ -13,8 +13,8 @@ use crate::{Image, ImageError};
 /// Example:
 ///
 /// ```
-/// use kornia::image::{Image, ImageSize};
-/// use kornia::image::ops::cast_and_scale;
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_image::ops::cast_and_scale;
 ///
 /// let image = Image::<u8, 1>::new(
 ///  ImageSize {

--- a/crates/kornia-imgproc/Cargo.toml
+++ b/crates/kornia-imgproc/Cargo.toml
@@ -24,7 +24,6 @@ thiserror = "1"
 
 [dev-dependencies]
 kornia-io.workspace = true
-kornia.workspace = true
 
 criterion = "0.5"
 image = "0.25.1"

--- a/crates/kornia-imgproc/benches/bench_color.rs
+++ b/crates/kornia-imgproc/benches/bench_color.rs
@@ -1,7 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 
-use kornia::imgproc::color::gray_from_rgb;
 use kornia_image::Image;
+use kornia_imgproc::color::gray_from_rgb;
 use rayon::prelude::*;
 
 // vanilla version

--- a/crates/kornia-imgproc/benches/bench_flip.rs
+++ b/crates/kornia-imgproc/benches/bench_flip.rs
@@ -1,7 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 
-use kornia::image::Image;
-use kornia::imgproc::flip;
+use kornia_image::Image;
+use kornia_imgproc::flip;
 
 use rayon::{
     iter::{IndexedParallelIterator, ParallelIterator},

--- a/crates/kornia-imgproc/benches/bench_metrics.rs
+++ b/crates/kornia-imgproc/benches/bench_metrics.rs
@@ -1,6 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 
-use kornia::{image::Image, imgproc::metrics};
+use kornia_image::Image;
+use kornia_imgproc::metrics;
 
 fn bench_mse(c: &mut Criterion) {
     let mut group = c.benchmark_group("mse");

--- a/crates/kornia-imgproc/benches/bench_resize.rs
+++ b/crates/kornia-imgproc/benches/bench_resize.rs
@@ -1,7 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 
-use kornia::image::{Image, ImageSize};
-use kornia::imgproc::{interpolation::InterpolationMode, resize};
+use kornia_image::{Image, ImageSize};
+use kornia_imgproc::{interpolation::InterpolationMode, resize};
 
 fn resize_image_crate(image: Image<u8, 3>, new_size: ImageSize) -> Image<u8, 3> {
     let image_data = image.as_slice();

--- a/crates/kornia-imgproc/benches/bench_warp.rs
+++ b/crates/kornia-imgproc/benches/bench_warp.rs
@@ -1,13 +1,10 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 
-use kornia::{
-    image::Image,
-    imgproc::{
-        interpolation::InterpolationMode,
-        warp::{get_rotation_matrix2d, warp_affine},
-    },
+use kornia_image::Image;
+use kornia_imgproc::{
+    interpolation::InterpolationMode,
+    warp::{get_rotation_matrix2d, warp_affine, warp_perspective},
 };
-use kornia_imgproc::warp::warp_perspective;
 
 fn bench_warp_affine(c: &mut Criterion) {
     let mut group = c.benchmark_group("WarpAffine");

--- a/crates/kornia-imgproc/src/color/gray.rs
+++ b/crates/kornia-imgproc/src/color/gray.rs
@@ -23,8 +23,8 @@ const BW: f64 = 0.114;
 /// # Example
 ///
 /// ```
-/// use kornia::image::{Image, ImageSize};
-/// use kornia::imgproc::color::gray_from_rgb;
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_imgproc::color::gray_from_rgb;
 ///
 /// let image = Image::<f32, 3>::new(
 ///     ImageSize {

--- a/crates/kornia-imgproc/src/color/hsv.rs
+++ b/crates/kornia-imgproc/src/color/hsv.rs
@@ -25,8 +25,8 @@ use kornia_image::{Image, ImageError};
 /// # Example
 ///
 /// ```
-/// use kornia::image::{Image, ImageSize};
-/// use kornia::imgproc::color::hsv_from_rgb;
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_imgproc::color::hsv_from_rgb;
 ///
 /// let image = Image::<f32, 3>::new(
 ///     ImageSize {

--- a/crates/kornia-imgproc/src/core.rs
+++ b/crates/kornia-imgproc/src/core.rs
@@ -19,8 +19,8 @@ use kornia_image::{Image, ImageError};
 /// # Example
 ///
 /// ```
-/// use kornia::image::{Image, ImageSize};
-/// use kornia::imgproc::core::std_mean;
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_imgproc::core::std_mean;
 ///
 /// let image = Image::<u8, 3>::new(
 ///    ImageSize {
@@ -81,8 +81,8 @@ pub fn std_mean(image: &Image<u8, 3>) -> (Vec<f64>, Vec<f64>) {
 /// # Example
 ///
 /// ```
-/// use kornia::image::{Image, ImageSize};
-/// use kornia::imgproc::core::bitwise_and;
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_imgproc::core::bitwise_and;
 ///
 /// let image = Image::<u8, 3>::new(
 ///    ImageSize {

--- a/crates/kornia-imgproc/src/flip.rs
+++ b/crates/kornia-imgproc/src/flip.rs
@@ -21,8 +21,8 @@ use rayon::{
 /// # Example
 ///
 /// ```
-/// use kornia::image::{Image, ImageSize};
-/// use kornia::imgproc::flip::horizontal_flip;
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_imgproc::flip::horizontal_flip;
 ///
 /// let image = Image::<f32, 3>::new(
 ///     ImageSize {
@@ -84,8 +84,8 @@ where
 /// # Example
 ///
 /// ```
-/// use kornia::image::{Image, ImageSize};
-/// use kornia::imgproc::flip::vertical_flip;
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_imgproc::flip::vertical_flip;
 ///
 /// let image = Image::<f32, 3>::new(
 ///     ImageSize {

--- a/crates/kornia-imgproc/src/histogram.rs
+++ b/crates/kornia-imgproc/src/histogram.rs
@@ -21,8 +21,8 @@ use kornia_image::{Image, ImageError};
 /// # Example
 ///
 /// ```
-/// use kornia::image::{Image, ImageSize};
-/// use kornia::imgproc::histogram::compute_histogram;
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_imgproc::histogram::compute_histogram;
 ///
 /// let image = Image::<u8, 1>::new(
 ///   ImageSize {

--- a/crates/kornia-imgproc/src/metrics/huber.rs
+++ b/crates/kornia-imgproc/src/metrics/huber.rs
@@ -23,7 +23,7 @@ use kornia_image::{Image, ImageError};
 /// # Example
 ///
 /// ```
-/// use kornia::image::{Image, ImageSize};
+/// use kornia_image::{Image, ImageSize};
 ///
 /// let image1 = Image::<f32, 1>::new(
 ///    ImageSize {
@@ -43,7 +43,7 @@ use kornia_image::{Image, ImageError};
 /// )
 /// .unwrap();
 ///
-/// let huber = kornia::imgproc::metrics::huber(&image1, &image2, 1.0).unwrap();
+/// let huber = kornia_imgproc::metrics::huber(&image1, &image2, 1.0).unwrap();
 /// assert_eq!(huber, 2.5);
 /// ```
 ///

--- a/crates/kornia-imgproc/src/metrics/l1.rs
+++ b/crates/kornia-imgproc/src/metrics/l1.rs
@@ -22,8 +22,8 @@ use kornia_image::{Image, ImageError};
 /// # Example
 ///
 /// ```
-/// use kornia::image::{Image, ImageSize};
-/// use kornia::imgproc::metrics::l1_loss;
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_imgproc::metrics::l1_loss;
 ///
 /// let image1 = Image::<f32, 1>::new(
 ///   ImageSize {

--- a/crates/kornia-imgproc/src/metrics/mse.rs
+++ b/crates/kornia-imgproc/src/metrics/mse.rs
@@ -20,8 +20,8 @@ use kornia_image::{Image, ImageError};
 /// # Example
 ///
 /// ```
-/// use kornia::image::{Image, ImageSize};
-/// use kornia::imgproc::metrics::mse;
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_imgproc::metrics::mse;
 ///
 /// let image1 = Image::<f32, 1>::new(
 ///    ImageSize {
@@ -91,8 +91,8 @@ pub fn mse<const C: usize>(
 ///
 /// # Example
 /// ```
-/// use kornia::image::{Image, ImageSize};
-/// use kornia::imgproc::metrics::psnr;
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_imgproc::metrics::psnr;
 ///
 /// let image1 = Image::<f32, 3>::new(
 ///   ImageSize {

--- a/crates/kornia-imgproc/src/normalize.rs
+++ b/crates/kornia-imgproc/src/normalize.rs
@@ -25,8 +25,8 @@ use crate::parallel;
 /// # Example
 ///
 /// ```
-/// use kornia::image::{Image, ImageSize};
-/// use kornia::imgproc::normalize::normalize_mean_std;
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_imgproc::normalize::normalize_mean_std;
 ///
 /// let image_data = vec![0f32, 1.0, 0.0, 1.0, 2.0, 3.0, 0.0, 1.0, 0.0, 1.0, 2.0, 3.0];
 /// let image = Image::<f32, 3>::new(
@@ -102,8 +102,8 @@ where
 /// # Example
 ///
 /// ```
-/// use kornia::image::{Image, ImageSize};
-/// use kornia::imgproc::normalize::find_min_max;
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_imgproc::normalize::find_min_max;
 ///
 /// let image_data = vec![0u8, 1, 0, 1, 2, 3, 0, 1, 0, 1, 2, 3];
 /// let image = Image::<u8, 3>::new(
@@ -167,8 +167,8 @@ where
 /// # Example
 ///
 /// ```
-/// use kornia::image::{Image, ImageSize};
-/// use kornia::imgproc::normalize::normalize_min_max;
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_imgproc::normalize::normalize_min_max;
 ///
 /// let image_data = vec![0.0f32, 1.0, 0.0, 1.0, 2.0, 3.0, 0.0, 1.0, 0.0, 1.0, 2.0, 3.0];
 /// let image = Image::<f32, 3>::new(

--- a/crates/kornia-imgproc/src/resize.rs
+++ b/crates/kornia-imgproc/src/resize.rs
@@ -24,9 +24,9 @@ use std::num::NonZeroU32;
 /// # Example
 ///
 /// ```
-/// use kornia::image::{Image, ImageSize};
-/// use kornia::imgproc::resize::resize_native;
-/// use kornia::imgproc::interpolation::InterpolationMode;
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_imgproc::resize::resize_native;
+/// use kornia_imgproc::interpolation::InterpolationMode;
 ///
 /// let image = Image::<_, 3>::new(
 ///     ImageSize {
@@ -107,9 +107,9 @@ where
 /// # Example
 ///
 /// ```
-/// use kornia::image::{Image, ImageSize};
-/// use kornia::imgproc::resize::resize_fast;
-/// use kornia::imgproc::interpolation::InterpolationMode;
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_imgproc::resize::resize_fast;
+/// use kornia_imgproc::interpolation::InterpolationMode;
 ///
 /// let image = Image::<_, 3>::new(
 ///    ImageSize {

--- a/crates/kornia-imgproc/src/threshold.rs
+++ b/crates/kornia-imgproc/src/threshold.rs
@@ -19,8 +19,8 @@ use crate::parallel;
 /// # Examples
 ///
 /// ```
-/// use kornia::image::{Image, ImageSize};
-/// use kornia::imgproc::threshold::threshold_binary;
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_imgproc::threshold::threshold_binary;
 ///
 /// let data = vec![100u8, 200, 50, 150, 200, 250];
 /// let image = Image::<_, 1>::new(ImageSize { width: 2, height: 3 }, data).unwrap();
@@ -78,8 +78,8 @@ where
 /// # Examples
 ///
 /// ```
-/// use kornia::image::{Image, ImageSize};
-/// use kornia::imgproc::threshold::threshold_binary_inverse;
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_imgproc::threshold::threshold_binary_inverse;
 ///
 /// let data = vec![100u8, 200, 50, 150, 200, 250];
 /// let image = Image::<_, 1>::new(ImageSize { width: 2, height: 3 }, data).unwrap();
@@ -135,8 +135,8 @@ where
 /// # Examples
 ///
 /// ```
-/// use kornia::image::{Image, ImageSize};
-/// use kornia::imgproc::threshold::threshold_truncate;
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_imgproc::threshold::threshold_truncate;
 ///
 /// let data = vec![100u8, 200, 50, 150, 200, 250];
 /// let image = Image::<_, 1>::new(ImageSize { width: 2, height: 3 }, data).unwrap();
@@ -191,8 +191,8 @@ where
 /// # Examples
 ///
 /// ```
-/// use kornia::image::{Image, ImageSize};
-/// use kornia::imgproc::threshold::threshold_to_zero;
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_imgproc::threshold::threshold_to_zero;
 ///
 /// let data = vec![100u8, 200, 50, 150, 200, 250];
 /// let image = Image::<_, 3>::new(ImageSize { width: 2, height: 1 }, data).unwrap();
@@ -247,8 +247,8 @@ where
 /// # Examples
 ///
 /// ```
-/// use kornia::image::{Image, ImageSize};
-/// use kornia::imgproc::threshold::threshold_to_zero_inverse;
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_imgproc::threshold::threshold_to_zero_inverse;
 ///
 /// let data = vec![100u8, 200, 50, 150, 200, 250];
 /// let image = Image::<_, 3>::new(ImageSize { width: 2, height: 1 }, data).unwrap();
@@ -307,8 +307,8 @@ where
 /// # Examples
 ///
 /// ```
-/// use kornia::image::{Image, ImageSize};
-/// use kornia::imgproc::threshold::in_range;
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_imgproc::threshold::in_range;
 ///
 /// let data = vec![100u8, 200, 50, 150, 200, 250];
 ///

--- a/crates/kornia-imgproc/src/warp/affine.rs
+++ b/crates/kornia-imgproc/src/warp/affine.rs
@@ -59,7 +59,7 @@ pub fn invert_affine_transform(m: &[f32; 6]) -> [f32; 6] {
 /// # Example
 ///
 /// ```
-/// use kornia::imgproc::warp::get_rotation_matrix2d;
+/// use kornia_imgproc::warp::get_rotation_matrix2d;
 ///
 /// let center = (0.0, 0.0);
 /// let angle = 90.0;
@@ -100,9 +100,9 @@ fn transform_point(x: f32, y: f32, m: &[f32; 6]) -> (f32, f32) {
 /// # Example
 ///
 /// ```
-/// use kornia::image::{Image, ImageSize};
-/// use kornia::imgproc::interpolation::InterpolationMode;
-/// use kornia::imgproc::warp::warp_affine;
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_imgproc::interpolation::InterpolationMode;
+/// use kornia_imgproc::warp::warp_affine;
 ///
 /// let src = Image::<_, 3>::from_size_val(
 ///    ImageSize {

--- a/crates/kornia-imgproc/src/warp/perspective.rs
+++ b/crates/kornia-imgproc/src/warp/perspective.rs
@@ -68,9 +68,9 @@ fn transform_point(x: f32, y: f32, m: &[f32; 9]) -> (f32, f32) {
 /// # Example
 ///
 /// ```
-/// use kornia::image::{Image, ImageSize};
-/// use kornia::imgproc::interpolation::InterpolationMode;
-/// use kornia::imgproc::warp::warp_perspective;
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_imgproc::interpolation::InterpolationMode;
+/// use kornia_imgproc::warp::warp_perspective;
 ///
 /// let src = Image::<f32, 1>::new(
 ///   ImageSize {

--- a/crates/kornia-io/Cargo.toml
+++ b/crates/kornia-io/Cargo.toml
@@ -33,7 +33,7 @@ turbojpeg = { version = "1.0.0", optional = true }
 [dev-dependencies]
 criterion = "0.5"
 tempfile = "3.10"
-kornia = { workspace = true, features = ["jpegturbo"] }
+kornia-io = { workspace = true, features = ["jpegturbo"] }
 
 [features]
 gstreamer = ["futures", "gst", "gst-app", "tokio"]

--- a/crates/kornia-io/Cargo.toml
+++ b/crates/kornia-io/Cargo.toml
@@ -33,7 +33,6 @@ turbojpeg = { version = "1.0.0", optional = true }
 [dev-dependencies]
 criterion = "0.5"
 tempfile = "3.10"
-kornia-io = { workspace = true, features = ["jpegturbo"] }
 
 [features]
 gstreamer = ["futures", "gst", "gst-app", "tokio"]

--- a/crates/kornia-io/benches/bench_io.rs
+++ b/crates/kornia-io/benches/bench_io.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
-use kornia::io::functional::{read_image_any, read_image_jpeg};
+use kornia_io::functional::{read_image_any, read_image_jpeg};
 
 fn bench_read_jpeg(c: &mut Criterion) {
     let mut group = c.benchmark_group("JpegReader");

--- a/crates/kornia-io/src/functional.rs
+++ b/crates/kornia-io/src/functional.rs
@@ -23,8 +23,8 @@ use super::jpeg::{ImageDecoder, ImageEncoder};
 /// # Example
 ///
 /// ```
-/// use kornia::image::Image;
-/// use kornia::io::functional as F;
+/// use kornia_image::Image;
+/// use kornia_io::functional as F;
 ///
 /// let image: Image<u8, 3> = F::read_image_jpeg("../../tests/data/dog.jpeg").unwrap();
 ///
@@ -92,8 +92,8 @@ pub fn write_image_jpeg(file_path: impl AsRef<Path>, image: &Image<u8, 3>) -> Re
 /// # Example
 ///
 /// ```
-/// use kornia::image::Image;
-/// use kornia::io::functional as F;
+/// use kornia_image::Image;
+/// use kornia_io::functional as F;
 ///
 /// let image: Image<u8, 3> = F::read_image_any("../../tests/data/dog.jpeg").unwrap();
 ///

--- a/examples/color_detector/src/main.rs
+++ b/examples/color_detector/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
-use kornia::image::{ops, Image};
 use std::path::PathBuf;
 
+use kornia::image::{ops, Image};
 use kornia::imgproc;
 use kornia::io::functional as F;
 

--- a/examples/rtspcam/README.md
+++ b/examples/rtspcam/README.md
@@ -1,4 +1,4 @@
-An example showing how to use the RTSP camera with the `kornia::io` module with the ability to cancel the feed after a certain amount of time. This example will display the webcam feed in a [`rerun`](https://github.com/rerun-io/rerun) window.
+An example showing how to use the RTSP camera with the `kornia_io` module with the ability to cancel the feed after a certain amount of time. This example will display the webcam feed in a [`rerun`](https://github.com/rerun-io/rerun) window.
 
 NOTE: This example requires the gstremer backend to be enabled. To enable the gstreamer backend, use the `gstreamer` feature flag when building the `kornia` crate and its dependencies.
 
@@ -6,12 +6,12 @@ NOTE: This example requires the gstremer backend to be enabled. To enable the gs
 Usage: rtspcam [OPTIONS] --username <USERNAME> --password <PASSWORD> --camera-ip <CAMERA_IP> --camera-port <CAMERA_PORT> --stream <STREAM>
 
 Options:
-  -u, --username <USERNAME>        
-  -p, --password <PASSWORD>        
-      --camera-ip <CAMERA_IP>      
-      --camera-port <CAMERA_PORT>  
-  -s, --stream <STREAM>            
-  -d, --duration <DURATION>        
+  -u, --username <USERNAME>
+  -p, --password <PASSWORD>
+      --camera-ip <CAMERA_IP>
+      --camera-port <CAMERA_PORT>
+  -s, --stream <STREAM>
+  -d, --duration <DURATION>
   -h, --help                       Print help
 ```
 

--- a/examples/video_write/README.md
+++ b/examples/video_write/README.md
@@ -1,4 +1,4 @@
-An example showing how to write a video file using the `kornia::io` module along with the webcam capture example. Visualizes the webcam feed in a [`rerun`](https://github.com/rerun-io/rerun) window.
+An example showing how to write a video file using the `kornia_io` module along with the webcam capture example. Visualizes the webcam feed in a [`rerun`](https://github.com/rerun-io/rerun) window.
 
 NOTE: This example requires the gstremer backend to be enabled. To enable the gstreamer backend, use the `gstreamer` feature flag when building the `kornia` crate and its dependencies.
 

--- a/examples/webcam/README.md
+++ b/examples/webcam/README.md
@@ -1,4 +1,4 @@
-An example showing how to use the webcam with the `kornia::io` module with the ability to cancel the feed after a certain amount of time. This example will display the webcam feed in a [`rerun`](https://github.com/rerun-io/rerun) window.
+An example showing how to use the webcam with the `kornia_io` module with the ability to cancel the feed after a certain amount of time. This example will display the webcam feed in a [`rerun`](https://github.com/rerun-io/rerun) window.
 
 NOTE: This example requires the gstremer backend to be enabled. To enable the gstreamer backend, use the `gstreamer` feature flag when building the `kornia` crate and its dependencies.
 

--- a/kornia-py/Cargo.toml
+++ b/kornia-py/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 license-file = "LICENSE"
 repository = "https://github.com/kornia/kornia-rs"
 rust-version = "1.76"
-version = "0.1.6+dev"
+version = "0.1.6-rc.4"
 
 [lib]
 name = "kornia_rs"

--- a/kornia-py/Cargo.toml
+++ b/kornia-py/Cargo.toml
@@ -18,7 +18,12 @@ crate-type = ["cdylib"]
 [dependencies]
 
 # kornia
-kornia = { path = "../crates/kornia", features = ["gstreamer", "jpegturbo"] }
+kornia-image = { path = "../crates/kornia-image" }
+kornia-imgproc = { path = "../crates/kornia-imgproc" }
+kornia-io = { path = "../crates/kornia-io", features = [
+    "gstreamer",
+    "jpegturbo",
+] }
 
 # external
 pyo3 = { version = "0.21.2", features = ["extension-module"] }

--- a/kornia-py/Cargo.toml
+++ b/kornia-py/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 license-file = "LICENSE"
 repository = "https://github.com/kornia/kornia-rs"
 rust-version = "1.76"
-version = "0.1.6-rc.4"
+version = "0.1.6-rc.5"
 
 [lib]
 name = "kornia_rs"

--- a/kornia-py/src/histogram.rs
+++ b/kornia-py/src/histogram.rs
@@ -1,7 +1,8 @@
 use pyo3::prelude::*;
 
 use crate::image::{FromPyImage, PyImage};
-use kornia::{image::Image, imgproc};
+use kornia_image::Image;
+use kornia_imgproc as imgproc;
 
 /// Compute the pixel-wise histogram of an image.
 /// --

--- a/kornia-py/src/image.rs
+++ b/kornia-py/src/image.rs
@@ -1,6 +1,6 @@
 use numpy::{PyArray, PyArray3, PyArrayMethods, PyUntypedArrayMethods};
 
-use kornia::image::{Image, ImageError, ImageSize};
+use kornia_image::{Image, ImageError, ImageSize};
 use pyo3::prelude::*;
 
 // type alias for a 3D numpy array of u8

--- a/kornia-py/src/io/functional.rs
+++ b/kornia-py/src/io/functional.rs
@@ -1,7 +1,8 @@
 use pyo3::prelude::*;
 
 use crate::image::{FromPyImage, PyImage, ToPyImage};
-use kornia::{image::Image, io::functional as F};
+use kornia_image::Image;
+use kornia_io::functional as F;
 
 #[pyfunction]
 pub fn read_image_jpeg(file_path: &str) -> PyResult<PyImage> {

--- a/kornia-py/src/io/jpeg.rs
+++ b/kornia-py/src/io/jpeg.rs
@@ -1,7 +1,5 @@
-use kornia::{
-    image::Image,
-    io::jpeg::{ImageDecoder, ImageEncoder},
-};
+use kornia_image::Image;
+use kornia_io::jpeg::{ImageDecoder, ImageEncoder};
 use pyo3::prelude::*;
 
 use crate::image::{FromPyImage, PyImage, PyImageSize, ToPyImage};

--- a/kornia-py/src/resize.rs
+++ b/kornia-py/src/resize.rs
@@ -1,10 +1,8 @@
 use pyo3::prelude::*;
 
 use crate::image::{FromPyImage, PyImage, ToPyImage};
-use kornia::{
-    image::{Image, ImageSize},
-    imgproc::{interpolation::InterpolationMode, resize::resize_fast},
-};
+use kornia_image::{Image, ImageSize};
+use kornia_imgproc::{interpolation::InterpolationMode, resize::resize_fast};
 
 #[pyfunction]
 pub fn resize(image: PyImage, new_size: (usize, usize), interpolation: &str) -> PyResult<PyImage> {

--- a/kornia-py/src/warp.rs
+++ b/kornia-py/src/warp.rs
@@ -1,9 +1,9 @@
 use pyo3::prelude::*;
 
 use crate::image::{FromPyImage, PyImage, ToPyImage};
-use kornia::image::{Image, ImageSize};
-use kornia::imgproc::interpolation::InterpolationMode;
-use kornia::imgproc::warp;
+use kornia_image::{Image, ImageSize};
+use kornia_imgproc::interpolation::InterpolationMode;
+use kornia_imgproc::warp;
 
 #[pyfunction]
 pub fn warp_affine(

--- a/kornia-serve/src/compute.rs
+++ b/kornia-serve/src/compute.rs
@@ -71,10 +71,10 @@ pub async fn compute_mean_std(query: Json<MeanStdQuery>) -> impl IntoResponse {
         .for_each(|image_path| {
             // read the image
             let image =
-                kornia::io::functional::read_image_jpeg(&image_path).expect("Failed to read image");
+                kornia_io::functional::read_image_jpeg(&image_path).expect("Failed to read image");
 
             // compute the std and mean
-            let (std, mean) = kornia::imgproc::core::std_mean(&image);
+            let (std, mean) = kornia_imgproc::core::std_mean(&image);
 
             // update the total std and mean
 

--- a/scripts/release_rust.sh
+++ b/scripts/release_rust.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+
+# Set dry-run as default
+DRY_RUN="--dry-run"
+
+# Check if --no-dry-run argument is passed
+if [[ "$1" == "--no-dry-run" ]]; then
+  DRY_RUN=""
+fi
+
+# Publish crates
+cross publish -p kornia-core $DRY_RUN
+cross publish -p kornia-image $DRY_RUN
+cross publish -p kornia-io --all-features $DRY_RUN
+cross publish -p kornia-imgproc $DRY_RUN
+cross publish -p kornia --all-features $DRY_RUN


### PR DESCRIPTION
fixes #118 

- bump to v0.1.6-rc.5 
- adjust imports to avoid conflicts when publishing
- add `scripts/release_rust.sh` to manually release