### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -34,10 +34,7 @@ jobs:
         profile: minimal
 
     - name: Install system dependencies
-      run: |
-        sudo apt-get install -y nasm libunwind-dev
-        sudo apt remove cmake -y
-        pip install cmake
+      run: sudo apt-get install -y nasm libunwind-dev
 
     - name: Setup project environment
       run: cd kornia-py/ && just install ${{ matrix.python-version }}
@@ -63,10 +60,7 @@ jobs:
         profile: minimal
 
     - name: Install system dependencies
-      run: |
-        sudo apt-get install -y nasm libunwind-dev
-        sudo apt remove cmake -y
-        pip install cmake
+      run: sudo apt-get install -y nasm libunwind-dev
 
     - name: Setup project environment
       run: cd kornia-py/ && just install-dev 3.13t

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -34,7 +34,10 @@ jobs:
         profile: minimal
 
     - name: Install system dependencies
-      run: sudo apt-get install -y cmake nasm libunwind-dev
+      run: |
+        sudo apt-get install -y nasm libunwind-dev
+        sudo apt remove cmake -y
+        pip install cmake
 
     - name: Setup project environment
       run: cd kornia-py/ && just install ${{ matrix.python-version }}
@@ -60,7 +63,10 @@ jobs:
         profile: minimal
 
     - name: Install system dependencies
-      run: sudo apt-get install -y cmake nasm libunwind-dev
+      run: |
+        sudo apt-get install -y nasm libunwind-dev
+        sudo apt remove cmake -y
+        pip install cmake
 
     - name: Setup project environment
       run: cd kornia-py/ && just install-dev 3.13t

--- a/kornia-py/requirements-dev.txt
+++ b/kornia-py/requirements-dev.txt
@@ -1,5 +1,6 @@
 # build
 maturin[patchelf]
+cmake
 
 # tests
 pre-commit


### PR DESCRIPTION
This PR attempts to fix the `python_test` workflow caused due to incorrect version of cmake available on venv

I have tested this on a [separate fork](https://github.com/as1100k-forks/kornia-rs-ci) and all the CI tests now passes