### PR TITLE
io: upgrade gsreamer to 0.23.5 and initialize

### DIFF
--- a/crates/kornia-io/Cargo.toml
+++ b/crates/kornia-io/Cargo.toml
@@ -21,8 +21,8 @@ log = { workspace = true }
 thiserror = { workspace = true }
 
 # optional dependencies
-gst = { version = "0.23.4", package = "gstreamer", optional = true }
-gst-app = { version = "0.23.4", package = "gstreamer-app", optional = true }
+gstreamer = { version = "0.23.5", optional = true }
+gstreamer-app = { version = "0.23.5", optional = true }
 turbojpeg = { version = "1.2", optional = true }
 
 [dev-dependencies]
@@ -30,7 +30,7 @@ criterion = { workspace = true }
 tempfile = { workspace = true }
 
 [features]
-gstreamer = ["gst", "gst-app"]
+gstreamer = ["dep:gstreamer", "dep:gstreamer-app"]
 turbojpeg = ["dep:turbojpeg"]
 
 [[bench]]

--- a/crates/kornia-io/Cargo.toml
+++ b/crates/kornia-io/Cargo.toml
@@ -15,6 +15,7 @@ all-features = true
 
 [dependencies]
 image = "0.25"
+circular-buffer = "1.1.0"
 kornia-image = { workspace = true }
 png = "0.17"
 log = { workspace = true }

--- a/crates/kornia-io/src/stream/error.rs
+++ b/crates/kornia-io/src/stream/error.rs
@@ -67,6 +67,6 @@ pub enum StreamCaptureError {
     PipelineNotRunning,
 
     /// An error occurred when the allocator is not found.
-    #[error("Cannot lock the last frame")]
-    LockError,
+    #[error("Could not lock the mutex")]
+    MutexPoisonError,
 }

