### PR TITLE
Implemented decoding images directly from raw bytes . Fixes #121 

### DIFF
--- a/crates/kornia-io/src/functional.rs
+++ b/crates/kornia-io/src/functional.rs
@@ -163,7 +163,7 @@ pub fn write_image_png_gray8(
     file_path: impl AsRef<Path>,
     image: &Image<u8, 1>,
 ) -> Result<(), IoError> {
-    crate::png::write_image_png_gray8(file_path, image.clone())
+    crate::png::write_image_png_gray8(file_path, image)
 }
 
 /// Write an RGB image (rgb8) to a PNG file.
@@ -197,7 +197,7 @@ pub fn write_image_png_rgb8(
     file_path: impl AsRef<Path>,
     image: &Image<u8, 3>,
 ) -> Result<(), IoError> {
-    crate::png::write_image_png_rgb8(file_path, image.clone())
+    crate::png::write_image_png_rgb8(file_path, image)
 }
 
 /// Write an RGBA image (rgba8) to a PNG file.
@@ -231,7 +231,7 @@ pub fn write_image_png_rgba8(
     file_path: impl AsRef<Path>,
     image: &Image<u8, 4>,
 ) -> Result<(), IoError> {
-    crate::png::write_image_png_rgba8(file_path, image.clone())
+    crate::png::write_image_png_rgba8(file_path, image)
 }
 
 /// Write a grayscale 16-bit image (gray16) to a PNG file.
