### PR TITLE
Added additional functions for kornia tensors

### DIFF
--- a/crates/kornia-tensor-ops/src/ops.rs
+++ b/crates/kornia-tensor-ops/src/ops.rs
@@ -122,13 +122,13 @@ where
 pub fn min<T, const N: usize>(
     tensor: &Tensor<T, N, CpuAllocator>,
     other: &Tensor<T, N, CpuAllocator>,
-) -> Tensor<T, N, CpuAllocator>
+) -> Result<Tensor<T, N, CpuAllocator>, TensorOpsError>
 where
     T: PartialOrd + Clone,
 {
     tensor
         .element_wise_op(other, |a, b| if a < b { a.clone() } else { b.clone() })
-        .expect("Tensor dimension mismatch")
+        .map_err(|_| TensorOpsError::ShapeMismatch(tensor.shape.to_vec(), other.shape.to_vec()))
 }
 
 /// Compute the dot product between two 1D tensors
@@ -367,15 +367,15 @@ mod tests {
     }
 
     #[test]
-    fn test_min_i32() -> Result<(), TensorError> {
-        let data_a: [i32; 5] = [3, 1, 4, 1, 5];
-        let data_b: [i32; 5] = [2, 7, 1, 8, 2];
+    fn test_min_f32() -> Result<(), TensorError> {
+        let data_a: [f32; 5] = [3.0, 1.0, 4.0, 1.0, 5.0];
+        let data_b: [f32; 5] = [2.0, 7.0, 1.0, 8.0, 2.0];
         let tensor_a =
-            Tensor::<i32, 1, CpuAllocator>::from_shape_slice([5], &data_a, CpuAllocator)?;
+            Tensor::<f32, 1, CpuAllocator>::from_shape_slice([5], &data_a, CpuAllocator)?;
         let tensor_b =
-            Tensor::<i32, 1, CpuAllocator>::from_shape_slice([5], &data_b, CpuAllocator)?;
-        let result = min(&tensor_a, &tensor_b);
-        let expected = vec![2, 1, 1, 1, 2];
+            Tensor::<f32, 1, CpuAllocator>::from_shape_slice([5], &data_b, CpuAllocator)?;
+        let result = min(&tensor_a, &tensor_b).unwrap();
+        let expected = vec![2.0, 1.0, 1.0, 1.0, 2.0];
         assert_eq!(result.as_slice(), expected.as_slice());
         Ok(())
     }

--- a/crates/kornia-tensor-ops/src/ops.rs
+++ b/crates/kornia-tensor-ops/src/ops.rs
@@ -1,5 +1,8 @@
-use kornia_tensor::{storage::TensorStorage, Tensor, TensorAllocator};
-use num_traits::Zero;
+use core::f32;
+use std::alloc::GlobalAlloc;
+
+use kornia_tensor::{storage::TensorStorage, CpuAllocator, Tensor, TensorAllocator};
+use num_traits::{Float, Zero};
 
 use crate::error::TensorOpsError;
 
@@ -75,6 +78,64 @@ where
         strides: out_strides,
     })
 }
+
+/// Multiply the pixel data by a scalar.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `n` - The scalar to multiply the pixel data by.
+    ///     
+    /// # Returns
+    /// 
+    /// A new image with the pixel data multiplied by the scalar.
+    pub fn mul_scalar<T, const N: usize, A>(
+        tensor:&Tensor<T, N, A>, 
+        n: T
+    ) -> Tensor<T, N, A>
+    where
+        T: Float + Clone,
+        A: TensorAllocator + Clone + 'static,
+    {
+        tensor.map(|&x| x * n)
+    }
+
+
+    /// Raise the pixel data to the power of a float.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `n` - The power to raise the pixel data to.
+    /// 
+    /// # Returns
+    /// 
+    /// A new image with the pixel data raised to the power.
+    pub fn powf<T, const N: usize, A>(
+        tensor:&Tensor<T, N, A>, 
+        n: T
+    ) -> Tensor<T, N, A>
+    where
+        T: Float + Clone,
+        A: TensorAllocator + Clone + 'static,
+    {
+        tensor.map(|x| x.powf(n))
+    }
+    /// Perform an element-wise minimum operation on two tensors.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `other` - The other tensor to compare.
+    /// 
+    /// # Returns
+    /// 
+    /// A new `Tensor` instance.
+    pub fn min<T, const N: usize, A>(tensor:&Tensor<T, N, CpuAllocator>,other:&Tensor<T, N, CpuAllocator>) -> Tensor<T, N, CpuAllocator>
+    where
+        T: PartialOrd + Clone,
+        A: TensorAllocator + Clone + 'static,
+    {
+        tensor.element_wise_op(other, |a, b| if a < b { a.clone() } else { b.clone() })
+            .expect("Tensor dimension mismatch")
+    }
 
 #[cfg(test)]
 mod tests {

--- a/crates/kornia-tensor/src/tensor.rs
+++ b/crates/kornia-tensor/src/tensor.rs
@@ -638,39 +638,6 @@ where
         self.map(|x| x.powi(n))
     }
 
