### PR TITLE
kornia_py: expose icp algorithm to pyo3

### DIFF
--- a/crates/kornia-icp/src/icp_vanilla.rs
+++ b/crates/kornia-icp/src/icp_vanilla.rs
@@ -21,7 +21,7 @@ pub struct ICPResult {
 }
 
 /// Structure to define the ICP parameters.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ICPConvergenceCriteria {
     /// Maximum number of iterations to perform.
     pub max_iterations: usize,

--- a/kornia-py/.gitignore
+++ b/kornia-py/.gitignore
@@ -1,4 +1,5 @@
 target/
+uv.lock
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/kornia-py/Cargo.toml
+++ b/kornia-py/Cargo.toml
@@ -20,6 +20,8 @@ crate-type = ["cdylib"]
 kornia-image = { path = "../crates/kornia-image" }
 kornia-imgproc = { path = "../crates/kornia-imgproc" }
 kornia-io = { path = "../crates/kornia-io", features = ["turbojpeg"] }
+kornia-icp = { path = "../crates/kornia-icp" }
+kornia-3d = { path = "../crates/kornia-3d" }
 
 # external
 pyo3 = { version = "0.23.0", features = ["extension-module"] }

--- a/kornia-py/src/icp.rs
+++ b/kornia-py/src/icp.rs
@@ -1,0 +1,137 @@
+use numpy::{PyArray1, PyArray2, PyArrayMethods};
+use pyo3::prelude::*;
+
+use kornia_3d::pointcloud::PointCloud;
+use kornia_icp::{icp_vanilla as icp_vanilla_fn, ICPConvergenceCriteria, ICPResult};
+
+use crate::pointcloud::{FromPyPointCloud, PyPointCloud};
+
+#[pyclass(name = "ICPConvergenceCriteria")]
+#[derive(Clone)]
+pub struct PyICPConvergenceCriteria(ICPConvergenceCriteria);
+
+#[pymethods]
+impl PyICPConvergenceCriteria {
+    #[new]
+    pub fn new(max_iterations: usize, tolerance: f64) -> PyResult<PyICPConvergenceCriteria> {
+        Ok(PyICPConvergenceCriteria(ICPConvergenceCriteria {
+            max_iterations,
+            tolerance,
+        }))
+    }
+
+    #[getter]
+    pub fn max_iterations(&self) -> usize {
+        self.0.max_iterations
+    }
+
+    #[getter]
+    pub fn tolerance(&self) -> f64 {
+        self.0.tolerance
+    }
+
+    fn __str__(&self) -> PyResult<String> {
+        Ok(format!(
+            "ICPConvergenceCriteria(max_iterations: {}, tolerance: {})",
+            self.0.max_iterations, self.0.tolerance
+        ))
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(format!(
+            "ICPConvergenceCriteria(max_iterations: {}, tolerance: {})",
+            self.0.max_iterations, self.0.tolerance
+        ))
+    }
+}
+
+#[pyclass(name = "ICPResult")]
+pub struct PyICPResult(ICPResult);
+
+#[pymethods]
+impl PyICPResult {
+    #[new]
+    pub fn new() -> PyResult<PyICPResult> {
+        Ok(PyICPResult(ICPResult {
+            rotation: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+            translation: [0.0, 0.0, 0.0],
+            num_iterations: 0,
+            rmse: 0.0,
+        }))
+    }
+
+    #[getter]
+    pub fn rotation(&self) -> [[f64; 3]; 3] {
+        self.0.rotation
+    }
+
+    #[getter]
+    pub fn translation(&self) -> [f64; 3] {
+        self.0.translation
+    }
+
+    #[getter]
+    pub fn num_iterations(&self) -> usize {
+        self.0.num_iterations
+    }
+
+    #[getter]
+    pub fn rmse(&self) -> f64 {
+        self.0.rmse
+    }
+
+    fn __str__(&self) -> PyResult<String> {
+        Ok(format!(
+            "ICPResult(rotation: {:?}, translation: {:?}, num_iterations: {}, rmse: {})",
+            self.0.rotation, self.0.translation, self.0.num_iterations, self.0.rmse
+        ))
+    }
+
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(format!(
+            "ICPResult(rotation: {:?}, translation: {:?}, num_iterations: {}, rmse: {})",
+            self.0.rotation, self.0.translation, self.0.num_iterations, self.0.rmse
+        ))
+    }
+}
+
+#[pyfunction]
+pub fn icp_vanilla(
+    source: PyPointCloud,
+    target: PyPointCloud,
+    initial_rot: Py<PyArray2<f64>>,
+    initial_trans: Py<PyArray1<f64>>,
+    criteria: PyICPConvergenceCriteria,
+) -> PyResult<PyICPResult> {
+    let source = PointCloud::from_pypointcloud(source)
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
+
+    let target = PointCloud::from_pypointcloud(target)
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
+
+    // convert the initial rotation and translation to a vector
+    let initial_rot = Python::with_gil(|py| {
+        let array = initial_rot.bind(py);
+        let data_slice =
+            unsafe { array.as_slice() }.expect("Failed to convert initial rotation to vector");
+        [
+            [data_slice[0], data_slice[1], data_slice[2]],
+            [data_slice[3], data_slice[4], data_slice[5]],
+            [data_slice[6], data_slice[7], data_slice[8]],
+        ]
+    });
+
+    let initial_trans = Python::with_gil(|py| {
+        let array = initial_trans.bind(py);
+        let data_slice =
+            unsafe { array.as_slice() }.expect("Failed to convert initial translation to vector");
+        [data_slice[0], data_slice[1], data_slice[2]]
+    });
+
+    // run the icp algorithm
+
+    let result = icp_vanilla_fn(&source, &target, initial_rot, initial_trans, criteria.0)
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
+
+    Ok(PyICPResult(result))
+}

