### PR TITLE
Remove unnecessary unsafe Send/Sync impl for StreamCaptureError

### DIFF
--- a/crates/kornia-io/src/stream/error.rs
+++ b/crates/kornia-io/src/stream/error.rs
@@ -84,7 +84,3 @@ pub enum StreamCaptureError {
     #[error("Cannot lock the last frame")]
     LockError,
 }
-
-// ensure that can be sent over threads
-unsafe impl Send for StreamCaptureError {}
-unsafe impl Sync for StreamCaptureError {}


### PR DESCRIPTION
I verified that Rust automatically derives these by looking at the docs for `StreamCaptureError` after applying this PR:

<img width="534" alt="image" src="https://github.com/user-attachments/assets/2f321da4-a80a-4817-8bd4-d7ea70f1a5a7" />
