### PR TITLE
Implement Zero copy images from gstreamer

### DIFF
--- a/crates/kornia-io/Cargo.toml
+++ b/crates/kornia-io/Cargo.toml
@@ -33,6 +33,7 @@ turbojpeg = { version = "1.2", optional = true }
 [dev-dependencies]
 criterion = { workspace = true }
 tempfile = { workspace = true }
+reqwest = { version = "0.12", features = ["blocking"] }
 
 [features]
 gstreamer = ["dep:gstreamer", "dep:gstreamer-app"]
@@ -41,3 +42,9 @@ turbojpeg = ["dep:turbojpeg"]
 [[bench]]
 name = "bench_io"
 harness = false
+required-features = ["turbojpeg"]
+
+[[bench]]
+name = "gstreamer"
+harness = false
+required-features = ["gstreamer"]

--- a/crates/kornia-io/Cargo.toml
+++ b/crates/kornia-io/Cargo.toml
@@ -19,6 +19,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 image = "0.25"
 circular-buffer = "1.1.0"
 kornia-image = { workspace = true }
+kornia-tensor = { workspace = true }
 png = "0.17"
 jpeg-encoder = "0.6"
 jpeg-decoder = "0.3"

--- a/crates/kornia-io/benches/gstreamer.rs
+++ b/crates/kornia-io/benches/gstreamer.rs
@@ -1,0 +1,52 @@
+use criterion::{black_box, Criterion};
+use reqwest::blocking::get;
+use std::io::copy;
+use std::path::PathBuf;
+use std::{fs::File, time::Duration};
+use tempfile::{tempdir, TempDir};
+
+const FILE_NAME: &str = "video.mp4";
+const VIDEO_LINK: &str =
+    "https://github.com/kornia/tutorials/raw/refs/heads/master/data/sharpening.mp4";
+
+fn download_video<'a>() -> (PathBuf, TempDir) {
+    let response = get(VIDEO_LINK).expect("Failed to download video");
+    let temp_dir = tempdir().expect("Failed to create temp directory");
+    let temp_file_path = temp_dir.path().join(FILE_NAME);
+    let mut temp_file = File::create(&temp_file_path).expect("Failed to create temp file");
+
+    copy(
+        &mut response.bytes().expect("Failed to read response").as_ref(),
+        &mut temp_file,
+    )
+    .expect("Failed to write video to temp file");
+
+    println!("Video downloaded to: {:?}", temp_file_path);
+    (temp_file_path, temp_dir)
+}
+
+fn benchmark_get_buffer(c: &mut Criterion) {
+    let (video_path, _temp_dir) = download_video();
+
+    let pipeline_desc = format!(
+        "filesrc location={} ! decodebin ! videoconvert ! video/x-raw,format=RGB,width=1024,height=688,framerate=8/1 ! appsink name=sink sync=false",
+        video_path.to_str().unwrap()
+    );
+
+    let mut stream_capture = kornia_io::stream::StreamCapture::new(&pipeline_desc).unwrap();
+    stream_capture.start().unwrap();
+
+    c.bench_function("grab", |b| {
+        b.iter(|| {
+            black_box(stream_capture.grab()).expect("Failed to grab the image");
+        });
+    });
+}
+
+criterion::criterion_group! {
+    name = benches;
+    config = Criterion::default().warm_up_time(Duration::from_secs(1));
+    targets = benchmark_get_buffer
+}
+
+criterion::criterion_main!(benches);


### PR DESCRIPTION
Fixes #331 

I followed the approach suggested by slomo at https://discourse.gstreamer.org/t/zero-copy-video-frames/3856/2

## Benchmarks
I have added `gstreamer.rs` benchmark, and this PR improves performance by <ins> **_~9.84%_** </ins> on my local machine.

```
Video downloaded to: "/tmp/.tmpJTJ1BC/video.mp4"
grab                    time:   [3.9711 ns 3.9861 ns 4.0036 ns]
                        change: [-9.8473% -9.3685% -8.8909%] (p = 0.00 < 0.05)
                        Performance has improved.
```

Also, I have used a video from [kornia/tutorials](https://github.com/kornia/tutorials) repository for the benchmark.