@@ -388,6 +388,9 @@ mod tests {
         use kornia_image::{Image, ImageSize};
         use std::path::PathBuf;
         use tempfile::tempdir;
+        // Convert to grayscale using the proper function
+        let mut image_gray = Image::<u8, 1>::from_size_val(image_rgb.size(), 0)?;
+        gray_from_rgb_u8(&image_rgb, &mut image_gray)?;
         
         // Create a temporary directory for our test file
         let temp_dir = tempdir()?;
@@ -418,35 +421,13 @@ mod tests {
     #[test]
     fn read_write_jpeg_gray() -> Result<(), IoError> {
         use kornia_image::{Image, ImageSize};
+        use kornia_imgproc::color::gray_from_rgb_u8;
         use std::path::PathBuf;
         use tempfile::tempdir;
         
         // First, read an RGB image
         let image_rgb = super::read_image_jpegturbo_rgb8("../../tests/data/dog.jpeg")?;
-        
-        // Convert to grayscale (simple average for testing)
-        let width = image_rgb.width();
-        let height = image_rgb.height();
-        let mut gray_data = Vec::with_capacity(width * height);
-        
-        for y in 0..height {
-            for x in 0..width {
-                let r = *image_rgb.get_pixel(x, y, 0).unwrap();
-                let g = *image_rgb.get_pixel(x, y, 1).unwrap();
-                let b = *image_rgb.get_pixel(x, y, 2).unwrap();
-                let gray = (r as u32 + g as u32 + b as u32) / 3;
-                gray_data.push(gray as u8);
-            }
-        }
-        
-        let image_gray = Image::<u8, 1>::new(
-            ImageSize {
-                width,
-                height,
-            },
-            gray_data,
-        )?;
-        
+
         // Create a temporary directory for our test file
         let temp_dir = tempdir()?;
         let file_path = temp_dir.path().join("test_gray.jpeg");
@@ -458,8 +439,8 @@ mod tests {
         let image_gray_back = super::read_image_jpegturbo_gray8(&file_path)?;
         
         // Check that dimensions match
-        assert_eq!(image_gray_back.width(), width);
-        assert_eq!(image_gray_back.height(), height);
+        assert_eq!(image_gray_back.width(), image_rgb.width());
+        assert_eq!(image_gray_back.height(), image_rgb.height());
         assert_eq!(image_gray_back.num_channels(), 1);
         
         Ok(())

--- a/crates/kornia-io/src/functional.rs
+++ b/crates/kornia-io/src/functional.rs
@@ -419,6 +419,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "turbojpeg")]
     fn read_write_jpeg_gray() -> Result<(), IoError> {
         use kornia_image::{Image, ImageSize};
         use kornia_imgproc::color::gray_from_rgb_u8;
@@ -427,7 +428,11 @@ mod tests {
         
         // First, read an RGB image
         let image_rgb = super::read_image_jpegturbo_rgb8("../../tests/data/dog.jpeg")?;
-
+        
+        // Convert to grayscale using the proper function
+        let mut image_gray = Image::<u8, 1>::from_size_val(image_rgb.size(), 0)?;
+        gray_from_rgb_u8(&image_rgb, &mut image_gray)?;
+        
         // Create a temporary directory for our test file
         let temp_dir = tempdir()?;
         let file_path = temp_dir.path().join("test_gray.jpeg");

--- a/crates/kornia-io/src/functional.rs
+++ b/crates/kornia-io/src/functional.rs
@@ -132,6 +132,212 @@ pub fn read_image_any_rgb8(file_path: impl AsRef<Path>) -> Result<Image<u8, 3>, 
     Ok(image)
 }
 
+/// Write a grayscale image (gray8) to a PNG file.
+///
+/// # Arguments
+///
+/// * `file_path` - The path to save the PNG file.
+/// * `image` - The grayscale image to save.
+///
+/// # Returns
+///
+/// `Ok(())` if the image was successfully written, or an error otherwise.
+///
+/// # Example
+///
+/// ```
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_io::functional as F;
+///
+/// let image = Image::<u8, 1>::new(
+///     ImageSize {
+///         width: 2,
+///         height: 1,
+///     },
+///     vec![0, 255],
+/// ).unwrap();
+///
+/// F::write_image_png_gray8("output.png", &image).unwrap();
+/// ```
+pub fn write_image_png_gray8(
+    file_path: impl AsRef<Path>,
+    image: &Image<u8, 1>,
+) -> Result<(), IoError> {
+    crate::png::write_image_png_gray8(file_path, image.clone())
+}
+
+/// Write an RGB image (rgb8) to a PNG file.
+///
+/// # Arguments
+///
+/// * `file_path` - The path to save the PNG file.
+/// * `image` - The RGB image to save.
+///
+/// # Returns
+///
+/// `Ok(())` if the image was successfully written, or an error otherwise.
+///
+/// # Example
+///
+/// ```
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_io::functional as F;
+///
+/// let image = Image::<u8, 3>::new(
+///     ImageSize {
+///         width: 2,
+///         height: 1,
+///     },
+///     vec![255, 0, 0, 0, 255, 0],
+/// ).unwrap();
+///
+/// F::write_image_png_rgb8("output.png", &image).unwrap();
+/// ```
+pub fn write_image_png_rgb8(
+    file_path: impl AsRef<Path>,
+    image: &Image<u8, 3>,
+) -> Result<(), IoError> {
+    crate::png::write_image_png_rgb8(file_path, image.clone())
+}
+
+/// Write an RGBA image (rgba8) to a PNG file.
+///
+/// # Arguments
+///
+/// * `file_path` - The path to save the PNG file.
+/// * `image` - The RGBA image to save.
+///
+/// # Returns
+///
+/// `Ok(())` if the image was successfully written, or an error otherwise.
+///
+/// # Example
+///
+/// ```
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_io::functional as F;
+///
+/// let image = Image::<u8, 4>::new(
+///     ImageSize {
+///         width: 2,
+///         height: 1,
+///     },
+///     vec![255, 0, 0, 255, 0, 255, 0, 128],
+/// ).unwrap();
+///
+/// F::write_image_png_rgba8("output.png", &image).unwrap();
+/// ```
+pub fn write_image_png_rgba8(
+    file_path: impl AsRef<Path>,
+    image: &Image<u8, 4>,
+) -> Result<(), IoError> {
+    crate::png::write_image_png_rgba8(file_path, image.clone())
+}
+
+/// Write a grayscale 16-bit image (gray16) to a PNG file.
+///
+/// # Arguments
+///
+/// * `file_path` - The path to save the PNG file.
+/// * `image` - The grayscale 16-bit image to save.
+///
+/// # Returns
+///
+/// `Ok(())` if the image was successfully written, or an error otherwise.
+///
+/// # Example
+///
+/// ```
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_io::functional as F;
+///
+/// let image = Image::<u16, 1>::new(
+///     ImageSize {
+///         width: 2,
+///         height: 1,
+///     },
+///     vec![0, 65535],
+/// ).unwrap();
+///
+/// F::write_image_png_gray16("output.png", &image).unwrap();
+/// ```
+pub fn write_image_png_gray16(
+    file_path: impl AsRef<Path>,
+    image: &Image<u16, 1>,
+) -> Result<(), IoError> {
+    crate::png::write_image_png_gray16(file_path, image.clone())
+}
+
+/// Reads a grayscale (gray8) image from a JPEG file using TurboJPEG.
+///
+/// # Arguments
+///
+/// * `file_path` - The path to the JPEG image.
+///
+/// # Returns
+///
+/// A tensor image containing the image data in grayscale format with shape (H, W, 1).
+///
+/// # Example
+///
+/// ```
+/// use kornia_image::Image;
+/// use kornia_io::functional as F;
+///
+/// let image: Image<u8, 1> = F::read_image_jpegturbo_gray8("../../tests/data/dog.jpeg").unwrap();
+/// ```
+#[cfg(feature = "turbojpeg")]
+pub fn read_image_jpegturbo_gray8(file_path: impl AsRef<Path>) -> Result<Image<u8, 1>, IoError> {
+    // load the file into a buffer
+    let file_path = file_path.as_ref();
+    let buf = std::fs::read(file_path)?;
+
+    // create an image decoder
+    let mut decoder = JpegTurboDecoder::new()?;
+
+    // read the image data
+    decoder.decode_gray8(&buf).map_err(Into::into)
+}
+
+/// Writes a grayscale (gray8) image to a JPEG file using TurboJPEG.
+///
+/// # Arguments
+///
+/// * `file_path` - The path to the JPEG image.
+/// * `image` - The tensor containing the grayscale image data.
+///
+/// # Example
+///
+/// ```
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_io::functional as F;
+///
+/// let image = Image::<u8, 1>::new(
+///     ImageSize {
+///         width: 2,
+///         height: 1,
+///     },
+///     vec![0, 255],
+/// ).unwrap();
+///
+/// F::write_image_jpegturbo_gray8("output.jpeg", &image).unwrap();
+/// ```
+#[cfg(feature = "turbojpeg")]
+pub fn write_image_jpegturbo_gray8(
+    file_path: impl AsRef<Path>,
+    image: &Image<u8, 1>,
+) -> Result<(), IoError> {
+    let file_path = file_path.as_ref().to_owned();
+
+    // compress the image
+    let jpeg_data = JpegTurboEncoder::new()?.encode_gray8(image)?;
+
+    // write the data directly to a file
+    std::fs::write(file_path, jpeg_data)?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use crate::error::IoError;
@@ -174,6 +380,88 @@ mod tests {
         assert_eq!(image_data_back.rows(), 195);
         assert_eq!(image_data_back.num_channels(), 3);
 
+        Ok(())
+    }
+
+    #[test]
+    fn write_read_png_gray8() -> Result<(), IoError> {
+        use kornia_image::{Image, ImageSize};
+        use std::path::PathBuf;
+        use tempfile::tempdir;
+        
+        // Create a temporary directory for our test file
+        let temp_dir = tempdir()?;
+        let file_path = temp_dir.path().join("test_gray8.png");
+        
+        // Create a test image
+        let image = Image::<u8, 1>::new(
+            ImageSize {
+                width: 2,
+                height: 2,
+            },
+            vec![0, 255, 128, 64],
+        )?;
+        
+        // Write the image to a file using the functional API
+        super::write_image_png_gray8(&file_path, &image)?;
+        
+        // Read the image back (we'll use the png module directly for reading)
+        let read_image = crate::png::read_image_png_mono8(&file_path)?;
+        
+        // Check that the images match
+        assert_eq!(read_image.size(), image.size());
+        assert_eq!(read_image.as_slice(), image.as_slice());
+        
+        Ok(())
+    }
+
+    #[test]
+    fn read_write_jpeg_gray() -> Result<(), IoError> {
+        use kornia_image::{Image, ImageSize};
+        use std::path::PathBuf;
+        use tempfile::tempdir;
+        
+        // First, read an RGB image
+        let image_rgb = super::read_image_jpegturbo_rgb8("../../tests/data/dog.jpeg")?;
+        
+        // Convert to grayscale (simple average for testing)
+        let width = image_rgb.width();
+        let height = image_rgb.height();
+        let mut gray_data = Vec::with_capacity(width * height);
+        
+        for y in 0..height {
+            for x in 0..width {
+                let r = *image_rgb.get_pixel(x, y, 0).unwrap();
+                let g = *image_rgb.get_pixel(x, y, 1).unwrap();
+                let b = *image_rgb.get_pixel(x, y, 2).unwrap();
+                let gray = (r as u32 + g as u32 + b as u32) / 3;
+                gray_data.push(gray as u8);
+            }
+        }
+        
+        let image_gray = Image::<u8, 1>::new(
+            ImageSize {
+                width,
+                height,
+            },
+            gray_data,
+        )?;
+        
+        // Create a temporary directory for our test file
+        let temp_dir = tempdir()?;
+        let file_path = temp_dir.path().join("test_gray.jpeg");
+        
+        // Write the grayscale JPEG
+        super::write_image_jpegturbo_gray8(&file_path, &image_gray)?;
+        
+        // Read it back
+        let image_gray_back = super::read_image_jpegturbo_gray8(&file_path)?;
+        
+        // Check that dimensions match
+        assert_eq!(image_gray_back.width(), width);
+        assert_eq!(image_gray_back.height(), height);
+        assert_eq!(image_gray_back.num_channels(), 1);
+        
         Ok(())
     }
 }

--- a/crates/kornia-io/src/png.rs
+++ b/crates/kornia-io/src/png.rs
@@ -1,7 +1,7 @@
 use std::{fs::File, path::Path};
 
 use kornia_image::Image;
-use png::Decoder;
+use png::{Decoder, Encoder, ColorType};
 
 use crate::error::IoError;
 
@@ -68,6 +68,217 @@ pub fn read_image_png_mono16(file_path: impl AsRef<Path>) -> Result<Image<u16, 1
     Ok(Image::new(size.into(), buf_u16)?)
 }
 
+/// Write a grayscale image with a single channel (gray8) to a PNG file.
+///
+/// # Arguments
+///
+/// * `file_path` - The path to save the PNG file.
+/// * `src` - The grayscale image to save.
+///
+/// # Returns
+///
+/// `Ok(())` if the image was successfully written, or an error otherwise.
+///
+/// # Example
+///
+/// ```
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_io::png::write_image_png_gray8;
+///
+/// let image = Image::<u8, 1>::new(
+///     ImageSize {
+///         width: 2,
+///         height: 1,
+///     },
+///     vec![0, 255],
+/// ).unwrap();
+///
+/// write_image_png_gray8("output.png", image).unwrap();
+/// ```
+pub fn write_image_png_gray8(file_path: impl AsRef<Path>, src: Image<u8, 1>) -> Result<(), IoError> {
+    let file_path = file_path.as_ref();
+    
+    // Create the output file
+    let file = File::create(file_path)?;
+    
+    let width = src.width() as u32;
+    let height = src.height() as u32;
+    
+    // Create PNG encoder
+    let mut encoder = Encoder::new(file, width, height);
+    encoder.set_color(ColorType::Grayscale);
+    encoder.set_depth(png::BitDepth::Eight);
+    
+    let mut writer = encoder.write_header()
+        .map_err(|e| IoError::PngDecodeError(e.to_string()))?;
+    
+    // Write the image data
+    writer.write_image_data(src.as_slice())
+        .map_err(|e| IoError::PngDecodeError(e.to_string()))?;
+    
+    Ok(())
+}
+
+/// Write a RGB image with three channels (rgb8) to a PNG file.
+///
+/// # Arguments
+///
+/// * `file_path` - The path to save the PNG file.
+/// * `src` - The RGB image to save.
+///
+/// # Returns
+///
+/// `Ok(())` if the image was successfully written, or an error otherwise.
+///
+/// # Example
+///
+/// ```
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_io::png::write_image_png_rgb8;
+///
+/// let image = Image::<u8, 3>::new(
+///     ImageSize {
+///         width: 2,
+///         height: 1,
+///     },
+///     vec![255, 0, 0, 0, 255, 0],
+/// ).unwrap();
+///
+/// write_image_png_rgb8("output.png", image).unwrap();
+/// ```
+pub fn write_image_png_rgb8(file_path: impl AsRef<Path>, src: Image<u8, 3>) -> Result<(), IoError> {
+    let file_path = file_path.as_ref();
+    
+    // Create the output file
+    let file = File::create(file_path)?;
+    
+    let width = src.width() as u32;
+    let height = src.height() as u32;
+    
+    // Create PNG encoder
+    let mut encoder = Encoder::new(file, width, height);
+    encoder.set_color(ColorType::Rgb);
+    encoder.set_depth(png::BitDepth::Eight);
+    
+    let mut writer = encoder.write_header()
+        .map_err(|e| IoError::PngDecodeError(e.to_string()))?;
+    
+    // Write the image data
+    writer.write_image_data(src.as_slice())
+        .map_err(|e| IoError::PngDecodeError(e.to_string()))?;
+    
+    Ok(())
+}
+
+/// Write a RGBA image with four channels (rgba8) to a PNG file.
+///
+/// # Arguments
+///
+/// * `file_path` - The path to save the PNG file.
+/// * `src` - The RGBA image to save.
+///
+/// # Returns
+///
+/// `Ok(())` if the image was successfully written, or an error otherwise.
+///
+/// # Example
+///
+/// ```
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_io::png::write_image_png_rgba8;
+///
+/// let image = Image::<u8, 4>::new(
+///     ImageSize {
+///         width: 2,
+///         height: 1,
+///     },
+///     vec![255, 0, 0, 255, 0, 255, 0, 128],
+/// ).unwrap();
+///
+/// write_image_png_rgba8("output.png", image).unwrap();
+/// ```
+pub fn write_image_png_rgba8(file_path: impl AsRef<Path>, src: Image<u8, 4>) -> Result<(), IoError> {
+    let file_path = file_path.as_ref();
+    
+    // Create the output file
+    let file = File::create(file_path)?;
+    
+    let width = src.width() as u32;
+    let height = src.height() as u32;
+    
+    // Create PNG encoder
+    let mut encoder = Encoder::new(file, width, height);
+    encoder.set_color(ColorType::Rgba);
+    encoder.set_depth(png::BitDepth::Eight);
+    
+    let mut writer = encoder.write_header()
+        .map_err(|e| IoError::PngDecodeError(e.to_string()))?;
+    
+    // Write the image data
+    writer.write_image_data(src.as_slice())
+        .map_err(|e| IoError::PngDecodeError(e.to_string()))?;
+    
+    Ok(())
+}
+
+/// Write a grayscale image with a single channel (gray16) to a PNG file.
+///
+/// # Arguments
+///
+/// * `file_path` - The path to save the PNG file.
+/// * `src` - The grayscale image to save.
+///
+/// # Returns
+///
+/// `Ok(())` if the image was successfully written, or an error otherwise.
+///
+/// # Example
+///
+/// ```
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_io::png::write_image_png_gray16;
+///
+/// let image = Image::<u16, 1>::new(
+///     ImageSize {
+///         width: 2,
+///         height: 1,
+///     },
+///     vec![0, 65535],
+/// ).unwrap();
+///
+/// write_image_png_gray16("output.png", image).unwrap();
+/// ```
+pub fn write_image_png_gray16(file_path: impl AsRef<Path>, src: Image<u16, 1>) -> Result<(), IoError> {
+    let file_path = file_path.as_ref();
+    
+    // Create the output file
+    let file = File::create(file_path)?;
+    
+    let width = src.width() as u32;
+    let height = src.height() as u32;
+    
+    // Create PNG encoder
+    let mut encoder = Encoder::new(file, width, height);
+    encoder.set_color(ColorType::Grayscale);
+    encoder.set_depth(png::BitDepth::Sixteen);
+    
+    // Convert u16 data to big-endian byte representation
+    let mut bytes = Vec::with_capacity(src.as_slice().len() * 2);
+    for &pixel in src.as_slice() {
+        let be_bytes = pixel.to_be_bytes();
+        bytes.extend_from_slice(&be_bytes);
+    }
+    
+    let mut writer = encoder.write_header()
+        .map_err(|e| IoError::PngDecodeError(e.to_string()))?;
+    
+    // Write the image data
+    writer.write_image_data(&bytes)
+        .map_err(|e| IoError::PngDecodeError(e.to_string()))?;
+    
+    Ok(())
+}
+
 // utility function to read the png file
 fn read_png_impl(file_path: impl AsRef<Path>) -> Result<(Vec<u8>, [usize; 2]), IoError> {
     // verify the file exists
@@ -108,6 +319,143 @@ mod tests {
         let image = read_image_png_mono8("../../tests/data/dog.png")?;
         assert_eq!(image.size().width, 258);
         assert_eq!(image.size().height, 195);
+        Ok(())
+    }
+
+    #[test]
+    fn write_read_png_gray8() -> Result<(), IoError> {
+        use kornia_image::{Image, ImageSize};
+        use std::path::PathBuf;
+        use tempfile::tempdir;
+        use crate::png::{write_image_png_gray8, read_image_png_mono8};
+        
+        // Create a temporary directory for our test file
+        let temp_dir = tempdir()?;
+        let file_path = temp_dir.path().join("test_gray8.png");
+        
+        // Create a test image
+        let image = Image::<u8, 1>::new(
+            ImageSize {
+                width: 2,
+                height: 2,
+            },
+            vec![0, 255, 128, 64],
+        )?;
+        
+        // Write the image to a file
+        write_image_png_gray8(&file_path, image.clone())?;
+        
+        // Read the image back
+        let read_image = read_image_png_mono8(&file_path)?;
+        
+        // Check that the images match
+        assert_eq!(read_image.size(), image.size());
+        assert_eq!(read_image.as_slice(), image.as_slice());
+        
+        Ok(())
+    }
+
+    #[test]
+    fn write_read_png_rgb8() -> Result<(), IoError> {
+        use kornia_image::{Image, ImageSize};
+        use tempfile::tempdir;
+        use crate::png::{write_image_png_rgb8, read_image_png_rgb8};
+        
+        // Create a temporary directory for our test file
+        let temp_dir = tempdir()?;
+        let file_path = temp_dir.path().join("test_rgb8.png");
+        
+        // Create a test image
+        let image = Image::<u8, 3>::new(
+            ImageSize {
+                width: 2,
+                height: 2,
+            },
+            vec![
+                255, 0, 0,  // Red
+                0, 255, 0,  // Green
+                0, 0, 255,  // Blue
+                255, 255, 0 // Yellow
+            ],
+        )?;
+        
+        // Write the image to a file
+        write_image_png_rgb8(&file_path, image.clone())?;
+        
+        // Read the image back
+        let read_image = read_image_png_rgb8(&file_path)?;
+        
+        // Check that the images match
+        assert_eq!(read_image.size(), image.size());
+        assert_eq!(read_image.as_slice(), image.as_slice());
+        
+        Ok(())
+    }
+
+    #[test]
+    fn write_read_png_rgba8() -> Result<(), IoError> {
+        use kornia_image::{Image, ImageSize};
+        use tempfile::tempdir;
+        use crate::png::{write_image_png_rgba8, read_image_png_rgba8};
+        
+        // Create a temporary directory for our test file
+        let temp_dir = tempdir()?;
+        let file_path = temp_dir.path().join("test_rgba8.png");
+        
+        // Create a test image
+        let image = Image::<u8, 4>::new(
+            ImageSize {
+                width: 2,
+                height: 1,
+            },
+            vec![
+                255, 0, 0, 255,    // Red with full alpha
+                0, 255, 0, 128     // Green with half alpha
+            ],
+        )?;
+        
+        // Write the image to a file
+        write_image_png_rgba8(&file_path, image.clone())?;
+        
+        // Read the image back
+        let read_image = read_image_png_rgba8(&file_path)?;
+        
+        // Check that the images match
+        assert_eq!(read_image.size(), image.size());
+        assert_eq!(read_image.as_slice(), image.as_slice());
+        
+        Ok(())
+    }
+
+    #[test]
+    fn write_read_png_gray16() -> Result<(), IoError> {
+        use kornia_image::{Image, ImageSize};
+        use tempfile::tempdir;
+        use crate::png::{write_image_png_gray16, read_image_png_mono16};
+        
+        // Create a temporary directory for our test file
+        let temp_dir = tempdir()?;
+        let file_path = temp_dir.path().join("test_gray16.png");
+        
+        // Create a test image
+        let image = Image::<u16, 1>::new(
+            ImageSize {
+                width: 2,
+                height: 2,
+            },
+            vec![0, 65535, 32768, 16384],
+        )?;
+        
+        // Write the image to a file
+        write_image_png_gray16(&file_path, image.clone())?;
+        
+        // Read the image back
+        let read_image = read_image_png_mono16(&file_path)?;
+        
+        // Check that the images match
+        assert_eq!(read_image.size(), image.size());
+        assert_eq!(read_image.as_slice(), image.as_slice());
+        
         Ok(())
     }
 }

--- a/crates/kornia-io/src/png.rs
+++ b/crates/kornia-io/src/png.rs
@@ -95,7 +95,7 @@ pub fn read_image_png_mono16(file_path: impl AsRef<Path>) -> Result<Image<u16, 1
 ///
 /// write_image_png_gray8("output.png", image).unwrap();
 /// ```
-pub fn write_image_png_gray8(file_path: impl AsRef<Path>, src: Image<u8, 1>) -> Result<(), IoError> {
+pub fn write_image_png_gray8(file_path: impl AsRef<Path>, src: &Image<u8, 1>) -> Result<(), IoError> {
     let file_path = file_path.as_ref();
     
     // Create the output file

--- a/crates/kornia-io/src/png.rs
+++ b/crates/kornia-io/src/png.rs
@@ -146,7 +146,7 @@ pub fn write_image_png_gray8(file_path: impl AsRef<Path>, src: &Image<u8, 1>) ->
 ///
 /// write_image_png_rgb8("output.png", image).unwrap();
 /// ```
-pub fn write_image_png_rgb8(file_path: impl AsRef<Path>, src: Image<u8, 3>) -> Result<(), IoError> {
+pub fn write_image_png_rgb8(file_path: impl AsRef<Path>, src: &Image<u8, 3>) -> Result<(), IoError> {
     let file_path = file_path.as_ref();
     
     // Create the output file
@@ -197,7 +197,7 @@ pub fn write_image_png_rgb8(file_path: impl AsRef<Path>, src: Image<u8, 3>) -> R
 ///
 /// write_image_png_rgba8("output.png", image).unwrap();
 /// ```
-pub fn write_image_png_rgba8(file_path: impl AsRef<Path>, src: Image<u8, 4>) -> Result<(), IoError> {
+pub fn write_image_png_rgba8(file_path: impl AsRef<Path>, src: &Image<u8, 4>) -> Result<(), IoError> {
     let file_path = file_path.as_ref();
     
     // Create the output file
@@ -248,7 +248,7 @@ pub fn write_image_png_rgba8(file_path: impl AsRef<Path>, src: Image<u8, 4>) -> 
 ///
 /// write_image_png_gray16("output.png", image).unwrap();
 /// ```
-pub fn write_image_png_gray16(file_path: impl AsRef<Path>, src: Image<u16, 1>) -> Result<(), IoError> {
+pub fn write_image_png_gray16(file_path: impl AsRef<Path>, src: &Image<u16, 1>) -> Result<(), IoError> {
     let file_path = file_path.as_ref();
     
     // Create the output file

--- a/examples/image_io/Cargo.toml
+++ b/examples/image_io/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 
 [dependencies]
 kornia-image = { path = "../../crates/kornia-image" }
-kornia-io = { path = "../../crates/kornia-io" }
+kornia-io = { path = "../../crates/kornia-io", features = ["turbojpeg"] }
 anyhow = "1.0.77"
 clap = { version = "4.4.11", features = ["derive"] }

--- a/examples/image_io/Cargo.toml
+++ b/examples/image_io/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "image_io"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+kornia-image = { path = "../../crates/kornia-image" }
+kornia-io = { path = "../../crates/kornia-io" }
+anyhow = "1.0.77"
+clap = { version = "4.4.11", features = ["derive"] }

--- a/examples/image_io/README.md
+++ b/examples/image_io/README.md
@@ -12,8 +12,14 @@ This example demonstrates how to use the image I/O functionality in kornia-rs to
 - Write images in JPEG format:
   - Grayscale (1 channel)
   - RGB (3 channels)
+- Decode images directly from raw bytes:
+  - Any image format (using format hint or automatic detection)
+  - Specialized JPEG decoding using libjpeg-turbo
+  - RGB and grayscale output formats
 
 ## Usage
+
+### Main I/O Example
 
 Run the example with:
 
@@ -30,6 +36,28 @@ Where:
   - 1 for grayscale
   - 3 for RGB (default)
   - 4 for RGBA (PNG only)
+
+### Decode from Bytes Example (Rust)
+
+This example demonstrates decoding images directly from raw bytes:
+
+```bash
+cargo run --bin decode_from_bytes -- --image-path <INPUT_IMAGE_PATH>
+```
+
+Where:
+
+- `<INPUT_IMAGE_PATH>` is the path to the input image.
+
+### Decode from Bytes Example (Python)
+
+```bash
+python src/python/decode_from_bytes.py --image-path <INPUT_IMAGE_PATH>
+```
+
+Where:
+
+- `<INPUT_IMAGE_PATH>` is the path to the input image.
 
 ## Examples
 
@@ -61,4 +89,41 @@ cargo run -- --input-path ../../tests/data/dog.jpeg --output-path dog_gray.jpeg 
 
 ```bash
 cargo run -- --input-path ../../tests/data/dog.jpeg --output-path dog_rgb.jpeg --format jpeg --channels 3
+```
+
+### Decode an image from raw bytes (Rust):
+
+```bash
+cargo run --bin decode_from_bytes -- --image-path ../../tests/data/dog.jpeg
+```
+
+### Decode an image from raw bytes (Python):
+
+```bash
+python src/python/decode_from_bytes.py --image-path ../../tests/data/dog.jpeg
+```
+
+## Using in Python
+
+```python
+import kornia_rs as K
+import numpy as np
+
+# Load an image from a file
+img = K.read_image_any("path/to/image.jpg")
+
+# Alternatively, read the image bytes and decode
+with open("path/to/image.jpg", "rb") as f:
+    image_data = f.read()
+
+# Decode with automatic format detection
+img_rgb = K.decode_image_bytes(image_data)
+img_gray = K.decode_image_bytes_gray(image_data)
+
+# Decode with format hint
+img_png = K.decode_image_bytes(image_data, "png")
+
+# For JPEG images, use specialized JPEG decoder for better performance
+img_jpeg = K.decode_jpeg_bytes(image_data)
+img_jpeg_gray = K.decode_jpeg_bytes_gray(image_data)
 ```

--- a/examples/image_io/README.md
+++ b/examples/image_io/README.md
@@ -1,0 +1,64 @@
+# Image I/O Example
+
+This example demonstrates how to use the image I/O functionality in kornia-rs to read images in various formats and write them in specific formats with different channel configurations.
+
+## Features
+
+- Read images in any format supported by the library
+- Write images in PNG format with different channel configurations:
+  - Grayscale (1 channel)
+  - RGB (3 channels)
+  - RGBA (4 channels)
+- Write images in JPEG format:
+  - Grayscale (1 channel)
+  - RGB (3 channels)
+
+## Usage
+
+Run the example with:
+
+```bash
+cargo run -- --input-path <INPUT_IMAGE_PATH> --output-path <OUTPUT_IMAGE_PATH> --format <FORMAT> --channels <CHANNELS>
+```
+
+Where:
+
+- `<INPUT_IMAGE_PATH>` is the path to the input image.
+- `<OUTPUT_IMAGE_PATH>` is the path where the output image will be saved.
+- `<FORMAT>` is the output format, can be "png" or "jpeg" (default: "png").
+- `<CHANNELS>` is the number of channels for the output image:
+  - 1 for grayscale
+  - 3 for RGB (default)
+  - 4 for RGBA (PNG only)
+
+## Examples
+
+### Convert an image to grayscale PNG:
+
+```bash
+cargo run -- --input-path ../../tests/data/dog.jpeg --output-path dog_gray.png --format png --channels 1
+```
+
+### Convert an image to RGB PNG:
+
+```bash
+cargo run -- --input-path ../../tests/data/dog.jpeg --output-path dog_rgb.png --format png --channels 3
+```
+
+### Convert an image to RGBA PNG:
+
+```bash
+cargo run -- --input-path ../../tests/data/dog.jpeg --output-path dog_rgba.png --format png --channels 4
+```
+
+### Convert an image to grayscale JPEG:
+
+```bash
+cargo run -- --input-path ../../tests/data/dog.jpeg --output-path dog_gray.jpeg --format jpeg --channels 1
+```
+
+### Convert an image to RGB JPEG:
+
+```bash
+cargo run -- --input-path ../../tests/data/dog.jpeg --output-path dog_rgb.jpeg --format jpeg --channels 3
+```

--- a/examples/image_io/src/bin/decode_from_bytes.rs
+++ b/examples/image_io/src/bin/decode_from_bytes.rs
@@ -1,0 +1,54 @@
+use clap::{Arg, ArgAction, Command};
+use kornia::image::Image;
+use kornia::io::functional as F;
+use std::fs;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let matches = Command::new("decode_from_bytes")
+        .arg(
+            Arg::new("image-path")
+                .short('i')
+                .long("image-path")
+                .action(ArgAction::Set)
+                .required(true)
+                .help("Path to the input image"),
+        )
+        .get_matches();
+
+    let image_path = matches
+        .get_one::<String>("image-path")
+        .expect("Required argument");
+
+    println!("Reading image from: {}", image_path);
+
+    // Read the image file as raw bytes
+    let image_data = fs::read(image_path)?;
+    println!("Image data size: {} bytes", image_data.len());
+
+    // Extract format from file extension
+    let format_hint = image_path.split('.').last();
+    println!("Format hint: {:?}", format_hint);
+
+    // Decode image in RGB format from bytes
+    let image_rgb: Image<u8, 3> = F::decode_image_bytes_rgb8(&image_data, format_hint)?;
+    println!("Decoded RGB image size: {:?}", image_rgb.size());
+
+    // Decode image in grayscale format from bytes
+    let image_gray: Image<u8, 1> = F::decode_image_bytes_gray8(&image_data, format_hint)?;
+    println!("Decoded grayscale image size: {:?}", image_gray.size());
+
+    // If it's a JPEG image, also try using the specialized JPEG decoder
+    if format_hint.map_or(false, |fmt| fmt.eq_ignore_ascii_case("jpg") || fmt.eq_ignore_ascii_case("jpeg")) {
+        println!("Using specialized JPEG decoder");
+        
+        let image_jpeg_rgb: Image<u8, 3> = F::decode_image_jpegturbo_rgb8(&image_data)?;
+        println!("Decoded JPEG RGB image size: {:?}", image_jpeg_rgb.size());
+        
+        let image_jpeg_gray: Image<u8, 1> = F::decode_image_jpegturbo_gray8(&image_data)?;
+        println!("Decoded JPEG grayscale image size: {:?}", image_jpeg_gray.size());
+    }
+
+    println!("All decoding methods successful!");
+
+    Ok(())
+} 

--- a/examples/image_io/src/main.rs
+++ b/examples/image_io/src/main.rs
@@ -1,0 +1,127 @@
+use anyhow::Result;
+use clap::Parser;
+use kornia_image::Image;
+use kornia_io::{
+    read_image_any_rgb8,
+    write_image_png_gray8, write_image_png_rgb8, write_image_png_rgba8,
+};
+
+#[cfg(feature = "turbojpeg")]
+use kornia_io::{
+    write_image_jpegturbo_gray8, write_image_jpegturbo_rgb8,
+};
+
+/// Command line arguments for the image_io example
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Path to the input image file
+    #[arg(short, long)]
+    input_path: String,
+
+    /// Path where the output image will be saved
+    #[arg(short, long)]
+    output_path: String,
+
+    /// Output format (png or jpeg)
+    #[arg(short, long, default_value = "png")]
+    format: String,
+
+    /// Number of channels for the output image (1 for grayscale, 3 for RGB, 4 for RGBA - PNG only)
+    #[arg(short, long, default_value_t = 3)]
+    channels: usize,
+}
+
+fn main() -> Result<()> {
+    // Parse command line arguments
+    let args = Args::parse();
+
+    // Validate input format
+    if !["png", "jpeg"].contains(&args.format.as_str()) {
+        anyhow::bail!("Unsupported format: {}. Only 'png' and 'jpeg' are supported.", args.format);
+    }
+
+    // Validate channels
+    if ![1, 3, 4].contains(&args.channels) {
+        anyhow::bail!("Unsupported number of channels: {}. Only 1, 3, and 4 are supported.", args.channels);
+    }
+
+    // Check if RGBA is requested with JPEG (which is not supported)
+    if args.format == "jpeg" && args.channels == 4 {
+        anyhow::bail!("RGBA (4 channels) is not supported for JPEG format.");
+    }
+
+    // Read the input image
+    println!("Reading image from: {}", args.input_path);
+    let input_image = read_image_any_rgb8(&args.input_path)?;
+    println!("Image dimensions: {}x{}, channels: {}", input_image.rows(), input_image.cols(), input_image.num_channels());
+
+    // Process and write the output image based on format and channels
+    match (args.format.as_str(), args.channels) {
+        ("png", 1) => {
+            // Convert to grayscale and write as PNG
+            let gray_image = to_grayscale(&input_image);
+            write_image_png_gray8(&args.output_path, &gray_image)?;
+        },
+        ("png", 3) => {
+            // Write as RGB PNG
+            write_image_png_rgb8(&args.output_path, &input_image)?;
+        },
+        ("png", 4) => {
+            // Convert to RGBA and write as PNG
+            let rgba_image = to_rgba(&input_image);
+            write_image_png_rgba8(&args.output_path, &rgba_image)?;
+        },
+        #[cfg(feature = "turbojpeg")]
+        ("jpeg", 1) => {
+            // Convert to grayscale and write as JPEG
+            let gray_image = to_grayscale(&input_image);
+            write_image_jpegturbo_gray8(&args.output_path, &gray_image)?;
+        },
+        #[cfg(feature = "turbojpeg")]
+        ("jpeg", 3) => {
+            // Write as RGB JPEG
+            write_image_jpegturbo_rgb8(&args.output_path, &input_image)?;
+        },
+        #[cfg(not(feature = "turbojpeg"))]
+        ("jpeg", _) => {
+            anyhow::bail!("JPEG writing is not supported because the 'turbojpeg' feature is not enabled.");
+        },
+        _ => unreachable!(), // Already validated above
+    }
+
+    println!("Image written to: {}", args.output_path);
+    Ok(())
+}
+
+/// Convert an RGB image to grayscale
+fn to_grayscale(rgb_image: &Image<u8, 3>) -> Image<u8, 1> {
+    let (rows, cols) = (rgb_image.rows(), rgb_image.cols());
+    let mut gray_image = Image::<u8, 1>::new(rows, cols);
+    
+    for r in 0..rows {
+        for c in 0..cols {
+            // Standard RGB to grayscale conversion formula: 0.299*R + 0.587*G + 0.114*B
+            let pixel = rgb_image.pixel(r, c);
+            let gray_value = (0.299 * pixel[0] as f32 + 0.587 * pixel[1] as f32 + 0.114 * pixel[2] as f32) as u8;
+            gray_image.set_pixel(r, c, [gray_value]);
+        }
+    }
+    
+    gray_image
+}
+
+/// Convert an RGB image to RGBA (with alpha = 255)
+fn to_rgba(rgb_image: &Image<u8, 3>) -> Image<u8, 4> {
+    let (rows, cols) = (rgb_image.rows(), rgb_image.cols());
+    let mut rgba_image = Image::<u8, 4>::new(rows, cols);
+    
+    for r in 0..rows {
+        for c in 0..cols {
+            let pixel = rgb_image.pixel(r, c);
+            rgba_image.set_pixel(r, c, [pixel[0], pixel[1], pixel[2], 255]);
+        }
+    }
+    
+    rgba_image
+} 

--- a/examples/image_io/src/python/decode_from_bytes.py
+++ b/examples/image_io/src/python/decode_from_bytes.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# Example that demonstrates decoding images directly from raw bytes in Python
+# using the kornia-rs library
+
+import argparse
+import kornia_rs as K
+import numpy as np
+import os
+
+
+def main():
+    # Parse command line arguments
+    parser = argparse.ArgumentParser(description="Decode images from raw bytes")
+    parser.add_argument(
+        "-i", "--image-path", type=str, required=True, help="Path to the input image"
+    )
+    args = parser.parse_args()
+
+    # Read the image file as raw bytes
+    with open(args.image_path, "rb") as f:
+        image_data = f.read()
+    
+    print(f"Image data size: {len(image_data)} bytes")
+
+    # Extract format from file extension
+    format_hint = os.path.splitext(args.image_path)[1][1:].lower()
+    print(f"Format hint: {format_hint}")
+
+    # Decode image in RGB format from bytes
+    img_rgb = K.decode_image_bytes(image_data, format_hint)
+    print(f"Decoded RGB image shape: {img_rgb.shape}")
+
+    # Decode image in grayscale format from bytes
+    img_gray = K.decode_image_bytes_gray(image_data, format_hint)
+    print(f"Decoded grayscale image shape: {img_gray.shape}")
+
+    # If it's a JPEG image, also try using the specialized JPEG decoder
+    if format_hint in ["jpg", "jpeg"]:
+        print("Using specialized JPEG decoder")
+        
+        img_jpeg_rgb = K.decode_jpeg_bytes(image_data)
+        print(f"Decoded JPEG RGB image shape: {img_jpeg_rgb.shape}")
+        
+        img_jpeg_gray = K.decode_jpeg_bytes_gray(image_data)
+        print(f"Decoded JPEG grayscale image shape: {img_jpeg_gray.shape}")
+
+    print("All decoding methods successful!")
+
+
+if __name__ == "__main__":
+    main() 

--- a/kornia-py/src/io/functional.rs
+++ b/kornia-py/src/io/functional.rs
@@ -26,3 +26,31 @@ pub fn read_image_any(file_path: &str) -> PyResult<PyImage> {
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyFileExistsError, _>(format!("{}", e)))?;
     Ok(image.to_pyimage())
 }
+
+#[pyfunction]
+pub fn decode_image_bytes(image_data: &[u8], format_hint: Option<&str> = None) -> PyResult<PyImage> {
+    let image = F::decode_image_bytes_rgb8(image_data, format_hint)
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
+    Ok(image.to_pyimage())
+}
+
+#[pyfunction]
+pub fn decode_image_bytes_gray(image_data: &[u8], format_hint: Option<&str> = None) -> PyResult<PyImage> {
+    let image = F::decode_image_bytes_gray8(image_data, format_hint)
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
+    Ok(image.to_pyimage())
+}
+
+#[pyfunction]
+pub fn decode_jpeg_bytes(jpeg_data: &[u8]) -> PyResult<PyImage> {
+    let image = F::decode_image_jpegturbo_rgb8(jpeg_data)
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
+    Ok(image.to_pyimage())
+}
+
+#[pyfunction]
+pub fn decode_jpeg_bytes_gray(jpeg_data: &[u8]) -> PyResult<PyImage> {
+    let image = F::decode_image_jpegturbo_gray8(jpeg_data)
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
+    Ok(image.to_pyimage())
+}

--- a/kornia-py/src/lib.rs
+++ b/kornia-py/src/lib.rs
@@ -10,7 +10,10 @@ mod warp;
 
 use crate::icp::{PyICPConvergenceCriteria, PyICPResult};
 use crate::image::PyImageSize;
-use crate::io::functional::{read_image_any, read_image_jpeg, write_image_jpeg};
+use crate::io::functional::{
+    read_image_any, read_image_jpeg, write_image_jpeg,
+    decode_image_bytes, decode_image_bytes_gray, decode_jpeg_bytes, decode_jpeg_bytes_gray
+};
 use crate::io::jpeg::{PyImageDecoder, PyImageEncoder};
 use pyo3::prelude::*;
 
@@ -35,6 +38,10 @@ pub fn kornia_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(read_image_jpeg, m)?)?;
     m.add_function(wrap_pyfunction!(write_image_jpeg, m)?)?;
     m.add_function(wrap_pyfunction!(read_image_any, m)?)?;
+    m.add_function(wrap_pyfunction!(decode_image_bytes, m)?)?;
+    m.add_function(wrap_pyfunction!(decode_image_bytes_gray, m)?)?;
+    m.add_function(wrap_pyfunction!(decode_jpeg_bytes, m)?)?;
+    m.add_function(wrap_pyfunction!(decode_jpeg_bytes_gray, m)?)?;
     m.add_function(wrap_pyfunction!(resize::resize, m)?)?;
     m.add_function(wrap_pyfunction!(warp::warp_affine, m)?)?;
     m.add_function(wrap_pyfunction!(warp::warp_perspective, m)?)?;


### PR DESCRIPTION
Here's a summary of what we've added:
Rust implementation:
Added decode_image_jpegturbo_rgb8 and decode_image_jpegturbo_gray8 functions to decode JPEG images from raw bytes using the turbojpeg backend
Added decode_image_bytes_rgb8 and decode_image_bytes_gray8 functions to decode any image format from raw bytes
Added unit tests for the new functions
Python bindings:
Added decode_image_bytes and decode_image_bytes_gray functions to decode any image format from raw bytes
Added decode_jpeg_bytes and decode_jpeg_bytes_gray functions to decode JPEG images from raw bytes using the turbojpeg backend
Registered these functions in the Python module
Examples:
Created a Rust example (decode_from_bytes.rs) demonstrating how to use the new functions
Created a Python example (decode_from_bytes.py) demonstrating how to use the new functions
Updated the README with documentation on the new functionality

Closes  #121 