--- a/crates/kornia-io/src/stream/error.rs
+++ b/crates/kornia-io/src/stream/error.rs
@@ -3,11 +3,11 @@
 pub enum StreamCaptureError {
     /// An error occurred during GStreamer initialization.
     #[error("Failed to initialize GStreamer")]
-    GStreamerError(#[from] gst::glib::Error),
+    GStreamerError(#[from] gstreamer::glib::Error),
 
     /// An error occurred during GStreamer downcast of pipeline element.
     #[error("Failed to downcast pipeline")]
-    DowncastPipelineError(gst::Element),
+    DowncastPipelineError(gstreamer::Element),
 
     /// An error occurred during GStreamer downcast of appsink.
     #[error("Failed to get an element by name")]
@@ -19,11 +19,11 @@ pub enum StreamCaptureError {
 
     /// An error occurred during GStreamer to set the pipeline state.
     #[error("Failed to set the pipeline state")]
-    SetPipelineStateError(#[from] gst::StateChangeError),
+    SetPipelineStateError(#[from] gstreamer::StateChangeError),
 
     /// An error occurred during GStreamer to pull sample from appsink.
     #[error("Failed to pull sample from appsink")]
-    PullSampleError(#[from] gst::glib::BoolError),
+    PullSampleError(#[from] gstreamer::glib::BoolError),
 
     /// An error occurred during GStreamer to get the caps from the sample.
     #[error("Failed to get the caps from the sample")]
@@ -70,7 +70,7 @@ pub enum StreamCaptureError {
 
     /// An error occurred during GStreamer to send end of stream event.
     #[error("Error ocurred in the gstreamer flow")]
-    GstreamerFlowError(#[from] gst::FlowError),
+    GstreamerFlowError(#[from] gstreamer::FlowError),
 
     /// An error occurred during checking the image format.
     #[error("Invalid image format: {0}")]

--- a/crates/kornia-io/src/stream/error.rs
+++ b/crates/kornia-io/src/stream/error.rs
@@ -2,7 +2,7 @@
 #[derive(thiserror::Error, Debug)]
 pub enum StreamCaptureError {
     /// An error occurred during GStreamer initialization.
-    #[error("Failed to initialize GStreamer")]
+    #[error(transparent)]
     GStreamerError(#[from] gstreamer::glib::Error),
 
     /// An error occurred during GStreamer downcast of pipeline element.
@@ -18,30 +18,16 @@ pub enum StreamCaptureError {
     BusError,
 
     /// An error occurred during GStreamer to set the pipeline state.
-    #[error("Failed to set the pipeline state")]
+    #[error(transparent)]
     SetPipelineStateError(#[from] gstreamer::StateChangeError),
 
     /// An error occurred during GStreamer to pull sample from appsink.
-    #[error("Failed to pull sample from appsink")]
+    #[error(transparent)]
     PullSampleError(#[from] gstreamer::glib::BoolError),
 
     /// An error occurred during GStreamer to get the caps from the sample.
-    #[error("Failed to get the caps from the sample")]
-    GetCapsError,
-
-    /// An error occurred during GStreamer to get the structure from the caps.
-    #[error("Failed to get the structure")]
-    GetStructureError,
-
-    // TODO: figure out the #[from] macro for this error
-    /// An error occurred during GStreamer to get the height from the structure.
-    #[error("Failed to get the height from the structure")]
-    GetHeightError,
-
-    // TODO: figure out the #[from] macro for this error
-    /// An error occurred during GStreamer to get the width from the structure.
-    #[error("Failed to get the width from the structure")]
-    GetWidthError,
+    #[error("Failed caps: {0}")]
+    GetCapsError(String),
 
     /// An error occurred during GStreamer to get the buffer from the sample.
     #[error("Failed to get the buffer from the sample")]
@@ -53,7 +39,7 @@ pub enum StreamCaptureError {
 
     // TODO: support later on ImageError
     /// An error occurred during processing the image frame.
-    #[error("Failed processing the image frame")]
+    #[error(transparent)]
     ProcessImageFrameError(#[from] Box<dyn std::error::Error + Send + Sync>),
 
     /// An error occurred during GStreamer to send eos event.
@@ -69,7 +55,7 @@ pub enum StreamCaptureError {
     InvalidConfig(String),
 
     /// An error occurred during GStreamer to send end of stream event.
-    #[error("Error ocurred in the gstreamer flow")]
+    #[error(transparent)]
     GstreamerFlowError(#[from] gstreamer::FlowError),
 
     /// An error occurred during checking the image format.


### PR DESCRIPTION
This pull request includes several changes to the `crates/kornia-io` package, focusing on updating dependencies and refactoring the `StreamCapture` and `VideoWriter` implementations to use the `circular-buffer` crate and the latest version of the `gstreamer` crate. The most important changes are listed below:

### Dependency Updates:
* Updated `gstreamer` and `gstreamer-app` dependencies to version `0.23.5` and added `circular-buffer` as a new dependency in `Cargo.toml`.

### Refactoring `StreamCapture`:
* Replaced `gst` and `gst-app` with `gstreamer` and `gstreamer-app` throughout the `StreamCapture` implementation in `capture.rs`. [[1]](diffhunk://#diff-54772eec9f4df3e91b9766d5d6e901987ebd59b387782130671c1b1590abcb73L1-R17) [[2]](diffhunk://#diff-54772eec9f4df3e91b9766d5d6e901987ebd59b387782130671c1b1590abcb73L31-R75)
* Introduced a `CircularBuffer` to store frames instead of using a single `last_frame` buffer. [[1]](diffhunk://#diff-54772eec9f4df3e91b9766d5d6e901987ebd59b387782130671c1b1590abcb73L31-R75) [[2]](diffhunk://#diff-54772eec9f4df3e91b9766d5d6e901987ebd59b387782130671c1b1590abcb73L93-R89)
* Modified the `grab` method to use `CircularBuffer` for frame retrieval.
* Updated error handling to provide more descriptive error messages.

### Refactoring `VideoWriter`:
* Replaced `gst` and `gst-app` with `gstreamer` and `gstreamer-app` throughout the `VideoWriter` implementation in `video.rs`. [[1]](diffhunk://#diff-a650bf907bc400f3a1ef37da1587b6bf6013a62c634e0a9e66b9be4decbdfbd5L1-R4) [[2]](diffhunk://#diff-a650bf907bc400f3a1ef37da1587b6bf6013a62c634e0a9e66b9be4decbdfbd5L27-R25)
* Ensured GStreamer initialization is only performed once.
* Updated the `start` method to handle bus messages using `gstreamer` types.

### Error Handling Improvements:
* Updated the `StreamCaptureError` enum to use `gstreamer` types and provide more detailed error messages. [[1]](diffhunk://#diff-06d2eee060e6e4efd36ad220f4fa8663679e54c8aeb5e2d19821f5081af47f00L5-R10) [[2]](diffhunk://#diff-06d2eee060e6e4efd36ad220f4fa8663679e54c8aeb5e2d19821f5081af47f00L21-R30) [[3]](diffhunk://#diff-06d2eee060e6e4efd36ad220f4fa8663679e54c8aeb5e2d19821f5081af47f00L56-R42) [[4]](diffhunk://#diff-06d2eee060e6e4efd36ad220f4fa8663679e54c8aeb5e2d19821f5081af47f00L72-R59) [[5]](diffhunk://#diff-06d2eee060e6e4efd36ad220f4fa8663679e54c8aeb5e2d19821f5081af47f00L84-R71)