### PR TITLE
Fix CI issue with sccache

### DIFF
--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -41,7 +41,7 @@ jobs:
         profile: minimal
 
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.3
+      uses: mozilla-actions/sccache-action@v0.0.8
 
     - name: Install system dependencies
       run: sudo apt-get install -y nasm libunwind-dev
@@ -87,7 +87,7 @@ jobs:
 
 
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.3
+      uses: mozilla-actions/sccache-action@v0.0.8
 
 
 
@@ -104,7 +104,7 @@ jobs:
         maturin develop -m Cargo.toml
         pytest --parallel-threads=8 --iterations=50
 
-        
+
     - name: Show sccache stats
       run: sccache --show-stats
 

--- a/.github/workflows/rust_lint.yml
+++ b/.github/workflows/rust_lint.yml
@@ -33,14 +33,14 @@ jobs:
         with:
           components: clippy
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.8
 
       - uses: giraffate/clippy-action@v1
         with:
-          reporter: 'github-pr-review'
+          reporter: "github-pr-review"
           github_token: ${{ secrets.GITHUB_TOKEN }}
           clippy_flags: -- -D warnings
-      
+
       - name: Show sccache stats
         run: sccache --show-stats
 
@@ -59,7 +59,7 @@ jobs:
       - run: rustup toolchain install stable
 
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.8
 
       - name: Install cross
         run: cargo install cross

--- a/.github/workflows/rust_release.yml
+++ b/.github/workflows/rust_release.yml
@@ -28,7 +28,7 @@ jobs:
           override: true
 
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.8
 
       - uses: actions-rs/cargo@v1
         with:
@@ -44,4 +44,3 @@ jobs:
 
       - name: Show sccache stats
         run: sccache --show-stats
-  

--- a/.github/workflows/rust_test.yml
+++ b/.github/workflows/rust_test.yml
@@ -35,9 +35,9 @@ jobs:
           rustup update stable
           rustup target add ${{ matrix.target }}
           rustup default stable
-    
+
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.8
 
       - name: Install cross-compilation tools
         run: cargo install cross --locked
@@ -67,9 +67,9 @@ jobs:
           rustup update stable
           rustup target add x86_64-unknown-linux-gnu
           rustup default stable
-      
+
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.3
+        uses: mozilla-actions/sccache-action@v0.0.8
 
       - name: Install cross-compilation tools
         run: cargo install cross --locked


### PR DESCRIPTION
This PR fixes the error thrown by the CI:
```
 error: process didn't exit successfully: `sccache /home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc -vV` (exit status: 2)
--- stderr
sccache: error: Server startup failed: cache storage failed to read: Unexpected (permanent) at read => {"$id":"1","innerException":null,"message":"This legacy service is shutting down, effective April 15, 2025. Migrate to the new service ASAP. For more information: https://gh.io/gha-cache-sunset","typeName":"Microsoft.Azure.DevOps.ArtifactCache.WebApi.ArtifactCacheServiceDecommissionedException, Microsoft.Azure.DevOps.ArtifactCache.WebApi","typeKey":"ArtifactCacheServiceDecommissionedException","errorCode":0,"eventId":3000}
```