--- a/kornia-py/src/lib.rs
+++ b/kornia-py/src/lib.rs
@@ -1,11 +1,14 @@
 mod color;
 mod enhance;
 mod histogram;
+mod icp;
 mod image;
 mod io;
+mod pointcloud;
 mod resize;
 mod warp;
 
+use crate::icp::{PyICPConvergenceCriteria, PyICPResult};
 use crate::image::PyImageSize;
 use crate::io::functional::{read_image_any, read_image_jpeg, write_image_jpeg};
 use crate::io::jpeg::{PyImageDecoder, PyImageEncoder};
@@ -28,6 +31,7 @@ pub fn kornia_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(color::bgr_from_rgb, m)?)?;
     m.add_function(wrap_pyfunction!(color::gray_from_rgb, m)?)?;
     m.add_function(wrap_pyfunction!(enhance::add_weighted, m)?)?;
+    m.add_function(wrap_pyfunction!(icp::icp_vanilla, m)?)?;
     m.add_function(wrap_pyfunction!(read_image_jpeg, m)?)?;
     m.add_function(wrap_pyfunction!(write_image_jpeg, m)?)?;
     m.add_function(wrap_pyfunction!(read_image_any, m)?)?;
@@ -38,5 +42,7 @@ pub fn kornia_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyImageSize>()?;
     m.add_class::<PyImageDecoder>()?;
     m.add_class::<PyImageEncoder>()?;
+    m.add_class::<PyICPConvergenceCriteria>()?;
+    m.add_class::<PyICPResult>()?;
     Ok(())
 }

--- a/kornia-py/src/pointcloud.rs
+++ b/kornia-py/src/pointcloud.rs
@@ -1,0 +1,31 @@
+use numpy::{PyArray2, PyArrayMethods};
+use pyo3::prelude::*;
+
+use kornia_3d::pointcloud::PointCloud;
+
+pub type PyPointCloud = Py<PyArray2<f64>>;
+
+pub trait FromPyPointCloud {
+    fn from_pypointcloud(
+        pointcloud: PyPointCloud,
+    ) -> Result<PointCloud, Box<dyn std::error::Error>>;
+}
+
+impl FromPyPointCloud for PointCloud {
+    fn from_pypointcloud(
+        pointcloud: PyPointCloud,
+    ) -> Result<PointCloud, Box<dyn std::error::Error>> {
+        Python::with_gil(|py| {
+            let array = pointcloud.bind(py);
+            let data_slice = unsafe { array.as_slice() }
+                .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
+
+            let points = data_slice
+                .chunks_exact(3)
+                .map(|c| [c[0], c[1], c[2]])
+                .collect();
+            let pointcloud = PointCloud::new(points, None, None);
+            Ok(pointcloud)
+        })
+    }
+}

