### PR TITLE
[wip] kornia-depth crate with depth anything

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,14 @@ members = [
     "crates/kornia-icp",
     # "kornia-py",
     "kornia-viz",
-    "crates/kornia-3d",
+    "crates/kornia-3d", "crates/kornia-depth",
 ]
 exclude = ["kornia-py", "kornia-serve"]
 
 [workspace.package]
 authors = ["kornia.org <edgar@kornia.org>"]
 categories = ["computer-vision", "science::robotics"]
-description = "Low-level computer vision library in Rust"
+description = "Low-level 3D computer vision library in Rust"
 edition = "2021"
 homepage = "http://kornia.org"
 include = ["Cargo.toml"]
@@ -33,6 +33,7 @@ version = "0.1.8-rc.1"
 # NOTE: remember to update the kornia-py package version in `kornia-py/Cargo.toml` when updating the Rust package version
 kornia-core = { path = "crates/kornia-core", version = "0.1.8-rc.1" }
 kornia-core-ops = { path = "crates/kornia-core-ops", version = "0.1.8-rc.1" }
+kornia-depth = { path = "crates/kornia-depth", version = "0.1.8-rc.1" }
 kornia-icp = { path = "crates/kornia-icp", version = "0.1.8-rc.1" }
 kornia-image = { path = "crates/kornia-image", version = "0.1.8-rc.1" }
 kornia-io = { path = "crates/kornia-io", version = "0.1.8-rc.1" }
@@ -44,6 +45,7 @@ kornia = { path = "crates/kornia", version = "0.1.8-rc.1" }
 argh = "0.1"
 approx = "0.5"
 criterion = "0.5"
+ctrlc = "3.4"
 env_logger = "0.11"
 log = "0.4"
 num-traits = "0.2"

