### PR TITLE
Add NVIDIA hardware acceleration support for StreamCapture (#137)

### DIFF
--- a/crates/kornia-io/src/error.rs
+++ b/crates/kornia-io/src/error.rs
@@ -29,4 +29,8 @@ pub enum IoError {
     /// Error to decode the PNG image.
     #[error("Failed to decode the image")]
     PngDecodeError(String),
+
+    /// Error getting the format
+    #[error("Failed to get correct format")]
+    GetFormatError,
 }

--- a/crates/kornia-io/src/stream/camera.rs
+++ b/crates/kornia-io/src/stream/camera.rs
@@ -7,6 +7,8 @@ use crate::stream::{
     StreamCapture,
 };
 
+use crate::stream::nvcamera::{nv_camera_pipeline_description, NVCameraConfig};
+
 /// A trait for camera capture configuration.
 ///
 /// This trait allows for different types of camera configurations to be used
@@ -62,10 +64,18 @@ impl CameraCapture {
                 ));
             }
             rtsp_camera_pipeline_description(&config.url, config.latency)
+        } else if let Some(config) = config.as_any().downcast_ref::<NVCameraConfig>() {
+            // check that the device is not empty
+            if config.device.is_empty() {
+                return Err(StreamCaptureError::InvalidConfig(
+                    "device is empty".to_string(),
+                ));
+            }
+            nv_camera_pipeline_description(&config.device, config.size, config.fps, config.use_nv12)
         } else {
-            return Err(StreamCaptureError::InvalidConfig(
-                "unknown config type".to_string(),
-            ));
+                return Err(StreamCaptureError::InvalidConfig(
+                    "unknown config type".to_string(),
+                ));
         };
 
         Ok(Self(StreamCapture::new(&pipeline)?))

--- a/crates/kornia-io/src/stream/capture.rs
+++ b/crates/kornia-io/src/stream/capture.rs
@@ -7,6 +7,7 @@ use kornia_image::Image;
 // utility struct to store the frame buffer
 struct FrameBuffer {
     buffer: gst::MappedBuffer<gst::buffer::Readable>,
+    sample: gst::Sample,
     width: usize,
     height: usize,
 }
@@ -94,16 +95,31 @@ impl StreamCapture {
             .last_frame
             .lock()
             .map_err(|_| StreamCaptureError::LockError)?;
-
+    
         last_frame.take().map_or(Ok(None), |frame_buffer| {
-            // TODO: solve the zero copy issue
-            // https://discourse.gstreamer.org/t/zero-copy-video-frames/3856/2
-            let img = Image::<u8, 3>::new(
-                [frame_buffer.width, frame_buffer.height].into(),
-                frame_buffer.buffer.to_owned(),
-            )
-            .map_err(|_| StreamCaptureError::CreateImageFrameError)?;
-
+            // Get the format from the caps
+            let caps = frame_buffer.sample.caps().ok_or_else(|| StreamCaptureError::GetCapsError)?;
+            let structure = caps.structure(0).ok_or_else(|| StreamCaptureError::GetStructureError)?;
+            
+            // Check if the format is NV12 or RGB
+            let format = structure.get::<String>("format")
+                .map_err(|_| StreamCaptureError::GetFormatError)?;
+            
+            let img = if format == "NV12" {
+                // Convert NV12 to RGB - note the Self:: prefix
+                Self::nv12_to_rgb(
+                    &frame_buffer.buffer,
+                    frame_buffer.width,
+                    frame_buffer.height,
+                )?
+            } else {
+                // Assume RGB format
+                Image::<u8, 3>::new(
+                    [frame_buffer.width, frame_buffer.height].into(),
+                    frame_buffer.buffer.to_owned(),
+                ).map_err(|_| StreamCaptureError::CreateImageFrameError)?
+            };
+    
             Ok(Some(img))
         })
     }
