### PR TITLE
Use Gstreamer Buffer map in StreamCapture

### DIFF
--- a/crates/kornia-io/Cargo.toml
+++ b/crates/kornia-io/Cargo.toml
@@ -20,8 +20,8 @@ log = { workspace = true }
 thiserror = { workspace = true }
 
 # optional dependencies
-gst = { version = "0.23.0", package = "gstreamer", optional = true }
-gst-app = { version = "0.23.0", package = "gstreamer-app", optional = true }
+gst = { version = "0.23.4", package = "gstreamer", optional = true }
+gst-app = { version = "0.23.4", package = "gstreamer-app", optional = true }
 memmap2 = "0.9.4"
 turbojpeg = { version = "1.0.0", optional = true }
 

--- a/crates/kornia-io/src/stream/capture.rs
+++ b/crates/kornia-io/src/stream/capture.rs
@@ -96,6 +96,8 @@ impl StreamCapture {
             .map_err(|_| StreamCaptureError::LockError)?;
 
         last_frame.take().map_or(Ok(None), |frame_buffer| {
+            // TODO: solve the zero copy issue
+            // https://discourse.gstreamer.org/t/zero-copy-video-frames/3856/2
             let img = Image::<u8, 3>::new(
                 [frame_buffer.width, frame_buffer.height].into(),
                 frame_buffer.buffer.to_owned(),

--- a/crates/kornia-io/src/stream/capture.rs
+++ b/crates/kornia-io/src/stream/capture.rs
@@ -159,9 +159,6 @@ impl StreamCapture {
         };
 
         Ok(frame_buffer)
-
-        //Image::<u8, 3>::new([width, height].into(), buffer.to_owned())
-        //    .map_err(|_| StreamCaptureError::CreateImageFrameError)
     }
 }
 

--- a/crates/kornia-io/src/stream/error.rs
+++ b/crates/kornia-io/src/stream/error.rs
@@ -79,6 +79,10 @@ pub enum StreamCaptureError {
     /// An error occurred when the pipeline is not running.
     #[error("Pipeline is not running")]
     PipelineNotRunning,
+
+    /// An error occurred when the allocator is not found.
+    #[error("Cannot lock the last frame")]
+    LockError,
 }
 
 // ensure that can be sent over threads

--- a/examples/features/src/main.rs
+++ b/examples/features/src/main.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // create a webcam capture object with camera id 0
     // and force the image size to 640x480
-    let webcam = V4L2CameraConfig::new().with_size(size).build()?;
+    let mut webcam = V4L2CameraConfig::new().with_size(size).build()?;
 
     // start the background pipeline
     webcam.start()?;

--- a/examples/filters/src/main.rs
+++ b/examples/filters/src/main.rs
@@ -45,7 +45,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // create a webcam capture object with camera id 0
     // and force the image size to 640x480
-    let webcam = V4L2CameraConfig::new().with_size(size).build()?;
+    let mut webcam = V4L2CameraConfig::new().with_size(size).build()?;
 
     // start the background pipeline
     webcam.start()?;

--- a/examples/rtspcam/src/main.rs
+++ b/examples/rtspcam/src/main.rs
@@ -34,7 +34,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("Kornia Rtsp Stream Capture App").spawn()?;
 
     //// create a stream capture object
-    let capture = RTSPCameraConfig::new()
+    let mut capture = RTSPCameraConfig::new()
         .with_settings(
             &args.username,
             &args.password,

--- a/examples/video_write/src/main.rs
+++ b/examples/video_write/src/main.rs
@@ -46,7 +46,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // create a webcam capture object with camera id 0
     // and force the image size to 640x480
-    let webcam = V4L2CameraConfig::new()
+    let mut webcam = V4L2CameraConfig::new()
         .with_camera_id(args.camera_id)
         .with_fps(args.fps as u32)
         .with_size(frame_size)

--- a/examples/webcam/src/main.rs
+++ b/examples/webcam/src/main.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // create a webcam capture object with camera id 0
     // and force the image size to 640x480
-    let webcam = V4L2CameraConfig::new()
+    let mut webcam = V4L2CameraConfig::new()
         .with_camera_id(args.camera_id)
         .with_fps(args.fps)
         .with_size(ImageSize {


### PR DESCRIPTION
After discussion: https://discourse.gstreamer.org/t/zero-copy-video-frames/3856/2

This pull request includes several changes to improve the functionality and reliability of the stream capture pipeline in the `kornia-io` crate. The most significant changes involve updating dependencies, introducing a new `FrameBuffer` struct, and modifying the `StreamCapture` implementation to use this new struct. Additionally, there are minor changes to example files to ensure proper mutability of capture objects.

Updates and Dependency Changes:

* Updated `gst` and `gst-app` dependencies to version `0.23.4` in `Cargo.toml`.

Stream Capture Improvements:

* Introduced a new `FrameBuffer` struct to store the frame buffer, width, and height.
* Modified the `StreamCapture` struct to include a `last_frame` field, which is an `Arc<Mutex<Option<FrameBuffer>>>`.
* Updated the `StreamCapture::new` method to set callbacks on `appsink` for capturing new samples and storing them in `last_frame`.
* Changed the `StreamCapture::grab` method to retrieve the last frame from `last_frame` and convert it to an `Image`.
* Refactored the `extract_frame_buffer` method to extract a `FrameBuffer` from the `AppSink`.

Error Handling:

* Added a new `LockError` variant to the `StreamCaptureError` enum to handle errors when locking the `last_frame` mutex.

Example Code Adjustments:

* Updated various example files to ensure capture objects are mutable by using `let mut` instead of `let`. [[1]](diffhunk://#diff-d1a9507751fe51694dbd92de394bf843c7e461cbb589405f4cfc81673f4dcdefL21-R21) [[2]](diffhunk://#diff-71e8dfecc00af3373cf6094b7df3b55e5897729730c33dacd7e1d23ac3df6b05L48-R48) [[3]](diffhunk://#diff-6e3aa130805ec86c1a27b8a401ff5021b6be0b9da40acf97f38007fbe2477903L37-R37) [[4]](diffhunk://#diff-66462c9c2b48ecd5a3227420cf2c9fcdd10aca589e5823aa70607aa9e147a4f0L49-R49) [[5]](diffhunk://#diff-8281947bc35843098a4e7d0250a24662cc25ef0dbfcf51da82a70d74ca2cd967L33-R33)