-    /// Multiply the pixel data by a scalar.
-    /// 
-    /// # Arguments
-    /// 
-    /// * `n` - The scalar to multiply the pixel data by.
-    ///     
-    /// # Returns
-    /// 
-    /// A new image with the pixel data multiplied by the scalar.
-    pub fn mul_scalar(&self, n: T) -> Tensor<T, N, A>
-    where
-        T: Float,
-    {
-        self.map(|&x| x * n)
-    }
-
-
-    /// Raise the pixel data to the power of a float.
-    /// 
-    /// # Arguments
-    /// 
-    /// * `n` - The power to raise the pixel data to.
-    /// 
-    /// # Returns
-    /// 
-    /// A new image with the pixel data raised to the power.
-    pub fn powf(&self, n: T) -> Tensor<T, N, A>
-    where
-        T: Float,
-    {
-        self.map(|x| x.powf(n))
-    }
-
     /// Compute absolute value of the pixel data.
     ///
     /// # Returns
@@ -922,23 +889,6 @@ where
         T: std::ops::Div<Output = T> + Clone,
     {
         self.element_wise_op(other, |a, b| a.clone() / b.clone())
-            .expect("Tensor dimension mismatch")
-    }
-
-    /// Perform an element-wise minimum operation on two tensors.
-    /// 
-    /// # Arguments
-    /// 
-    /// * `other` - The other tensor to compare.
-    /// 
-    /// # Returns
-    /// 
-    /// A new `Tensor` instance.
-    pub fn min(&self, other: &Tensor<T, N, CpuAllocator>) -> Tensor<T, N, CpuAllocator>
-    where
-        T: PartialOrd + Clone,
-    {
-        self.element_wise_op(other, |a, b| if a < b { a.clone() } else { b.clone() })
             .expect("Tensor dimension mismatch")
     }
 }

--- a/crates/kornia-tensor/src/tensor.rs
+++ b/crates/kornia-tensor/src/tensor.rs
@@ -638,6 +638,39 @@ where
         self.map(|x| x.powi(n))
     }
 
+    /// Multiply the pixel data by a scalar.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `n` - The scalar to multiply the pixel data by.
+    ///     
+    /// # Returns
+    /// 
+    /// A new image with the pixel data multiplied by the scalar.
+    pub fn mul_scalar(&self, n: T) -> Tensor<T, N, A>
+    where
+        T: Float,
+    {
+        self.map(|&x| x * n)
+    }
+
+
+    /// Raise the pixel data to the power of a float.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `n` - The power to raise the pixel data to.
+    /// 
+    /// # Returns
+    /// 
+    /// A new image with the pixel data raised to the power.
+    pub fn powf(&self, n: T) -> Tensor<T, N, A>
+    where
+        T: Float,
+    {
+        self.map(|x| x.powf(n))
+    }
+
     /// Compute absolute value of the pixel data.
     ///
     /// # Returns
@@ -889,6 +922,23 @@ where
         T: std::ops::Div<Output = T> + Clone,
     {
         self.element_wise_op(other, |a, b| a.clone() / b.clone())
+            .expect("Tensor dimension mismatch")
+    }
+
+    /// Perform an element-wise minimum operation on two tensors.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `other` - The other tensor to compare.
+    /// 
+    /// # Returns
+    /// 
+    /// A new `Tensor` instance.
+    pub fn min(&self, other: &Tensor<T, N, CpuAllocator>) -> Tensor<T, N, CpuAllocator>
+    where
+        T: PartialOrd + Clone,
+    {
+        self.element_wise_op(other, |a, b| if a < b { a.clone() } else { b.clone() })
             .expect("Tensor dimension mismatch")
     }
 }


### PR DESCRIPTION
- `mul_scalar`:- multiplies the tensor by any scalar number
- `powf`:- raises a tensor to a float power
- `min`:- implementation of `torch.minimum` function of pytorch

these functions are used in the implementation of #243, #244 