@@ -156,11 +172,60 @@ impl StreamCapture {
 
         let frame_buffer = FrameBuffer {
             buffer,
+            sample: sample.clone(),
             width,
             height,
         };
 
         Ok(frame_buffer)
+    }
+
+    // Helper function to convert NV12 to RGB
+    fn nv12_to_rgb(
+        buffer: &[u8],
+        width: usize,
+        height: usize,
+    ) -> Result<Image<u8, 3>, StreamCaptureError> {
+        // Allocate memory for RGB output
+        let mut rgb_data = vec![0u8; width * height * 3];
+        
+        // Implement NV12 to RGB conversion
+        // NV12 format: Y plane followed by interleaved U and V planes
+        let y_plane_size = width * height;
+        let uv_plane_offset = y_plane_size;
+        
+        for y in 0..height {
+            for x in 0..width {
+                let y_index = y * width + x;
+                let y_value = buffer[y_index] as f32;
+                
+                // UV values are subsampled (one U,V pair per 2x2 Y values)
+                let uv_index = uv_plane_offset + (y / 2) * width + (x / 2) * 2;
+                let u_value = buffer[uv_index] as f32 - 128.0;
+                let v_value = buffer[uv_index + 1] as f32 - 128.0;
+                
+                // Standard YUV to RGB conversion
+                let r = y_value + 1.402 * v_value;
+                let g = y_value - 0.344136 * u_value - 0.714136 * v_value;
+                let b = y_value + 1.772 * u_value;
+                
+                // Clamp values to 0-255 range
+                let r = r.max(0.0).min(255.0) as u8;
+                let g = g.max(0.0).min(255.0) as u8;
+                let b = b.max(0.0).min(255.0) as u8;
+                
+                // Write to output buffer
+                let rgb_index = y_index * 3;
+                rgb_data[rgb_index] = r;
+                rgb_data[rgb_index + 1] = g;
+                rgb_data[rgb_index + 2] = b;
+            }
+        }
+        
+        Image::<u8, 3>::new(
+            [width, height].into(),
+            rgb_data,
+        ).map_err(|_| StreamCaptureError::CreateImageFrameError)
     }
 }
 

--- a/crates/kornia-io/src/stream/error.rs
+++ b/crates/kornia-io/src/stream/error.rs
@@ -83,6 +83,10 @@ pub enum StreamCaptureError {
     /// An error occurred when the allocator is not found.
     #[error("Cannot lock the last frame")]
     LockError,
+
+    /// Error occurred when trying to get the format from GStreamer pipeline.
+    #[error("Failed to get correct format")]
+    GetFormatError,
 }
 
 // ensure that can be sent over threads

--- a/crates/kornia-io/src/stream/mod.rs
+++ b/crates/kornia-io/src/stream/mod.rs
@@ -16,9 +16,13 @@ pub mod v4l2;
 /// A module for capturing video streams from video files.
 pub mod video;
 
+/// Module providing NVIDIA hardware-accelerated video capture capabilities.
+pub mod nvcamera;
+
 pub use crate::stream::camera::{CameraCapture, CameraCaptureConfig};
 pub use crate::stream::capture::StreamCapture;
 pub use crate::stream::error::StreamCaptureError;
 pub use crate::stream::rtsp::RTSPCameraConfig;
 pub use crate::stream::v4l2::V4L2CameraConfig;
+pub use crate::stream::nvcamera::NVCameraConfig;
 pub use crate::stream::video::VideoWriter;

