### PR TITLE
refactor ci pipelines

### DIFF
--- a/.github/workflows/rust_lint.yml
+++ b/.github/workflows/rust_lint.yml
@@ -14,43 +14,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: rustup toolchain install stable --component rustfmt
+      - run: cargo fmt --all -- --check
 
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
-      - uses: giraffate/clippy-action@v1
-        with:
-          reporter: 'github-pr-review'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          clippy_flags: -- -D warnings
+      - run: rustup toolchain install stable --component clippy
+      - run: cargo clippy --all-features -- -D warnings
 
   check:
     name: Check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all --all-features
-          use-cross: true
+      - run: rustup toolchain install stable
+      - run: cargo check --all --all-features

--- a/.github/workflows/rust_lint.yml
+++ b/.github/workflows/rust_lint.yml
@@ -23,7 +23,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: rustup toolchain install stable --component clippy
-      - run: cargo clippy --all-features -- -D warnings
+      - name: Install cross
+        run: cargo install cross
+      - run: cross clippy --all-features -- -D warnings
 
   check:
     name: Check
@@ -31,4 +33,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: rustup toolchain install stable
-      - run: cargo check --all --all-features
+      - name: Install cross
+        run: cargo install cross
+      - run: cross check --all --all-features

--- a/.github/workflows/rust_lint.yml
+++ b/.github/workflows/rust_lint.yml
@@ -22,10 +22,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: rustup toolchain install stable --component clippy
-      - name: Install cross
-        run: cargo install cross
-      - run: cross clippy --all-features -- -D warnings
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: giraffate/clippy-action@v1
+        with:
+          reporter: 'github-pr-review'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          clippy_flags: -- -D warnings
 
   check:
     name: Check

--- a/.github/workflows/rust_test.yml
+++ b/.github/workflows/rust_test.yml
@@ -21,30 +21,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          target: ${{ matrix.target }}
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --target ${{ matrix.target }} --all-features
-          use-cross: true
+
+      - name: Install Rust toolchain
+        run: |
+          rustup update stable
+          rustup target add ${{ matrix.target }}
+          rustup default stable
+
+      - name: Install cross-compilation tools
+        run: cargo install cross --locked
+
+      - name: Run tests
+        run: cross test --target ${{ matrix.target }} --all-features
+
   build_examples:
     name: Build Examples
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          target: x86_64-unknown-linux-gnu
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --examples
-          use-cross: true
+
+      - name: Install Rust toolchain
+        run: |
+          rustup update stable
+          rustup target add x86_64-unknown-linux-gnu
+          rustup default stable
+
+      - name: Install cross-compilation tools
+        run: cargo install cross --locked
+
+      - name: Build examples
+        run: cross build --examples

--- a/.github/workflows/rust_test.yml
+++ b/.github/workflows/rust_test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         target:
-          - i686-unknown-linux-gnu
+          #- i686-unknown-linux-gnu
           - x86_64-unknown-linux-gnu
           - aarch64-unknown-linux-gnu
 

--- a/devel-x86_64.Dockerfile
+++ b/devel-x86_64.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.81
+FROM rust:1.83
 
 RUN rustup update stable
 


### PR DESCRIPTION
This pull request includes several updates to the GitHub Actions workflows and a Dockerfile to improve the Rust toolchain installation and usage. The changes simplify the setup process and ensure the use of the latest stable Rust version.

Improvements to GitHub Actions workflows:

* [`.github/workflows/rust_lint.yml`](diffhunk://#diff-28463188e5bcf22600fa82f6d59c8a38cc226e9ca959375b2e40bb6b6940a340L17-R18): Replaced the use of `actions-rs/toolchain` and `actions-rs/cargo` with direct `rustup` and `cargo` commands for installing the Rust toolchain and running `rustfmt` and `clippy`. [[1]](diffhunk://#diff-28463188e5bcf22600fa82f6d59c8a38cc226e9ca959375b2e40bb6b6940a340L17-R18) [[2]](diffhunk://#diff-28463188e5bcf22600fa82f6d59c8a38cc226e9ca959375b2e40bb6b6940a340L47-R42)
* [`.github/workflows/rust_test.yml`](diffhunk://#diff-c4aa2f31e21e0c7019edb15e7cecf7d02515badbbb305bae1317b151e940c95cL17-R53): Updated the workflow to use direct `rustup` and `cargo` commands for installing the Rust toolchain, adding targets, and running tests. Also commented out the `i686-unknown-linux-gnu` target.

Dockerfile update:

* [`devel-x86_64.Dockerfile`](diffhunk://#diff-780e204f3a9bec1e3d9b5ac2342451495cd1885374839c51a849a4d0d338994dL1-R1): Updated the base image from Rust version 1.81 to 1.83.