--- a/crates/kornia-depth/Cargo.toml
+++ b/crates/kornia-depth/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "kornia-depth"
+authors.workspace = true
+categories.workspace = true
+description.workspace = true
+edition.workspace = true
+homepage.workspace = true
+include.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+candle-core = { git = "https://github.com/huggingface/candle.git", branch = "main", features = ["cuda"] }
+candle-nn = { git = "https://github.com/huggingface/candle.git", branch = "main", features = ["cuda"] }
+candle-transformers = { git = "https://github.com/huggingface/candle.git", branch = "main", features = ["cuda"] }
+env_logger = { workspace = true }
+hf-hub = "0.3.2"
+log = { workspace = true }
+kornia-image = { workspace = true }
+kornia-imgproc = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/kornia-depth/src/depth_anything.rs
+++ b/crates/kornia-depth/src/depth_anything.rs
@@ -1,0 +1,185 @@
+use std::{path::PathBuf, sync::Arc};
+
+use candle_core::{DType, Device, Module, Tensor};
+use candle_nn::VarBuilder;
+use candle_transformers::models::depth_anything_v2::{DepthAnythingV2, DepthAnythingV2Config};
+use candle_transformers::models::dinov2;
+
+use kornia_image::{ops, Image, ImageError};
+use kornia_imgproc::{
+    interpolation::InterpolationMode,
+    normalize::{normalize_mean_std, normalize_min_max},
+    resize::resize_fast,
+};
+
+#[derive(thiserror::Error, Debug)]
+pub enum DepthAnythingError {
+    #[error("Failed to load preprocess the image")]
+    PreprocessError(#[from] ImageError),
+
+    #[error("Failed to convert the image to a tensor")]
+    TensorError(#[from] candle_core::Error),
+}
+
+struct DepthAnythingV2Preprocessor {
+    resized_image: Image<u8, 3>,
+    resized_image_f32: Image<f32, 3>,
+    normalized_image: Image<f32, 3>,
+}
+
+impl DepthAnythingV2Preprocessor {
+    // taken these from: https://huggingface.co/spaces/depth-anything/Depth-Anything-V2/blob/main/depth_anything_v2/dpt.py#L207
+    const MAGIC_MEAN: [f32; 3] = [0.485, 0.456, 0.406];
+    const MAGIC_STD: [f32; 3] = [0.229, 0.224, 0.225];
+
+    const DINO_IMG_SIZE: usize = 518;
+
+    pub fn new() -> Result<Self, DepthAnythingError> {
+        let new_size = [Self::DINO_IMG_SIZE, Self::DINO_IMG_SIZE].into();
+        Ok(Self {
+            resized_image: Image::from_size_val(new_size, 0u8)?,
+            resized_image_f32: Image::from_size_val(new_size, 0f32)?,
+            normalized_image: Image::from_size_val(new_size, 0f32)?,
+        })
+    }
+
+    pub fn preprocess(
+        &mut self,
+        image: &Image<u8, 3>,
+        device: &Device,
+    ) -> Result<Tensor, DepthAnythingError> {
+        // resize the image to the desired size
+        resize_fast(image, &mut self.resized_image, InterpolationMode::Bilinear)?;
+
+        // cast the image to f32 and scale it to the range [0, 1]
+        ops::cast_and_scale(
+            &self.resized_image,
+            &mut self.resized_image_f32,
+            1.0 / 255.0,
+        )?;
+
+        // normalize the image to the mean and std
+        normalize_mean_std(
+            &self.resized_image_f32,
+            &mut self.normalized_image,
+            &Self::MAGIC_MEAN,
+            &Self::MAGIC_STD,
+        )?;
+
+        // convert the image to a candle tensor
+
+        let img_t = Tensor::from_slice(
+            self.normalized_image.as_slice(),
+            &[Self::DINO_IMG_SIZE, Self::DINO_IMG_SIZE, 3],
+            device,
+        )?;
+
+        // permute the image to the shape (1, c, h, w)
+        let img_t = img_t.permute((2, 0, 1))?.unsqueeze(0)?;
+
+        Ok(img_t)
+    }
+}
+
+struct DepthAnythingV2Postprocessor {
+    normalized_depth: Image<f32, 1>,
+}
+
+impl DepthAnythingV2Postprocessor {
+    const OUTPUT_IMG_SIZE: usize = 520;
+
+    pub fn new() -> Result<Self, DepthAnythingError> {
+        Ok(Self {
+            normalized_depth: Image::from_size_val(
+                [Self::OUTPUT_IMG_SIZE, Self::OUTPUT_IMG_SIZE].into(),
+                0f32,
+            )?,
+        })
+    }
+
+    pub fn postprocess(&mut self, depth: &Tensor) -> Result<&Image<f32, 1>, DepthAnythingError> {
+        // convert the depth tensor to an image of shape (h, w, 1)
+        let (_, _, rows, cols) = depth.dims4()?;
+
+        let depth_data = depth.flatten_all()?.to_vec1::<f32>()?;
+        let depth_image = Image::from_size_slice([rows, cols].into(), depth_data.as_slice())?;
+
+        // normalize the depth image to the range [0, 1]
+        normalize_min_max(&depth_image, &mut self.normalized_depth, 0.0, 1.0)?;
+
+        Ok(&self.normalized_depth)
+    }
+}
+
+pub struct DepthAnything {
+    #[allow(unused)]
+    dinov2: Arc<dinov2::DinoVisionTransformer>,
+    depth_anything: DepthAnythingV2,
+    preprocessor: DepthAnythingV2Preprocessor,
+    postprocessor: DepthAnythingV2Postprocessor,
+    device: Device,
+}
+
+impl DepthAnything {
+    pub fn new(
+        dinov2_model: Option<PathBuf>,
+        depth_anything_v2_model: Option<PathBuf>,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        // set the device to cuda if available, otherwise use cpu
+        let device = match Device::cuda_if_available(0) {
+            Ok(device) => device,
+            Err(e) => {
+                log::warn!("Failed to use CUDA, using CPU instead: {}", e);
+                Device::Cpu
+            }
+        };
+
+        let dinov2_model_file = match dinov2_model {
+            None => {
+                let api = hf_hub::api::sync::Api::new()?;
+                let api = api.model("lmz/candle-dino-v2".into());
+                api.get("dinov2_vits14.safetensors")?
+            }
+            Some(dinov2_model) => dinov2_model,
+        };
+
+        let vb = unsafe {
+            VarBuilder::from_mmaped_safetensors(&[dinov2_model_file], DType::F32, &device)?
+        };
+        let dinov2 = Arc::new(dinov2::vit_small(vb)?);
+
+        let depth_anything_model_file = match depth_anything_v2_model {
+            None => {
+                let api = hf_hub::api::sync::Api::new()?;
+                let api = api.model("jeroenvlek/depth-anything-v2-safetensors".into());
+                api.get("depth_anything_v2_vits.safetensors")?
+            }
+            Some(depth_anything_model) => depth_anything_model,
+        };
+
+        let vb = unsafe {
+            VarBuilder::from_mmaped_safetensors(&[depth_anything_model_file], DType::F32, &device)?
+        };
+
+        let config = DepthAnythingV2Config::vit_small();
+        let depth_anything = DepthAnythingV2::new(dinov2.clone(), config, vb)?;
+
+        let preprocessor = DepthAnythingV2Preprocessor::new()?;
+        let postprocessor = DepthAnythingV2Postprocessor::new()?;
+
+        Ok(Self {
+            dinov2,
+            depth_anything,
+            preprocessor,
+            postprocessor,
+            device,
+        })
+    }
+
+    pub fn forward(&mut self, image: &Image<u8, 3>) -> Result<&Image<f32, 1>, DepthAnythingError> {
+        let img_t = self.preprocessor.preprocess(image, &self.device)?;
+        let depth_t = self.depth_anything.forward(&img_t)?;
+        let depth = self.postprocessor.postprocess(&depth_t)?;
+        Ok(depth)
+    }
+}

--- a/crates/kornia-depth/src/lib.rs
+++ b/crates/kornia-depth/src/lib.rs
@@ -1,0 +1,2 @@
+mod depth_anything;
+pub use depth_anything::DepthAnything;

--- a/examples/depth_anything/Cargo.toml
+++ b/examples/depth_anything/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "depth_anything"
+authors.workspace = true
+categories.workspace = true
+description.workspace = true
+edition.workspace = true
+homepage.workspace = true
+include.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+argh = { workspace = true }
+ctrlc = { workspace = true }
+env_logger = { workspace = true }
+kornia = { workspace = true }
+kornia-depth = { workspace = true }
+rerun = { workspace = true }

--- a/examples/depth_anything/src/main.rs
+++ b/examples/depth_anything/src/main.rs
@@ -1,0 +1,82 @@
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+
+use kornia::io::stream::V4L2CameraConfig;
+use kornia_depth::DepthAnything;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    // create a rerun recorder
+    let rec = rerun::RecordingStreamBuilder::new("depth_anything").spawn()?;
+
+    // create a depth anything model
+    let mut depth_anything = DepthAnything::new(None, None)?;
+
+    // create a webcam capture object
+    let mut webcam = V4L2CameraConfig::new()
+        .with_size([640, 480].into())
+        .build()?;
+
+    // start the background pipeline
+    webcam.start()?;
+
+    // create a cancel token to stop the webcam capture
+    let cancel_token = Arc::new(AtomicBool::new(false));
+
+    ctrlc::set_handler({
+        let cancel_token = cancel_token.clone();
+        move || {
+            println!("Received Ctrl-C signal. Sending cancel signal !!");
+            cancel_token.store(true, Ordering::SeqCst);
+        }
+    })?;
+
+    let mut img_count = 0;
+
+    // start grabbing frames from the camera
+    while !cancel_token.load(Ordering::SeqCst) {
+        let Some(img) = webcam.grab()? else {
+            continue;
+        };
+
+        let now = std::time::Instant::now();
+
+        println!("Processing image {}", img_count);
+
+        let depth = depth_anything.forward(&img)?;
+
+        let elapsed = now.elapsed();
+        println!("Elapsed time: {:?}", elapsed);
+
+        // log the image
+        rec.log_static(
+            "image",
+            &rerun::Image::from_elements(img.as_slice(), img.size().into(), rerun::ColorModel::RGB),
+        )?;
+
+        let depth_viz = depth.scale_and_cast::<u8>(255.0)?;
+        let depth_image = rerun::DepthImage::new(
+            depth_viz.as_slice().to_vec(),
+            rerun::ImageFormat::depth(depth_viz.size().into(), rerun::ChannelDatatype::U8),
+        );
+
+        rec.log(
+            "world/camera",
+            &rerun::Pinhole::from_focal_length_and_resolution([200.0, 200.0], [640.0, 480.0]),
+        )?;
+
+        rec.log_static("world/camera/depth", &depth_image)?;
+
+        img_count += 1;
+    }
+
+    // NOTE: this is important to close the webcam properly, otherwise the app will hang
+    webcam.close()?;
+
+    println!("Finished recording. Closing app.");
+
+    Ok(())
+}

--- a/examples/rtspcam/Cargo.toml
+++ b/examples/rtspcam/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 
 [dependencies]
 clap = { version = "4.5.4", features = ["derive"] }
-ctrlc = "3.4.4"
+ctrlc = { workspace = true }
 kornia = { workspace = true, features = ["gstreamer"] }
 rerun = { workspace = true }

--- a/examples/video_write tasks/Cargo.toml
+++ b/examples/video_write tasks/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 clap = { version = "4.5.4", features = ["derive"] }
-ctrlc = "3.4.4"
+ctrlc = { workspace = true }
 kornia = { workspace = true, features = ["gstreamer"] }
 rerun = { workspace = true }
 tokio = { version = "1", features = ["full", "signal"] }

--- a/examples/video_write/Cargo.toml
+++ b/examples/video_write/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 
 [dependencies]
 clap = { version = "4.5.4", features = ["derive"] }
-ctrlc = "3.4.4"
+ctrlc = { workspace = true }
 kornia = { workspace = true, features = ["gstreamer"] }
 rerun = { workspace = true }

--- a/examples/webcam/Cargo.toml
+++ b/examples/webcam/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 
 [dependencies]
 clap = { version = "4.5.4", features = ["derive"] }
-ctrlc = "3.4.4"
+ctrlc = { workspace = true }
 kornia = { workspace = true, features = ["gstreamer"] }
 rerun = { workspace = true }


### PR DESCRIPTION
This pull request introduces a new crate `kornia-depth` and integrates it into the existing workspace. Additionally, it includes a new example demonstrating the usage of the `kornia-depth` crate for depth estimation using a webcam.

https://github.com/user-attachments/assets/367b62ed-569a-41e8-8fc4-99de9cd91b35

New crate addition:

* Added the `kornia-depth` crate with dependencies and configurations in `crates/kornia-depth/Cargo.toml`.
* Implemented the `DepthAnything` struct and its methods for depth estimation in `crates/kornia-depth/src/depth_anything.rs`.
* Exposed the `DepthAnything` struct in `crates/kornia-depth/src/lib.rs`.

Workspace and dependency updates:

* Updated `Cargo.toml` to include `kornia-depth` in the workspace members and added the necessary dependencies. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L14-R21) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R36) [[3]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R48)
* Modified several example `Cargo.toml` files to use the workspace version of the `ctrlc` dependency. [[1]](diffhunk://#diff-5338818f2aacf67293f68d70ee01b619a905d871831f31d934ae0dbc59a65f9aL11-R11) [[2]](diffhunk://#diff-10d643dae33d3c5ce362f6cee9e3f49ae3a08118ca1ac6f13114617fd2da96a6L11-R11) [[3]](diffhunk://#diff-ec69f091e5230018d989b6c9626b378fc720065d18d930d81335f4b32dc84ffbL11-R11) [[4]](diffhunk://#diff-fa4285e5c2656312484364795787f5cced71f6ad5e751bad35e67cf638a894b1L11-R11)

New example:

* Added a new example `depth_anything` demonstrating the usage of the `DepthAnything` struct for depth estimation using a webcam in `examples/depth_anything/Cargo.toml` and `examples/depth_anything/src/main.rs`. [[1]](diffhunk://#diff-90833a2da3af39a9ebc4ddb374987f7ec3da034f1910b03fc9eee77448101582R1-R21) [[2]](diffhunk://#diff-0a8102480af4139749ecc96e7ffae5bb2cf4b0f2df4b9e2a8919ab39c538872cR1-R82)