### PR TITLE
chore: bump version to v0.1.9-rc2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = ["kornia-py"]
 
 [workspace.package]
 authors = ["kornia.org <edgar@kornia.org>"]
-categories = ["computer-vision", "robotics"]
+categories = ["computer-vision", "science::robotics"]
 description = "Low-level 3D computer vision library in Rust"
 edition = "2021"
 homepage = "http://kornia.org"
@@ -20,18 +20,18 @@ license-file = "LICENSE"
 readme = "README.md"
 repository = "https://github.com/kornia/kornia-rs"
 rust-version = "1.76"
-version = "0.1.9-rc.1"
+version = "0.1.9-rc.2"
 
 [workspace.dependencies]
 # NOTE: remember to update the kornia-py package version in `kornia-py/Cargo.toml` when updating the Rust package version
-kornia-tensor = { path = "crates/kornia-tensor", version = "0.1.9-rc.1" }
-kornia-tensor-ops = { path = "crates/kornia-tensor-ops", version = "0.1.9-rc.1" }
-kornia-icp = { path = "crates/kornia-icp", version = "0.1.9-rc.1" }
-kornia-image = { path = "crates/kornia-image", version = "0.1.9-rc.1" }
-kornia-io = { path = "crates/kornia-io", version = "0.1.9-rc.1" }
-kornia-imgproc = { path = "crates/kornia-imgproc", version = "0.1.9-rc.1" }
-kornia-3d = { path = "crates/kornia-3d", version = "0.1.9-rc.1" }
-kornia = { path = "crates/kornia", version = "0.1.9-rc.1" }
+kornia-tensor = { path = "crates/kornia-tensor", version = "0.1.9-rc.2" }
+kornia-tensor-ops = { path = "crates/kornia-tensor-ops", version = "0.1.9-rc.2" }
+kornia-icp = { path = "crates/kornia-icp", version = "0.1.9-rc.2" }
+kornia-image = { path = "crates/kornia-image", version = "0.1.9-rc.2" }
+kornia-io = { path = "crates/kornia-io", version = "0.1.9-rc.2" }
+kornia-imgproc = { path = "crates/kornia-imgproc", version = "0.1.9-rc.2" }
+kornia-3d = { path = "crates/kornia-3d", version = "0.1.9-rc.2" }
+kornia = { path = "crates/kornia", version = "0.1.9-rc.2" }
 
 # dev dependencies for workspace
 argh = "0.1"

--- a/kornia-py/Cargo.toml
+++ b/kornia-py/Cargo.toml
@@ -8,7 +8,7 @@ include = ["Cargo.toml"]
 license = "Apache-2.0"
 repository = "https://github.com/kornia/kornia-rs"
 rust-version = "1.76"
-version = "0.1.9-rc.1"
+version = "0.1.9-rc.2"
 
 [lib]
 name = "kornia_rs"

--- a/scripts/release_rust.sh
+++ b/scripts/release_rust.sh
@@ -15,7 +15,7 @@ fi
 cross publish -p kornia-tensor --all-features $DRY_RUN
 cross publish -p kornia-tensor-ops $DRY_RUN
 cross publish -p kornia-image $DRY_RUN
-cross publish -p kornia-3d $DRY_RUsN
+cross publish -p kornia-3d $DRY_RUN
 cross publish -p kornia-icp $DRY_RUN
 cross publish -p kornia-io --all-features $DRY_RUN
 cross publish -p kornia-imgproc $DRY_RUN


### PR DESCRIPTION
This pull request includes updates to the `Cargo.toml` files and a script correction to ensure consistency and correct functionality across the project. The most important changes include updating the version numbers for multiple dependencies and correcting a typo in the release script.

Updates to `Cargo.toml` files:

* Updated category for the `kornia` package to "science::robotics" in `Cargo.toml`.
* Updated version numbers for multiple dependencies from "0.1.9-rc.1" to "0.1.9-rc.2" in `Cargo.toml` and `kornia-py/Cargo.toml`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L23-R34) [[2]](diffhunk://#diff-b578890f0af57d109322f0341862126b0c113a3203c7fbcedf2a7d9bf1308fd2L11-R11)

Script correction:

* Fixed a typo in the `scripts/release_rust.sh` script to ensure the correct variable `$DRY_RUN` is used.