### PR TITLE
implement bincode for tensor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ kornia = { path = "crates/kornia", version = "0.1.8-rc.1" }
 # dev dependencies for workspace
 argh = "0.1"
 approx = "0.5"
+bincode = { version = "2.0.0-rc.3", features = ["serde"] }
 criterion = "0.5"
 env_logger = "0.11"
 faer = "0.20.1"

--- a/crates/kornia-tensor/Cargo.toml
+++ b/crates/kornia-tensor/Cargo.toml
@@ -12,5 +12,13 @@ version.workspace = true
 
 [dependencies]
 num-traits = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, optional = true }
+bincode = { workspace = true, optional = true }
 thiserror = { workspace = true }
+
+[features]
+serde = ["dep:serde"]
+bincode = ["dep:bincode"]
+
+[dev-dependencies]
+serde_json = "1"

--- a/crates/kornia-tensor/src/bincode.rs
+++ b/crates/kornia-tensor/src/bincode.rs
@@ -12,8 +12,8 @@ where
         &self,
         encoder: &mut E,
     ) -> Result<(), bincode::error::EncodeError> {
-        bincode::Encode::encode(&self.shape.to_vec(), encoder)?;
-        bincode::Encode::encode(&self.strides.to_vec(), encoder)?;
+        bincode::Encode::encode(&self.shape, encoder)?;
+        bincode::Encode::encode(&self.strides, encoder)?;
         bincode::Encode::encode(&self.storage.as_slice(), encoder)?;
         Ok(())
     }
@@ -26,12 +26,12 @@ where
     fn decode<D: bincode::de::Decoder>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {
-        let shape: Vec<usize> = bincode::Decode::decode(decoder)?;
-        let strides: Vec<usize> = bincode::Decode::decode(decoder)?;
-        let data: Vec<T> = bincode::Decode::decode(decoder)?;
+        let shape = bincode::Decode::decode(decoder)?;
+        let strides = bincode::Decode::decode(decoder)?;
+        let data = bincode::Decode::decode(decoder)?;
         Ok(Self {
-            shape: shape.try_into().expect("shape is not valid"),
-            strides: strides.try_into().expect("strides is not valid"),
+            shape,
+            strides,
             storage: TensorStorage::from_vec(data, CpuAllocator),
         })
     }

--- a/crates/kornia-tensor/src/bincode.rs
+++ b/crates/kornia-tensor/src/bincode.rs
@@ -1,0 +1,59 @@
+use crate::{
+    allocator::{CpuAllocator, TensorAllocator},
+    storage::TensorStorage,
+    Tensor,
+};
+
+impl<T, const N: usize, A: TensorAllocator + 'static> bincode::enc::Encode for Tensor<T, N, A>
+where
+    T: bincode::enc::Encode + 'static,
+{
+    fn encode<E: bincode::enc::Encoder>(
+        &self,
+        encoder: &mut E,
+    ) -> Result<(), bincode::error::EncodeError> {
+        bincode::Encode::encode(&self.shape.to_vec(), encoder)?;
+        bincode::Encode::encode(&self.strides.to_vec(), encoder)?;
+        bincode::Encode::encode(&self.storage.as_slice(), encoder)?;
+        Ok(())
+    }
+}
+
+impl<T, const N: usize> bincode::de::Decode for Tensor<T, N, CpuAllocator>
+where
+    T: bincode::de::Decode + 'static,
+{
+    fn decode<D: bincode::de::Decoder>(
+        decoder: &mut D,
+    ) -> Result<Self, bincode::error::DecodeError> {
+        let shape: Vec<usize> = bincode::Decode::decode(decoder)?;
+        let strides: Vec<usize> = bincode::Decode::decode(decoder)?;
+        let data: Vec<T> = bincode::Decode::decode(decoder)?;
+        Ok(Self {
+            shape: shape.try_into().expect("shape is not valid"),
+            strides: strides.try_into().expect("strides is not valid"),
+            storage: TensorStorage::from_vec(data, CpuAllocator),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bincode() -> Result<(), Box<dyn std::error::Error>> {
+        let tensor = Tensor::<u8, 2, CpuAllocator>::from_shape_vec(
+            [2, 3],
+            vec![1, 2, 3, 4, 5, 6],
+            CpuAllocator,
+        )?;
+        let mut serialized = vec![0u8; 100];
+        let config = bincode::config::standard();
+        let length = bincode::encode_into_slice(&tensor, &mut serialized, config)?;
+        let deserialized: (Tensor<u8, 2, CpuAllocator>, usize) =
+            bincode::decode_from_slice(&serialized[..length], config)?;
+        assert_eq!(tensor.as_slice(), deserialized.0.as_slice());
+        Ok(())
+    }
+}

--- a/crates/kornia-tensor/src/lib.rs
+++ b/crates/kornia-tensor/src/lib.rs
@@ -4,10 +4,15 @@
 /// allocator module containing the memory management utilities.
 pub mod allocator;
 
+/// bincode module containing the serialization and deserialization utilities.
+#[cfg(feature = "bincode")]
+pub mod bincode;
+
 /// tensor module containing the tensor and storage implementations.
 pub mod tensor;
 
 /// serde module containing the serialization and deserialization utilities.
+#[cfg(feature = "serde")]
 pub mod serde;
 
 /// storage module containing the storage implementations.

--- a/crates/kornia-tensor/src/serde.rs
+++ b/crates/kornia-tensor/src/serde.rs
@@ -59,3 +59,19 @@ where
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::allocator::CpuAllocator;
+
+    #[test]
+    fn test_serde() -> Result<(), Box<dyn std::error::Error>> {
+        let data = vec![1, 2, 3, 4, 5, 6];
+        let tensor = Tensor::<u8, 2, CpuAllocator>::from_shape_vec([2, 3], data, CpuAllocator)?;
+        let serialized = serde_json::to_string(&tensor)?;
+        let deserialized: Tensor<u8, 2, CpuAllocator> = serde_json::from_str(&serialized)?;
+        assert_eq!(tensor.as_slice(), deserialized.as_slice());
+        Ok(())
+    }
+}

--- a/justfile
+++ b/justfile
@@ -34,6 +34,11 @@ clean:
 test name='':
   @cargo test {{ name }}
 
+# Test the code with all features
+test-all:
+  @cargo test --all-features
+
+
 # ------------------------------------------------------------------------------
 # Recipes for the kornia-py project
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This pull request introduces several changes to add support for `bincode` serialization and deserialization to the `kornia-tensor` crate. The changes include updates to dependencies, new module implementations, and additional test cases.

### Dependency updates:
* Added `bincode` as a dependency in `Cargo.toml` and made `serde` and `bincode` optional dependencies in `crates/kornia-tensor/Cargo.toml`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R39) [[2]](diffhunk://#diff-fd43adde823ced4d13b0c4119a4a997b798994f48ab67affb37471fe10cbc6ccL15-R24)

### Serialization and deserialization implementation:
* Implemented `bincode` serialization and deserialization for the `Tensor` struct in `crates/kornia-tensor/src/bincode.rs`.
* Added `bincode` module to `crates/kornia-tensor/src/lib.rs`.

### Testing:
* Added test cases for `bincode` serialization and deserialization in `crates/kornia-tensor/src/bincode.rs`.
* Added test cases for `serde` serialization and deserialization in `crates/kornia-tensor/src/serde.rs`.

### Build and test scripts:
* Added a new `test-all` recipe to the `justfile` to test the code with all features enabled.