### PR TITLE
Fix TensorStorage memory deallocation

### DIFF
--- a/crates/kornia-core/src/allocator.rs
+++ b/crates/kornia-core/src/allocator.rs
@@ -1,4 +1,5 @@
-use std::alloc::{GlobalAlloc, Layout, System};
+use std::alloc;
+use std::alloc::Layout;
 
 use thiserror::Error;
 
@@ -55,7 +56,7 @@ impl TensorAllocator for CpuAllocator {
     ///
     /// A non-null pointer to the allocated memory if successful, otherwise an error.
     fn alloc(&self, layout: Layout) -> Result<*mut u8, TensorAllocatorError> {
-        let ptr = unsafe { System.alloc(layout) };
+        let ptr = unsafe { alloc::alloc(layout) };
         if ptr.is_null() {
             Err(TensorAllocatorError::NullPointer)?
         }
@@ -74,7 +75,7 @@ impl TensorAllocator for CpuAllocator {
     /// The pointer must be non-null and the layout must be correct.
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        unsafe { System.dealloc(ptr, layout) }
+        unsafe { alloc::dealloc(ptr, layout) }
     }
 }
 

--- a/crates/kornia-core/src/serde.rs
+++ b/crates/kornia-core/src/serde.rs
@@ -7,9 +7,10 @@ use crate::{
 use serde::ser::SerializeStruct;
 use serde::Deserialize;
 
-impl<T, const N: usize, A: TensorAllocator> serde::Serialize for Tensor<T, N, A>
+impl<T, const N: usize, A> serde::Serialize for Tensor<T, N, A>
 where
     T: serde::Serialize + SafeTensorType,
+    A: TensorAllocator + 'static,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -23,7 +24,7 @@ where
     }
 }
 
-impl<'de, T, const N: usize, A: TensorAllocator + Default> serde::Deserialize<'de>
+impl<'de, T, const N: usize, A: TensorAllocator + Default + 'static> serde::Deserialize<'de>
     for Tensor<T, N, A>
 where
     T: serde::Deserialize<'de> + SafeTensorType,

--- a/crates/kornia-core/src/storage.rs
+++ b/crates/kornia-core/src/storage.rs
@@ -395,7 +395,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tensor_storage_allocator() {
+    fn test_tensor_storage_allocator() -> Result<(), TensorAllocatorError> {
         // A test TensorAllocator that keeps a count of the bytes that are allocated but not yet
         // deallocated via the allocator.
         #[derive(Clone)]
@@ -421,7 +421,7 @@ mod tests {
         // TensorStorage::new()
         // Deallocation should happen when `storage` goes out of scope.
         {
-            let _storage = TensorStorage::<u8, _>::new(len, allocator.clone()).unwrap();
+            let _storage = TensorStorage::<u8, _>::new(len, allocator.clone())?;
             assert_eq!(*allocator.bytes_allocated.borrow(), len as i32);
         }
         assert_eq!(*allocator.bytes_allocated.borrow(), 0);
@@ -430,7 +430,7 @@ mod tests {
         // TensorStorage::into_vec() consumes the storage and creates a copy (in this case).
         // This should cause deallocation of the original memory.
         {
-            let storage = TensorStorage::<u8, _>::new(len, allocator.clone()).unwrap();
+            let storage = TensorStorage::<u8, _>::new(len, allocator.clone())?;
             assert_eq!(*allocator.bytes_allocated.borrow(), len as i32);
 
             let _vec = storage.into_vec();
@@ -464,5 +464,7 @@ mod tests {
             }
             assert_eq!(*allocator.bytes_allocated.borrow(), 0);
         }
+
+        Ok(())
     }
 }

--- a/crates/kornia-core/src/tensor.rs
+++ b/crates/kornia-core/src/tensor.rs
@@ -90,7 +90,7 @@ where
 impl<T, const N: usize, A> Tensor<T, N, A>
 where
     T: SafeTensorType,
-    A: TensorAllocator,
+    A: TensorAllocator + 'static,
 {
     /// Create a new `Tensor` with uninitialized data.
     ///
@@ -875,7 +875,7 @@ where
 impl<T, const N: usize, A> Clone for Tensor<T, N, A>
 where
     T: SafeTensorType + Clone,
-    A: TensorAllocator + Clone,
+    A: TensorAllocator + Clone + 'static,
 {
     fn clone(&self) -> Self {
         Self {

--- a/crates/kornia-core/src/view.rs
+++ b/crates/kornia-core/src/view.rs
@@ -14,7 +14,7 @@ pub struct TensorView<'a, T: SafeTensorType, const N: usize, A: TensorAllocator>
     pub strides: [usize; N],
 }
 
-impl<'a, T: SafeTensorType, const N: usize, A: TensorAllocator> TensorView<'a, T, N, A> {
+impl<'a, T: SafeTensorType, const N: usize, A: TensorAllocator + 'static> TensorView<'a, T, N, A> {
     /// Returns the data slice of the tensor.
     #[inline]
     pub fn as_slice(&self) -> &[T] {


### PR DESCRIPTION
**Changes in this PR**
- Adds checks to make sure the TensorAllocator is invoked properly.
- Fixes memory leaks/issues observed in https://github.com/kornia/kornia-rs/issues/134#issuecomment-2363726170 and https://github.com/kornia/kornia-rs/pull/117#issuecomment-2343983888.

**Details**
A new struct `TensorCustomAllocationOwner` is added to represent a custom memory allocations made by TensorAllocators. This struct implements the `Drop` trait to deallocate the associated memory. An instance of this struct is then passed as owner to `arrow_buffer::Buffer::from_custom_allocation`, so that when the Arrow buffer is dropped, this memory will also be deallocated using the correct TensorAllocator.

**Future changes**
When the `allocator_api` feature comes to stable rust, it may be possible to use a standard container such as `Vec<T, A=..>` instead of the above mentioned struct to handle custom deallocation.