--- a/crates/kornia-io/src/stream/nvcamera.rs
+++ b/crates/kornia-io/src/stream/nvcamera.rs
@@ -1,0 +1,106 @@
+
+use std::any::Any;
+use crate::stream::{
+    camera::{CameraCapture, CameraCaptureConfig},
+    error::StreamCaptureError,
+};
+use kornia_image::ImageSize;
+
+/// A configuration object for capturing frames using NVIDIA hardware acceleration.
+pub struct NVCameraConfig {
+    /// The camera device path
+    pub device: String,
+    /// The desired image size
+    pub size: Option<ImageSize>,
+    /// The desired frames per second
+    pub fps: u32,
+    /// Whether to use NV12 format (more lightweight) instead of RGB
+    pub use_nv12: bool,
+}
+
+impl CameraCaptureConfig for NVCameraConfig {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+impl NVCameraConfig {
+    /// Creates a new NVCameraConfig object with default values.
+    pub fn new() -> Self {
+        Self {
+            device: "/dev/video0".to_string(),
+            size: None,
+            fps: 30,
+            use_nv12: false,
+        }
+    }
+
+    /// Sets the camera device path for the NVCameraConfig.
+    pub fn with_device(mut self, device: &str) -> Self {
+        self.device = device.to_string();
+        self
+    }
+
+    /// Sets the camera device path based on the camera id.
+    pub fn with_camera_id(mut self, camera_id: u32) -> Self {
+        self.device = format!("/dev/video{}", camera_id);
+        self
+    }
+
+    /// Sets the image size for the NVCameraConfig.
+    pub fn with_size(mut self, size: ImageSize) -> Self {
+        self.size = Some(size);
+        self
+    }
+
+    /// Sets the frames per second for the NVCameraConfig.
+    pub fn with_fps(mut self, fps: u32) -> Self {
+        self.fps = fps;
+        self
+    }
+
+    /// Sets whether to use NV12 format.
+    pub fn with_nv12(mut self, use_nv12: bool) -> Self {
+        self.use_nv12 = use_nv12;
+        self
+    }
+
+    /// Create a new [`CameraCapture`] object.
+    pub fn build(self) -> Result<CameraCapture, StreamCaptureError> {
+        CameraCapture::new(&self)
+    }
+}
+
+impl Default for NVCameraConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Returns a GStreamer pipeline string for capturing frames using NVIDIA hardware acceleration.
+pub fn nv_camera_pipeline_description(
+    device: &str, 
+    size: Option<ImageSize>, 
+    fps: u32,
+    use_nv12: bool
+) -> String {
+    let video_resize = if let Some(size) = size {
+        format!("! video/x-raw,width={},height={} ", size.width, size.height)
+    } else {
+        "".to_string()
+    };
+
+    // If NV12 format is requested, we'll use a different output format
+    let format_conversion = if use_nv12 {
+        // NV12 format - more lightweight for real-time applications
+        "! nvvidconv ! video/x-raw(memory:NVMM),format=NV12 ! appsink name=sink"
+    } else {
+        // RGB format - convert to standard RGB format
+        "! nvvidconv ! video/x-raw,format=RGB ! appsink name=sink"
+    };
+
+    format!(
+        "v4l2src device={} {}! videorate ! video/x-raw,framerate={}/1 ! nvvideoconvert ! nvv4l2decoder enable-max-performance=true ! nvvideoconvert {}",
+        device, video_resize, fps, format_conversion
+    )
+}

--- a/kornia-viz/src/bin/app.rs
+++ b/kornia-viz/src/bin/app.rs
@@ -27,7 +27,8 @@ struct KorniaApp {
 
 impl Default for KorniaApp {
     fn default() -> Self {
-        let capture = kornia::io::stream::V4L2CameraConfig::new()
+        // Use NVCameraConfig instead of V4L2CameraConfig for GPU acceleration
+        let capture = kornia::io::stream::NVCameraConfig::new()
             .with_camera_id(0)
             .build()
             .unwrap();


### PR DESCRIPTION
- Implement NVCameraConfig with NV12 format support
- Create hardware-accelerated GStreamer pipeline using nvcodec
- Add NV12 to RGB conversion for efficient real-time streaming
- Update error handling for format detection
- Integrate with existing camera capture architecture
- Maintain backward compatibility with V4L2 capture

This implementation enables GPU-accelerated video decoding through the nvv4l2decoder element, providing better performance for high-resolution streams and reducing CPU usage. Both RGB and more lightweight NV12 formats are supported for different use cases.