### PR TITLE
implement XYZRgbNormalsProperty in ply parser

### DIFF
--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install dependencies
-        run: sudo apt-get install -y cmake nasm libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libunwind-dev
+        run: sudo apt-get install -y cmake nasm libunwind-dev
       - name: Build and test
         run: make test-python
   # NOTE: there's a systematic fail with the ci on macos

--- a/crates/kornia-3d/src/io/ply/mod.rs
+++ b/crates/kornia-3d/src/io/ply/mod.rs
@@ -3,3 +3,15 @@ mod properties;
 
 pub use parser::*;
 pub use properties::*;
+
+#[derive(Debug, thiserror::Error)]
+pub enum PlyError {
+    #[error("Failed to read PLY file")]
+    Io(#[from] std::io::Error),
+
+    #[error("Failed to deserialize PLY file")]
+    Deserialize(#[from] bincode::Error),
+
+    #[error("Unsupported PLY property")]
+    UnsupportedProperty,
+}

--- a/crates/kornia-3d/src/io/ply/parser.rs
+++ b/crates/kornia-3d/src/io/ply/parser.rs
@@ -20,6 +20,7 @@ pub fn read_ply_binary(path: impl AsRef<Path>, property: PlyType) -> Result<Poin
     let mut reader = std::io::BufReader::new(file);
 
     // read the header
+    // TODO: parse automatically the header
     let mut header = String::new();
     loop {
         let mut line = String::new();
@@ -30,7 +31,6 @@ pub fn read_ply_binary(path: impl AsRef<Path>, property: PlyType) -> Result<Poin
         }
         header.push_str(&line);
     }
-    println!("{:?}", header);
 
     // create a buffer for the points
     let mut buffer = vec![0u8; property.size_of()];

--- a/crates/kornia-3d/src/io/ply/parser.rs
+++ b/crates/kornia-3d/src/io/ply/parser.rs
@@ -1,24 +1,12 @@
 use std::io::{BufRead, Read};
 use std::path::Path;
 
-use super::properties::{OpenSplatProperty, PlyProperty};
+use super::{properties::PlyType, PlyError, PlyPropertyTrait};
 use crate::pointcloud::PointCloud;
-
-#[derive(Debug, thiserror::Error)]
-pub enum PlyError {
-    #[error("Failed to read PLY file")]
-    Io(#[from] std::io::Error),
-
-    #[error("Failed to deserialize PLY file")]
-    Deserialize(#[from] bincode::Error),
-
-    #[error("Unsupported PLY property")]
-    UnsupportedProperty,
-}
 
 /// Read a PLY file in binary format.
 ///
-/// NOTE: This function only supports the OpenSplat PLY file format format for now.
+/// NOTE: This function only supports the OpenSplat and XYZRgbNormals PLY file format for now.
 /// REF: https://github.com/pierotofy/OpenSplat
 ///
 /// Args:
@@ -26,29 +14,23 @@ pub enum PlyError {
 ///
 /// Returns:
 ///     A `PointCloud` struct containing the points, colors, and normals.
-pub fn read_ply_binary(
-    path: impl AsRef<Path>,
-    property: PlyProperty,
-) -> Result<PointCloud, PlyError> {
-    if property != PlyProperty::OpenSplat {
-        return Err(PlyError::UnsupportedProperty);
-    }
-
+pub fn read_ply_binary(path: impl AsRef<Path>, property: PlyType) -> Result<PointCloud, PlyError> {
     // open the file
     let file = std::fs::File::open(path)?;
     let mut reader = std::io::BufReader::new(file);
 
     // read the header
-    // TODO support other formats headers
     let mut header = String::new();
     loop {
         let mut line = String::new();
         reader.read_line(&mut line)?;
         if line.starts_with("end_header") {
+            header.push_str(&line);
             break;
         }
         header.push_str(&line);
     }
+    println!("{:?}", header);
 
     // create a buffer for the points
     let mut buffer = vec![0u8; property.size_of()];
@@ -59,18 +41,10 @@ pub fn read_ply_binary(
     let mut normals = Vec::new();
 
     while reader.read_exact(&mut buffer).is_ok() {
-        match property {
-            PlyProperty::OpenSplat => {
-                let property: OpenSplatProperty = bincode::deserialize(&buffer)?;
-                points.push([property.x as f64, property.y as f64, property.z as f64]);
-                colors.push([
-                    (property.f_dc_0 * 255.0) as u8,
-                    (property.f_dc_1 * 255.0) as u8,
-                    (property.f_dc_2 * 255.0) as u8,
-                ]);
-                normals.push([property.nx as f64, property.ny as f64, property.nz as f64]);
-            }
-        }
+        let property_entry = property.deserialize(&buffer)?;
+        points.push(property_entry.to_point());
+        colors.push(property_entry.to_color());
+        normals.push(property_entry.to_normal());
     }
 
     Ok(PointCloud::new(points, Some(colors), Some(normals)))

--- a/crates/kornia-3d/src/io/ply/properties.rs
+++ b/crates/kornia-3d/src/io/ply/properties.rs
@@ -1,21 +1,58 @@
 use serde::Deserialize;
 
+use super::PlyError;
+
 /// Supported PLY properties.
 #[derive(Debug, PartialEq)]
-pub enum PlyProperty {
+pub enum PlyType {
     OpenSplat,
+    XYZRgbNormals,
 }
 
-impl PlyProperty {
-    /// Get the size of the property in bytes.
-    pub fn size_of(&self) -> usize {
-        match self {
-            PlyProperty::OpenSplat => std::mem::size_of::<OpenSplatProperty>(),
-        }
+/// Trait to represent the PLY property.
+pub trait PlyPropertyTrait {
+    /// Convert the property to a point.
+    fn to_point(&self) -> [f64; 3];
+
+    /// Convert the property to a color.
+    fn to_color(&self) -> [u8; 3];
+
+    /// Convert the property to a normal.
+    fn to_normal(&self) -> [f64; 3];
+}
+
+/// Header of the XYZRgbNormals PLY file format.
+///
+/// Contains points, colors, and normals.
+#[derive(Debug, Deserialize)]
+pub struct XYZRgbNormalsProperty {
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+    pub red: u8,
+    pub green: u8,
+    pub blue: u8,
+    pub nx: f32,
+    pub ny: f32,
+    pub nz: f32,
+}
+
+impl PlyPropertyTrait for XYZRgbNormalsProperty {
+    fn to_point(&self) -> [f64; 3] {
+        //println!("x: {}, y: {}, z: {}", self.x, self.y, self.z);
+        [self.x as f64, self.y as f64, self.z as f64]
+    }
+
+    fn to_color(&self) -> [u8; 3] {
+        [self.red, self.green, self.blue]
+    }
+
+    fn to_normal(&self) -> [f64; 3] {
+        [self.nx as f64, self.ny as f64, self.nz as f64]
     }
 }
 
-/// Header of the OpenSplat PLY file format.
+///// Header of the OpenSplat PLY file format.
 /// REF: https://github.com/pierotofy/OpenSplat
 #[derive(Debug, Deserialize)]
 pub struct OpenSplatProperty {
@@ -81,4 +118,74 @@ pub struct OpenSplatProperty {
     pub rot_1: f32,
     pub rot_2: f32,
     pub rot_3: f32,
+}
+
+impl PlyPropertyTrait for OpenSplatProperty {
+    fn to_point(&self) -> [f64; 3] {
+        [self.x as f64, self.y as f64, self.z as f64]
+    }
+
+    fn to_color(&self) -> [u8; 3] {
+        [
+            (self.f_dc_0 * 255.0) as u8,
+            (self.f_dc_1 * 255.0) as u8,
+            (self.f_dc_2 * 255.0) as u8,
+        ]
+    }
+
+    fn to_normal(&self) -> [f64; 3] {
+        [self.nx as f64, self.ny as f64, self.nz as f64]
+    }
+}
+
+/// Enum to represent the PLY property.
+pub enum PlyProperty {
+    OpenSplat(OpenSplatProperty),
+    XYZRgbNormals(XYZRgbNormalsProperty),
+}
+
+impl PlyType {
+    /// Deserialize the property from the buffer.
+    pub fn deserialize(&self, buffer: &[u8]) -> Result<PlyProperty, PlyError> {
+        match self {
+            PlyType::OpenSplat => {
+                let property: OpenSplatProperty = bincode::deserialize(buffer)?;
+                Ok(PlyProperty::OpenSplat(property))
+            }
+            PlyType::XYZRgbNormals => {
+                let property: XYZRgbNormalsProperty = bincode::deserialize(buffer)?;
+                Ok(PlyProperty::XYZRgbNormals(property))
+            }
+        }
+    }
+
+    pub fn size_of(&self) -> usize {
+        match self {
+            PlyType::OpenSplat => std::mem::size_of::<OpenSplatProperty>(),
+            PlyType::XYZRgbNormals => std::mem::size_of::<XYZRgbNormalsProperty>(),
+        }
+    }
+}
+
+impl PlyPropertyTrait for PlyProperty {
+    fn to_point(&self) -> [f64; 3] {
+        match self {
+            PlyProperty::OpenSplat(property) => property.to_point(),
+            PlyProperty::XYZRgbNormals(property) => property.to_point(),
+        }
+    }
+
+    fn to_color(&self) -> [u8; 3] {
+        match self {
+            PlyProperty::OpenSplat(property) => property.to_color(),
+            PlyProperty::XYZRgbNormals(property) => property.to_color(),
+        }
+    }
+
+    fn to_normal(&self) -> [f64; 3] {
+        match self {
+            PlyProperty::OpenSplat(property) => property.to_normal(),
+            PlyProperty::XYZRgbNormals(property) => property.to_normal(),
+        }
+    }
 }

--- a/crates/kornia-3d/src/io/ply/properties.rs
+++ b/crates/kornia-3d/src/io/ply/properties.rs
@@ -40,7 +40,6 @@ pub struct XYZRgbNormalsProperty {
 
 impl PlyPropertyTrait for XYZRgbNormalsProperty {
     fn to_point(&self) -> [f64; 3] {
-        //println!("x: {}, y: {}, z: {}", self.x, self.y, self.z);
         [self.x as f64, self.y as f64, self.z as f64]
     }
 
@@ -53,7 +52,7 @@ impl PlyPropertyTrait for XYZRgbNormalsProperty {
     }
 }
 
-///// Header of the OpenSplat PLY file format.
+/// Header of the OpenSplat PLY file format.
 /// REF: https://github.com/pierotofy/OpenSplat
 #[repr(packed)]
 #[derive(Debug, Deserialize)]

--- a/crates/kornia-3d/src/io/ply/properties.rs
+++ b/crates/kornia-3d/src/io/ply/properties.rs
@@ -24,6 +24,7 @@ pub trait PlyPropertyTrait {
 /// Header of the XYZRgbNormals PLY file format.
 ///
 /// Contains points, colors, and normals.
+#[repr(packed)]
 #[derive(Debug, Deserialize)]
 pub struct XYZRgbNormalsProperty {
     pub x: f32,
@@ -54,6 +55,7 @@ impl PlyPropertyTrait for XYZRgbNormalsProperty {
 
 ///// Header of the OpenSplat PLY file format.
 /// REF: https://github.com/pierotofy/OpenSplat
+#[repr(packed)]
 #[derive(Debug, Deserialize)]
 pub struct OpenSplatProperty {
     pub x: f32,
@@ -140,7 +142,7 @@ impl PlyPropertyTrait for OpenSplatProperty {
 
 /// Enum to represent the PLY property.
 pub enum PlyProperty {
-    OpenSplat(OpenSplatProperty),
+    OpenSplat(Box<OpenSplatProperty>),
     XYZRgbNormals(XYZRgbNormalsProperty),
 }
 
@@ -150,7 +152,7 @@ impl PlyType {
         match self {
             PlyType::OpenSplat => {
                 let property: OpenSplatProperty = bincode::deserialize(buffer)?;
-                Ok(PlyProperty::OpenSplat(property))
+                Ok(PlyProperty::OpenSplat(Box::new(property)))
             }
             PlyType::XYZRgbNormals => {
                 let property: XYZRgbNormalsProperty = bincode::deserialize(buffer)?;

--- a/examples/ply_rerun/README.md
+++ b/examples/ply_rerun/README.md
@@ -1,4 +1,4 @@
-Example showing how to read a PLY file from OpenSplat and visualize it using Rerun.io
+Example showing how to read a PLY file from ClouCompare and visualize it using Rerun.io
 
 ```bash
 Usage: ply_rerun --ply-path <ply-path> --ply-type <ply-type>
@@ -17,8 +17,7 @@ Example:
 cargo run -p ply_rerun -- --ply-path banana.ply --ply-type default
 ```
 
-NOTE: Get the `banana.ply` file from [here](https://drive.google.com/file/d/12lmvVWpFlFPL6nxl2e2d-4u4a31RCSKT/view?usp=sharing).
-
 Output:
 
-![rerun_banana](https://github.com/user-attachments/assets/e6c926b0-77bd-4073-acdd-508f39da0cf6)
+https://github.com/user-attachments/assets/ead3b767-4b57-4e3f-8bcf-0f93fe6ab962
+

--- a/examples/ply_rerun/README.md
+++ b/examples/ply_rerun/README.md
@@ -1,17 +1,20 @@
 Example showing how to read a PLY file from OpenSplat and visualize it using Rerun.io
 
 ```bash
-Usage: ply-rerun --ply-path <PLY_PATH>
+Usage: ply_rerun --ply-path <ply-path> --ply-type <ply-type>
+
+Read a PLY file and log it to Rerun
 
 Options:
-  -p, --ply-path <PLY_PATH>
-  -h, --help                     Print help
+  --ply-path        path to the PLY file
+  --ply-type        property type to read
+  --help            display usage information
 ```
 
 Example:
 
 ```bash
-cargo run -p ply-rerun -- --ply-path banana.ply
+cargo run -p ply_rerun -- --ply-path banana.ply --ply-type default
 ```
 
 NOTE: Get the `banana.ply` file from [here](https://drive.google.com/file/d/12lmvVWpFlFPL6nxl2e2d-4u4a31RCSKT/view?usp=sharing).

--- a/examples/ply_rerun/src/main.rs
+++ b/examples/ply_rerun/src/main.rs
@@ -10,7 +10,7 @@ struct Args {
     #[argh(option)]
     ply_path: PathBuf,
 
-    /// property to read
+    /// property type to read
     #[argh(option)]
     ply_type: String,
 }

--- a/examples/ply_rerun/src/main.rs
+++ b/examples/ply_rerun/src/main.rs
@@ -9,14 +9,23 @@ struct Args {
     /// path to the PLY file
     #[argh(option)]
     ply_path: PathBuf,
+
+    /// property to read
+    #[argh(option)]
+    ply_type: String,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Args = argh::from_env();
 
+    let ply_type = match args.ply_type.to_lowercase().as_str() {
+        "default" => k3d::io::ply::PlyType::XYZRgbNormals,
+        "opensplat" => k3d::io::ply::PlyType::OpenSplat,
+        _ => return Err(format!("Unsupported property: {}", args.ply_type).into()),
+    };
+
     // read the image
-    let pointcloud =
-        k3d::io::ply::read_ply_binary(args.ply_path, k3d::io::ply::PlyProperty::OpenSplat)?;
+    let pointcloud = k3d::io::ply::read_ply_binary(args.ply_path, ply_type)?;
     println!("Read #{} points", pointcloud.len());
 
     // create a Rerun recording stream


### PR DESCRIPTION
This pull request introduces significant enhancements to the PLY file handling in the `kornia-3d` crate, including support for additional PLY formats and refactoring of existing code to improve modularity and readability.

https://github.com/user-attachments/assets/56a9657f-e126-499e-a530-79897ffea88c

Key changes include:

### PLY Error Handling and Enum Refactoring:
* Added a new `PlyError` enum in `crates/kornia-3d/src/io/ply/mod.rs` for standardized error handling across PLY operations.
* Refactored the `PlyProperty` enum to `PlyType` and introduced the `PlyPropertyTrait` trait to handle different PLY property types more generically.

### PLY Property Handling:
* Implemented the `PlyPropertyTrait` for `OpenSplatProperty` and `XYZRgbNormalsProperty` to convert properties to points, colors, and normals.
* Updated the `read_ply_binary` function to use the new `PlyType` enum and `PlyPropertyTrait` for deserialization and property handling.

### Parser and Property Updates:
* Updated the `read_ply_binary` function to support the `XYZRgbNormals` PLY format in addition to the existing `OpenSplat` format.
* Added the `XYZRgbNormalsProperty` struct to represent the new PLY format.

### Example and Documentation Updates:
* Updated the example in `examples/ply_rerun` to include a new `--ply-type` argument, allowing users to specify the PLY property type to read. [[1]](diffhunk://#diff-2b25e15fbd129743cb158b28159ba2dc584f254fc27409efd804f4c39f454c69L4-R17) [[2]](diffhunk://#diff-2701568f793d8ad64d0b875829f56a60c6905e33038eee9f1c4d294fdb64af9cR12-R28)