### PR TITLE
support python 3.13

### DIFF
--- a/.github/workflows/python_release.yml
+++ b/.github/workflows/python_release.yml
@@ -130,21 +130,21 @@ jobs:
           name: wheels
           path: dist
 
-  release:
-    name: Release
-    runs-on: ubuntu-latest
-    needs: [macos, windows, linux]
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: wheels
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-      - name: Publish to PyPi
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_PASSWORD }}
-        uses: messense/maturin-action@v1
-        with:
-          command: upload
-          args: --skip-existing *
+  #release:
+  #  name: Release
+  #  runs-on: ubuntu-latest
+  #  needs: [macos, windows, linux]
+  #  steps:
+  #    - uses: actions/download-artifact@v3
+  #      with:
+  #        name: wheels
+  #    - uses: actions/setup-python@v2
+  #      with:
+  #        python-version: 3.9
+  #    - name: Publish to PyPi
+  #      env:
+  #        MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_PASSWORD }}
+  #      uses: messense/maturin-action@v1
+  #      with:
+  #        command: upload
+  #        args: --skip-existing *

--- a/.github/workflows/python_release.yml
+++ b/.github/workflows/python_release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         target: [x86_64, aarch64]
 
     steps:
@@ -23,7 +23,7 @@ jobs:
           target: ${{ matrix.target }}
           manylinux: auto
           command: build
-          args: --release --out dist -i python${{ matrix.python-version }} -m kornia-py/Cargo.toml --sdist 
+          args: --release --out dist -i python${{ matrix.python-version }} -m kornia-py/Cargo.toml --sdist
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:
@@ -71,6 +71,12 @@ jobs:
           - runs-on: macos-14
             python-version: "3.12"
             target: aarch64
+          - runs-on: macos-14
+            python-version: "3.13"
+            target: x86_64
+          - runs-on: macos-14
+            python-version: "3.13"
+            target: aarch64
     steps:
       - uses: ilammy/setup-nasm@v1
       - uses: actions/checkout@v4
@@ -99,7 +105,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         target: [x64, x86]
     steps:
       - uses: ilammy/setup-nasm@v1

--- a/.github/workflows/python_release.yml
+++ b/.github/workflows/python_release.yml
@@ -113,7 +113,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: ${{ matrix.target }}
+          # x86 python needs to be available for the win32 wheel
+          architecture: ${{ ( matrix.os == 'windows-latest' && matrix.target == 'i686' ) && 'x86' || null }}
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/python_release.yml
+++ b/.github/workflows/python_release.yml
@@ -131,21 +131,21 @@ jobs:
           name: wheels
           path: dist
 
-  #release:
-  #  name: Release
-  #  runs-on: ubuntu-latest
-  #  needs: [macos, windows, linux]
-  #  steps:
-  #    - uses: actions/download-artifact@v3
-  #      with:
-  #        name: wheels
-  #    - uses: actions/setup-python@v2
-  #      with:
-  #        python-version: 3.9
-  #    - name: Publish to PyPi
-  #      env:
-  #        MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_PASSWORD }}
-  #      uses: messense/maturin-action@v1
-  #      with:
-  #        command: upload
-  #        args: --skip-existing *
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [macos, windows, linux]
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: wheels
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Publish to PyPi
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_PASSWORD }}
+        uses: messense/maturin-action@v1
+        with:
+          command: upload
+          args: --skip-existing *

--- a/crates/kornia-imgproc/Cargo.toml
+++ b/crates/kornia-imgproc/Cargo.toml
@@ -20,6 +20,7 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
+image = "0.25"
 kornia-io = { workspace = true }
 ndarray = { version = "0.15", features = ["rayon"] }
 

--- a/kornia-py/Cargo.toml
+++ b/kornia-py/Cargo.toml
@@ -22,5 +22,5 @@ kornia-imgproc = { path = "../crates/kornia-imgproc" }
 kornia-io = { path = "../crates/kornia-io", features = ["jpegturbo"] }
 
 # external
-pyo3 = { version = "0.21.2", features = ["extension-module"] }
-numpy = { version = "0.21.0" }
+pyo3 = { version = "0.23.0", features = ["extension-module"] }
+numpy = { version = "0.23.0" }

