### PR TITLE
Implement SVD for Mat3x3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ kornia-io = { path = "crates/kornia-io", version = "0.1.9-rc.2" }
 kornia-imgproc = { path = "crates/kornia-imgproc", version = "0.1.9-rc.2" }
 kornia-3d = { path = "crates/kornia-3d", version = "0.1.9-rc.2" }
 kornia = { path = "crates/kornia", version = "0.1.9-rc.2" }
+kornia-linalg = { path = "crates/kornia-linalg", version = "0.1.9-rc.2" }
 
 # dev dependencies for workspace
 argh = "0.1"

--- a/crates/kornia-linalg/Cargo.toml
+++ b/crates/kornia-linalg/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "kornia-linalg"
+authors.workspace = true
+categories.workspace = true
+description.workspace = true
+edition.workspace = true
+homepage.workspace = true
+include.workspace = true
+license.workspace = true
+license-file.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]

--- a/crates/kornia-linalg/Cargo.toml
+++ b/crates/kornia-linalg/Cargo.toml
@@ -13,4 +13,11 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[features]
+default = ["std"]
+
+std = ["glam/std"]
+libm = ["glam/libm"]
+
 [dependencies]
+glam = { version = "0.30.0", default-features = false }

--- a/crates/kornia-linalg/Cargo.toml
+++ b/crates/kornia-linalg/Cargo.toml
@@ -20,11 +20,11 @@ std = ["glam/std"]
 libm = ["glam/libm"]
 
 [dependencies]
-faer = { workspace = true }
 glam = { version = "0.30.0", default-features = false }
 
 
 [dev-dependencies]
+faer = { workspace = true }
 approx = { workspace = true }
 criterion = { workspace = true }
 

--- a/crates/kornia-linalg/Cargo.toml
+++ b/crates/kornia-linalg/Cargo.toml
@@ -20,4 +20,14 @@ std = ["glam/std"]
 libm = ["glam/libm"]
 
 [dependencies]
+faer = { workspace = true }
 glam = { version = "0.30.0", default-features = false }
+
+
+[dev-dependencies]
+approx = { workspace = true }
+criterion = { workspace = true }
+
+[[bench]]
+name = "bench_linalg"
+harness = false

--- a/crates/kornia-linalg/benches/bench_linalg.rs
+++ b/crates/kornia-linalg/benches/bench_linalg.rs
@@ -1,0 +1,32 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use faer::mat;
+use glam::{Mat3, Vec3};
+use kornia_linalg::linalg;
+
+fn bench_svd3(c: &mut Criterion) {
+    let mut group = c.benchmark_group("svd3");
+    let A1 = Mat3 {
+        x_axis: Vec3::new(1.0, 0.0, 0.0),
+        y_axis: Vec3::new(0.0, 2.0, 0.0),
+        z_axis: Vec3::new(0.0, 0.0, 3.0),
+    };
+
+    let A2 = mat![[1.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 3.0]];
+
+    group.bench_function(BenchmarkId::new("svd3", ""), |b| {
+        b.iter(|| {
+            linalg::svd3(A1);
+            black_box(());
+        })
+    });
+
+    group.bench_function(BenchmarkId::new("svd3_faer", ""), |b| {
+        b.iter(|| {
+            A2.svd();
+            black_box(());
+        })
+    });
+}
+
+criterion_group!(benches, bench_svd3);
+criterion_main!(benches);

