### PR TITLE
improve image tensor conversions

### DIFF
--- a/crates/kornia-core/src/tensor.rs
+++ b/crates/kornia-core/src/tensor.rs
@@ -237,7 +237,7 @@ where
         if numel != data.len() {
             return Err(TensorError::InvalidShape(numel));
         }
-        let storage = TensorStorage::from_slice(data, alloc)?;
+        let storage = TensorStorage::from_slice(data, alloc);
         let strides = get_strides_from_shape(shape);
         Ok(Self {
             storage,


### PR DESCRIPTION
- use builtin `Buffer::from_slice_ref` in TensorStorage creation
- add method `from_size_slice` in `Image`
- implement `TryFrom` for Image/Tensor conversion
- added tests