### PR TITLE
Simplify stream capture and remove thread

### DIFF
--- a/crates/kornia-io/src/stream/capture.rs
+++ b/crates/kornia-io/src/stream/capture.rs
@@ -35,7 +35,7 @@ impl StreamCapture {
     }
 
     /// Starts the stream capture pipeline and processes messages on the bus.
-    pub fn start(&mut self) -> Result<(), StreamCaptureError> {
+    pub fn start(&self) -> Result<(), StreamCaptureError> {
         self.pipeline.set_state(gst::State::Playing)?;
 
         let bus = self
@@ -63,7 +63,7 @@ impl StreamCapture {
     }
 
     /// Closes the stream capture pipeline.
-    pub fn close(&mut self) -> Result<(), StreamCaptureError> {
+    pub fn close(&self) -> Result<(), StreamCaptureError> {
         let res = self.pipeline.send_event(gst::event::Eos::new());
         if !res {
             return Err(StreamCaptureError::SendEosError);

--- a/crates/kornia-io/src/stream/capture.rs
+++ b/crates/kornia-io/src/stream/capture.rs
@@ -1,15 +1,11 @@
-use std::sync::{Arc, Mutex};
-
 use crate::stream::error::StreamCaptureError;
 use gst::prelude::*;
-use kornia_image::{Image, ImageSize};
+use kornia_image::Image;
 
 /// Represents a stream capture pipeline using GStreamer.
 pub struct StreamCapture {
     pipeline: gst::Pipeline,
-    last_frame: Arc<Mutex<Option<Image<u8, 3>>>>,
-    running: bool,
-    handle: Option<std::thread::JoinHandle<()>>,
+    appsink: gst_app::AppSink,
 }
 
 impl StreamCapture {
@@ -35,64 +31,20 @@ impl StreamCapture {
             .dynamic_cast::<gst_app::AppSink>()
             .map_err(StreamCaptureError::DowncastPipelineError)?;
 
-        let last_frame = Arc::new(Mutex::new(None));
-
-        appsink.set_callbacks(
-            gst_app::AppSinkCallbacks::builder()
-                .new_sample({
-                    let last_frame = last_frame.clone();
-                    move |sink| match Self::extract_image_frame(sink) {
-                        Ok(frame) => {
-                            // SAFETY: we have a lock on the last_frame
-                            *last_frame.lock().unwrap() = Some(frame);
-                            Ok(gst::FlowSuccess::Ok)
-                        }
-                        Err(_) => Err(gst::FlowError::Error),
-                    }
-                })
-                .build(),
-        );
-
-        Ok(Self {
-            pipeline,
-            last_frame,
-            running: false,
-            handle: None,
-        })
+        Ok(Self { pipeline, appsink })
     }
 
     /// Starts the stream capture pipeline and processes messages on the bus.
     pub fn start(&mut self) -> Result<(), StreamCaptureError> {
         self.pipeline.set_state(gst::State::Playing)?;
-        self.running = true;
 
         let bus = self
             .pipeline
             .bus()
             .ok_or_else(|| StreamCaptureError::BusError)?;
 
-        let handle = std::thread::spawn(move || {
-            for msg in bus.iter_timed(gst::ClockTime::NONE) {
-                use gst::MessageView;
-                match msg.view() {
-                    MessageView::Eos(..) => {
-                        break;
-                    }
-                    MessageView::Error(err) => {
-                        eprintln!(
-                            "Error from {:?}: {} ({:?})",
-                            msg.src().map(|s| s.path_string()),
-                            err.error(),
-                            err.debug()
-                        );
-                        break;
-                    }
-                    _ => (),
-                }
-            }
-        });
-
-        self.handle = Some(handle);
+        // handle bus messages
+        bus.set_sync_handler(|_bus, _msg| gst::BusSyncReply::Pass);
 
         Ok(())
     }
@@ -103,12 +55,11 @@ impl StreamCapture {
     ///
     /// An Option containing the last captured Image or None if no image has been captured yet.
     pub fn grab(&self) -> Result<Option<Image<u8, 3>>, StreamCaptureError> {
-        if !self.running {
-            return Err(StreamCaptureError::PipelineNotRunning);
-        }
-
-        // SAFETY: we have a lock on the last_frame
-        Ok(self.last_frame.lock().unwrap().take())
+        // NOTE: this is a blocking call with a timeout of 1ns, so it should not block the thread at all
+        self.appsink
+            .try_pull_sample(gst::ClockTime::from_nseconds(1))
+            .map(Self::extract_image_frame)
+            .transpose()
     }
 
     /// Closes the stream capture pipeline.
@@ -118,12 +69,8 @@ impl StreamCapture {
             return Err(StreamCaptureError::SendEosError);
         }
 
-        if let Some(handle) = self.handle.take() {
-            handle.join().expect("Failed to join thread");
-        }
-
         self.pipeline.set_state(gst::State::Null)?;
-        self.running = false;
+
         Ok(())
     }
 
@@ -131,14 +78,12 @@ impl StreamCapture {
     ///
     /// # Arguments
     ///
-    /// * `appsink` - The AppSink to extract the frame from.
+    /// * `sample` - The sample to extract the frame from.
     ///
     /// # Returns
     ///
     /// A Result containing the extracted Image or a StreamCaptureError.
-    fn extract_image_frame(appsink: &gst_app::AppSink) -> Result<Image<u8, 3>, StreamCaptureError> {
-        let sample = appsink.pull_sample()?;
-
+    fn extract_image_frame(sample: gst::Sample) -> Result<Image<u8, 3>, StreamCaptureError> {
         let caps = sample
             .caps()
             .ok_or_else(|| StreamCaptureError::GetCapsError)?;
@@ -160,7 +105,7 @@ impl StreamCapture {
             .ok_or_else(|| StreamCaptureError::GetBufferError)?
             .map_readable()?;
 
-        Image::<u8, 3>::new(ImageSize { width, height }, buffer.as_slice().to_vec())
+        Image::<u8, 3>::new([width, height].into(), buffer.to_owned())
             .map_err(|_| StreamCaptureError::CreateImageFrameError)
     }
 }

--- a/crates/kornia-io/src/stream/capture.rs
+++ b/crates/kornia-io/src/stream/capture.rs
@@ -55,9 +55,8 @@ impl StreamCapture {
     ///
     /// An Option containing the last captured Image or None if no image has been captured yet.
     pub fn grab(&self) -> Result<Option<Image<u8, 3>>, StreamCaptureError> {
-        // NOTE: this is a blocking call with a timeout of 1ns, so it should not block the thread at all
         self.appsink
-            .try_pull_sample(gst::ClockTime::from_nseconds(1))
+            .try_pull_sample(gst::ClockTime::ZERO)
             .map(Self::extract_image_frame)
             .transpose()
     }

--- a/examples/features/src/main.rs
+++ b/examples/features/src/main.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // create a webcam capture object with camera id 0
     // and force the image size to 640x480
-    let mut webcam = V4L2CameraConfig::new().with_size(size).build()?;
+    let webcam = V4L2CameraConfig::new().with_size(size).build()?;
 
     // start the background pipeline
     webcam.start()?;

--- a/examples/filters/src/main.rs
+++ b/examples/filters/src/main.rs
@@ -45,7 +45,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // create a webcam capture object with camera id 0
     // and force the image size to 640x480
-    let mut webcam = V4L2CameraConfig::new().with_size(size).build()?;
+    let webcam = V4L2CameraConfig::new().with_size(size).build()?;
 
     // start the background pipeline
     webcam.start()?;

--- a/examples/rtspcam/src/main.rs
+++ b/examples/rtspcam/src/main.rs
@@ -34,7 +34,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("Kornia Rtsp Stream Capture App").spawn()?;
 
     //// create a stream capture object
-    let mut capture = RTSPCameraConfig::new()
+    let capture = RTSPCameraConfig::new()
         .with_settings(
             &args.username,
             &args.password,

--- a/examples/video_write/src/main.rs
+++ b/examples/video_write/src/main.rs
@@ -46,7 +46,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // create a webcam capture object with camera id 0
     // and force the image size to 640x480
-    let mut webcam = V4L2CameraConfig::new()
+    let webcam = V4L2CameraConfig::new()
         .with_camera_id(args.camera_id)
         .with_fps(args.fps as u32)
         .with_size(frame_size)

--- a/examples/webcam/src/main.rs
+++ b/examples/webcam/src/main.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // create a webcam capture object with camera id 0
     // and force the image size to 640x480
-    let mut webcam = V4L2CameraConfig::new()
+    let webcam = V4L2CameraConfig::new()
         .with_camera_id(args.camera_id)
         .with_fps(args.fps)
         .with_size(ImageSize {

--- a/kornia-viz/src/bin/app.rs
+++ b/kornia-viz/src/bin/app.rs
@@ -27,7 +27,7 @@ struct KorniaApp {
 
 impl Default for KorniaApp {
     fn default() -> Self {
-        let mut capture = kornia::io::stream::V4L2CameraConfig::new()
+        let capture = kornia::io::stream::V4L2CameraConfig::new()
             .with_camera_id(0)
             .build()
             .unwrap();


### PR DESCRIPTION
This pull request includes significant refactoring and simplification of the `StreamCapture` implementation in the `kornia-io` crate, as well as minor changes in several example files to remove unnecessary mutability.

Refactoring and simplification of `StreamCapture`:

* Removed the use of `Arc` and `Mutex` for `last_frame` and simplified the `StreamCapture` struct by replacing `last_frame` and `handle` with `appsink` (`crates/kornia-io/src/stream/capture.rs`, [crates/kornia-io/src/stream/capture.rsL1-R8](diffhunk://#diff-54772eec9f4df3e91b9766d5d6e901987ebd59b387782130671c1b1590abcb73L1-R8)).
* Simplified the `start` method by removing the thread handling and using `bus.set_sync_handler` to handle bus messages (`crates/kornia-io/src/stream/capture.rs`, [crates/kornia-io/src/stream/capture.rsL38-R47](diffhunk://#diff-54772eec9f4df3e91b9766d5d6e901987ebd59b387782130671c1b1590abcb73L38-R47)).
* Updated the `grab` method to use `appsink.try_pull_sample` instead of accessing `last_frame` (`crates/kornia-io/src/stream/capture.rs`, [crates/kornia-io/src/stream/capture.rsL106-R85](diffhunk://#diff-54772eec9f4df3e91b9766d5d6e901987ebd59b387782130671c1b1590abcb73L106-R85)).
* Simplified the `extract_image_frame` method by directly using the sample parameter instead of pulling it from `appsink` (`crates/kornia-io/src/stream/capture.rs`, [crates/kornia-io/src/stream/capture.rsL163-R107](diffhunk://#diff-54772eec9f4df3e91b9766d5d6e901987ebd59b387782130671c1b1590abcb73L163-R107)).

Removal of unnecessary mutability in example files:

* Removed `mut` from `webcam` and `capture` variable declarations in multiple example files (`examples/features/src/main.rs`, `examples/filters/src/main.rs`, `examples/rtspcam/src/main.rs`, `examples/video_write/src/main.rs`, `examples/webcam/src/main.rs`, [[1]](diffhunk://#diff-d1a9507751fe51694dbd92de394bf843c7e461cbb589405f4cfc81673f4dcdefL21-R21) [[2]](diffhunk://#diff-71e8dfecc00af3373cf6094b7df3b55e5897729730c33dacd7e1d23ac3df6b05L48-R48) [[3]](diffhunk://#diff-6e3aa130805ec86c1a27b8a401ff5021b6be0b9da40acf97f38007fbe2477903L37-R37) [[4]](diffhunk://#diff-66462c9c2b48ecd5a3227420cf2c9fcdd10aca589e5823aa70607aa9e147a4f0L49-R49) [[5]](diffhunk://#diff-8281947bc35843098a4e7d0250a24662cc25ef0dbfcf51da82a70d74ca2cd967L33-R33).