--- a/kornia-py/tests/test_icp.py
+++ b/kornia-py/tests/test_icp.py
@@ -1,0 +1,36 @@
+import kornia_rs as K
+import numpy as np
+
+
+def test_icp_smoke():
+    criteria = K.ICPConvergenceCriteria(max_iterations=100, tolerance=1e-6)
+    assert criteria.max_iterations == 100
+    assert criteria.tolerance == 1e-6
+
+    result = K.ICPResult()
+    assert result.rotation == [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    assert result.translation == [0.0, 0.0, 0.0]
+    assert result.num_iterations == 0
+    assert result.rmse == 0.0
+
+
+def test_icp_vanilla():
+    # create a point cloud with 10 points
+    source = np.ones((10, 3))
+    target = np.ones((10, 3))
+
+    # create a criteria
+    criteria = K.ICPConvergenceCriteria(max_iterations=100, tolerance=1e-6)
+
+    # create a initial rotation and translation
+    initial_rot = np.eye(3)
+    initial_trans = np.zeros(3)
+
+    # run the icp algorithm
+    result = K.icp_vanilla(source, target, initial_rot, initial_trans, criteria)
+
+    # assert the result
+    assert result.rotation == [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    assert result.translation == [0.0, 0.0, 0.0]
+    assert result.num_iterations == 2
+    assert result.rmse == 0.0


### PR DESCRIPTION
This pull request introduces several changes to add ICP (Iterative Closest Point) functionality to the `kornia-py` package, including new modules, classes, and tests. The most important changes include adding new dependencies, implementing the ICP algorithm in Rust and exposing it to Python, and creating corresponding unit tests.

### New Features:

* [`kornia-py/Cargo.toml`](diffhunk://#diff-b578890f0af57d109322f0341862126b0c113a3203c7fbcedf2a7d9bf1308fd2R23-R24): Added dependencies for `kornia-icp` and `kornia-3d` crates.
* [`kornia-py/src/icp.rs`](diffhunk://#diff-f644a24f54b90dc5ecdd879826fc028d571e594912b8bfd9d68a89f3b7c9f697R1-R137): Implemented the `PyICPConvergenceCriteria` and `PyICPResult` classes and the `icp_vanilla` function to expose the ICP algorithm to Python.
* [`kornia-py/src/pointcloud.rs`](diffhunk://#diff-d97f2b98a1a2172b6aaca393acc21b7cb395821b5f910878de33e3c6c3de8213R1-R31): Added `FromPyPointCloud` trait and `PyPointCloud` type to facilitate point cloud data conversion between Python and Rust.

### Code Integration:

* [`kornia-py/src/lib.rs`](diffhunk://#diff-fc49a49c7d8a2f8edf696b5e63cefd6e56e8aa9ff9411e15899c31f17bb81746R4-R11): Integrated the new ICP functionality by importing the necessary modules and adding the new classes and functions to the Python module. [[1]](diffhunk://#diff-fc49a49c7d8a2f8edf696b5e63cefd6e56e8aa9ff9411e15899c31f17bb81746R4-R11) [[2]](diffhunk://#diff-fc49a49c7d8a2f8edf696b5e63cefd6e56e8aa9ff9411e15899c31f17bb81746R34) [[3]](diffhunk://#diff-fc49a49c7d8a2f8edf696b5e63cefd6e56e8aa9ff9411e15899c31f17bb81746R45-R46)

### Testing:

* [`kornia-py/tests/test_icp.py`](diffhunk://#diff-50206b05bd604854ad7177f0ae34b5c6a5e608417cef346594ad633d97fef702R1-R36): Added unit tests for the new ICP functionality, including tests for `ICPConvergenceCriteria`, `ICPResult`, and the `icp_vanilla` function.

### Miscellaneous:

* [`kornia-py/.gitignore`](diffhunk://#diff-f44198471ef755b563a8cce5c103874ec2c324db72e60d63f767743efdb7d81eR2): Added `uv.lock` to the `.gitignore` file.
* [`crates/kornia-icp/src/icp_vanilla.rs`](diffhunk://#diff-1d9987e275875d1bf6560670fce639bf9fe9cef529f7cd2e5ecafbb7107dbd81L24-R24): Added `Clone` trait to `ICPConvergenceCriteria` struct.