--- a/kornia-py/src/image.rs
+++ b/kornia-py/src/image.rs
@@ -14,7 +14,7 @@ pub trait ToPyImage {
 impl<const C: usize> ToPyImage for Image<u8, C> {
     fn to_pyimage(self) -> PyImage {
         Python::with_gil(|py| unsafe {
-            let array = PyArray::<u8, _>::new_bound(py, [self.height(), self.width(), C], false);
+            let array = PyArray::<u8, _>::new(py, [self.height(), self.width(), C], false);
             // TODO: verify that the data is contiguous, otherwise iterate over the image and copy
             std::ptr::copy_nonoverlapping(self.as_ptr(), array.data(), self.numel());
             array.unbind()

--- a/kornia-py/src/io/jpeg.rs
+++ b/kornia-py/src/io/jpeg.rs
@@ -9,9 +9,6 @@ pub struct PyImageDecoder {
     pub inner: ImageDecoder,
 }
 
-unsafe impl Send for PyImageDecoder {}
-unsafe impl Sync for PyImageDecoder {}
-
 #[pymethods]
 impl PyImageDecoder {
     #[new]
@@ -42,9 +39,6 @@ impl PyImageDecoder {
 pub struct PyImageEncoder {
     pub inner: ImageEncoder,
 }
-
-unsafe impl Send for PyImageEncoder {}
-unsafe impl Sync for PyImageEncoder {}
 
 #[pymethods]
 impl PyImageEncoder {

--- a/kornia-py/src/io/jpeg.rs
+++ b/kornia-py/src/io/jpeg.rs
@@ -9,6 +9,9 @@ pub struct PyImageDecoder {
     pub inner: ImageDecoder,
 }
 
+unsafe impl Send for PyImageDecoder {}
+unsafe impl Sync for PyImageDecoder {}
+
 #[pymethods]
 impl PyImageDecoder {
     #[new]
@@ -39,6 +42,9 @@ impl PyImageDecoder {
 pub struct PyImageEncoder {
     pub inner: ImageEncoder,
 }
+
+unsafe impl Send for PyImageEncoder {}
+unsafe impl Sync for PyImageEncoder {}
 
 #[pymethods]
 impl PyImageEncoder {


### PR DESCRIPTION
fixes #178 

This pull request includes several changes to the build and dependency management configurations, as well as modifications to the JPEG encoder and decoder implementations to improve thread safety. The most important changes are grouped into build configuration updates and codebase improvements.

### Build Configuration Updates:
* [`.github/workflows/python_release.yml`](diffhunk://#diff-ab7d347c52bff9333700f9be8b88adeec2d9663e0eb07728f36461d3c5b09e34L15-R15): Added Python 3.13 to the matrix for Ubuntu, macOS, and Windows builds. [[1]](diffhunk://#diff-ab7d347c52bff9333700f9be8b88adeec2d9663e0eb07728f36461d3c5b09e34L15-R15) [[2]](diffhunk://#diff-ab7d347c52bff9333700f9be8b88adeec2d9663e0eb07728f36461d3c5b09e34R74-R79) [[3]](diffhunk://#diff-ab7d347c52bff9333700f9be8b88adeec2d9663e0eb07728f36461d3c5b09e34L102-R117)
* [`crates/kornia-imgproc/Cargo.toml`](diffhunk://#diff-d446f6d1509e77bfc7093c37b96ae3a3e7390609f73c7ec7b430b9486c47223cR23): Added `image` crate as a development dependency.
* [`kornia-py/Cargo.toml`](diffhunk://#diff-b578890f0af57d109322f0341862126b0c113a3203c7fbcedf2a7d9bf1308fd2L25-R26): Updated `pyo3` to version 0.23.0 and `numpy` to version 0.23.0.

### Codebase Improvements:
* [`crates/kornia-io/src/jpeg.rs`](diffhunk://#diff-60a1d9bf7a0b66a3ae525ba7725968faf2813212ae1d822b4376ab77043f24dfR1): Refactored `ImageEncoder` and `ImageDecoder` to use `Arc<Mutex<>>` for the `turbojpeg` compressor and decompressor to ensure thread safety. [[1]](diffhunk://#diff-60a1d9bf7a0b66a3ae525ba7725968faf2813212ae1d822b4376ab77043f24dfR1) [[2]](diffhunk://#diff-60a1d9bf7a0b66a3ae525ba7725968faf2813212ae1d822b4376ab77043f24dfL24-R31) [[3]](diffhunk://#diff-60a1d9bf7a0b66a3ae525ba7725968faf2813212ae1d822b4376ab77043f24dfL64-R67) [[4]](diffhunk://#diff-60a1d9bf7a0b66a3ae525ba7725968faf2813212ae1d822b4376ab77043f24dfL90-R93) [[5]](diffhunk://#diff-60a1d9bf7a0b66a3ae525ba7725968faf2813212ae1d822b4376ab77043f24dfL99-R102) [[6]](diffhunk://#diff-60a1d9bf7a0b66a3ae525ba7725968faf2813212ae1d822b4376ab77043f24dfL112-R117) [[7]](diffhunk://#diff-60a1d9bf7a0b66a3ae525ba7725968faf2813212ae1d822b4376ab77043f24dfL130-R135) [[8]](diffhunk://#diff-60a1d9bf7a0b66a3ae525ba7725968faf2813212ae1d822b4376ab77043f24dfL164-R172)
* [`kornia-py/src/image.rs`](diffhunk://#diff-9e75e791f62ce64de35e7267d9f64acc1fd26cc84dda24bb86ffd73566c74632L17-R17): Modified `to_pyimage` method to use `PyArray::new` instead of `PyArray::new_bound`.