### PR TITLE
kornia_io: refactor jpegturbo api and specify image types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,8 @@ resolver = "2"
 members = [
     "crates/*",
     "examples/*",
-    # "kornia-py",
     "kornia-viz",
+    # "kornia-py",
 ]
 exclude = ["kornia-py"]
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ use kornia::io::functional as F;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // read the image
-    let image: Image<u8, 3> = F::read_image_any("tests/data/dog.jpeg")?;
+    let image: Image<u8, 3> = F::read_image_any_rgb8("tests/data/dog.jpeg")?;
 
     println!("Hello, world! 🦀");
     println!("Loaded Image size: {:?}", image.size());
@@ -84,17 +84,18 @@ Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-kornia = "v0.1.7"
+kornia = "v0.1.8"
 ```
 
 Alternatively, you can use each sub-crate separately:
 
 ```toml
 [dependencies]
-kornia-core = { git = "https://github.com/kornia/kornia-rs", tag = "v0.1.7" }
-kornia-io = { git = "https://github.com/kornia/kornia-rs", tag = "v0.1.7" }
-kornia-image = { git = "https://github.com/kornia/kornia-rs", tag = "v0.1.7" }
-kornia-imgproc = { git = "https://github.com/kornia/kornia-rs", tag = "v0.1.7" }
+kornia-tensor = { git = "https://github.com/kornia/kornia-rs", tag = "v0.1.8" }
+kornia-io = { git = "https://github.com/kornia/kornia-rs", tag = "v0.1.8" }
+kornia-image = { git = "https://github.com/kornia/kornia-rs", tag = "v0.1.8" }
+kornia-imgproc = { git = "https://github.com/kornia/kornia-rs", tag = "v0.1.8" }
+kornia-3d = { git = "https://github.com/kornia/kornia-rs", tag = "v0.1.8" }
 ```
 
 ### 🐍 Python
@@ -115,7 +116,7 @@ use kornia::io::functional as F;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // read the image
-    let image: Image<u8, 3> = F::read_image_any("tests/data/dog.jpeg")?;
+    let image: Image<u8, 3> = F::read_image_any_rgb8("tests/data/dog.jpeg")?;
     let image_viz = image.clone();
 
     let image_f32: Image<f32, 3> = image.cast_and_scale::<f32>(1.0 / 255.0)?;

--- a/crates/kornia-imgproc/src/color/gray.rs
+++ b/crates/kornia-imgproc/src/color/gray.rs
@@ -162,7 +162,7 @@ mod tests {
 
     #[test]
     fn gray_from_rgb() -> Result<(), Box<dyn std::error::Error>> {
-        let image = F::read_image_any("../../tests/data/dog.jpeg")?;
+        let image = F::read_image_any_rgb8("../../tests/data/dog.jpeg")?;
 
         let mut image_norm = Image::from_size_val(image.size(), 0.0)?;
         ops::cast_and_scale(&image, &mut image_norm, 1. / 255.0)?;
@@ -171,8 +171,8 @@ mod tests {
         super::gray_from_rgb(&image_norm, &mut gray)?;
 
         assert_eq!(gray.num_channels(), 1);
-        assert_eq!(gray.size().width, 258);
-        assert_eq!(gray.size().height, 195);
+        assert_eq!(gray.cols(), 258);
+        assert_eq!(gray.rows(), 195);
 
         Ok(())
     }

--- a/crates/kornia-io/Cargo.toml
+++ b/crates/kornia-io/Cargo.toml
@@ -23,8 +23,7 @@ thiserror = { workspace = true }
 # optional dependencies
 gst = { version = "0.23.4", package = "gstreamer", optional = true }
 gst-app = { version = "0.23.4", package = "gstreamer-app", optional = true }
-memmap2 = "0.9.4"
-turbojpeg = { version = "1.0.0", optional = true }
+turbojpeg = { version = "1.2", optional = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
@@ -32,7 +31,7 @@ tempfile = { workspace = true }
 
 [features]
 gstreamer = ["gst", "gst-app"]
-jpegturbo = ["turbojpeg"]
+turbojpeg = ["dep:turbojpeg"]
 
 [[bench]]
 name = "bench_io"

--- a/crates/kornia-io/benches/bench_io.rs
+++ b/crates/kornia-io/benches/bench_io.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
-use kornia_io::functional::{read_image_any, read_image_jpeg};
+use kornia_io::functional::{read_image_any_rgb8, read_image_jpegturbo_rgb8};
 
 fn bench_read_jpeg(c: &mut Criterion) {
     let mut group = c.benchmark_group("JpegReader");
@@ -9,11 +9,11 @@ fn bench_read_jpeg(c: &mut Criterion) {
 
     // NOTE: this is the fastest method
     group.bench_function("jpegturbo", |b| {
-        b.iter(|| black_box(read_image_jpeg(img_path)).unwrap())
+        b.iter(|| black_box(read_image_jpegturbo_rgb8(img_path)).unwrap())
     });
 
     group.bench_function("image_any", |b| {
-        b.iter(|| black_box(read_image_any(img_path).unwrap()))
+        b.iter(|| black_box(read_image_any_rgb8(img_path)).unwrap())
     });
 
     group.finish();

--- a/crates/kornia-io/src/error.rs
+++ b/crates/kornia-io/src/error.rs
@@ -14,9 +14,9 @@ pub enum IoError {
     FileError(#[from] std::io::Error),
 
     /// Error to map the file to memory.
-    #[cfg(feature = "jpegturbo")]
+    #[cfg(feature = "turbojpeg")]
     #[error("Error with Jpeg encoding/decoding")]
-    JpegError(#[from] crate::jpeg::JpegError),
+    JpegTurboError(#[from] crate::jpegturbo::JpegTurboError),
 
     /// Error to create the image.
     #[error("Failed to create image")]

--- a/crates/kornia-io/src/functional.rs
+++ b/crates/kornia-io/src/functional.rs
@@ -4,11 +4,11 @@ use kornia_image::{Image, ImageSize};
 
 use crate::error::IoError;
 
-#[cfg(feature = "jpegturbo")]
-use super::jpeg::{ImageDecoder, ImageEncoder};
+#[cfg(feature = "turbojpeg")]
+use super::jpegturbo::{JpegTurboDecoder, JpegTurboEncoder};
 
-#[cfg(feature = "jpegturbo")]
-/// Reads a JPEG image from the given file path.
+#[cfg(feature = "turbojpeg")]
+/// Reads a JPEG image in `RGB8` format from the given file path.
 ///
 /// The method reads the JPEG image data directly from a file leveraging the libjpeg-turbo library.
 ///
@@ -26,13 +26,13 @@ use super::jpeg::{ImageDecoder, ImageEncoder};
 /// use kornia_image::Image;
 /// use kornia_io::functional as F;
 ///
-/// let image: Image<u8, 3> = F::read_image_jpeg("../../tests/data/dog.jpeg").unwrap();
+/// let image: Image<u8, 3> = F::read_image_jpegturbo_rgb8("../../tests/data/dog.jpeg").unwrap();
 ///
-/// assert_eq!(image.size().width, 258);
-/// assert_eq!(image.size().height, 195);
+/// assert_eq!(image.cols(), 258);
+/// assert_eq!(image.rows(), 195);
 /// assert_eq!(image.num_channels(), 3);
 /// ```
