### PR TITLE
fix: resolve conflict between arrow-arith and chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,9 @@ kornia = { path = "crates/kornia", version = "0.1.9-rc.2" }
 kornia-linalg = { path = "crates/kornia-linalg", version = "0.1.9-rc.2" }
 kernels = { path = "crates/kernels", version = "0.1.9-rc.2" }
 
+arrow-arith = { version = "=53.3.0", features = [] }
+chrono = { version = "=0.4.39", default-features = false }
+
 # dev dependencies for workspace
 argh = "0.1"
 approx = "0.5"


### PR DESCRIPTION
Perhaps the previous changes didn’t take effect? This time, I declared the dependencies under [workspace.dependencies], using version pinning (=53.3.0 and =0.4.39). I also disabled the default features of chrono to reduce conflicts, and tried to ensure that all subprojects correctly inherit these versions by using workspace = true as you added (the effectiveness still needs to be verified through CI testing).
#308 