### PR TITLE
create Image and Tensor/Storage from parts

### DIFF
--- a/crates/kornia-image/src/image.rs
+++ b/crates/kornia-image/src/image.rs
@@ -169,6 +169,29 @@ impl<T, const C: usize> Image<T, C> {
         Ok(image)
     }
 
+    /// Create a new image from raw parts.
+    ///
+    /// # Arguments
+    ///
+    /// * `size` - The size of the image in pixels.
+    /// * `data` - A pointer to the pixel data.
+    /// * `len` - The length of the pixel data.
+    ///
+    /// # Returns
+    ///
+    /// A new image created from the given size and pixel data.
+    pub unsafe fn from_raw_parts(
+        size: ImageSize,
+        data: *const T,
+        len: usize,
+    ) -> Result<Self, ImageError>
+    where
+        T: Clone,
+    {
+        let tensor = Tensor::from_raw_parts([size.height, size.width, C], data, len, CpuAllocator)?;
+        Image::try_from(tensor)
+    }
+
     /// Create a new image from a slice of pixel data.
     ///
     /// # Arguments

--- a/crates/kornia-tensor/src/allocator.rs
+++ b/crates/kornia-tensor/src/allocator.rs
@@ -75,7 +75,9 @@ impl TensorAllocator for CpuAllocator {
     /// The pointer must be non-null and the layout must be correct.
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        unsafe { alloc::dealloc(ptr, layout) }
+        if !ptr.is_null() {
+            unsafe { alloc::dealloc(ptr, layout) }
+        }
     }
 }
 

--- a/crates/kornia-tensor/src/storage.rs
+++ b/crates/kornia-tensor/src/storage.rs
@@ -86,6 +86,10 @@ impl<T, A: TensorAllocator> TensorStorage<T, A> {
     }
 
     /// Creates a new tensor buffer from a raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// The pointer must be non-null and the length must be valid.
     pub unsafe fn from_raw_parts(data: *const T, len: usize, alloc: A) -> Self {
         let ptr = NonNull::new_unchecked(data as _);
         let layout = Layout::from_size_align_unchecked(len, std::mem::size_of::<T>());

--- a/crates/kornia-tensor/src/tensor.rs
+++ b/crates/kornia-tensor/src/tensor.rs
@@ -216,6 +216,10 @@ where
     /// * `data` - A pointer to the data of the tensor.
     /// * `len` - The length of the data.
     /// * `alloc` - The allocator to use.
+    ///
+    /// # Safety
+    ///
+    /// The pointer must be non-null and the length must be valid.
     pub unsafe fn from_raw_parts(
         shape: [usize; N],
         data: *const T,

--- a/crates/kornia-tensor/src/tensor.rs
+++ b/crates/kornia-tensor/src/tensor.rs
@@ -208,6 +208,33 @@ where
         })
     }
 
+    /// Creates a new `Tensor` with the given shape and raw parts.
+    ///
+    /// # Arguments
+    ///
+    /// * `shape` - An array containing the shape of the tensor.
+    /// * `data` - A pointer to the data of the tensor.
+    /// * `len` - The length of the data.
+    /// * `alloc` - The allocator to use.
+    pub unsafe fn from_raw_parts(
+        shape: [usize; N],
+        data: *const T,
+        len: usize,
+        alloc: A,
+    ) -> Result<Self, TensorError>
+    where
+        T: Clone,
+    {
+        let storage = TensorStorage::from_raw_parts(data, len, alloc);
+        let strides = get_strides_from_shape(shape);
+        Ok(Self {
+            storage,
+            shape,
+            strides,
+        })
+    }
+
+    /// Creates a new `Tensor` with the given shape and a default value.
     /// Creates a new `Tensor` with the given shape and a default value.
     ///
     /// # Arguments
@@ -1579,6 +1606,16 @@ mod tests {
         assert!(t
             .get_index(12)
             .is_err_and(|x| x == TensorError::IndexOutOfBounds(12)));
+        Ok(())
+    }
+
+    #[test]
+    fn from_raw_parts() -> Result<(), TensorError> {
+        let data: Vec<u8> = vec![1, 2, 3, 4];
+        let t = unsafe { Tensor::from_raw_parts([2, 2], data.as_ptr(), data.len(), CpuAllocator)? };
+        std::mem::forget(data);
+        assert_eq!(t.shape, [2, 2]);
+        assert_eq!(t.as_slice(), &[1, 2, 3, 4]);
         Ok(())
     }
 }


### PR DESCRIPTION
This pull request includes several important changes to the `kornia-image` and `kornia-tensor` crates. The changes introduce new methods for creating images and tensors from raw parts, add corresponding tests, and improve memory safety checks in deallocation.

Needed by: https://github.com/copper-project/copper-rs/pull/193/files

New methods for creating images and tensors from raw parts:

* [`crates/kornia-image/src/image.rs`](diffhunk://#diff-d7c919b32e685719baf394dd4faedad8e3f13d3ed905d1ac09cb91ceb3b6618fR172-R197): Added the `from_raw_parts` method to the `Image` struct, which allows creating an image from raw parts. This method includes safety documentation and argument descriptions.
* [`crates/kornia-tensor/src/storage.rs`](diffhunk://#diff-9bceae2c8e26efdd86f447b2f7916b10181a76194b8d743d968b0c2797bb6de2R88-R103): Added the `from_raw_parts` method to the `TensorStorage` struct, enabling the creation of tensor storage from raw parts. This method includes safety documentation.
* [`crates/kornia-tensor/src/tensor.rs`](diffhunk://#diff-79e99646606722ba787c4dc536950ea99c34bd2a5d075e625e7dafd02dd45ac9R211-R241): Added the `from_raw_parts` method to the `Tensor` struct, allowing the creation of a tensor from raw parts. This method includes safety documentation and argument descriptions.

Tests for new methods:

* [`crates/kornia-image/src/image.rs`](diffhunk://#diff-d7c919b32e685719baf394dd4faedad8e3f13d3ed905d1ac09cb91ceb3b6618fR683-R694): Added a test for the `from_raw_parts` method in the `mod tests` section to ensure the method works correctly.
* [`crates/kornia-tensor/src/tensor.rs`](diffhunk://#diff-79e99646606722ba787c4dc536950ea99c34bd2a5d075e625e7dafd02dd45ac9R1615-R1624): Added a test for the `from_raw_parts` method in the `mod tests` section to verify its functionality.

Memory safety improvements:

* [`crates/kornia-tensor/src/allocator.rs`](diffhunk://#diff-8e9fdac6ab400db9ac406599a8b5c4bb6767adef01d8a543cbd0cc9543bda52fR78-R82): Added a null pointer check before deallocating memory in the `dealloc` method of the `CpuAllocator` struct to improve memory safety.