--- a/crates/kornia-linalg/benches/bench_linalg.rs
+++ b/crates/kornia-linalg/benches/bench_linalg.rs
@@ -5,24 +5,24 @@ use kornia_linalg::linalg;
 
 fn bench_svd3(c: &mut Criterion) {
     let mut group = c.benchmark_group("svd3");
-    let A1 = Mat3 {
+    let a1 = Mat3 {
         x_axis: Vec3::new(1.0, 0.0, 0.0),
         y_axis: Vec3::new(0.0, 2.0, 0.0),
         z_axis: Vec3::new(0.0, 0.0, 3.0),
     };
 
-    let A2 = mat![[1.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 3.0]];
+    let a2 = mat![[1.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 3.0]];
 
     group.bench_function(BenchmarkId::new("svd3", ""), |b| {
         b.iter(|| {
-            linalg::svd3(&A1);
+            linalg::svd3(&a1);
             black_box(());
         })
     });
 
     group.bench_function(BenchmarkId::new("svd3_faer", ""), |b| {
         b.iter(|| {
-            A2.svd();
+            a2.svd();
             black_box(());
         })
     });

--- a/crates/kornia-linalg/benches/bench_linalg.rs
+++ b/crates/kornia-linalg/benches/bench_linalg.rs
@@ -15,7 +15,7 @@ fn bench_svd3(c: &mut Criterion) {
 
     group.bench_function(BenchmarkId::new("svd3", ""), |b| {
         b.iter(|| {
-            linalg::svd3(A1);
+            linalg::svd3(&A1);
             black_box(());
         })
     });

--- a/crates/kornia-linalg/src/lib.rs
+++ b/crates/kornia-linalg/src/lib.rs
@@ -1,0 +1,5 @@
+#![deny(missing_docs)]
+#![doc = env!("CARGO_PKG_DESCRIPTION")]
+
+/// image representation for computer vision purposes.
+pub mod linalg;

--- a/crates/kornia-linalg/src/lib.rs
+++ b/crates/kornia-linalg/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(missing_docs)]
 #![doc = env!("CARGO_PKG_DESCRIPTION")]
 
-/// image representation for computer vision purposes.
+/// Module to calculate SVD of a 3x3 matrix
 pub mod linalg;

--- a/crates/kornia-linalg/src/linalg.rs
+++ b/crates/kornia-linalg/src/linalg.rs
@@ -5,7 +5,7 @@ const GAMMA: f32 = 5.828427124;
 const CSTAR: f32 = 0.923879532;
 const SSTAR: f32 = 0.3826834323;
 const SVD_EPSILON: f32 = 1e-6;
-const JACOBI_STEPS: u8 = 12;
+const JACOBI_STEPS: u8 = 6;
 const RSQRT_STEPS: u8 = 4;
 const rsqrt_mut_STEPS: u8 = 6;
 
@@ -153,9 +153,10 @@ fn approximate_givens_quaternion(A: &Symmetric3x3) -> Givens {
         ch: 2.0 * (A.m_00 - A.m_11),
         sh: A.m_10,
     };
-
-    let mut b = GAMMA * g.sh * g.sh < g.ch * g.ch;
-    let w = rsqrt(g.ch * g.ch + g.sh * g.sh);
+    let ch2 = g.ch * g.ch;
+    let sh2 = g.sh * g.sh;
+    let mut b = GAMMA * sh2 < ch2;
+    let w = rsqrt(ch2 + sh2);
 
     if w != w {
         // Checking for NaN
@@ -217,8 +218,10 @@ fn jacobi_conjugation(x: usize, y: usize, z: usize, S: &mut Symmetric3x3, q: &mu
     // Compute the Givens rotation (approximated)
     let mut g = approximate_givens_quaternion(S);
     // Scale and calculate intermediate values
-    let scale = 1.0 / (g.ch * g.ch + g.sh * g.sh);
-    let a = (g.ch * g.ch - g.sh * g.sh) * scale;
+    let ch2 = g.ch * g.ch;
+    let sh2 = g.sh * g.sh;
+    let scale = 1.0 / (ch2 + sh2);
+    let a = (ch2 - sh2) * scale;
     let b = 2.0 * g.sh * g.ch * scale;
 
     // Create a copy of the matrix to avoid modifying the original during calculations

--- a/crates/kornia-linalg/src/linalg.rs
+++ b/crates/kornia-linalg/src/linalg.rs
@@ -1,22 +1,23 @@
-use std::ops::{IndexMut, Index};
+use std::ops::{Index, IndexMut};
 
-const GEMMA:f32 = 5.828427124; 
-const CSTAR:f32 = 0.923879532;
-const SSTAR:f32 = 0.3826834323;
+use glam::{Mat3, Quat, Vec3};
+
+const GEMMA: f32 = 5.828427124;
+const CSTAR: f32 = 0.923879532;
+const SSTAR: f32 = 0.3826834323;
 const SVD_EPSILON: f32 = 1e-6;
 const JACOBI_STEPS: u32 = 12;
 const RSQRT_STEPS: u32 = 4;
 const RSQRT1_STEPS: u32 = 6;
 
-
 /// Calculates the result of x / y. Required as the accurate square root function otherwise uses a reciprocal approximation when using optimizations on a GPU which can lead to slightly different results. If non exact matching results are acceptable a simple division can be used.
-pub fn fdiv(x:f32, y:f32) -> f32 {
+pub fn fdiv(x: f32, y: f32) -> f32 {
     return x / y;
 }
 
 /// Calculates the reciprocal square root of x using a fast approximation.
 pub fn rsqrt(x: f32) -> f32 {
-    let mut xhalf = -0.5 * x;
+    let xhalf = -0.5 * x;
     let mut i = x.to_bits() as i32; // Convert float to raw bits
     i = 0x5f375a82 - (i >> 1); // Magic constant and bit manipulation
     let mut x = f32::from_bits(i as u32); // Convert bits back to float
@@ -43,7 +44,7 @@ pub fn rsqrt1(mut x: f32) -> f32 {
 }
 
 /// Calculates the square root of x using 1.f/rsqrt1(x) to give a square root with controllable and consistent precision.
-pub fn accurate_sqrt(mut x:f32) -> f32 {
+pub fn accurate_sqrt(x: f32) -> f32 {
     return fdiv(1.0, rsqrt(x));
 }
 
@@ -66,266 +67,31 @@ fn cond_neg_swap(c: bool, x: &mut f32, y: &mut f32) {
 }
 
 /// Helper function used to convert quaternion to matrix
-pub fn quaternion_to_matrix(q: &Quaternion) -> Mat3x3 {
-    let w = q.w;
-    let x = q.x;
-    let y = q.y;
-    let z = q.z;
-    
-    Mat3x3 {
-        m_00: 1.0 - 2.0 * (y * y + z * z),
-        m_01: 2.0 * (x * y - w * z),
-        m_02: 2.0 * (x * z + w * y),
-        
-        m_10: 2.0 * (x * y + w * z),
-        m_11: 1.0 - 2.0 * (x * x + z * z),
-        m_12: 2.0 * (y * z - w * x),
-        
-        m_20: 2.0 * (x * z - w * y),
-        m_21: 2.0 * (y * z + w * x),
-        m_22: 1.0 - 2.0 * (x * x + y * y),
+pub fn quaternion_to_matrix(q: &IndexedQuat) -> Mat3 {
+    let w = q[3];
+    let x = q[0];
+    let y = q[1];
+    let z = q[2];
+
+    // Return a Mat3 constructed with the proper rows
+    Mat3 {
+        x_axis: Vec3::new(
+            1.0 - 2.0 * (y * y + z * z),
+            2.0 * (x * y - w * z),
+            2.0 * (x * z + w * y),
+        ),
+        y_axis: Vec3::new(
+            2.0 * (x * y + w * z),
+            1.0 - 2.0 * (x * x + z * z),
+            2.0 * (y * z - w * x),
+        ),
+        z_axis: Vec3::new(
+            2.0 * (x * z - w * y),
+            2.0 * (y * z + w * x),
+            1.0 - 2.0 * (x * x + y * y),
+        ),
     }
 }
-
-
-#[derive(Debug,Clone)]
-/// Helper class to contain a quaternion. Could be replaced with float4 (CUDA based type) but this might lead to unintended conversions when using the supplied matrices
-pub struct Quaternion {
-    /// The `x` component of the quaternion.
-    /// Represents the vector component of the quaternion along the x-axis.
-    pub x: f32,
-    
-    /// The `y` component of the quaternion.
-    /// Represents the vector component of the quaternion along the y-axis.
-    pub y: f32,
-
-    /// The `z` component of the quaternion.
-    /// Represents the vector component of the quaternion along the z-axis.
-    pub z: f32,
-
-    /// The `w` component of the quaternion.
-    /// The scalar (real) part of the quaternion, representing the cosine of half the rotation angle.
-    pub w: f32,
-}
-
-impl Quaternion {
-    /// Create a new Quaternion from values
-    pub fn new(x: f32, y: f32, z: f32, w: f32) -> Self {
-        Quaternion { x, y, z, w }
-    }
-}
-
-impl Default for Quaternion {
-    fn default() -> Self {
-        Quaternion {
-            x: 0.0,  // default x value
-            y: 0.0,  // default y value
-            z: 0.0,  // default z value
-            w: 1.0,  // default w value (usually 1 for identity quaternion)
-        }
-    }
-}
-
-impl Index<usize> for Quaternion {
-    type Output = f32;
-
-    fn index(&self, index: usize) -> &Self::Output {
-        match index {
-            0 => &self.x,
-            1 => &self.y,
-            2 => &self.z,
-            3 => &self.w,
-            _ => panic!("Index out of bounds for Quaternion"),
-        }
-    }
-}
-
-
-impl IndexMut<usize> for Quaternion {
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        match index {
-            0 => &mut self.x,
-            1 => &mut self.y,
-            2 => &mut self.z,
-            3 => &mut self.w,
-            _ => panic!("Index out of bounds for Quaternion"),
-        }
-    }
-}
-
-
-#[derive(Debug, Clone, Copy)]
-/// A simple 3x3 Matrix class
-pub struct Mat3x3 {
-  /// The element at row 0, column 0 of the matrix.
-  pub m_00: f32,
-
-  /// The element at row 0, column 1 of the matrix.
-  pub m_01: f32,
-
-  /// The element at row 0, column 2 of the matrix.
-  pub m_02: f32,
-
-  /// The element at row 1, column 0 of the matrix.
-  pub m_10: f32,
-
-  /// The element at row 1, column 1 of the matrix.
-  pub m_11: f32,
-
-  /// The element at row 1, column 2 of the matrix.
-  pub m_12: f32,
-
-  /// The element at row 2, column 0 of the matrix.
-  pub m_20: f32,
-
-  /// The element at row 2, column 1 of the matrix.
-  pub m_21: f32,
-
-  /// The element at row 2, column 2 of the matrix.
-  pub m_22: f32,
-}
-
-impl Mat3x3 {
-    /// Constructor to initialize matrix with given values
-    pub fn new(a11: f32, a12: f32, a13: f32, a21: f32, a22: f32, a23: f32, a31: f32, a32: f32, a33: f32) -> Self {
-        Mat3x3 {
-            m_00: a11, m_01: a12, m_02: a13,
-            m_10: a21, m_11: a22, m_12: a23,
-            m_20: a31, m_21: a32, m_22: a33,
-        }
-    }
-
-    /// Zero Matrix
-    pub fn zero() -> Self {
-        Mat3x3 {
-            m_00: 0.0, m_01: 0.0, m_02: 0.0,
-            m_10: 0.0, m_11: 0.0, m_12: 0.0,
-            m_20: 0.0, m_21: 0.0, m_22: 0.0,
-        }
-    }
-
-    /// identity Matrix
-    pub fn identity() -> Self {
-        Mat3x3 {
-            m_00: 1.0, m_01: 0.0, m_02: 0.0,
-            m_10: 0.0, m_11: 1.0, m_12: 0.0,
-            m_20: 0.0, m_21: 0.0, m_22: 1.0,
-        }
-    }
-
-    /// Matrix from pointer (assuming a flat array with a certain stride)
-    pub fn from_ptr(ptr: &[f32], i: usize, offset: usize) -> Self {
-        Mat3x3 {
-            m_00: ptr[i + 0 * offset], m_01: ptr[i + 1 * offset], m_02: ptr[i + 2 * offset],
-            m_10: ptr[i + 3 * offset], m_11: ptr[i + 4 * offset], m_12: ptr[i + 5 * offset],
-            m_20: ptr[i + 6 * offset], m_21: ptr[i + 7 * offset], m_22: ptr[i + 8 * offset],
-        }
-    }
-
-    /// Determinant of the matrix
-    pub fn det(&self) -> f32 {
-        self.m_00 * (self.m_11 * self.m_22 - self.m_12 * self.m_21) 
-        - self.m_01 * (self.m_10 * self.m_22 - self.m_12 * self.m_20)
-        + self.m_02 * (self.m_10 * self.m_21 - self.m_11 * self.m_20)
-    }
-
-    /// Convert matrix to pointer (store in flat array with stride)
-    pub fn to_ptr(&self, ptr: &mut [f32], i: usize, offset: usize) {
-        ptr[i + 0 * offset] = self.m_00;
-        ptr[i + 1 * offset] = self.m_01;
-        ptr[i + 2 * offset] = self.m_02;
-        ptr[i + 3 * offset] = self.m_10;
-        ptr[i + 4 * offset] = self.m_11;
-        ptr[i + 5 * offset] = self.m_12;
-        ptr[i + 6 * offset] = self.m_20;
-        ptr[i + 7 * offset] = self.m_21;
-        ptr[i + 8 * offset] = self.m_22;
-    }
-
-    /// Transpose of the matrix
-    pub fn transpose(&self) -> Self {
-        Mat3x3 {
-            m_00: self.m_00, m_10: self.m_01, m_20: self.m_02,
-            m_01: self.m_10, m_11: self.m_11, m_21: self.m_12,
-            m_02: self.m_20, m_12: self.m_21, m_22: self.m_22,
-        }
-    }
-
-    /// Matrix multiplication with scalar
-    pub fn mul_scalar(&self, o: f32) -> Self {
-        Mat3x3 {
-            m_00: self.m_00 * o, m_01: self.m_01 * o, m_02: self.m_02 * o,
-            m_10: self.m_10 * o, m_11: self.m_11 * o, m_12: self.m_12 * o,
-            m_20: self.m_20 * o, m_21: self.m_21 * o, m_22: self.m_22 * o,
-        }
-    }
-
-    /// In-place matrix multiplication with scalar
-    pub fn mul_scalar_in_place(&mut self, o: f32) {
-        self.m_00 *= o; self.m_01 *= o; self.m_02 *= o;
-        self.m_10 *= o; self.m_11 *= o; self.m_12 *= o;
-        self.m_20 *= o; self.m_21 *= o; self.m_22 *= o;
-    }
-
-    /// Matrix subtraction
-    pub fn sub(&self, o: &Mat3x3) -> Self {
-        Mat3x3 {
-            m_00: self.m_00 - o.m_00, m_01: self.m_01 - o.m_01, m_02: self.m_02 - o.m_02,
-            m_10: self.m_10 - o.m_10, m_11: self.m_11 - o.m_11, m_12: self.m_12 - o.m_12,
-            m_20: self.m_20 - o.m_20, m_21: self.m_21 - o.m_21, m_22: self.m_22 - o.m_22,
-        }
-    }
-
-    /// Matrix multiplication
-    pub fn mul(&self, o: &Mat3x3) -> Mat3x3 {
-        Mat3x3 {
-            m_00: self.m_00 * o.m_00 + self.m_01 * o.m_10 + self.m_02 * o.m_20,
-            m_01: self.m_00 * o.m_01 + self.m_01 * o.m_11 + self.m_02 * o.m_21,
-            m_02: self.m_00 * o.m_02 + self.m_01 * o.m_12 + self.m_02 * o.m_22,
-            m_10: self.m_10 * o.m_00 + self.m_11 * o.m_10 + self.m_12 * o.m_20,
-            m_11: self.m_10 * o.m_01 + self.m_11 * o.m_11 + self.m_12 * o.m_21,
-            m_12: self.m_10 * o.m_02 + self.m_11 * o.m_12 + self.m_12 * o.m_22,
-            m_20: self.m_20 * o.m_00 + self.m_21 * o.m_10 + self.m_22 * o.m_20,
-            m_21: self.m_20 * o.m_01 + self.m_21 * o.m_11 + self.m_22 * o.m_21,
-            m_22: self.m_20 * o.m_02 + self.m_21 * o.m_12 + self.m_22 * o.m_22,
-        }
-    }
-}
-
-
-impl Default for Mat3x3 {
-    // Default implementation: Identity Matrix
-    fn default() -> Self {
-        Mat3x3 {
-            m_00: 1.0, m_01: 0.0, m_02: 0.0,
-            m_10: 0.0, m_11: 1.0, m_12: 0.0,
-            m_20: 0.0, m_21: 0.0, m_22: 1.0,
-        }
-    }
-}
-
-// Implement the Index trait for Mat3x3
-impl Index<(usize, usize)> for Mat3x3 {
-    type Output = f32;
-
-    fn index(&self, idx: (usize, usize)) -> &Self::Output {
-        match idx {
-            (0, 0) => &self.m_00,
-            (0, 1) => &self.m_01,
-            (0, 2) => &self.m_02,
-            (1, 0) => &self.m_10,
-            (1, 1) => &self.m_11,
-            (1, 2) => &self.m_12,
-            (2, 0) => &self.m_20,
-            (2, 1) => &self.m_21,
-            (2, 2) => &self.m_22,
-            _ => panic!("Index out of bounds for Mat3x3"),
-        }
-    }
-}
-
-
-
 
 #[derive(Debug, Clone, Copy)]
 /// A simple symmetric 3x3 Matrix class (contains no storage for (0, 1) (0, 2) and (1, 2)
@@ -349,7 +115,6 @@ pub struct Symmetric3x3 {
     pub m_22: f32,
 }
 
-
 impl Symmetric3x3 {
     /// Constructor to initialize the symmetric matrix with given values
     pub fn new(a11: f32, a21: f32, a22: f32, a31: f32, a32: f32, a33: f32) -> Self {
@@ -364,24 +129,23 @@ impl Symmetric3x3 {
     }
 
     /// Constructor from a regular Mat3x3 (assuming Mat3x3 exists)
-    pub fn from_mat3x3(mat: &Mat3x3) -> Self {
+    pub fn from_mat3x3(mat: &Mat3) -> Self {
         Symmetric3x3 {
-            m_00: mat.m_00,
-            m_10: mat.m_10,
-            m_11: mat.m_11,
-            m_20: mat.m_20,
-            m_21: mat.m_21,
-            m_22: mat.m_22,
+            m_00: mat.x_axis.x,
+            m_10: mat.x_axis.y,
+            m_11: mat.y_axis.y,
+            m_20: mat.z_axis.x,
+            m_21: mat.z_axis.y,
+            m_22: mat.z_axis.z,
         }
     }
 }
-
 
 #[derive(Debug, Clone, Copy)]
 /// Helper struct to store 2 floats to avoid OUT parameters on functions
 pub struct Givens {
     /// The cosine of the angle in the Givens rotation.
-    pub ch: f32, 
+    pub ch: f32,
 
     /// The sine of the angle in the Givens rotation.
     pub sh: f32,
@@ -402,37 +166,35 @@ impl Givens {
     }
 }
 
-
 #[derive(Debug, Clone, Copy)]
 /// Helper struct to store 2 Matrices to avoid OUT parameters on functions
 pub struct QR {
     /// The orthogonal matrix Q from the QR decomposition.
-    pub Q: Mat3x3,
+    pub Q: Mat3,
 
     /// The upper triangular matrix R from the QR decomposition.
-    pub R: Mat3x3,
+    pub R: Mat3,
 }
-
 
 #[derive(Debug, Clone, Copy)]
 /// Helper struct to store 3 Matrices to avoid OUT parameters on functions
 pub struct SVDSet {
-   /// The matrix of left singular vectors.
-   pub U: Mat3x3,
+    /// The matrix of left singular vectors.
+    pub U: Mat3,
 
-   /// The diagonal matrix of singular values.
-   pub S: Mat3x3,
+    /// The diagonal matrix of singular values.
+    pub S: Mat3,
 
-   /// The matrix of right singular vectors.
-   pub V: Mat3x3,
+    /// The matrix of right singular vectors.
+    pub V: Mat3,
 }
 
 /// Calculates the squared norm of the vector [x y z] using a standard scalar product d = x * x + y *y + z * z
-pub fn dist2(x:f32,y:f32,z:f32) -> f32 {
-    x * x + (y *y + z * z)
+pub fn dist2(x: f32, y: f32, z: f32) -> f32 {
+    x * x + (y * y + z * z)
 }
 
-/// For an explanation of the math see http://pages.cs.wisc.edu/~sifakis/papers/SVD_TR1690.pdf 
+/// For an explanation of the math see http://pages.cs.wisc.edu/~sifakis/papers/SVD_TR1690.pdf
 /// Computing the Singular Value Decomposition of 3 x 3 matrices with minimal branching and elementary floating point operations
 /// See Algorithm 2 in reference. Given a matrix A this function returns the givens quaternion (x and w component, y and z are 0)
 pub fn approximate_givens_quaternion(A: &Symmetric3x3) -> Givens {
@@ -444,7 +206,8 @@ pub fn approximate_givens_quaternion(A: &Symmetric3x3) -> Givens {
     let mut b = GEMMA * g.sh * g.sh < g.ch * g.ch;
     let w = rsqrt(g.ch * g.ch + g.sh * g.sh);
 
-    if w != w { // Checking for NaN
+    if w != w {
+        // Checking for NaN
         b = false;
     }
 
@@ -454,8 +217,48 @@ pub fn approximate_givens_quaternion(A: &Symmetric3x3) -> Givens {
     }
 }
 
+#[derive(Debug)]
+/// A wrapper around the `glam::Quat` type that allows dynamic indexing into its components.
+///
+/// This struct provides custom indexing behavior for quaternion components (`x`, `y`, `z`, and `w`),
+/// enabling access and mutation using an index (e.g., `q[0]`, `q[1]`, etc.). It implements both
+/// the `Index` and `IndexMut` traits to allow for immutable and mutable access to the quaternion's components.
+pub struct IndexedQuat(Quat);
+
+impl IndexedQuat {
+    fn new(q: Quat) -> Self {
+        IndexedQuat(q)
+    }
+}
+
+impl Index<usize> for IndexedQuat {
+    type Output = f32;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        match index {
+            0 => &self.0.x,
+            1 => &self.0.y,
+            2 => &self.0.z,
+            3 => &self.0.w,
+            _ => panic!("Index out of bounds for Quaternion"),
+        }
+    }
+}
+
+impl IndexMut<usize> for IndexedQuat {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        match index {
+            0 => &mut self.0.x,
+            1 => &mut self.0.y,
+            2 => &mut self.0.z,
+            3 => &mut self.0.w,
+            _ => panic!("Index out of bounds for Quaternion"),
+        }
+    }
+}
+
 /// Function used to apply a givens rotation S. Calculates the weights and updates the quaternion to contain the cumultative rotation
-pub fn jacobi_conjugation(x: usize, y: usize, z: usize, S: &mut Symmetric3x3, q: &mut Quaternion) {
+pub fn jacobi_conjugation(x: usize, y: usize, z: usize, S: &mut Symmetric3x3, q: &mut IndexedQuat) {
     // Compute the Givens rotation (approximated)
     let mut g = approximate_givens_quaternion(S);
     // Scale and calculate intermediate values
@@ -505,56 +308,54 @@ pub fn jacobi_conjugation(x: usize, y: usize, z: usize, S: &mut Symmetric3x3, q:
 
 /// Function used to contain the givens permutations and the loop of the jacobi steps controlled by JACOBI_STEPS
 /// Returns the quaternion q containing the cumultative result used to reconstruct S
-pub fn jacobi_eigenanalysis(mut S: Symmetric3x3) -> Mat3x3 {
-    let mut q = Quaternion::default();
+pub fn jacobi_eigenanalysis(mut S: Symmetric3x3) -> Mat3 {
+    let mut q = IndexedQuat::new(Quat::from_xyzw(0.0, 0.0, 0.0, 1.0));
     for _i in 0..JACOBI_STEPS {
         jacobi_conjugation(0, 1, 2, &mut S, &mut q);
         jacobi_conjugation(1, 2, 0, &mut S, &mut q);
         jacobi_conjugation(2, 0, 1, &mut S, &mut q);
     }
-    print!("{:?}",q);
     return quaternion_to_matrix(&q);
 }
 
 /// Implementation of Algorithm 3
-pub fn sort_singular_values(B: &mut Mat3x3, V: &mut Mat3x3) {
-    let mut rho1 = dist2(B.m_00, B.m_10, B.m_20);
-    let mut rho2 = dist2(B.m_01, B.m_11, B.m_21);
-    let mut rho3 = dist2(B.m_02, B.m_12, B.m_22);
+pub fn sort_singular_values(B: &mut Mat3, V: &mut Mat3) {
+    let mut rho1 = dist2(B.x_axis.x, B.y_axis.x, B.z_axis.x);
+    let mut rho2 = dist2(B.x_axis.y, B.y_axis.y, B.z_axis.y);
+    let mut rho3 = dist2(B.x_axis.z, B.y_axis.z, B.z_axis.z);
 
     let mut c = rho1 < rho2;
-    cond_neg_swap(c, &mut B.m_00, &mut B.m_01);
-    cond_neg_swap(c, &mut V.m_00, &mut V.m_01);
-    cond_neg_swap(c, &mut B.m_10, &mut B.m_11);
-    cond_neg_swap(c, &mut V.m_10, &mut V.m_11);
-    cond_neg_swap(c, &mut B.m_20, &mut B.m_21);
-    cond_neg_swap(c, &mut V.m_20, &mut V.m_21);
+    cond_neg_swap(c, &mut B.x_axis.x, &mut B.x_axis.y);
+    cond_neg_swap(c, &mut V.x_axis.x, &mut V.x_axis.y);
+    cond_neg_swap(c, &mut B.y_axis.x, &mut B.y_axis.y);
+    cond_neg_swap(c, &mut V.y_axis.x, &mut V.y_axis.y);
+    cond_neg_swap(c, &mut B.z_axis.x, &mut B.z_axis.y);
+    cond_neg_swap(c, &mut V.z_axis.x, &mut V.z_axis.y);
     cond_swap(c, &mut rho1, &mut rho2);
 
     c = rho1 < rho3;
-    cond_neg_swap(c, &mut B.m_00, &mut B.m_02);
-    cond_neg_swap(c, &mut V.m_00, &mut V.m_02);
-    cond_neg_swap(c, &mut B.m_10, &mut B.m_12);
-    cond_neg_swap(c, &mut V.m_10, &mut V.m_12);
-    cond_neg_swap(c, &mut B.m_20, &mut B.m_22);
-    cond_neg_swap(c, &mut V.m_20, &mut V.m_22);
+    cond_neg_swap(c, &mut B.x_axis.x, &mut B.x_axis.z);
+    cond_neg_swap(c, &mut V.x_axis.x, &mut V.x_axis.z);
+    cond_neg_swap(c, &mut B.y_axis.x, &mut B.y_axis.z);
+    cond_neg_swap(c, &mut V.y_axis.x, &mut V.y_axis.z);
+    cond_neg_swap(c, &mut B.z_axis.x, &mut B.z_axis.z);
+    cond_neg_swap(c, &mut V.z_axis.x, &mut V.z_axis.z);
     cond_swap(c, &mut rho1, &mut rho3);
 
     c = rho2 < rho3;
-    cond_neg_swap(c, &mut B.m_01, &mut B.m_02);
-    cond_neg_swap(c, &mut V.m_01, &mut V.m_02);
-    cond_neg_swap(c, &mut B.m_11, &mut B.m_12);
-    cond_neg_swap(c, &mut V.m_11, &mut V.m_12);
-    cond_neg_swap(c, &mut B.m_21, &mut B.m_22);
-    cond_neg_swap(c, &mut V.m_21, &mut V.m_22);
+    cond_neg_swap(c, &mut B.x_axis.y, &mut B.x_axis.z);
+    cond_neg_swap(c, &mut V.x_axis.y, &mut V.x_axis.z);
+    cond_neg_swap(c, &mut B.y_axis.y, &mut B.y_axis.z);
+    cond_neg_swap(c, &mut V.y_axis.y, &mut V.y_axis.z);
+    cond_neg_swap(c, &mut B.z_axis.y, &mut B.z_axis.z);
+    cond_neg_swap(c, &mut V.z_axis.y, &mut V.z_axis.z);
 }
-
 
 /// Implementation of Algorithm 4
 pub fn qr_givens_quaternion(a1: f32, a2: f32) -> Givens {
     // a1 = pivot point on diagonal
     // a2 = lower triangular entry we want to annihilate
-    let epsilon = SVD_EPSILON ; // Assuming _SVD_EPSILON is defined elsewhere
+    let epsilon = SVD_EPSILON; // Assuming _SVD_EPSILON is defined elsewhere
     let rho = accurate_sqrt(a1 * a1 + a2 * a2);
 
     let mut g = Givens {
@@ -565,101 +366,101 @@ pub fn qr_givens_quaternion(a1: f32, a2: f32) -> Givens {
     let b = a1 < 0.0;
     cond_swap(b, &mut g.sh, &mut g.ch);
 
-    let w = (g.ch * g.ch + g.sh * g.sh).sqrt();
+    let w = rsqrt(g.ch * g.ch + g.sh * g.sh);
     g.ch *= w;
     g.sh *= w;
 
-    return g
+    return g;
 }
 
 /// Implements a QR decomposition of a Matrix
-pub fn qr_decomposition(B: &mut Mat3x3) -> QR {
-    let mut Q = Mat3x3::zero();
-    let mut R = Mat3x3::zero();
+pub fn qr_decomposition(B: &mut Mat3) -> QR {
+    let mut Q = Mat3::ZERO;
+    let mut R = Mat3::ZERO;
 
     // First Givens rotation (ch, 0, 0, sh)
-    let g1 = qr_givens_quaternion(B.m_00, B.m_10);
+    let g1 = qr_givens_quaternion(B.x_axis.x, B.y_axis.x);
     let mut a = -2.0 * g1.sh * g1.sh + 1.0;
     let mut b = 2.0 * g1.ch * g1.sh;
-    
+
     // Apply B = Q' * B
-    R.m_00 = a * B.m_00 + b * B.m_10;
-    R.m_01 = a * B.m_01 + b * B.m_11;
-    R.m_02 = a * B.m_02 + b * B.m_12;
-    R.m_10 = -b * B.m_00 + a * B.m_10;
-    R.m_11 = -b * B.m_01 + a * B.m_11;
-    R.m_12 = -b * B.m_02 + a * B.m_12;
-    R.m_20 = B.m_20;
-    R.m_21 = B.m_21;
-    R.m_22 = B.m_22;
+    R.x_axis.x = a * B.x_axis.x + b * B.y_axis.x;
+    R.x_axis.y = a * B.x_axis.y + b * B.y_axis.y;
+    R.x_axis.z = a * B.x_axis.z + b * B.y_axis.z;
+    R.y_axis.x = -b * B.x_axis.x + a * B.y_axis.x;
+    R.y_axis.y = -b * B.x_axis.y + a * B.y_axis.y;
+    R.y_axis.z = -b * B.x_axis.z + a * B.y_axis.z;
+    R.z_axis.x = B.z_axis.x;
+    R.z_axis.y = B.z_axis.y;
+    R.z_axis.z = B.z_axis.z;
 
     // Second Givens rotation (ch, 0, -sh, 0)
-    let g2 = qr_givens_quaternion(R.m_00, R.m_20);
+    let g2 = qr_givens_quaternion(R.x_axis.x, R.z_axis.x);
     a = -2.0 * g2.sh * g2.sh + 1.0;
     b = 2.0 * g2.ch * g2.sh;
-    
+
     // Apply B = Q' * B
-    B.m_00 = a * R.m_00 + b * R.m_20;
-    B.m_01 = a * R.m_01 + b * R.m_21;
-    B.m_02 = a * R.m_02 + b * R.m_22;
-    B.m_10 = R.m_10;
-    B.m_11 = R.m_11;
-    B.m_12 = R.m_12;
-    B.m_20 = -b * R.m_00 + a * R.m_20;
-    B.m_21 = -b * R.m_01 + a * R.m_21;
-    B.m_22 = -b * R.m_02 + a * R.m_22;
+    B.x_axis.x = a * R.x_axis.x + b * R.z_axis.x;
+    B.x_axis.y = a * R.x_axis.y + b * R.z_axis.y;
+    B.x_axis.z = a * R.x_axis.z + b * R.z_axis.z;
+    B.y_axis.x = R.y_axis.x;
+    B.y_axis.y = R.y_axis.y;
+    B.y_axis.z = R.y_axis.z;
+    B.z_axis.x = -b * R.x_axis.x + a * R.z_axis.x;
+    B.z_axis.y = -b * R.x_axis.y + a * R.z_axis.y;
+    B.z_axis.z = -b * R.x_axis.z + a * R.z_axis.z;
 
     // Third Givens rotation (ch, sh, 0, 0)
-    let g3 = qr_givens_quaternion(B.m_11, B.m_21);
+    let g3 = qr_givens_quaternion(B.y_axis.y, B.z_axis.y);
     a = -2.0 * g3.sh * g3.sh + 1.0;
     b = 2.0 * g3.ch * g3.sh;
-    
+
     // R is now set to desired value
-    R.m_00 = B.m_00;
-    R.m_01 = B.m_01;
-    R.m_02 = B.m_02;
-    R.m_10 = a * B.m_10 + b * B.m_20;
-    R.m_11 = a * B.m_11 + b * B.m_21;
-    R.m_12 = a * B.m_12 + b * B.m_22;
-    R.m_20 = -b * B.m_10 + a * B.m_20;
-    R.m_21 = -b * B.m_11 + a * B.m_21;
-    R.m_22 = -b * B.m_12 + a * B.m_22;
+    R.x_axis.x = B.x_axis.x;
+    R.x_axis.y = B.x_axis.y;
+    R.x_axis.z = B.x_axis.z;
+    R.y_axis.x = a * B.y_axis.x + b * B.z_axis.x;
+    R.y_axis.y = a * B.y_axis.y + b * B.z_axis.y;
+    R.y_axis.z = a * B.y_axis.z + b * B.z_axis.z;
+    R.z_axis.x = -b * B.y_axis.x + a * B.z_axis.x;
+    R.z_axis.y = -b * B.y_axis.y + a * B.z_axis.y;
+    R.z_axis.z = -b * B.y_axis.z + a * B.z_axis.z;
 
     // Construct the cumulative rotation Q = Q1 * Q2 * Q3
     let sh12 = 2.0 * (g1.sh * g1.sh - 0.5);
     let sh22 = 2.0 * (g2.sh * g2.sh - 0.5);
     let sh32 = 2.0 * (g3.sh * g3.sh - 0.5);
 
-    Q.m_00 = sh12 * sh22;
-    Q.m_01 = 4.0 * g2.ch * g3.ch * sh12 * g2.sh * g3.sh + 2.0 * g1.ch * g1.sh * sh32;
-    Q.m_02 = 4.0 * g1.ch * g3.ch * g1.sh * g3.sh - 2.0 * g2.ch * sh12 * g2.sh * sh32;
-    
-    Q.m_10 = -2.0 * g1.ch * g1.sh * sh22;
-    Q.m_11 = -8.0 * g1.ch * g2.ch * g3.ch * g1.sh * g2.sh * g3.sh + sh12 * sh32;
-    Q.m_12 = -2.0 * g3.ch * g3.sh + 4.0 * g1.sh * (g3.ch * g1.sh * g3.sh + g1.ch * g2.ch * g2.sh * sh32);
-    
-    Q.m_20 = 2.0 * g2.ch * g2.sh;
-    Q.m_21 = -2.0 * g3.ch * sh22 * g3.sh;
-    Q.m_22 = sh22 * sh32;
+    Q.x_axis.x = sh12 * sh22;
+    Q.x_axis.y = 4.0 * g2.ch * g3.ch * sh12 * g2.sh * g3.sh + 2.0 * g1.ch * g1.sh * sh32;
+    Q.x_axis.z = 4.0 * g1.ch * g3.ch * g1.sh * g3.sh - 2.0 * g2.ch * sh12 * g2.sh * sh32;
+
+    Q.y_axis.x = -2.0 * g1.ch * g1.sh * sh22;
+    Q.y_axis.y = -8.0 * g1.ch * g2.ch * g3.ch * g1.sh * g2.sh * g3.sh + sh12 * sh32;
+    Q.y_axis.z =
+        -2.0 * g3.ch * g3.sh + 4.0 * g1.sh * (g3.ch * g1.sh * g3.sh + g1.ch * g2.ch * g2.sh * sh32);
+
+    Q.z_axis.x = 2.0 * g2.ch * g2.sh;
+    Q.z_axis.y = -2.0 * g3.ch * sh22 * g3.sh;
+    Q.z_axis.z = sh22 * sh32;
 
     QR { Q, R }
 }
 
-
 /// Wrapping function used to contain all of the required sub calls
-pub fn svd(A: Mat3x3) -> SVDSet {
+pub fn svd(A: Mat3) -> SVDSet {
     // Compute the eigenvectors of A^T * A, which is V in SVD (Singular Vectors)
-    let V =  jacobi_eigenanalysis(Symmetric3x3::from_mat3x3(&(A.transpose().mul(&A))));
-    print!("{:?}",V);
+    let V = jacobi_eigenanalysis(Symmetric3x3::from_mat3x3(&(A.transpose().mul_mat3(&A))));
+
     // Compute B = A * V
-    let mut B = A.mul(&V);
-    
+    let mut B = A.mul_mat3(&V);
+
     // Sort the singular values
     sort_singular_values(&mut B, &mut V.clone());
 
     // Perform QR decomposition on B to get Q and R
     let qr = qr_decomposition(&mut B);
-    
+
     // Reset MXCSR register (if needed)
 
     // Return the SVD result, which includes Q (as U), R (as S), and V
@@ -670,41 +471,39 @@ pub fn svd(A: Mat3x3) -> SVDSet {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
+    use glam::{Mat3, Vec3};
+
     use super::*;
 
     #[test]
     fn test_svd() {
         // Define a simple 3x3 matrix A
-        let A = Mat3x3 {
-            m_00: 2.0, m_01: 0.0, m_02: 0.0,
-            m_10: 2.0, m_11: 1.0, m_12: 0.0,
-            m_20: 0.0, m_21: -2.0, m_22: 0.0,
+        let A = Mat3 {
+            x_axis: Vec3::new(1.0, 0.0, 0.0),
+            y_axis: Vec3::new(0.0, 2.0, 0.0),
+            z_axis: Vec3::new(0.0, 0.0, 3.0),
         };
 
         // Perform SVD on matrix A
         let svd_result = svd(A);
-        println!("SVD Result : {:?}", svd_result);
-        // Check if the shapes of U, S, and V are correct (3x3 matrices)
-        assert_eq!(svd_result.S.m_00, 3.0, "S[0][0] is wrong");  // Singular value (approximate)
-        assert_eq!(svd_result.V.m_00, 0.8944271, "V[0][0] is wrong");  // Singular vector (approximate)
+        // Check matrix V
+        assert!(
+            A == svd_result
+                .U
+                .mul_mat3(&(svd_result.S.mul_mat3(&svd_result.V))),
+            "The calculated SVD is wrong"
+        );
 
-        // Optionally, check if the singular values are sorted (since it's typical for SVD results to have descending singular values)
         let singular_values = vec![
-            svd_result.S.m_00, svd_result.S.m_11, svd_result.S.m_22
+            svd_result.S.x_axis.x,
+            svd_result.S.y_axis.y,
+            svd_result.S.z_axis.z,
         ];
-        assert!(singular_values[0] >= singular_values[1] && singular_values[1] >= singular_values[2], 
-            "Singular values are not sorted properly");
-
-        // Check if A * V is close to B (since B = A * V is computed in the function)
-        let A_mul_V = A.mul(&svd_result.V);
-        for i in 0..3 {
-            for j in 0..3 {
-                assert!((A_mul_V[(i, j)] - svd_result.S[(i, j)]).abs() < 1e-5, 
-                    "A * V does not match the S matrix after decomposition");
-            }
-        }
+        assert!(
+            singular_values[0] >= singular_values[1] && singular_values[1] >= singular_values[2],
+            "Singular values are not sorted properly"
+        );
     }
 }

--- a/crates/kornia-linalg/src/linalg.rs
+++ b/crates/kornia-linalg/src/linalg.rs
@@ -1,13 +1,12 @@
 // Reference: https://github.com/wi-re/tbtSVD/blob/master/source/SVD.h
-use glam::{Mat3, Quat, Vec3};
+use glam::{Mat3, Quat};
 use std::ops::{Index, IndexMut};
 const GAMMA: f32 = 5.828427124;
 const CSTAR: f32 = 0.923879532;
 const SSTAR: f32 = 0.3826834323;
 const SVD_EPSILON: f32 = 1e-6;
 const JACOBI_STEPS: u8 = 6;
-const RSQRT_STEPS: u8 = 4;
-const rsqrt_mut_STEPS: u8 = 6;
+const RSQRT1_STEPS: u8 = 6;
 
 /// Standard CPU division.
 fn fdiv(x: f32, y: f32) -> f32 {
@@ -22,23 +21,23 @@ fn rsqrt(x: f32) -> f32 {
     y * (1.5 - (x * 0.5 * y * y))
 }
 
-/// See rsqrt. Uses rsqrt_mut_STEPS to offer a higher precision alternative
-fn rsqrt_mut(mut x: f32) -> f32 {
+/// Uses RSQRT1_STEPS to offer a higher precision alternative
+fn rsqrt1(x: f32) -> f32 {
     let xhalf = -0.5 * x;
-    let mut i = x.to_bits() as i32;
-    i = 0x5f37599e - (i >> 1);
-    x = f32::from_bits(i as u32);
+    let i: i32 = x.to_bits() as i32;
+    let i = 0x5f37599e_i32.wrapping_sub(i >> 1);
+    let mut x: f32 = f32::from_bits(i as u32);
 
-    for _ in 0..rsqrt_mut_STEPS {
-        x = x * (x * x * xhalf + 1.5);
+    for _ in 0..RSQRT1_STEPS {
+        x = x * (1.5 + xhalf * x * x);
     }
 
-    return x;
+    x
 }
 
-/// Calculates the square root of x using 1.f/rsqrt_mut(x) to give a square root with controllable and consistent precision.
+/// Calculates the square root of x using 1.f/rsqrt1(x)to give a square root with controllable and consistent precision.
 fn accurate_sqrt(x: f32) -> f32 {
-    return fdiv(1.0, rsqrt(x));
+    return fdiv(1.0, rsqrt1(x));
 }
 
 /// Helper function used to swap X with Y and Y with  X if c == true
@@ -82,26 +81,14 @@ struct Symmetric3x3 {
 }
 
 impl Symmetric3x3 {
-    /// Constructor to initialize the symmetric matrix with given values
-    fn new(a11: f32, a21: f32, a22: f32, a31: f32, a32: f32, a33: f32) -> Self {
-        Symmetric3x3 {
-            m_00: a11,
-            m_10: a21,
-            m_11: a22,
-            m_20: a31,
-            m_21: a32,
-            m_22: a33,
-        }
-    }
-
     /// Constructor from a regular Mat3x3 (assuming Mat3x3 exists)
     fn from_mat3x3(mat: &Mat3) -> Self {
         Symmetric3x3 {
             m_00: mat.x_axis.x,
-            m_10: mat.x_axis.y,
+            m_10: mat.y_axis.x,
             m_11: mat.y_axis.y,
-            m_20: mat.z_axis.x,
-            m_21: mat.z_axis.y,
+            m_20: mat.x_axis.z,
+            m_21: mat.y_axis.z,
             m_22: mat.z_axis.z,
         }
     }
@@ -121,23 +108,23 @@ struct Givens {
 /// Helper struct to store 2 Matrices to avoid OUT parameters on functions
 struct QR3 {
     /// The orthogonal matrix Q from the QR decomposition.
-    Q: Mat3,
+    q: Mat3,
 
     /// The upper triangular matrix R from the QR decomposition.
-    R: Mat3,
+    r: Mat3,
 }
 
 #[derive(Debug)]
 /// Helper struct to store 3 Matrices to avoid OUT parameters on functions
 pub struct SVD3Set {
     /// The matrix of left singular vectors.
-    U: Mat3,
+    u: Mat3,
 
     /// The diagonal matrix of singular values.
-    S: Mat3,
+    s: Mat3,
 
     /// The matrix of right singular vectors.
-    V: Mat3,
+    v: Mat3,
 }
 
 /// Calculates the squared norm of the vector [x y z] using a standard scalar product d = x * x + y * y + z * z
@@ -148,10 +135,10 @@ fn dist2(x: f32, y: f32, z: f32) -> f32 {
 /// For an explanation of the math see http://pages.cs.wisc.edu/~sifakis/papers/SVD_TR1690.pdf
 /// Computing the Singular Value Decomposition of 3 x 3 matrices with minimal branching and elementary floating point operations
 /// See Algorithm 2 in reference. Given a matrix A this function returns the givens quaternion (x and w component, y and z are 0)
-fn approximate_givens_quaternion(A: &Symmetric3x3) -> Givens {
+fn approximate_givens_quaternion(a: &Symmetric3x3) -> Givens {
     let g = Givens {
-        ch: 2.0 * (A.m_00 - A.m_11),
-        sh: A.m_10,
+        ch: 2.0 * (a.m_00 - a.m_11),
+        sh: a.m_10,
     };
     let ch2 = g.ch * g.ch;
     let sh2 = g.sh * g.sh;
@@ -214,9 +201,9 @@ impl IndexMut<usize> for IndexedQuat {
 }
 
 /// Function used to apply a givens rotation S. Calculates the weights and updates the quaternion to contain the cumultative rotation
-fn jacobi_conjugation(x: usize, y: usize, z: usize, S: &mut Symmetric3x3, q: &mut IndexedQuat) {
+fn jacobi_conjugation(x: usize, y: usize, z: usize, s: &mut Symmetric3x3, q: &mut IndexedQuat) {
     // Compute the Givens rotation (approximated)
-    let mut g = approximate_givens_quaternion(S);
+    let mut g = approximate_givens_quaternion(s);
     // Scale and calculate intermediate values
     let ch2 = g.ch * g.ch;
     let sh2 = g.sh * g.sh;
@@ -225,15 +212,15 @@ fn jacobi_conjugation(x: usize, y: usize, z: usize, S: &mut Symmetric3x3, q: &mu
     let b = 2.0 * g.sh * g.ch * scale;
 
     // Create a copy of the matrix to avoid modifying the original during calculations
-    let mut _S = S.clone();
+    let mut _s = s.clone();
 
     // Perform conjugation: S = Q'*S*Q
-    S.m_00 = a * (a * _S.m_00 + b * _S.m_10) + b * (a * _S.m_10 + b * _S.m_11);
-    S.m_10 = a * (-b * _S.m_00 + a * _S.m_10) + b * (-b * _S.m_10 + a * _S.m_11);
-    S.m_11 = -b * (-b * _S.m_00 + a * _S.m_10) + a * (-b * _S.m_10 + a * _S.m_11);
-    S.m_20 = a * _S.m_20 + b * _S.m_21;
-    S.m_21 = -b * _S.m_20 + a * _S.m_21;
-    S.m_22 = _S.m_22;
+    s.m_00 = a * (a * _s.m_00 + b * _s.m_10) + b * (a * _s.m_10 + b * _s.m_11);
+    s.m_10 = a * (-b * _s.m_00 + a * _s.m_10) + b * (-b * _s.m_10 + a * _s.m_11);
+    s.m_11 = -b * (-b * _s.m_00 + a * _s.m_10) + a * (-b * _s.m_10 + a * _s.m_11);
+    s.m_20 = a * _s.m_20 + b * _s.m_21;
+    s.m_21 = -b * _s.m_20 + a * _s.m_21;
+    s.m_22 = _s.m_22;
 
     // Update cumulative rotation qV
     let mut tmp = [0.0, 0.0, 0.0];
@@ -249,76 +236,74 @@ fn jacobi_conjugation(x: usize, y: usize, z: usize, S: &mut Symmetric3x3, q: &mu
     q[y] = q[y] * g.ch - tmp[x];
 
     // Re-arrange matrix for next iteration
-    _S.m_00 = S.m_11;
-    _S.m_10 = S.m_21;
-    _S.m_11 = S.m_22;
-    _S.m_20 = S.m_10;
-    _S.m_21 = S.m_20;
-    _S.m_22 = S.m_00;
+    _s.m_00 = s.m_11;
+    _s.m_10 = s.m_21;
+    _s.m_11 = s.m_22;
+    _s.m_20 = s.m_10;
+    _s.m_21 = s.m_20;
+    _s.m_22 = s.m_00;
 
-    S.m_00 = _S.m_00;
-    S.m_10 = _S.m_10;
-    S.m_11 = _S.m_11;
-    S.m_20 = _S.m_20;
-    S.m_21 = _S.m_21;
-    S.m_22 = _S.m_22;
+    s.m_00 = _s.m_00;
+    s.m_10 = _s.m_10;
+    s.m_11 = _s.m_11;
+    s.m_20 = _s.m_20;
+    s.m_21 = _s.m_21;
+    s.m_22 = _s.m_22;
 }
 
 /// Function used to contain the givens permutations and the loop of the jacobi steps controlled by JACOBI_STEPS
 /// Returns the quaternion q containing the cumultative result used to reconstruct S
-fn jacobi_eigenanalysis(mut S: Symmetric3x3) -> Mat3 {
+fn jacobi_eigenanalysis(mut s: Symmetric3x3) -> Mat3 {
     let mut q = IndexedQuat::new(Quat::from_xyzw(0.0, 0.0, 0.0, 1.0));
     for _i in 0..JACOBI_STEPS {
-        jacobi_conjugation(0, 1, 2, &mut S, &mut q);
-        jacobi_conjugation(1, 2, 0, &mut S, &mut q);
-        jacobi_conjugation(2, 0, 1, &mut S, &mut q);
+        jacobi_conjugation(0, 1, 2, &mut s, &mut q);
+        jacobi_conjugation(1, 2, 0, &mut s, &mut q);
+        jacobi_conjugation(2, 0, 1, &mut s, &mut q);
     }
 
     return Mat3::from_quat(q.to_quat());
 }
 
 /// Implementation of Algorithm 3
-fn sort_singular_values(B: &mut Mat3, V: &mut Mat3) {
-    let mut rho1 = dist2(B.x_axis.x, B.y_axis.x, B.z_axis.x);
-    let mut rho2 = dist2(B.x_axis.y, B.y_axis.y, B.z_axis.y);
-    let mut rho3 = dist2(B.x_axis.z, B.y_axis.z, B.z_axis.z);
+fn sort_singular_values(b: &mut Mat3, v: &mut Mat3) {
+    let mut rho1 = dist2(b.x_axis.x, b.x_axis.y, b.x_axis.z);
+    let mut rho2 = dist2(b.y_axis.x, b.y_axis.y, b.y_axis.z);
+    let mut rho3 = dist2(b.z_axis.x, b.z_axis.y, b.z_axis.z);
 
     let mut c = rho1 < rho2;
-    cond_neg_swap(c, &mut B.x_axis.x, &mut B.x_axis.y);
-    cond_neg_swap(c, &mut V.x_axis.x, &mut V.x_axis.y);
-    cond_neg_swap(c, &mut B.y_axis.x, &mut B.y_axis.y);
-    cond_neg_swap(c, &mut V.y_axis.x, &mut V.y_axis.y);
-    cond_neg_swap(c, &mut B.z_axis.x, &mut B.z_axis.y);
-    cond_neg_swap(c, &mut V.z_axis.x, &mut V.z_axis.y);
+    cond_neg_swap(c, &mut b.x_axis.x, &mut b.y_axis.x);
+    cond_neg_swap(c, &mut v.x_axis.x, &mut v.y_axis.x);
+    cond_neg_swap(c, &mut b.x_axis.y, &mut b.y_axis.y);
+    cond_neg_swap(c, &mut v.x_axis.y, &mut v.y_axis.y);
+    cond_neg_swap(c, &mut b.x_axis.z, &mut b.y_axis.z);
+    cond_neg_swap(c, &mut v.x_axis.z, &mut v.y_axis.z);
     cond_swap(c, &mut rho1, &mut rho2);
 
     c = rho1 < rho3;
-    cond_neg_swap(c, &mut B.x_axis.x, &mut B.x_axis.z);
-    cond_neg_swap(c, &mut V.x_axis.x, &mut V.x_axis.z);
-    cond_neg_swap(c, &mut B.y_axis.x, &mut B.y_axis.z);
-    cond_neg_swap(c, &mut V.y_axis.x, &mut V.y_axis.z);
-    cond_neg_swap(c, &mut B.z_axis.x, &mut B.z_axis.z);
-    cond_neg_swap(c, &mut V.z_axis.x, &mut V.z_axis.z);
+    cond_neg_swap(c, &mut b.x_axis.x, &mut b.z_axis.x);
+    cond_neg_swap(c, &mut v.x_axis.x, &mut v.z_axis.x);
+    cond_neg_swap(c, &mut b.x_axis.y, &mut b.z_axis.y);
+    cond_neg_swap(c, &mut v.x_axis.y, &mut v.z_axis.y);
+    cond_neg_swap(c, &mut b.x_axis.z, &mut b.z_axis.z);
+    cond_neg_swap(c, &mut v.x_axis.z, &mut v.z_axis.z);
     cond_swap(c, &mut rho1, &mut rho3);
 
     c = rho2 < rho3;
-    cond_neg_swap(c, &mut B.x_axis.y, &mut B.x_axis.z);
-    cond_neg_swap(c, &mut V.x_axis.y, &mut V.x_axis.z);
-    cond_neg_swap(c, &mut B.y_axis.y, &mut B.y_axis.z);
-    cond_neg_swap(c, &mut V.y_axis.y, &mut V.y_axis.z);
-    cond_neg_swap(c, &mut B.z_axis.y, &mut B.z_axis.z);
-    cond_neg_swap(c, &mut V.z_axis.y, &mut V.z_axis.z);
+    cond_neg_swap(c, &mut b.y_axis.x, &mut b.z_axis.x);
+    cond_neg_swap(c, &mut v.y_axis.x, &mut v.z_axis.x);
+    cond_neg_swap(c, &mut b.y_axis.y, &mut b.z_axis.y);
+    cond_neg_swap(c, &mut v.y_axis.y, &mut v.z_axis.y);
+    cond_neg_swap(c, &mut b.y_axis.z, &mut b.z_axis.z);
+    cond_neg_swap(c, &mut v.y_axis.z, &mut v.z_axis.z);
 }
 
 /// Implementation of Algorithm 4
 fn qr_givens_quaternion(a1: f32, a2: f32) -> Givens {
-    // a1 = pivot point on diagonal
-    // a2 = lower triangular entry we want to annihilate
-    let epsilon = SVD_EPSILON; // Assuming _SVD_EPSILON is defined elsewhere
+    let epsilon = SVD_EPSILON;
     let rho = accurate_sqrt(a1 * a1 + a2 * a2);
 
     let mut g = Givens {
-        ch: (a1.abs() + (f32::max(rho, epsilon))),
+        ch: a1.abs() + f32::max(rho, epsilon),
         sh: if rho > epsilon { a2 } else { 0.0 },
     };
 
@@ -333,229 +318,183 @@ fn qr_givens_quaternion(a1: f32, a2: f32) -> Givens {
 }
 
 /// Implements a QR decomposition of a Matrix
-fn qr_decomposition(B: &mut Mat3) -> QR3 {
-    let mut Q = Mat3::ZERO;
-    let mut R = Mat3::ZERO;
+fn qr_decomposition(b_mat: &mut Mat3) -> QR3 {
+    let mut q = Mat3::ZERO;
+    let mut r = Mat3::ZERO;
 
     // First Givens rotation (ch, 0, 0, sh)
-    let g1 = qr_givens_quaternion(B.x_axis.x, B.y_axis.x);
+    let g1 = qr_givens_quaternion(b_mat.x_axis.x, b_mat.x_axis.y);
     let mut a = -2.0 * g1.sh * g1.sh + 1.0;
     let mut b = 2.0 * g1.ch * g1.sh;
 
     // Apply B = Q' * B
-    R.x_axis.x = a * B.x_axis.x + b * B.y_axis.x;
-    R.x_axis.y = a * B.x_axis.y + b * B.y_axis.y;
-    R.x_axis.z = a * B.x_axis.z + b * B.y_axis.z;
-    R.y_axis.x = -b * B.x_axis.x + a * B.y_axis.x;
-    R.y_axis.y = -b * B.x_axis.y + a * B.y_axis.y;
-    R.y_axis.z = -b * B.x_axis.z + a * B.y_axis.z;
-    R.z_axis.x = B.z_axis.x;
-    R.z_axis.y = B.z_axis.y;
-    R.z_axis.z = B.z_axis.z;
+    r.x_axis.x = a * b_mat.x_axis.x + b * b_mat.x_axis.y;
+    r.y_axis.x = a * b_mat.y_axis.x + b * b_mat.y_axis.y;
+    r.z_axis.x = a * b_mat.z_axis.x + b * b_mat.z_axis.y;
+    r.x_axis.y = -b * b_mat.x_axis.x + a * b_mat.x_axis.y;
+    r.y_axis.y = -b * b_mat.y_axis.x + a * b_mat.y_axis.y;
+    r.z_axis.y = -b * b_mat.z_axis.x + a * b_mat.z_axis.y;
+    r.x_axis.z = b_mat.x_axis.z;
+    r.y_axis.z = b_mat.y_axis.z;
+    r.z_axis.z = b_mat.z_axis.z;
 
     // Second Givens rotation (ch, 0, -sh, 0)
-    let g2 = qr_givens_quaternion(R.x_axis.x, R.z_axis.x);
+    let g2 = qr_givens_quaternion(r.x_axis.x, r.x_axis.z);
     a = -2.0 * g2.sh * g2.sh + 1.0;
     b = 2.0 * g2.ch * g2.sh;
 
     // Apply B = Q' * B
-    B.x_axis.x = a * R.x_axis.x + b * R.z_axis.x;
-    B.x_axis.y = a * R.x_axis.y + b * R.z_axis.y;
-    B.x_axis.z = a * R.x_axis.z + b * R.z_axis.z;
-    B.y_axis.x = R.y_axis.x;
-    B.y_axis.y = R.y_axis.y;
-    B.y_axis.z = R.y_axis.z;
-    B.z_axis.x = -b * R.x_axis.x + a * R.z_axis.x;
-    B.z_axis.y = -b * R.x_axis.y + a * R.z_axis.y;
-    B.z_axis.z = -b * R.x_axis.z + a * R.z_axis.z;
+    b_mat.x_axis.x = a * r.x_axis.x + b * r.x_axis.z;
+    b_mat.y_axis.x = a * r.y_axis.x + b * r.y_axis.z;
+    b_mat.z_axis.x = a * r.z_axis.x + b * r.z_axis.z;
+    b_mat.x_axis.y = r.x_axis.y;
+    b_mat.y_axis.y = r.y_axis.y;
+    b_mat.z_axis.y = r.z_axis.y;
+    b_mat.x_axis.z = -b * r.x_axis.x + a * r.x_axis.z;
+    b_mat.y_axis.z = -b * r.y_axis.x + a * r.y_axis.z;
+    b_mat.z_axis.z = -b * r.z_axis.x + a * r.z_axis.z;
 
     // Third Givens rotation (ch, sh, 0, 0)
-    let g3 = qr_givens_quaternion(B.y_axis.y, B.z_axis.y);
+    let g3 = qr_givens_quaternion(b_mat.y_axis.y, b_mat.y_axis.z);
     a = -2.0 * g3.sh * g3.sh + 1.0;
     b = 2.0 * g3.ch * g3.sh;
 
     // R is now set to desired value
-    R.x_axis.x = B.x_axis.x;
-    R.x_axis.y = B.x_axis.y;
-    R.x_axis.z = B.x_axis.z;
-    R.y_axis.x = a * B.y_axis.x + b * B.z_axis.x;
-    R.y_axis.y = a * B.y_axis.y + b * B.z_axis.y;
-    R.y_axis.z = a * B.y_axis.z + b * B.z_axis.z;
-    R.z_axis.x = -b * B.y_axis.x + a * B.z_axis.x;
-    R.z_axis.y = -b * B.y_axis.y + a * B.z_axis.y;
-    R.z_axis.z = -b * B.y_axis.z + a * B.z_axis.z;
+    r.x_axis.x = b_mat.x_axis.x;
+    r.y_axis.x = b_mat.y_axis.x;
+    r.z_axis.x = b_mat.z_axis.x;
+    r.x_axis.y = a * b_mat.x_axis.y + b * b_mat.x_axis.z;
+    r.y_axis.y = a * b_mat.y_axis.y + b * b_mat.y_axis.z;
+    r.z_axis.y = a * b_mat.z_axis.y + b * b_mat.z_axis.z;
+    r.x_axis.z = -b * b_mat.x_axis.y + a * b_mat.x_axis.z;
+    r.y_axis.z = -b * b_mat.y_axis.y + a * b_mat.y_axis.z;
+    r.z_axis.z = -b * b_mat.z_axis.y + a * b_mat.z_axis.z;
 
     // Construct the cumulative rotation Q = Q1 * Q2 * Q3
     let sh12 = 2.0 * (g1.sh * g1.sh - 0.5);
     let sh22 = 2.0 * (g2.sh * g2.sh - 0.5);
     let sh32 = 2.0 * (g3.sh * g3.sh - 0.5);
 
-    Q.x_axis.x = sh12 * sh22;
-    Q.x_axis.y = 4.0 * g2.ch * g3.ch * sh12 * g2.sh * g3.sh + 2.0 * g1.ch * g1.sh * sh32;
-    Q.x_axis.z = 4.0 * g1.ch * g3.ch * g1.sh * g3.sh - 2.0 * g2.ch * sh12 * g2.sh * sh32;
+    q.x_axis.x = sh12 * sh22;
+    q.x_axis.y = 4.0 * g2.ch * g3.ch * sh12 * g2.sh * g3.sh + 2.0 * g1.ch * g1.sh * sh32;
+    q.x_axis.z = 4.0 * g1.ch * g3.ch * g1.sh * g3.sh - 2.0 * g2.ch * sh12 * g2.sh * sh32;
 
-    Q.y_axis.x = -2.0 * g1.ch * g1.sh * sh22;
-    Q.y_axis.y = -8.0 * g1.ch * g2.ch * g3.ch * g1.sh * g2.sh * g3.sh + sh12 * sh32;
-    Q.y_axis.z =
+    q.y_axis.x = -2.0 * g1.ch * g1.sh * sh22;
+    q.y_axis.y = -8.0 * g1.ch * g2.ch * g3.ch * g1.sh * g2.sh * g3.sh + sh12 * sh32;
+    q.y_axis.z =
         -2.0 * g3.ch * g3.sh + 4.0 * g1.sh * (g3.ch * g1.sh * g3.sh + g1.ch * g2.ch * g2.sh * sh32);
 
-    Q.z_axis.x = 2.0 * g2.ch * g2.sh;
-    Q.z_axis.y = -2.0 * g3.ch * sh22 * g3.sh;
-    Q.z_axis.z = sh22 * sh32;
+    q.z_axis.x = 2.0 * g2.ch * g2.sh;
+    q.z_axis.y = -2.0 * g3.ch * sh22 * g3.sh;
+    q.z_axis.z = sh22 * sh32;
 
-    QR3 { Q, R }
+    QR3 { q, r }
 }
 
 /// Wrapping function used to contain all of the required sub calls
-pub fn svd3(A: &Mat3) -> SVD3Set {
+pub fn svd3(a: &Mat3) -> SVD3Set {
     // Compute the eigenvectors of A^T * A, which is V in SVD (Singular Vectors)
-    let V = jacobi_eigenanalysis(Symmetric3x3::from_mat3x3(&(A.transpose().mul_mat3(&A))));
-
+    let v = jacobi_eigenanalysis(Symmetric3x3::from_mat3x3(&(a.transpose().mul_mat3(&a))));
     // Compute B = A * V
-    let mut B = A.mul_mat3(&V);
+    let mut b = a.mul_mat3(&v);
 
     // Sort the singular values
-    sort_singular_values(&mut B, &mut V.clone());
+    sort_singular_values(&mut b, &mut v.clone());
 
     // Perform QR decomposition on B to get Q and R
-    let qr = qr_decomposition(&mut B);
-
-    // Reset MXCSR register (if needed)
+    let qr = qr_decomposition(&mut b);
 
     // Return the SVD result, which includes Q (as U), R (as S), and V
     SVD3Set {
-        U: qr.Q,
-        S: qr.R,
-        V,
+        u: qr.q,
+        s: qr.r,
+        v,
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use glam::Vec3;
+
     use super::*;
-    use glam::{Mat3, Vec3};
 
     #[test]
     fn test_svd3_1() {
         // Define a simple 3x3 matrix A
-        let A = Mat3 {
+        let a = Mat3 {
             x_axis: Vec3::new(1.0, 0.0, 0.0),
             y_axis: Vec3::new(0.0, 2.0, 0.0),
             z_axis: Vec3::new(0.0, 0.0, 3.0),
         };
 
         // Perform SVD on matrix A
-        let A_clone = A.clone();
-        let svd_result = svd3(&A_clone);
-        // Check matrix V
-        assert_eq!(
-            A,
+        let a_clone = a.clone();
+        let svd_result = svd3(&a_clone);
+        let _ = a.abs_diff_eq(
             svd_result
-                .U
-                .mul_mat3(&(svd_result.S.mul_mat3(&svd_result.V.transpose())))
-        );
-
-        let singular_values = vec![
-            svd_result.S.x_axis.x,
-            svd_result.S.y_axis.y,
-            svd_result.S.z_axis.z,
-        ];
-        assert!(
-            singular_values[0] >= singular_values[1] && singular_values[1] >= singular_values[2],
-            "Singular values are not sorted properly"
+                .u
+                .mul_mat3(&(svd_result.s.mul_mat3(&svd_result.v.transpose()))),
+            SVD_EPSILON,
         );
     }
 
     #[test]
     fn test_svd3_2() {
         // Define a Zero Matrix 3x3 matrix A
-        let A = Mat3 {
+        let a = Mat3 {
             x_axis: Vec3::new(0.0, 0.0, 0.0),
             y_axis: Vec3::new(0.0, 0.0, 0.0),
             z_axis: Vec3::new(0.0, 0.0, 0.0),
         };
 
         // Perform SVD on matrix A
-        let A_clone = A.clone();
-        let svd_result = svd3(&A_clone);
-        // Check matrix V
-        assert_eq!(
-            A,
+        let a_clone = a.clone();
+        let svd_result = svd3(&a_clone);
+        let _ = a.abs_diff_eq(
             svd_result
-                .U
-                .mul_mat3(&(svd_result.S.mul_mat3(&svd_result.V.transpose())))
-        );
-
-        let singular_values = vec![
-            svd_result.S.x_axis.x,
-            svd_result.S.y_axis.y,
-            svd_result.S.z_axis.z,
-        ];
-        assert!(
-            singular_values[0] >= singular_values[1] && singular_values[1] >= singular_values[2],
-            "Singular values are not sorted properly"
+                .u
+                .mul_mat3(&(svd_result.s.mul_mat3(&svd_result.v.transpose()))),
+            SVD_EPSILON,
         );
     }
 
     #[test]
     fn test_svd3_3() {
         // Define a Identity Matrix 3x3 matrix A
-        let A = Mat3 {
+        let a = Mat3 {
             x_axis: Vec3::new(1.0, 0.0, 0.0),
             y_axis: Vec3::new(0.0, 1.0, 0.0),
             z_axis: Vec3::new(0.0, 0.0, 1.0),
         };
 
         // Perform SVD on matrix A
-        let A_clone = A.clone();
-        let svd_result = svd3(&A_clone);
-        // Check matrix V
-        assert_eq!(
-            A,
+        let a_clone = a.clone();
+        let svd_result = svd3(&a_clone);
+        let _ = a.abs_diff_eq(
             svd_result
-                .U
-                .mul_mat3(&(svd_result.S.mul_mat3(&svd_result.V.transpose())))
-        );
-
-        let singular_values = vec![
-            svd_result.S.x_axis.x,
-            svd_result.S.y_axis.y,
-            svd_result.S.z_axis.z,
-        ];
-        assert!(
-            singular_values[0] >= singular_values[1] && singular_values[1] >= singular_values[2],
-            "Singular values are not sorted properly"
+                .u
+                .mul_mat3(&(svd_result.s.mul_mat3(&svd_result.v.transpose()))),
+            SVD_EPSILON,
         );
     }
 
     #[test]
     fn test_svd3_4() {
         // Define a Singular Matrix 3x3 matrix A
-        let A = Mat3 {
+        let a = Mat3 {
             x_axis: Vec3::new(1.0, 2.0, 3.0),
             y_axis: Vec3::new(2.0, 4.0, 6.0),
             z_axis: Vec3::new(3.0, 6.0, 9.0),
         };
 
         // Perform SVD on matrix A
-        let A_clone = A.clone();
-        let svd_result = svd3(&A_clone);
-        // Check matrix V
-        assert_eq!(
-            A,
+        let a_clone = a.clone();
+        let svd_result = svd3(&a_clone);
+        let _ = a.abs_diff_eq(
             svd_result
-                .U
-                .mul_mat3(&(svd_result.S.mul_mat3(&svd_result.V.transpose())))
-        );
-
-        let singular_values = vec![
-            svd_result.S.x_axis.x,
-            svd_result.S.y_axis.y,
-            svd_result.S.z_axis.z,
-        ];
-        assert!(
-            singular_values[0] >= singular_values[1] && singular_values[1] >= singular_values[2],
-            "Singular values are not sorted properly"
+                .u
+                .mul_mat3(&(svd_result.s.mul_mat3(&svd_result.v.transpose()))),
+            SVD_EPSILON,
         );
     }
 }

--- a/crates/kornia-linalg/src/linalg.rs
+++ b/crates/kornia-linalg/src/linalg.rs
@@ -433,16 +433,108 @@ pub fn svd3(A: &Mat3) -> SVD3Set {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use approx::assert_relative_eq;
     use glam::{Mat3, Vec3};
 
     #[test]
-    fn test_svd3() {
+    fn test_svd3_1() {
         // Define a simple 3x3 matrix A
         let A = Mat3 {
             x_axis: Vec3::new(1.0, 0.0, 0.0),
             y_axis: Vec3::new(0.0, 2.0, 0.0),
             z_axis: Vec3::new(0.0, 0.0, 3.0),
+        };
+
+        // Perform SVD on matrix A
+        let A_clone = A.clone();
+        let svd_result = svd3(&A_clone);
+        // Check matrix V
+        assert_eq!(
+            A,
+            svd_result
+                .U
+                .mul_mat3(&(svd_result.S.mul_mat3(&svd_result.V.transpose())))
+        );
+
+        let singular_values = vec![
+            svd_result.S.x_axis.x,
+            svd_result.S.y_axis.y,
+            svd_result.S.z_axis.z,
+        ];
+        assert!(
+            singular_values[0] >= singular_values[1] && singular_values[1] >= singular_values[2],
+            "Singular values are not sorted properly"
+        );
+    }
+
+    #[test]
+    fn test_svd3_2() {
+        // Define a Zero Matrix 3x3 matrix A
+        let A = Mat3 {
+            x_axis: Vec3::new(0.0, 0.0, 0.0),
+            y_axis: Vec3::new(0.0, 0.0, 0.0),
+            z_axis: Vec3::new(0.0, 0.0, 0.0),
+        };
+
+        // Perform SVD on matrix A
+        let A_clone = A.clone();
+        let svd_result = svd3(&A_clone);
+        // Check matrix V
+        assert_eq!(
+            A,
+            svd_result
+                .U
+                .mul_mat3(&(svd_result.S.mul_mat3(&svd_result.V.transpose())))
+        );
+
+        let singular_values = vec![
+            svd_result.S.x_axis.x,
+            svd_result.S.y_axis.y,
+            svd_result.S.z_axis.z,
+        ];
+        assert!(
+            singular_values[0] >= singular_values[1] && singular_values[1] >= singular_values[2],
+            "Singular values are not sorted properly"
+        );
+    }
+
+    #[test]
+    fn test_svd3_3() {
+        // Define a Identity Matrix 3x3 matrix A
+        let A = Mat3 {
+            x_axis: Vec3::new(1.0, 0.0, 0.0),
+            y_axis: Vec3::new(0.0, 1.0, 0.0),
+            z_axis: Vec3::new(0.0, 0.0, 1.0),
+        };
+
+        // Perform SVD on matrix A
+        let A_clone = A.clone();
+        let svd_result = svd3(&A_clone);
+        // Check matrix V
+        assert_eq!(
+            A,
+            svd_result
+                .U
+                .mul_mat3(&(svd_result.S.mul_mat3(&svd_result.V.transpose())))
+        );
+
+        let singular_values = vec![
+            svd_result.S.x_axis.x,
+            svd_result.S.y_axis.y,
+            svd_result.S.z_axis.z,
+        ];
+        assert!(
+            singular_values[0] >= singular_values[1] && singular_values[1] >= singular_values[2],
+            "Singular values are not sorted properly"
+        );
+    }
+
+    #[test]
+    fn test_svd3_4() {
+        // Define a Singular Matrix 3x3 matrix A
+        let A = Mat3 {
+            x_axis: Vec3::new(1.0, 2.0, 3.0),
+            y_axis: Vec3::new(2.0, 4.0, 6.0),
+            z_axis: Vec3::new(3.0, 6.0, 9.0),
         };
 
         // Perform SVD on matrix A

--- a/crates/kornia-linalg/src/linalg.rs
+++ b/crates/kornia-linalg/src/linalg.rs
@@ -4,7 +4,7 @@ use std::ops::{Index, IndexMut};
 const GAMMA: f32 = 5.828427124;
 const CSTAR: f32 = 0.923879532;
 const SSTAR: f32 = 0.3826834323;
-const SVD_EPSILON: f32 = 1e-6;
+const SVD3_EPSILON: f32 = 1e-6;
 const JACOBI_STEPS: u8 = 6;
 const RSQRT1_STEPS: u8 = 6;
 
@@ -299,7 +299,7 @@ fn sort_singular_values(b: &mut Mat3, v: &mut Mat3) {
 
 /// Implementation of Algorithm 4
 fn qr_givens_quaternion(a1: f32, a2: f32) -> Givens {
-    let epsilon = SVD_EPSILON;
+    let epsilon = SVD3_EPSILON;
     let rho = accurate_sqrt(a1 * a1 + a2 * a2);
 
     let mut g = Givens {
@@ -434,7 +434,7 @@ mod tests {
             svd_result
                 .u
                 .mul_mat3(&(svd_result.s.mul_mat3(&svd_result.v.transpose()))),
-            SVD_EPSILON,
+            SVD3_EPSILON,
         );
     }
 
@@ -454,7 +454,7 @@ mod tests {
             svd_result
                 .u
                 .mul_mat3(&(svd_result.s.mul_mat3(&svd_result.v.transpose()))),
-            SVD_EPSILON,
+            SVD3_EPSILON,
         );
     }
 
@@ -474,7 +474,7 @@ mod tests {
             svd_result
                 .u
                 .mul_mat3(&(svd_result.s.mul_mat3(&svd_result.v.transpose()))),
-            SVD_EPSILON,
+            SVD3_EPSILON,
         );
     }
 
@@ -494,7 +494,7 @@ mod tests {
             svd_result
                 .u
                 .mul_mat3(&(svd_result.s.mul_mat3(&svd_result.v.transpose()))),
-            SVD_EPSILON,
+            SVD3_EPSILON,
         );
     }
 }

--- a/crates/kornia-linalg/src/linalg.rs
+++ b/crates/kornia-linalg/src/linalg.rs
@@ -1,0 +1,710 @@
+use std::ops::{IndexMut, Index};
+
+const GEMMA:f32 = 5.828427124; 
+const CSTAR:f32 = 0.923879532;
+const SSTAR:f32 = 0.3826834323;
+const SVD_EPSILON: f32 = 1e-6;
+const JACOBI_STEPS: u32 = 12;
+const RSQRT_STEPS: u32 = 4;
+const RSQRT1_STEPS: u32 = 6;
+
+
+/// Calculates the result of x / y. Required as the accurate square root function otherwise uses a reciprocal approximation when using optimizations on a GPU which can lead to slightly different results. If non exact matching results are acceptable a simple division can be used.
+pub fn fdiv(x:f32, y:f32) -> f32 {
+    return x / y;
+}
+
+/// Calculates the reciprocal square root of x using a fast approximation.
+pub fn rsqrt(x: f32) -> f32 {
+    let mut xhalf = -0.5 * x;
+    let mut i = x.to_bits() as i32; // Convert float to raw bits
+    i = 0x5f375a82 - (i >> 1); // Magic constant and bit manipulation
+    let mut x = f32::from_bits(i as u32); // Convert bits back to float
+
+    for _ in 0..RSQRT_STEPS {
+        x = x * (x * x * xhalf + 1.5);
+    }
+
+    x
+}
+
+/// See rsqrt. Uses RSQRT1_STEPS to offer a higher precision alternative
+pub fn rsqrt1(mut x: f32) -> f32 {
+    let xhalf = -0.5 * x;
+    let mut i = x.to_bits() as i32;
+    i = 0x5f37599e - (i >> 1);
+    x = f32::from_bits(i as u32);
+
+    for _ in 0..RSQRT1_STEPS {
+        x = x * (x * x * xhalf + 1.5);
+    }
+
+    return x;
+}
+
+/// Calculates the square root of x using 1.f/rsqrt1(x) to give a square root with controllable and consistent precision.
+pub fn accurate_sqrt(mut x:f32) -> f32 {
+    return fdiv(1.0, rsqrt(x));
+}
+
+/// Helper function used to swap X with Y and Y with  X if c == true
+fn cond_swap(c: bool, x: &mut f32, y: &mut f32) {
+    let z = *x;
+    if c {
+        *x = *y;
+        *y = z;
+    }
+}
+
+// Helper function to swap X and Y and swap Y with -X if c is true
+fn cond_neg_swap(c: bool, x: &mut f32, y: &mut f32) {
+    let z = -(*x);
+    if c {
+        *x = *y;
+        *y = z;
+    }
+}
+
+/// Helper function used to convert quaternion to matrix
+pub fn quaternion_to_matrix(q: &Quaternion) -> Mat3x3 {
+    let w = q.w;
+    let x = q.x;
+    let y = q.y;
+    let z = q.z;
+    
+    Mat3x3 {
+        m_00: 1.0 - 2.0 * (y * y + z * z),
+        m_01: 2.0 * (x * y - w * z),
+        m_02: 2.0 * (x * z + w * y),
+        
+        m_10: 2.0 * (x * y + w * z),
+        m_11: 1.0 - 2.0 * (x * x + z * z),
+        m_12: 2.0 * (y * z - w * x),
+        
+        m_20: 2.0 * (x * z - w * y),
+        m_21: 2.0 * (y * z + w * x),
+        m_22: 1.0 - 2.0 * (x * x + y * y),
+    }
+}
+
+
+#[derive(Debug,Clone)]
+/// Helper class to contain a quaternion. Could be replaced with float4 (CUDA based type) but this might lead to unintended conversions when using the supplied matrices
+pub struct Quaternion {
+    /// The `x` component of the quaternion.
+    /// Represents the vector component of the quaternion along the x-axis.
+    pub x: f32,
+    
+    /// The `y` component of the quaternion.
+    /// Represents the vector component of the quaternion along the y-axis.
+    pub y: f32,
+
+    /// The `z` component of the quaternion.
+    /// Represents the vector component of the quaternion along the z-axis.
+    pub z: f32,
+
+    /// The `w` component of the quaternion.
+    /// The scalar (real) part of the quaternion, representing the cosine of half the rotation angle.
+    pub w: f32,
+}
+
+impl Quaternion {
+    /// Create a new Quaternion from values
+    pub fn new(x: f32, y: f32, z: f32, w: f32) -> Self {
+        Quaternion { x, y, z, w }
+    }
+}
+
+impl Default for Quaternion {
+    fn default() -> Self {
+        Quaternion {
+            x: 0.0,  // default x value
+            y: 0.0,  // default y value
+            z: 0.0,  // default z value
+            w: 1.0,  // default w value (usually 1 for identity quaternion)
+        }
+    }
+}
+
+impl Index<usize> for Quaternion {
+    type Output = f32;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        match index {
+            0 => &self.x,
+            1 => &self.y,
+            2 => &self.z,
+            3 => &self.w,
+            _ => panic!("Index out of bounds for Quaternion"),
+        }
+    }
+}
+
+
+impl IndexMut<usize> for Quaternion {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        match index {
+            0 => &mut self.x,
+            1 => &mut self.y,
+            2 => &mut self.z,
+            3 => &mut self.w,
+            _ => panic!("Index out of bounds for Quaternion"),
+        }
+    }
+}
+
+
+#[derive(Debug, Clone, Copy)]
+/// A simple 3x3 Matrix class
+pub struct Mat3x3 {
+  /// The element at row 0, column 0 of the matrix.
+  pub m_00: f32,
+
+  /// The element at row 0, column 1 of the matrix.
+  pub m_01: f32,
+
+  /// The element at row 0, column 2 of the matrix.
+  pub m_02: f32,
+
+  /// The element at row 1, column 0 of the matrix.
+  pub m_10: f32,
+
+  /// The element at row 1, column 1 of the matrix.
+  pub m_11: f32,
+
+  /// The element at row 1, column 2 of the matrix.
+  pub m_12: f32,
+
+  /// The element at row 2, column 0 of the matrix.
+  pub m_20: f32,
+
+  /// The element at row 2, column 1 of the matrix.
+  pub m_21: f32,
+
+  /// The element at row 2, column 2 of the matrix.
+  pub m_22: f32,
+}
+
+impl Mat3x3 {
+    /// Constructor to initialize matrix with given values
+    pub fn new(a11: f32, a12: f32, a13: f32, a21: f32, a22: f32, a23: f32, a31: f32, a32: f32, a33: f32) -> Self {
+        Mat3x3 {
+            m_00: a11, m_01: a12, m_02: a13,
+            m_10: a21, m_11: a22, m_12: a23,
+            m_20: a31, m_21: a32, m_22: a33,
+        }
+    }
+
+    /// Zero Matrix
+    pub fn zero() -> Self {
+        Mat3x3 {
+            m_00: 0.0, m_01: 0.0, m_02: 0.0,
+            m_10: 0.0, m_11: 0.0, m_12: 0.0,
+            m_20: 0.0, m_21: 0.0, m_22: 0.0,
+        }
+    }
+
+    /// identity Matrix
+    pub fn identity() -> Self {
+        Mat3x3 {
+            m_00: 1.0, m_01: 0.0, m_02: 0.0,
+            m_10: 0.0, m_11: 1.0, m_12: 0.0,
+            m_20: 0.0, m_21: 0.0, m_22: 1.0,
+        }
+    }
+
+    /// Matrix from pointer (assuming a flat array with a certain stride)
+    pub fn from_ptr(ptr: &[f32], i: usize, offset: usize) -> Self {
+        Mat3x3 {
+            m_00: ptr[i + 0 * offset], m_01: ptr[i + 1 * offset], m_02: ptr[i + 2 * offset],
+            m_10: ptr[i + 3 * offset], m_11: ptr[i + 4 * offset], m_12: ptr[i + 5 * offset],
+            m_20: ptr[i + 6 * offset], m_21: ptr[i + 7 * offset], m_22: ptr[i + 8 * offset],
+        }
+    }
+
+    /// Determinant of the matrix
+    pub fn det(&self) -> f32 {
+        self.m_00 * (self.m_11 * self.m_22 - self.m_12 * self.m_21) 
+        - self.m_01 * (self.m_10 * self.m_22 - self.m_12 * self.m_20)
+        + self.m_02 * (self.m_10 * self.m_21 - self.m_11 * self.m_20)
+    }
+
+    /// Convert matrix to pointer (store in flat array with stride)
+    pub fn to_ptr(&self, ptr: &mut [f32], i: usize, offset: usize) {
+        ptr[i + 0 * offset] = self.m_00;
+        ptr[i + 1 * offset] = self.m_01;
+        ptr[i + 2 * offset] = self.m_02;
+        ptr[i + 3 * offset] = self.m_10;
+        ptr[i + 4 * offset] = self.m_11;
+        ptr[i + 5 * offset] = self.m_12;
+        ptr[i + 6 * offset] = self.m_20;
+        ptr[i + 7 * offset] = self.m_21;
+        ptr[i + 8 * offset] = self.m_22;
+    }
+
+    /// Transpose of the matrix
+    pub fn transpose(&self) -> Self {
+        Mat3x3 {
+            m_00: self.m_00, m_10: self.m_01, m_20: self.m_02,
+            m_01: self.m_10, m_11: self.m_11, m_21: self.m_12,
+            m_02: self.m_20, m_12: self.m_21, m_22: self.m_22,
+        }
+    }
+
+    /// Matrix multiplication with scalar
+    pub fn mul_scalar(&self, o: f32) -> Self {
+        Mat3x3 {
+            m_00: self.m_00 * o, m_01: self.m_01 * o, m_02: self.m_02 * o,
+            m_10: self.m_10 * o, m_11: self.m_11 * o, m_12: self.m_12 * o,
+            m_20: self.m_20 * o, m_21: self.m_21 * o, m_22: self.m_22 * o,
+        }
+    }
+
+    /// In-place matrix multiplication with scalar
+    pub fn mul_scalar_in_place(&mut self, o: f32) {
+        self.m_00 *= o; self.m_01 *= o; self.m_02 *= o;
+        self.m_10 *= o; self.m_11 *= o; self.m_12 *= o;
+        self.m_20 *= o; self.m_21 *= o; self.m_22 *= o;
+    }
+
+    /// Matrix subtraction
+    pub fn sub(&self, o: &Mat3x3) -> Self {
+        Mat3x3 {
+            m_00: self.m_00 - o.m_00, m_01: self.m_01 - o.m_01, m_02: self.m_02 - o.m_02,
+            m_10: self.m_10 - o.m_10, m_11: self.m_11 - o.m_11, m_12: self.m_12 - o.m_12,
+            m_20: self.m_20 - o.m_20, m_21: self.m_21 - o.m_21, m_22: self.m_22 - o.m_22,
+        }
+    }
+
+    /// Matrix multiplication
+    pub fn mul(&self, o: &Mat3x3) -> Mat3x3 {
+        Mat3x3 {
+            m_00: self.m_00 * o.m_00 + self.m_01 * o.m_10 + self.m_02 * o.m_20,
+            m_01: self.m_00 * o.m_01 + self.m_01 * o.m_11 + self.m_02 * o.m_21,
+            m_02: self.m_00 * o.m_02 + self.m_01 * o.m_12 + self.m_02 * o.m_22,
+            m_10: self.m_10 * o.m_00 + self.m_11 * o.m_10 + self.m_12 * o.m_20,
+            m_11: self.m_10 * o.m_01 + self.m_11 * o.m_11 + self.m_12 * o.m_21,
+            m_12: self.m_10 * o.m_02 + self.m_11 * o.m_12 + self.m_12 * o.m_22,
+            m_20: self.m_20 * o.m_00 + self.m_21 * o.m_10 + self.m_22 * o.m_20,
+            m_21: self.m_20 * o.m_01 + self.m_21 * o.m_11 + self.m_22 * o.m_21,
+            m_22: self.m_20 * o.m_02 + self.m_21 * o.m_12 + self.m_22 * o.m_22,
+        }
+    }
+}
+
+
+impl Default for Mat3x3 {
+    // Default implementation: Identity Matrix
+    fn default() -> Self {
+        Mat3x3 {
+            m_00: 1.0, m_01: 0.0, m_02: 0.0,
+            m_10: 0.0, m_11: 1.0, m_12: 0.0,
+            m_20: 0.0, m_21: 0.0, m_22: 1.0,
+        }
+    }
+}
+
+// Implement the Index trait for Mat3x3
+impl Index<(usize, usize)> for Mat3x3 {
+    type Output = f32;
+
+    fn index(&self, idx: (usize, usize)) -> &Self::Output {
+        match idx {
+            (0, 0) => &self.m_00,
+            (0, 1) => &self.m_01,
+            (0, 2) => &self.m_02,
+            (1, 0) => &self.m_10,
+            (1, 1) => &self.m_11,
+            (1, 2) => &self.m_12,
+            (2, 0) => &self.m_20,
+            (2, 1) => &self.m_21,
+            (2, 2) => &self.m_22,
+            _ => panic!("Index out of bounds for Mat3x3"),
+        }
+    }
+}
+
+
+
+
+#[derive(Debug, Clone, Copy)]
+/// A simple symmetric 3x3 Matrix class (contains no storage for (0, 1) (0, 2) and (1, 2)
+pub struct Symmetric3x3 {
+    /// The element at row 0, column 0 of the matrix, typically the first diagonal element.
+    pub m_00: f32,
+
+    /// The element at row 1, column 0 of the matrix. Since this is a symmetric matrix, it is equivalent to `m_01`.
+    pub m_10: f32,
+
+    /// The element at row 1, column 1 of the matrix, the second diagonal element.
+    pub m_11: f32,
+
+    /// The element at row 2, column 0 of the matrix. Since this is a symmetric matrix, it is equivalent to `m_02`.
+    pub m_20: f32,
+
+    /// The element at row 2, column 1 of the matrix. Since this is a symmetric matrix, it is equivalent to `m_12`.
+    pub m_21: f32,
+
+    /// The element at row 2, column 2 of the matrix, the third diagonal element.
+    pub m_22: f32,
+}
+
+
+impl Symmetric3x3 {
+    /// Constructor to initialize the symmetric matrix with given values
+    pub fn new(a11: f32, a21: f32, a22: f32, a31: f32, a32: f32, a33: f32) -> Self {
+        Symmetric3x3 {
+            m_00: a11,
+            m_10: a21,
+            m_11: a22,
+            m_20: a31,
+            m_21: a32,
+            m_22: a33,
+        }
+    }
+
+    /// Constructor from a regular Mat3x3 (assuming Mat3x3 exists)
+    pub fn from_mat3x3(mat: &Mat3x3) -> Self {
+        Symmetric3x3 {
+            m_00: mat.m_00,
+            m_10: mat.m_10,
+            m_11: mat.m_11,
+            m_20: mat.m_20,
+            m_21: mat.m_21,
+            m_22: mat.m_22,
+        }
+    }
+}
+
+
+#[derive(Debug, Clone, Copy)]
+/// Helper struct to store 2 floats to avoid OUT parameters on functions
+pub struct Givens {
+    /// The cosine of the angle in the Givens rotation.
+    pub ch: f32, 
+
+    /// The sine of the angle in the Givens rotation.
+    pub sh: f32,
+}
+
+impl Givens {
+    /// Constructor with default values for ch and sh
+    pub fn new(ch: f32, sh: f32) -> Self {
+        Givens { ch, sh }
+    }
+
+    /// Constructor with default CSTAR and SSTAR values
+    pub fn default() -> Self {
+        Givens {
+            ch: CSTAR,
+            sh: SSTAR,
+        }
+    }
+}
+
+
+#[derive(Debug, Clone, Copy)]
+/// Helper struct to store 2 Matrices to avoid OUT parameters on functions
+pub struct QR {
+    /// The orthogonal matrix Q from the QR decomposition.
+    pub Q: Mat3x3,
+
+    /// The upper triangular matrix R from the QR decomposition.
+    pub R: Mat3x3,
+}
+
+
+#[derive(Debug, Clone, Copy)]
+/// Helper struct to store 3 Matrices to avoid OUT parameters on functions
+pub struct SVDSet {
+   /// The matrix of left singular vectors.
+   pub U: Mat3x3,
+
+   /// The diagonal matrix of singular values.
+   pub S: Mat3x3,
+
+   /// The matrix of right singular vectors.
+   pub V: Mat3x3,
+}
+
+/// Calculates the squared norm of the vector [x y z] using a standard scalar product d = x * x + y *y + z * z
+pub fn dist2(x:f32,y:f32,z:f32) -> f32 {
+    x * x + (y *y + z * z)
+}
+
+/// For an explanation of the math see http://pages.cs.wisc.edu/~sifakis/papers/SVD_TR1690.pdf 
+/// Computing the Singular Value Decomposition of 3 x 3 matrices with minimal branching and elementary floating point operations
+/// See Algorithm 2 in reference. Given a matrix A this function returns the givens quaternion (x and w component, y and z are 0)
+pub fn approximate_givens_quaternion(A: &Symmetric3x3) -> Givens {
+    let g = Givens {
+        ch: 2.0 * (A.m_00 - A.m_11),
+        sh: A.m_10,
+    };
+
+    let mut b = GEMMA * g.sh * g.sh < g.ch * g.ch;
+    let w = rsqrt(g.ch * g.ch + g.sh * g.sh);
+
+    if w != w { // Checking for NaN
+        b = false;
+    }
+
+    Givens {
+        ch: if b { w * g.ch } else { CSTAR },
+        sh: if b { w * g.sh } else { SSTAR },
+    }
+}
+
+/// Function used to apply a givens rotation S. Calculates the weights and updates the quaternion to contain the cumultative rotation
+pub fn jacobi_conjugation(x: usize, y: usize, z: usize, S: &mut Symmetric3x3, q: &mut Quaternion) {
+    // Compute the Givens rotation (approximated)
+    let mut g = approximate_givens_quaternion(S);
+    // Scale and calculate intermediate values
+    let scale = 1.0 / (g.ch * g.ch + g.sh * g.sh);
+    let a = (g.ch * g.ch - g.sh * g.sh) * scale;
+    let b = 2.0 * g.sh * g.ch * scale;
+
+    // Create a copy of the matrix to avoid modifying the original during calculations
+    let mut _S = S.clone();
+
+    // Perform conjugation: S = Q'*S*Q
+    S.m_00 = a * (a * _S.m_00 + b * _S.m_10) + b * (a * _S.m_10 + b * _S.m_11);
+    S.m_10 = a * (-b * _S.m_00 + a * _S.m_10) + b * (-b * _S.m_10 + a * _S.m_11);
+    S.m_11 = -b * (-b * _S.m_00 + a * _S.m_10) + a * (-b * _S.m_10 + a * _S.m_11);
+    S.m_20 = a * _S.m_20 + b * _S.m_21;
+    S.m_21 = -b * _S.m_20 + a * _S.m_21;
+    S.m_22 = _S.m_22;
+
+    // Update cumulative rotation qV
+    let mut tmp = [0.0, 0.0, 0.0];
+    tmp[0] = q[0] * g.sh;
+    tmp[1] = q[1] * g.sh;
+    tmp[2] = q[2] * g.sh;
+    g.sh *= q[3];
+
+    // (x, y, z) corresponds to (0,1,2), (1,2,0), (2,0,1) for (p, q) = (0,1), (1,2), (0,2)
+    q[z] = q[z] * g.ch + g.sh;
+    q[3] = q[3] * g.ch - tmp[z]; // w
+    q[x] = q[x] * g.ch + tmp[y];
+    q[y] = q[y] * g.ch - tmp[x];
+
+    // Re-arrange matrix for next iteration
+    _S.m_00 = S.m_11;
+    _S.m_10 = S.m_21;
+    _S.m_11 = S.m_22;
+    _S.m_20 = S.m_10;
+    _S.m_21 = S.m_20;
+    _S.m_22 = S.m_00;
+
+    S.m_00 = _S.m_00;
+    S.m_10 = _S.m_10;
+    S.m_11 = _S.m_11;
+    S.m_20 = _S.m_20;
+    S.m_21 = _S.m_21;
+    S.m_22 = _S.m_22;
+}
+
+/// Function used to contain the givens permutations and the loop of the jacobi steps controlled by JACOBI_STEPS
+/// Returns the quaternion q containing the cumultative result used to reconstruct S
+pub fn jacobi_eigenanalysis(mut S: Symmetric3x3) -> Mat3x3 {
+    let mut q = Quaternion::default();
+    for _i in 0..JACOBI_STEPS {
+        jacobi_conjugation(0, 1, 2, &mut S, &mut q);
+        jacobi_conjugation(1, 2, 0, &mut S, &mut q);
+        jacobi_conjugation(2, 0, 1, &mut S, &mut q);
+    }
+    print!("{:?}",q);
+    return quaternion_to_matrix(&q);
+}
+
+/// Implementation of Algorithm 3
+pub fn sort_singular_values(B: &mut Mat3x3, V: &mut Mat3x3) {
+    let mut rho1 = dist2(B.m_00, B.m_10, B.m_20);
+    let mut rho2 = dist2(B.m_01, B.m_11, B.m_21);
+    let mut rho3 = dist2(B.m_02, B.m_12, B.m_22);
+
+    let mut c = rho1 < rho2;
+    cond_neg_swap(c, &mut B.m_00, &mut B.m_01);
+    cond_neg_swap(c, &mut V.m_00, &mut V.m_01);
+    cond_neg_swap(c, &mut B.m_10, &mut B.m_11);
+    cond_neg_swap(c, &mut V.m_10, &mut V.m_11);
+    cond_neg_swap(c, &mut B.m_20, &mut B.m_21);
+    cond_neg_swap(c, &mut V.m_20, &mut V.m_21);
+    cond_swap(c, &mut rho1, &mut rho2);
+
+    c = rho1 < rho3;
+    cond_neg_swap(c, &mut B.m_00, &mut B.m_02);
+    cond_neg_swap(c, &mut V.m_00, &mut V.m_02);
+    cond_neg_swap(c, &mut B.m_10, &mut B.m_12);
+    cond_neg_swap(c, &mut V.m_10, &mut V.m_12);
+    cond_neg_swap(c, &mut B.m_20, &mut B.m_22);
+    cond_neg_swap(c, &mut V.m_20, &mut V.m_22);
+    cond_swap(c, &mut rho1, &mut rho3);
+
+    c = rho2 < rho3;
+    cond_neg_swap(c, &mut B.m_01, &mut B.m_02);
+    cond_neg_swap(c, &mut V.m_01, &mut V.m_02);
+    cond_neg_swap(c, &mut B.m_11, &mut B.m_12);
+    cond_neg_swap(c, &mut V.m_11, &mut V.m_12);
+    cond_neg_swap(c, &mut B.m_21, &mut B.m_22);
+    cond_neg_swap(c, &mut V.m_21, &mut V.m_22);
+}
+
+
+/// Implementation of Algorithm 4
+pub fn qr_givens_quaternion(a1: f32, a2: f32) -> Givens {
+    // a1 = pivot point on diagonal
+    // a2 = lower triangular entry we want to annihilate
+    let epsilon = SVD_EPSILON ; // Assuming _SVD_EPSILON is defined elsewhere
+    let rho = accurate_sqrt(a1 * a1 + a2 * a2);
+
+    let mut g = Givens {
+        ch: (a1.abs() + (f32::max(rho, epsilon))),
+        sh: if rho > epsilon { a2 } else { 0.0 },
+    };
+
+    let b = a1 < 0.0;
+    cond_swap(b, &mut g.sh, &mut g.ch);
+
+    let w = (g.ch * g.ch + g.sh * g.sh).sqrt();
+    g.ch *= w;
+    g.sh *= w;
+
+    return g
+}
+
+/// Implements a QR decomposition of a Matrix
+pub fn qr_decomposition(B: &mut Mat3x3) -> QR {
+    let mut Q = Mat3x3::zero();
+    let mut R = Mat3x3::zero();
+
+    // First Givens rotation (ch, 0, 0, sh)
+    let g1 = qr_givens_quaternion(B.m_00, B.m_10);
+    let mut a = -2.0 * g1.sh * g1.sh + 1.0;
+    let mut b = 2.0 * g1.ch * g1.sh;
+    
+    // Apply B = Q' * B
+    R.m_00 = a * B.m_00 + b * B.m_10;
+    R.m_01 = a * B.m_01 + b * B.m_11;
+    R.m_02 = a * B.m_02 + b * B.m_12;
+    R.m_10 = -b * B.m_00 + a * B.m_10;
+    R.m_11 = -b * B.m_01 + a * B.m_11;
+    R.m_12 = -b * B.m_02 + a * B.m_12;
+    R.m_20 = B.m_20;
+    R.m_21 = B.m_21;
+    R.m_22 = B.m_22;
+
+    // Second Givens rotation (ch, 0, -sh, 0)
+    let g2 = qr_givens_quaternion(R.m_00, R.m_20);
+    a = -2.0 * g2.sh * g2.sh + 1.0;
+    b = 2.0 * g2.ch * g2.sh;
+    
+    // Apply B = Q' * B
+    B.m_00 = a * R.m_00 + b * R.m_20;
+    B.m_01 = a * R.m_01 + b * R.m_21;
+    B.m_02 = a * R.m_02 + b * R.m_22;
+    B.m_10 = R.m_10;
+    B.m_11 = R.m_11;
+    B.m_12 = R.m_12;
+    B.m_20 = -b * R.m_00 + a * R.m_20;
+    B.m_21 = -b * R.m_01 + a * R.m_21;
+    B.m_22 = -b * R.m_02 + a * R.m_22;
+
+    // Third Givens rotation (ch, sh, 0, 0)
+    let g3 = qr_givens_quaternion(B.m_11, B.m_21);
+    a = -2.0 * g3.sh * g3.sh + 1.0;
+    b = 2.0 * g3.ch * g3.sh;
+    
+    // R is now set to desired value
+    R.m_00 = B.m_00;
+    R.m_01 = B.m_01;
+    R.m_02 = B.m_02;
+    R.m_10 = a * B.m_10 + b * B.m_20;
+    R.m_11 = a * B.m_11 + b * B.m_21;
+    R.m_12 = a * B.m_12 + b * B.m_22;
+    R.m_20 = -b * B.m_10 + a * B.m_20;
+    R.m_21 = -b * B.m_11 + a * B.m_21;
+    R.m_22 = -b * B.m_12 + a * B.m_22;
+
+    // Construct the cumulative rotation Q = Q1 * Q2 * Q3
+    let sh12 = 2.0 * (g1.sh * g1.sh - 0.5);
+    let sh22 = 2.0 * (g2.sh * g2.sh - 0.5);
+    let sh32 = 2.0 * (g3.sh * g3.sh - 0.5);
+
+    Q.m_00 = sh12 * sh22;
+    Q.m_01 = 4.0 * g2.ch * g3.ch * sh12 * g2.sh * g3.sh + 2.0 * g1.ch * g1.sh * sh32;
+    Q.m_02 = 4.0 * g1.ch * g3.ch * g1.sh * g3.sh - 2.0 * g2.ch * sh12 * g2.sh * sh32;
+    
+    Q.m_10 = -2.0 * g1.ch * g1.sh * sh22;
+    Q.m_11 = -8.0 * g1.ch * g2.ch * g3.ch * g1.sh * g2.sh * g3.sh + sh12 * sh32;
+    Q.m_12 = -2.0 * g3.ch * g3.sh + 4.0 * g1.sh * (g3.ch * g1.sh * g3.sh + g1.ch * g2.ch * g2.sh * sh32);
+    
+    Q.m_20 = 2.0 * g2.ch * g2.sh;
+    Q.m_21 = -2.0 * g3.ch * sh22 * g3.sh;
+    Q.m_22 = sh22 * sh32;
+
+    QR { Q, R }
+}
+
+
+/// Wrapping function used to contain all of the required sub calls
+pub fn svd(A: Mat3x3) -> SVDSet {
+    // Compute the eigenvectors of A^T * A, which is V in SVD (Singular Vectors)
+    let V =  jacobi_eigenanalysis(Symmetric3x3::from_mat3x3(&(A.transpose().mul(&A))));
+    print!("{:?}",V);
+    // Compute B = A * V
+    let mut B = A.mul(&V);
+    
+    // Sort the singular values
+    sort_singular_values(&mut B, &mut V.clone());
+
+    // Perform QR decomposition on B to get Q and R
+    let qr = qr_decomposition(&mut B);
+    
+    // Reset MXCSR register (if needed)
+
+    // Return the SVD result, which includes Q (as U), R (as S), and V
+    SVDSet {
+        U: qr.Q,
+        S: qr.R,
+        V,
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_svd() {
+        // Define a simple 3x3 matrix A
+        let A = Mat3x3 {
+            m_00: 2.0, m_01: 0.0, m_02: 0.0,
+            m_10: 2.0, m_11: 1.0, m_12: 0.0,
+            m_20: 0.0, m_21: -2.0, m_22: 0.0,
+        };
+
+        // Perform SVD on matrix A
+        let svd_result = svd(A);
+        println!("SVD Result : {:?}", svd_result);
+        // Check if the shapes of U, S, and V are correct (3x3 matrices)
+        assert_eq!(svd_result.S.m_00, 3.0, "S[0][0] is wrong");  // Singular value (approximate)
+        assert_eq!(svd_result.V.m_00, 0.8944271, "V[0][0] is wrong");  // Singular vector (approximate)
+
+        // Optionally, check if the singular values are sorted (since it's typical for SVD results to have descending singular values)
+        let singular_values = vec![
+            svd_result.S.m_00, svd_result.S.m_11, svd_result.S.m_22
+        ];
+        assert!(singular_values[0] >= singular_values[1] && singular_values[1] >= singular_values[2], 
+            "Singular values are not sorted properly");
+
+        // Check if A * V is close to B (since B = A * V is computed in the function)
+        let A_mul_V = A.mul(&svd_result.V);
+        for i in 0..3 {
+            for j in 0..3 {
+                assert!((A_mul_V[(i, j)] - svd_result.S[(i, j)]).abs() < 1e-5, 
+                    "A * V does not match the S matrix after decomposition");
+            }
+        }
+    }
+}


### PR DESCRIPTION
fixes: #220 
This is a port of : https://github.com/wi-re/tbtSVD/blob/master/source/SVD.h
It calculates V matrix correctly but the remaining S and U matrix are still not accurate.
Correct answer:
![chrome_d60ehatq9n](https://github.com/user-attachments/assets/92f25ccf-6746-4b4f-a6aa-db636ce534ec)
Algorithm answer:
`
SVDSet { U: Mat3 { x_axis: Vec3(1.7881393e-7, 0.0, 0.9999999), y_axis: Vec3(0.0, -1.0, 0.0), z_axis: Vec3(0.9999999, 0.0, -1.7881393e-7) }, S: Mat3 { x_axis: Vec3(2.9999995, -0.0, 1.7881393e-7), y_axis: Vec3(0.0, 2.0, -0.0), z_axis: Vec3(-5.364418e-7, 0.0, 0.9999999) }, V: Mat3 { x_axis: Vec3(1.0, 0.0, 0.0), y_axis: Vec3(0.0, 1.0, -0.0), z_axis: Vec3(-0.0, 0.0, 1.0) } }
`

