### PR TITLE
Update python release automation, add free-threaded builds

### DIFF
--- a/.github/workflows/python_release.yml
+++ b/.github/workflows/python_release.yml
@@ -23,6 +23,9 @@ jobs:
           target: ${{ matrix.target }}
           manylinux: auto
           command: build
+          before-script-linux: |
+            if command -v dnf &> /dev/null; then dnf install cmake3 -y; elif command -v yum &> /dev/null; then yum install cmake3 -y; elif command -v apt-get &> /dev/null; then apt-get update && apt-get install cmake -y; else echo "None of dnf, yum, or apt found."; fi
+            if command -v cmake3 &> /dev/null; then export CMAKE=cmake3; fi
           args: --release --out dist -i python${{ matrix.python-version }} -m kornia-py/Cargo.toml --sdist
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -96,6 +99,8 @@ jobs:
           toolchain: stable
           target: ${{ matrix.target }}-apple-darwin
           override: true
+      - run: |
+          pip install cmake<4
       - uses: messense/maturin-action@v1
         with:
           command: build
@@ -126,6 +131,8 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      - run: |
+          pip install cmake<4
       - uses: messense/maturin-action@v1
         with:
           command: build

--- a/.github/workflows/python_release.yml
+++ b/.github/workflows/python_release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: linux-${{ matrix.target }}-${{ matrix.python-version }}-wheels
           path: dist
 
   macos:
@@ -99,8 +99,6 @@ jobs:
           toolchain: stable
           target: ${{ matrix.target }}-apple-darwin
           override: true
-      - run: |
-          pip install cmake<4
       - uses: messense/maturin-action@v1
         with:
           command: build
@@ -109,7 +107,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: macos-${{ matrix.target }}-${{ matrix.python-version }}-wheels
           path: dist
 
   windows:
@@ -141,7 +139,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: windows-${{ matrix.target }}-${{ matrix.python-version }}-wheels
           path: dist
 
   release:
@@ -150,10 +148,8 @@ jobs:
     needs: [macos, windows, linux]
     steps:
       - run: sudo apt-get update
-      - uses: actions/download-artifact@v3
-        with:
-          name: wheels
-      - uses: actions/setup-python@v2
+      - uses: actions/download-artifact@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Publish to PyPi

--- a/.github/workflows/python_release.yml
+++ b/.github/workflows/python_release.yml
@@ -103,7 +103,7 @@ jobs:
         with:
           command: build
           maturin-version: latest
-          args: --release --target ${{ matrix.target }}-apple-darwin --out dist -i python${{ matrix.python-version }} -m kornia-py/Cargo.toml --sdist
+          args: --release --target ${{ matrix.target }}-apple-darwin --out dist -i python${{ matrix.python-version }} -m kornia-py/Cargo.toml
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -135,7 +135,7 @@ jobs:
         with:
           command: build
           maturin-version: latest
-          args: --release --out dist -i python${{ matrix.python-version }} -m kornia-py/Cargo.toml --sdist
+          args: --release --out dist -i python${{ matrix.python-version }} -m kornia-py/Cargo.toml
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -158,4 +158,4 @@ jobs:
         uses: messense/maturin-action@v1
         with:
           command: upload
-          args: --skip-existing *
+          args: --skip-existing *-wheels/*

--- a/.github/workflows/python_release.yml
+++ b/.github/workflows/python_release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.13t"]
         target: [x86_64, aarch64]
 
     steps:
@@ -77,6 +77,12 @@ jobs:
           - runs-on: macos-14
             python-version: "3.13"
             target: aarch64
+          - runs-on: macos-14
+            python-version: "3.13t"
+            target: x86_64
+          - runs-on: macos-14
+            python-version: "3.13t"
+            target: aarch64
     steps:
       - uses: ilammy/setup-nasm@v1
       - uses: actions/checkout@v4
@@ -105,7 +111,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.13t"]
         target: [x64, x86]
     steps:
       - uses: ilammy/setup-nasm@v1

--- a/.github/workflows/python_release.yml
+++ b/.github/workflows/python_release.yml
@@ -25,7 +25,7 @@ jobs:
           command: build
           args: --release --out dist -i python${{ matrix.python-version }} -m kornia-py/Cargo.toml --sdist
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: dist
@@ -102,7 +102,7 @@ jobs:
           maturin-version: latest
           args: --release --target ${{ matrix.target }}-apple-darwin --out dist -i python${{ matrix.python-version }} -m kornia-py/Cargo.toml --sdist
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: dist
@@ -132,7 +132,7 @@ jobs:
           maturin-version: latest
           args: --release --out dist -i python${{ matrix.python-version }} -m kornia-py/Cargo.toml --sdist
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: dist


### PR DESCRIPTION
Fixes #226 (🚀🧵)

Most of this is fixing bitrot in the Python release automation:

* Works around issues with cmake4 and turbojpeg-sys. I opened https://github.com/honzasp/rust-turbojpeg/issues/30 to track this upstream. Way more complicated than I originally expected because it turns out maturin-action might be running on any one of RHEL 7-9 or Ubuntu!
* Updates to upload-artifact and download-artifact v4, which required updating naming bookkeeping to avoid generating artifacts with duplicate names, which is now banned.