### PR TITLE
Bumpt fast resize

### DIFF
--- a/crates/kornia-imgproc/Cargo.toml
+++ b/crates/kornia-imgproc/Cargo.toml
@@ -11,7 +11,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-fast_image_resize = "3.0.4"
+fast_image_resize = "5.1.0"
 kornia-core = { workspace = true }
 kornia-image = { workspace = true }
 num-traits = { workspace = true }


### PR DESCRIPTION
This pull request includes several updates to the `kornia-imgproc` crate, primarily focusing on updating dependencies and refactoring the image resizing code to improve performance and maintainability. The most important changes are listed below:

Dependency updates:
* [`crates/kornia-imgproc/Cargo.toml`](diffhunk://#diff-d446f6d1509e77bfc7093c37b96ae3a3e7390609f73c7ec7b430b9486c47223cL14-R14): Updated the `fast_image_resize` dependency from version `3.0.4` to `5.1.0`.

Code refactoring:
* [`crates/kornia-imgproc/src/resize.rs`](diffhunk://#diff-ce256f3c43d4a27bbe09f39e4ed5d90f82c701a8f60fcc70253ea626a8fb9d8eL7): Removed the `NonZeroU32` import as it is no longer used in the code.
* [`crates/kornia-imgproc/src/resize.rs`](diffhunk://#diff-ce256f3c43d4a27bbe09f39e4ed5d90f82c701a8f60fcc70253ea626a8fb9d8eL160-R190): Refactored the `resize_fast` function to use the new API of the `fast_image_resize` crate. This includes changes to how the source and destination images are prepared and how the resizer is configured and used.