### PR TITLE
Python: make encoders and decoders frozen pyclasses

### DIFF
--- a/crates/kornia-io/src/functional.rs
+++ b/crates/kornia-io/src/functional.rs
@@ -50,7 +50,7 @@ pub fn read_image_jpegturbo_rgb8(file_path: impl AsRef<Path>) -> Result<Image<u8
 
     // decode the data directly from memory
     let image: Image<u8, 3> = {
-        let mut decoder = JpegTurboDecoder::new()?;
+        let decoder = JpegTurboDecoder::new()?;
         decoder.decode_rgb8(&jpeg_data)?
     };
 

--- a/crates/kornia-io/src/jpegturbo.rs
+++ b/crates/kornia-io/src/jpegturbo.rs
@@ -69,7 +69,7 @@ impl JpegTurboEncoder {
     /// # Returns
     ///
     /// The encoded data as `Vec<u8>`.
-    pub fn encode_rgb8(&mut self, image: &Image<u8, 3>) -> Result<Vec<u8>, JpegTurboError> {
+    pub fn encode_rgb8(&self, image: &Image<u8, 3>) -> Result<Vec<u8>, JpegTurboError> {
         // get the image data
         let image_data = image.as_slice();
 
@@ -95,7 +95,7 @@ impl JpegTurboEncoder {
     /// # Arguments
     ///
     /// * `quality` - The quality to set.
-    pub fn set_quality(&mut self, quality: i32) -> Result<(), JpegTurboError> {
+    pub fn set_quality(&self, quality: i32) -> Result<(), JpegTurboError> {
         Ok(self
             .0
             .lock()
@@ -129,7 +129,7 @@ impl JpegTurboDecoder {
     /// # Panics
     ///
     /// Panics if the header cannot be read.
-    pub fn read_header(&mut self, jpeg_data: &[u8]) -> Result<ImageSize, JpegTurboError> {
+    pub fn read_header(&self, jpeg_data: &[u8]) -> Result<ImageSize, JpegTurboError> {
         // read the JPEG header with image size
         let header = self
             .0
@@ -152,7 +152,7 @@ impl JpegTurboDecoder {
     /// # Returns
     ///
     /// The decoded data as Image<u8, 3>.
-    pub fn decode_rgb8(&mut self, jpeg_data: &[u8]) -> Result<Image<u8, 3>, JpegTurboError> {
+    pub fn decode_rgb8(&self, jpeg_data: &[u8]) -> Result<Image<u8, 3>, JpegTurboError> {
         // get the image size to allocate th data storage
         let image_size = self.read_header(jpeg_data)?;
 

--- a/kornia-py/src/io/jpeg.rs
+++ b/kornia-py/src/io/jpeg.rs
@@ -3,7 +3,7 @@ use kornia_image::Image;
 use kornia_io::jpegturbo::{JpegTurboDecoder, JpegTurboEncoder};
 use pyo3::prelude::*;
 
-#[pyclass(name = "ImageDecoder")]
+#[pyclass(name = "ImageDecoder", frozen)]
 pub struct PyImageDecoder(JpegTurboDecoder);
 
 #[pymethods]
@@ -15,7 +15,7 @@ impl PyImageDecoder {
         Ok(PyImageDecoder(decoder))
     }
 
-    pub fn read_header(&mut self, jpeg_data: &[u8]) -> PyResult<PyImageSize> {
+    pub fn read_header(&self, jpeg_data: &[u8]) -> PyResult<PyImageSize> {
         let image_size = self
             .0
             .read_header(jpeg_data)
@@ -23,7 +23,7 @@ impl PyImageDecoder {
         Ok(image_size.into())
     }
 
-    pub fn decode(&mut self, jpeg_data: &[u8]) -> PyResult<PyImage> {
+    pub fn decode(&self, jpeg_data: &[u8]) -> PyResult<PyImage> {
         let image = self
             .0
             .decode_rgb8(jpeg_data)
@@ -32,7 +32,7 @@ impl PyImageDecoder {
     }
 }
 
-#[pyclass(name = "ImageEncoder")]
+#[pyclass(name = "ImageEncoder", frozen)]
 pub struct PyImageEncoder(JpegTurboEncoder);
 
 #[pymethods]
@@ -44,7 +44,7 @@ impl PyImageEncoder {
         Ok(PyImageEncoder(encoder))
     }
 
-    pub fn encode(&mut self, image: PyImage) -> PyResult<Vec<u8>> {
+    pub fn encode(&self, image: PyImage) -> PyResult<Vec<u8>> {
         let image = Image::from_pyimage(image)
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
         let jpeg_data = self
@@ -54,7 +54,7 @@ impl PyImageEncoder {
         Ok(jpeg_data)
     }
 
-    pub fn set_quality(&mut self, quality: i32) -> PyResult<()> {
+    pub fn set_quality(&self, quality: i32) -> PyResult<()> {
         self.0
             .set_quality(quality)
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;


### PR DESCRIPTION
Note this is targeted at the PR branch for #334.

Since you're using interior mutability via a `Mutex`, all this `mut` isn't necessary.