### PR TITLE
Use pytest-run-parallel in free-threaded CI

### DIFF
--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -73,7 +73,7 @@ jobs:
         cd kornia-py/
         source .venv/bin/activate
         maturin develop -m Cargo.toml
-        pytest
+        pytest --parallel-threads=8 --iterations=50
 
   # NOTE: there's a systematic fail with the ci on macos
   # test-python-macos:

--- a/kornia-py/requirements-dev.txt
+++ b/kornia-py/requirements-dev.txt
@@ -4,6 +4,7 @@ maturin[patchelf]
 # tests
 pre-commit
 pytest
+pytest-run-parallel
 numpy
 
 --extra-index-url https://download.pytorch.org/whl/cpu

--- a/kornia-py/tests/test_io.py
+++ b/kornia-py/tests/test_io.py
@@ -1,4 +1,6 @@
+import tempfile
 from pathlib import Path
+
 import kornia_rs as K
 
 import torch
@@ -73,7 +75,7 @@ def test_compress_decompress():
     assert (decoded_img - img).sum() == 3
 
 
-def test_write_read_jpeg(tmpdir):
+def test_write_read_jpeg():
     img = np.array([
         [0, 0, 0, 0, 0],
         [0, 127, 255, 127, 0],
@@ -83,11 +85,12 @@ def test_write_read_jpeg(tmpdir):
     img = np.repeat(img[..., None], 3, axis=-1)
 
     # write the image to a file
-    img_path = tmpdir / "test_write_read_jpeg.jpg"
-    K.write_image_jpeg(str(img_path), img)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        img_path = Path(tmpdir) / "test_write_read_jpeg.jpg"
+        K.write_image_jpeg(str(img_path), img)
 
-    # read the image back
-    img_read = K.read_image_jpeg(str(img_path))
+        # read the image back
+        img_read = K.read_image_jpeg(str(img_path))
 
     # check the image properties
     assert img_read.shape == (4, 5, 3)


### PR DESCRIPTION
`pytest-run-parallel` is a tool for converting existing Python test suites into multithreaded stress tests. If there's any use of global state in the implementation of any tested functionality or in any tests, `pytest-run-parallel` usually does a good job of triggering race conditions.

It doesn't replace real multithreaded stress tests of mutable objects but is a good first-pass to shake out any use of global state.

The only test failure was due to use of a thread-unsafe pytest [`tmpdir` fixture](https://docs.pytest.org/en/stable/how-to/tmp_path.html#the-tmpdir-and-tmpdir-factory-fixtures) and I replaced it with direct use of the [`tempfile.TemporaryDirectory` context manager](https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryDirectory), which is thread-safe.