### PR TITLE
fix sdist and add trove classifiers

### DIFF
--- a/kornia-py/Cargo.toml
+++ b/kornia-py/Cargo.toml
@@ -4,7 +4,6 @@ categories = ["computer-vision", "science::robotics"]
 description = "Python bindings for Kornia Rust library"
 edition = "2021"
 homepage = "http://kornia.org"
-include = ["Cargo.toml"]
 license = "Apache-2.0"
 repository = "https://github.com/kornia/kornia-rs"
 rust-version = "1.76"

--- a/kornia-py/pyproject.toml
+++ b/kornia-py/pyproject.toml
@@ -25,6 +25,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: Free Threading :: 3 - Stable",
     "Programming Language :: Rust",
     "Topic :: Scientific/Engineering",
     "Programming Language :: Rust",


### PR DESCRIPTION
The `include` option in the `kornia-py` `Cargo.toml` file is causing the sdist to miss almost all files.

Also includes trove classifiers.

Fixes the issue pointed out by @zboszor here: https://github.com/kornia/kornia-rs/issues/360#issuecomment-2889989223