-pub fn read_image_jpeg(file_path: impl AsRef<Path>) -> Result<Image<u8, 3>, IoError> {
+pub fn read_image_jpegturbo_rgb8(file_path: impl AsRef<Path>) -> Result<Image<u8, 3>, IoError> {
     let file_path = file_path.as_ref().to_owned();
     // verify the file exists and is a JPEG
     if !file_path.exists() {
@@ -46,30 +46,32 @@ pub fn read_image_jpeg(file_path: impl AsRef<Path>) -> Result<Image<u8, 3>, IoEr
     }
 
     // open the file and map it to memory
-    let file = std::fs::File::open(file_path)?;
-    let mmap = unsafe { memmap2::Mmap::map(&file)? };
+    let jpeg_data = std::fs::read(file_path)?;
 
     // decode the data directly from memory
     let image: Image<u8, 3> = {
-        let mut decoder = ImageDecoder::new()?;
-        decoder.decode(&mmap)?
+        let mut decoder = JpegTurboDecoder::new()?;
+        decoder.decode_rgb8(&jpeg_data)?
     };
 
     Ok(image)
 }
 
-#[cfg(feature = "jpegturbo")]
+#[cfg(feature = "turbojpeg")]
 /// Writes the given JPEG data to the given file path.
 ///
 /// # Arguments
 ///
 /// * `file_path` - The path to the JPEG image.
 /// * `image` - The tensor containing the JPEG image data.
-pub fn write_image_jpeg(file_path: impl AsRef<Path>, image: &Image<u8, 3>) -> Result<(), IoError> {
+pub fn write_image_jpegturbo_rgb8(
+    file_path: impl AsRef<Path>,
+    image: &Image<u8, 3>,
+) -> Result<(), IoError> {
     let file_path = file_path.as_ref().to_owned();
 
     // compress the image
-    let jpeg_data = ImageEncoder::new()?.encode(image)?;
+    let jpeg_data = JpegTurboEncoder::new()?.encode_rgb8(image)?;
 
     // write the data directly to a file
     std::fs::write(file_path, jpeg_data)?;
@@ -77,7 +79,7 @@ pub fn write_image_jpeg(file_path: impl AsRef<Path>, image: &Image<u8, 3>) -> Re
     Ok(())
 }
 
-/// Reads an image from the given file path.
+/// Reads a RGB8 image from the given file path.
 ///
 /// The method tries to read from any image format supported by the image crate.
 ///
@@ -87,7 +89,7 @@ pub fn write_image_jpeg(file_path: impl AsRef<Path>, image: &Image<u8, 3>) -> Re
 ///
 /// # Returns
 ///
-/// A tensor containing the image data.
+/// A tensor image containing the image data in RGB8 format with shape (H, W, 3).
 ///
 /// # Example
 ///
@@ -95,13 +97,13 @@ pub fn write_image_jpeg(file_path: impl AsRef<Path>, image: &Image<u8, 3>) -> Re
 /// use kornia_image::Image;
 /// use kornia_io::functional as F;
 ///
-/// let image: Image<u8, 3> = F::read_image_any("../../tests/data/dog.jpeg").unwrap();
+/// let image: Image<u8, 3> = F::read_image_any_rgb8("../../tests/data/dog.jpeg").unwrap();
 ///
-/// assert_eq!(image.size().width, 258);
-/// assert_eq!(image.size().height, 195);
+/// assert_eq!(image.cols(), 258);
+/// assert_eq!(image.rows(), 195);
 /// assert_eq!(image.num_channels(), 3);
 /// ```
-pub fn read_image_any(file_path: impl AsRef<Path>) -> Result<Image<u8, 3>, IoError> {
+pub fn read_image_any_rgb8(file_path: impl AsRef<Path>) -> Result<Image<u8, 3>, IoError> {
     let file_path = file_path.as_ref().to_owned();
 
     // verify the file exists
@@ -110,13 +112,10 @@ pub fn read_image_any(file_path: impl AsRef<Path>) -> Result<Image<u8, 3>, IoErr
     }
 
     // open the file and map it to memory
-    let file = std::fs::File::open(file_path)?;
-    let mmap = unsafe { memmap2::Mmap::map(&file)? };
+    let jpeg_data = std::fs::read(file_path)?;
 
     // decode the data directly from memory
-    // TODO: update the image crate
-    #[allow(deprecated)]
-    let img = image::io::Reader::new(std::io::Cursor::new(&mmap))
+    let img = image::ImageReader::new(std::io::Cursor::new(&jpeg_data))
         .with_guessed_format()?
         .decode()?;
 
@@ -136,43 +135,43 @@ pub fn read_image_any(file_path: impl AsRef<Path>) -> Result<Image<u8, 3>, IoErr
 #[cfg(test)]
 mod tests {
     use crate::error::IoError;
-    use crate::functional::read_image_any;
+    use crate::functional::read_image_any_rgb8;
 
-    #[cfg(feature = "jpegturbo")]
-    use crate::functional::{read_image_jpeg, write_image_jpeg};
+    #[cfg(feature = "turbojpeg")]
+    use crate::functional::{read_image_jpegturbo_rgb8, write_image_jpegturbo_rgb8};
 
     #[test]
     fn read_any() -> Result<(), IoError> {
-        let image = read_image_any("../../tests/data/dog.jpeg")?;
-        assert_eq!(image.size().width, 258);
-        assert_eq!(image.size().height, 195);
+        let image = read_image_any_rgb8("../../tests/data/dog.jpeg")?;
+        assert_eq!(image.cols(), 258);
+        assert_eq!(image.rows(), 195);
         Ok(())
     }
 
     #[test]
-    #[cfg(feature = "jpegturbo")]
+    #[cfg(feature = "turbojpeg")]
     fn read_jpeg() -> Result<(), IoError> {
-        let image = read_image_jpeg("../../tests/data/dog.jpeg")?;
-        assert_eq!(image.size().width, 258);
-        assert_eq!(image.size().height, 195);
+        let image = read_image_jpegturbo_rgb8("../../tests/data/dog.jpeg")?;
+        assert_eq!(image.cols(), 258);
+        assert_eq!(image.rows(), 195);
         Ok(())
     }
 
     #[test]
-    #[cfg(feature = "jpegturbo")]
+    #[cfg(feature = "turbojpeg")]
     fn read_write_jpeg() -> Result<(), IoError> {
         let tmp_dir = tempfile::tempdir()?;
         std::fs::create_dir_all(tmp_dir.path())?;
 
         let file_path = tmp_dir.path().join("dog.jpeg");
-        let image_data = read_image_jpeg("../../tests/data/dog.jpeg")?;
-        write_image_jpeg(&file_path, &image_data)?;
+        let image_data = read_image_jpegturbo_rgb8("../../tests/data/dog.jpeg")?;
+        write_image_jpegturbo_rgb8(&file_path, &image_data)?;
 
-        let image_data_back = read_image_jpeg(&file_path)?;
+        let image_data_back = read_image_jpegturbo_rgb8(&file_path)?;
         assert!(file_path.exists(), "File does not exist: {:?}", file_path);
 
-        assert_eq!(image_data_back.size().width, 258);
-        assert_eq!(image_data_back.size().height, 195);
+        assert_eq!(image_data_back.cols(), 258);
+        assert_eq!(image_data_back.rows(), 195);
         assert_eq!(image_data_back.num_channels(), 3);
 
         Ok(())

--- a/crates/kornia-io/src/lib.rs
+++ b/crates/kornia-io/src/lib.rs
@@ -11,8 +11,8 @@ pub mod fps_counter;
 pub mod functional;
 
 /// TurboJPEG image encoding and decoding.
-#[cfg(feature = "jpegturbo")]
-pub mod jpeg;
+#[cfg(feature = "turbojpeg")]
+pub mod jpegturbo;
 
 /// PNG image encoding and decoding.
 pub mod png;

--- a/crates/kornia/Cargo.toml
+++ b/crates/kornia/Cargo.toml
@@ -13,7 +13,7 @@ version.workspace = true
 
 [features]
 gstreamer = ["kornia-io/gstreamer"]
-jpegturbo = ["kornia-io/jpegturbo"]
+turbojpeg = ["kornia-io/turbojpeg"]
 
 [dependencies]
 kornia-tensor.workspace = true

--- a/examples/binarize/src/main.rs
+++ b/examples/binarize/src/main.rs
@@ -14,7 +14,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
     // read the image
-    let image: Image<u8, 3> = F::read_image_any(args.image_path)?;
+    let image: Image<u8, 3> = F::read_image_any_rgb8(args.image_path)?;
 
     // binarize the image as u8
     let mut bin = Image::<u8, 3>::from_size_val(image.size(), 0)?;

--- a/examples/color_detector/src/main.rs
+++ b/examples/color_detector/src/main.rs
@@ -15,7 +15,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
     // read the image
-    let rgb = F::read_image_any(args.image_path)?;
+    let rgb = F::read_image_any_rgb8(args.image_path)?;
 
     // cast the image to f32
     let mut rgb_f32 = Image::<f32, 3>::from_size_val(rgb.size(), 0.0)?;

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -14,7 +14,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
     // read the image
-    let image: Image<u8, 3> = F::read_image_any(args.image_path)?;
+    let image: Image<u8, 3> = F::read_image_any_rgb8(args.image_path)?;
 
     println!("Hello, world! 🦀");
     println!("Loaded Image size: {:?}", image.size());

--- a/examples/histogram/src/main.rs
+++ b/examples/histogram/src/main.rs
@@ -17,7 +17,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
     // read the image
-    let image: Image<u8, 3> = F::read_image_any(args.image_path)?;
+    let image: Image<u8, 3> = F::read_image_any_rgb8(args.image_path)?;
 
     // compute the histogram per channel
     let histograms = image

--- a/examples/imgproc/src/main.rs
+++ b/examples/imgproc/src/main.rs
@@ -17,7 +17,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
     // read the image
-    let image: Image<u8, 3> = F::read_image_any(args.image_path)?;
+    let image: Image<u8, 3> = F::read_image_any_rgb8(args.image_path)?;
 
     // convert the image to f32 and scale it
     let mut image_f32 = Image::<f32, 3>::from_size_val(image.size(), 0.0)?;

--- a/examples/metrics/src/main.rs
+++ b/examples/metrics/src/main.rs
@@ -17,7 +17,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
     // read the image
-    let image: Image<u8, 3> = F::read_image_any(args.image_path)?;
+    let image: Image<u8, 3> = F::read_image_any_rgb8(args.image_path)?;
 
     // convert the image to f32 and scale it
     let mut image_f32 = Image::<f32, 3>::from_size_val(image.size(), 0.0)?;

--- a/examples/normalize/src/main.rs
+++ b/examples/normalize/src/main.rs
@@ -14,7 +14,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
     // read the image
-    let image: Image<u8, 3> = F::read_image_any(args.image_path)?;
+    let image: Image<u8, 3> = F::read_image_any_rgb8(args.image_path)?;
 
     // cast the image to floating point
     let image_f32 = image.clone().cast::<f32>()?;

--- a/examples/normalize_ii/src/main.rs
+++ b/examples/normalize_ii/src/main.rs
@@ -14,7 +14,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
     // read the image
-    let image: Image<u8, 3> = F::read_image_any(args.image_path)?;
+    let image: Image<u8, 3> = F::read_image_any_rgb8(args.image_path)?;
 
     // cast the image to floating point
     let image_f32: Image<f32, 3> = image.cast_and_scale::<f32>(1.0 / 255.0)?;

--- a/examples/onnx/src/main.rs
+++ b/examples/onnx/src/main.rs
@@ -45,7 +45,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     std::env::set_var("ORT_DYLIB_PATH", &args.ort_dylib_path);
 
     // read the image
-    let image: Image<u8, 3> = F::read_image_any(&args.image_path)?;
+    let image: Image<u8, 3> = F::read_image_any_rgb8(&args.image_path)?;
 
     // read the onnx model
 

--- a/examples/rerun_viz/src/main.rs
+++ b/examples/rerun_viz/src/main.rs
@@ -14,7 +14,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
     // read the image
-    let image: Image<u8, 3> = F::read_image_any(args.image_path)?;
+    let image: Image<u8, 3> = F::read_image_any_rgb8(args.image_path)?;
 
     // create a Rerun recording stream
     let rec = rerun::RecordingStreamBuilder::new("Kornia App").spawn()?;

--- a/examples/rotate/src/main.rs
+++ b/examples/rotate/src/main.rs
@@ -14,7 +14,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
     // read the image
-    let image: Image<u8, 3> = F::read_image_any(args.image_path)?;
+    let image: Image<u8, 3> = F::read_image_any_rgb8(args.image_path)?;
     let image: Image<f32, 3> = image.cast_and_scale::<f32>(1.0 / 255.0)?;
 
     let rec = rerun::RecordingStreamBuilder::new("Kornia App").spawn()?;

--- a/examples/std_mean/src/main.rs
+++ b/examples/std_mean/src/main.rs
@@ -70,7 +70,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .progress_with(pb)
         .for_each(|image_path| {
             // read the image
-            let image = F::read_image_any(image_path).expect("Failed to read image");
+            let image = F::read_image_any_rgb8(image_path).expect("Failed to read image");
 
             // compute the std and mean
             let (std, mean) = imgproc::core::std_mean(&image);

--- a/examples/undistort_image/src/main.rs
+++ b/examples/undistort_image/src/main.rs
@@ -21,7 +21,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
     // read the image
-    let img = F::read_image_any(args.image_path)?;
+    let img = F::read_image_any_rgb8(args.image_path)?;
 
     // the intrinsic parameters of an Oak-D camera
     let intrinsic = CameraIntrinsic {

--- a/justfile
+++ b/justfile
@@ -38,11 +38,9 @@ test name='':
 test-all:
   @cargo test --all-features
 
-
 # ------------------------------------------------------------------------------
 # Recipes for the kornia-py project
 # ------------------------------------------------------------------------------
-
 
 # Create virtual environment, and install dev requirements
 py-install py_version='3.9':

--- a/kornia-py/Cargo.toml
+++ b/kornia-py/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 # kornia
 kornia-image = { path = "../crates/kornia-image" }
 kornia-imgproc = { path = "../crates/kornia-imgproc" }
-kornia-io = { path = "../crates/kornia-io", features = ["jpegturbo"] }
+kornia-io = { path = "../crates/kornia-io", features = ["turbojpeg"] }
 
 # external
 pyo3 = { version = "0.23.0", features = ["extension-module"] }

--- a/kornia-py/justfile
+++ b/kornia-py/justfile
@@ -24,10 +24,10 @@ install py_version='3.9':
   @just install-dev {{ py_version }}
   uv pip install -e .
 
-
 # Test the code with pytest
-test:
+test py_version='3.9' flags='':
   @echo "🚀 Testing code: Running pytest"
+  @just build {{ py_version }} {{ flags }}
   @uv run pytest
 
 # Compile and install kornia-py for development (run maturin develop)

--- a/kornia-py/src/io/functional.rs
+++ b/kornia-py/src/io/functional.rs
@@ -6,7 +6,7 @@ use kornia_io::functional as F;
 
 #[pyfunction]
 pub fn read_image_jpeg(file_path: &str) -> PyResult<PyImage> {
-    let image = F::read_image_jpeg(file_path)
+    let image = F::read_image_jpegturbo_rgb8(file_path)
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyFileExistsError, _>(format!("{}", e)))?;
     Ok(image.to_pyimage())
 }
@@ -15,14 +15,14 @@ pub fn read_image_jpeg(file_path: &str) -> PyResult<PyImage> {
 pub fn write_image_jpeg(file_path: &str, image: PyImage) -> PyResult<()> {
     let image = Image::from_pyimage(image)
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
-    F::write_image_jpeg(file_path, &image)
+    F::write_image_jpegturbo_rgb8(file_path, &image)
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
     Ok(())
 }
 
 #[pyfunction]
 pub fn read_image_any(file_path: &str) -> PyResult<PyImage> {
-    let image = F::read_image_any(file_path)
+    let image = F::read_image_any_rgb8(file_path)
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyFileExistsError, _>(format!("{}", e)))?;
     Ok(image.to_pyimage())
 }

--- a/kornia-py/src/io/jpeg.rs
+++ b/kornia-py/src/io/jpeg.rs
@@ -1,19 +1,19 @@
 use kornia_image::Image;
-use kornia_io::jpeg::{ImageDecoder, ImageEncoder};
+use kornia_io::jpegturbo::{JpegTurboDecoder, JpegTurboEncoder};
 use pyo3::prelude::*;
 
 use crate::image::{FromPyImage, PyImage, PyImageSize, ToPyImage};
 
 #[pyclass(name = "ImageDecoder")]
 pub struct PyImageDecoder {
-    pub inner: ImageDecoder,
+    pub inner: JpegTurboDecoder,
 }
 
 #[pymethods]
 impl PyImageDecoder {
     #[new]
     pub fn new() -> PyResult<PyImageDecoder> {
-        let inner = ImageDecoder::new()
+        let inner = JpegTurboDecoder::new()
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
         Ok(PyImageDecoder { inner })
     }
@@ -29,7 +29,7 @@ impl PyImageDecoder {
     pub fn decode(&mut self, jpeg_data: &[u8]) -> PyResult<PyImage> {
         let image = self
             .inner
-            .decode(jpeg_data)
+            .decode_rgb8(jpeg_data)
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
         Ok(image.to_pyimage())
     }
@@ -37,14 +37,14 @@ impl PyImageDecoder {
 
 #[pyclass(name = "ImageEncoder")]
 pub struct PyImageEncoder {
-    pub inner: ImageEncoder,
+    pub inner: JpegTurboEncoder,
 }
 
 #[pymethods]
 impl PyImageEncoder {
     #[new]
     pub fn new() -> PyResult<PyImageEncoder> {
-        let inner = ImageEncoder::new()
+        let inner = JpegTurboEncoder::new()
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
         Ok(PyImageEncoder { inner })
     }
@@ -54,7 +54,7 @@ impl PyImageEncoder {
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
         let jpeg_data = self
             .inner
-            .encode(&image)
+            .encode_rgb8(&image)
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
         Ok(jpeg_data)
     }


### PR DESCRIPTION
This pull request includes several changes to the Kornia library, focusing on updating dependencies, renaming functions for clarity, and improving the handling of JPEG images using the turbojpeg library. The most important changes are grouped by theme below.

### Dependency Updates:
* Updated the `kornia` dependency version from `v0.1.7` to `v0.1.8` in `Cargo.toml` and `README.md`.
* Updated the `turbojpeg` dependency version from `1.0.0` to `1.2` in `crates/kornia-io/Cargo.toml`.

### Function Renaming and Refactoring:
* Renamed functions to include `_rgb8` suffix for clarity, such as `read_image_any` to `read_image_any_rgb8` and `read_image_jpeg` to `read_image_jpegturbo_rgb8` in `crates/kornia-io/src/functional.rs`. [[1]](diffhunk://#diff-066f8bb7233a0547534d17b285cbcce1bd3600f7f2e059c9dc6464aaa729c3d3L29-R35) [[2]](diffhunk://#diff-066f8bb7233a0547534d17b285cbcce1bd3600f7f2e059c9dc6464aaa729c3d3L90-R106)
* Updated function calls in `README.md` and test files to reflect the new function names. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R23) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L118-R119) [[3]](diffhunk://#diff-014d6b35f21545c5d54689cdad0f58a16cb91b5c20d28d359fc73d429f53054bL165-R165) [[4]](diffhunk://#diff-4ee5911ec5e7ebe0255fd50e2f552a8eb539101420ee3d7328e172cb9b38b53dL3-R3) [[5]](diffhunk://#diff-4ee5911ec5e7ebe0255fd50e2f552a8eb539101420ee3d7328e172cb9b38b53dL12-R16)

### JPEG Handling Improvements:
* Replaced `memmap2` with direct file reading for JPEG data in `crates/kornia-io/src/functional.rs`. [[1]](diffhunk://#diff-066f8bb7233a0547534d17b285cbcce1bd3600f7f2e059c9dc6464aaa729c3d3L49-R82) [[2]](diffhunk://#diff-066f8bb7233a0547534d17b285cbcce1bd3600f7f2e059c9dc6464aaa729c3d3L113-R118)
* Renamed `jpeg.rs` to `jpegturbo.rs` and updated relevant structs and error types to `JpegTurbo` in `crates/kornia-io/src/jpegturbo.rs`. [[1]](diffhunk://#diff-66b29b681b0ff0485470b26e88f8cee0296e06aae99fcf9af24892a31ee80b35L8-R8) [[2]](diffhunk://#diff-66b29b681b0ff0485470b26e88f8cee0296e06aae99fcf9af24892a31ee80b35L23-R34) [[3]](diffhunk://#diff-66b29b681b0ff0485470b26e88f8cee0296e06aae99fcf9af24892a31ee80b35L53-R53) [[4]](diffhunk://#diff-66b29b681b0ff0485470b26e88f8cee0296e06aae99fcf9af24892a31ee80b35L133-R164)

### Test and Example Updates:
* Updated tests and examples to use the new function names and improved JPEG handling in `crates/kornia-io/src/functional.rs` and `crates/kornia-imgproc/src/color/gray.rs`. [[1]](diffhunk://#diff-066f8bb7233a0547534d17b285cbcce1bd3600f7f2e059c9dc6464aaa729c3d3L139-R174) [[2]](diffhunk://#diff-014d6b35f21545c5d54689cdad0f58a16cb91b5c20d28d359fc73d429f53054bL174-R175)

### Miscellaneous:
* Added `kornia-py` back to the members list in `Cargo.toml`.