### PR TITLE
remove static from tensor allocator

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ use kornia::io::functional as F;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // read the image
-    let image: Image<u8, 3> = F::read_image_any_rgb8("tests/data/dog.jpeg")?;
+    let image: Image<u8, 3, _> = F::read_image_any_rgb8("tests/data/dog.jpeg")?;
 
     println!("Hello, world! 🦀");
     println!("Loaded Image size: {:?}", image.size());
@@ -123,13 +123,13 @@ use kornia::io::functional as F;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // read the image
-    let image: Image<u8, 3> = F::read_image_any_rgb8("tests/data/dog.jpeg")?;
+    let image: Image<u8, 3, _> = F::read_image_any_rgb8("tests/data/dog.jpeg")?;
     let image_viz = image.clone();
 
-    let image_f32: Image<f32, 3> = image.cast_and_scale::<f32>(1.0 / 255.0)?;
+    let image_f32: Image<f32, 3, _> = image.cast_and_scale::<f32>(1.0 / 255.0)?;
 
     // convert the image to grayscale
-    let mut gray = Image::<f32, 1>::from_size_val(image_f32.size(), 0.0)?;
+    let mut gray = Image::<f32, 1, _>::from_size_val(image_f32.size(), 0.0)?;
     imgproc::color::gray_from_rgb(&image_f32, &mut gray)?;
 
     // resize the image
@@ -138,7 +138,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         height: 128,
     };
 
-    let mut gray_resized = Image::<f32, 1>::from_size_val(new_size, 0.0)?;
+    let mut gray_resized = Image::<f32, 1, _>::from_size_val(new_size, 0.0)?;
     imgproc::resize::resize_native(
         &gray, &mut gray_resized,
         imgproc::interpolation::InterpolationMode::Bilinear,

--- a/crates/kornia-image/src/allocator.rs
+++ b/crates/kornia-image/src/allocator.rs
@@ -1,6 +1,6 @@
-use kornia_tensor::TensorAllocator;
-
+// Re-export the CpuAllocator from kornia-tensor
 pub use kornia_tensor::CpuAllocator;
+use kornia_tensor::TensorAllocator;
 
 /// A marker trait for allocating and deallocating memory for images.
 pub trait ImageAllocator: TensorAllocator {}

--- a/crates/kornia-image/src/image.rs
+++ b/crates/kornia-image/src/image.rs
@@ -1,7 +1,5 @@
-use super::allocator::ImageAllocator;
-use kornia_tensor::{CpuAllocator, Tensor, Tensor2, Tensor3};
-
-use crate::error::ImageError;
+use crate::{allocator::ImageAllocator, error::ImageError};
+use kornia_tensor::{Tensor, Tensor2, Tensor3};
 
 /// Image size in pixels
 ///
@@ -57,7 +55,7 @@ impl From<ImageSize> for [u32; 2] {
 /// Represents an image with pixel data.
 ///
 /// The image is represented as a 3D Tensor with shape (H, W, C), where H is the height of the image,
-pub struct Image<T, const C: usize, A: ImageAllocator + 'static = CpuAllocator>(pub Tensor3<T, A>);
+pub struct Image<T, const C: usize, A: ImageAllocator>(pub Tensor3<T, A>);
 
 /// helper to deference the inner tensor
 impl<T, const C: usize, A: ImageAllocator> std::ops::Deref for Image<T, C, A> {
@@ -100,7 +98,7 @@ impl<T, const C: usize, A: ImageAllocator> Image<T, C, A> {
     /// use kornia_image::{Image, ImageSize};
     /// use kornia_image::allocator::CpuAllocator;
     ///
-    /// let image = Image::<u8, 3>::new(
+    /// let image = Image::<u8, 3, _>::new(
     ///    ImageSize {
     ///       width: 10,
     ///      height: 20,
@@ -155,7 +153,7 @@ impl<T, const C: usize, A: ImageAllocator> Image<T, C, A> {
     /// use kornia_image::{Image, ImageSize};
     /// use kornia_image::allocator::CpuAllocator;
     ///
-    /// let image = Image::<u8, 3>::from_size_val(
+    /// let image = Image::<u8, 3, _>::from_size_val(
     ///   ImageSize {
     ///     width: 10,
     ///    height: 20,
@@ -314,7 +312,7 @@ impl<T, const C: usize, A: ImageAllocator> Image<T, C, A> {
     /// use kornia_image::{Image, ImageSize};
     /// use kornia_image::allocator::CpuAllocator;
     ///
-    /// let image = Image::<f32, 2>::from_size_val(
+    /// let image = Image::<f32, 2, _>::from_size_val(
     ///   ImageSize {
     ///    width: 10,
     ///   height: 20,
@@ -393,7 +391,7 @@ impl<T, const C: usize, A: ImageAllocator> Image<T, C, A> {
     ///
     /// let data = vec![0u8, 0, 255, 0, 0, 255];
     ///
-    /// let image_u8 = Image::<u8, 3>::new(
+    /// let image_u8 = Image::<u8, 3, _>::new(
     /// ImageSize {
     ///   height: 2,
     ///   width: 1,

--- a/crates/kornia-imgproc/src/core.rs
+++ b/crates/kornia-imgproc/src/core.rs
@@ -27,7 +27,7 @@ use rayon::{
 /// use kornia_image::allocator::CpuAllocator;
 /// use kornia_imgproc::core::std_mean;
 ///
-/// let image = Image::<u8, 3>::new(
+/// let image = Image::<u8, 3, _>::new(
 ///    ImageSize {
 ///      width: 2,
 ///      height: 2,

--- a/crates/kornia-imgproc/src/filter/ops.rs
+++ b/crates/kornia-imgproc/src/filter/ops.rs
@@ -109,16 +109,16 @@ pub fn box_blur_fast<const C: usize, A: ImageAllocator>(
         height: src.size().width,
     };
 
-    let mut input_img = src.clone();
+    let mut input_img = src;
     let mut transposed = Image::<f32, C, _>::from_size_val(transposed_size, 0.0, CpuAllocator)?;
 
     for (half_kernel_x_size, half_kernel_y_size) in
         half_kernel_x_sizes.iter().zip(half_kernel_y_sizes.iter())
     {
-        fast_horizontal_filter(&input_img, &mut transposed, *half_kernel_x_size)?;
+        fast_horizontal_filter(input_img, &mut transposed, *half_kernel_x_size)?;
         fast_horizontal_filter(&transposed, dst, *half_kernel_y_size)?;
 
-        input_img = dst.clone();
+        input_img = dst;
     }
 
     Ok(())

--- a/crates/kornia-imgproc/src/flip.rs
+++ b/crates/kornia-imgproc/src/flip.rs
@@ -89,7 +89,7 @@ where
 /// use kornia_image::allocator::CpuAllocator;
 /// use kornia_imgproc::flip::vertical_flip;
 ///
-/// let image = Image::<f32, 3>::new(
+/// let image = Image::<f32, 3, _>::new(
 ///     ImageSize {
 ///         width: 2,
 ///         height: 3,
@@ -99,7 +99,7 @@ where
 /// )
 /// .unwrap();
 ///
-/// let mut flipped = Image::<f32, 3>::from_size_val(image.size(), 0.0, CpuAllocator).unwrap();
+/// let mut flipped = Image::<f32, 3, _>::from_size_val(image.size(), 0.0, CpuAllocator).unwrap();
 ///
 /// vertical_flip(&image, &mut flipped).unwrap();
 ///

--- a/crates/kornia-imgproc/src/normalize.rs
+++ b/crates/kornia-imgproc/src/normalize.rs
@@ -188,7 +188,7 @@ where
 /// )
 /// .unwrap();
 ///
-/// let mut image_normalized = Image::<f32, 3>::from_size_val(image.size(), 0.0, CpuAllocator).unwrap();
+/// let mut image_normalized = Image::<f32, 3, _>::from_size_val(image.size(), 0.0, CpuAllocator).unwrap();
 ///
 /// normalize_min_max(&image, &mut image_normalized, 0.0, 1.0).unwrap();
 ///

--- a/crates/kornia-io/src/functional.rs
+++ b/crates/kornia-io/src/functional.rs
@@ -17,10 +17,10 @@ use std::path::Path;
 /// # Example
 ///
 /// ```
-/// use kornia_image::Image;
+/// use kornia_image::{Image, allocator::CpuAllocator};
 /// use kornia_io::functional as F;
 ///
-/// let image: Image<u8, 3> = F::read_image_any_rgb8("../../tests/data/dog.jpeg").unwrap();
+/// let image: Image<u8, 3, CpuAllocator> = F::read_image_any_rgb8("../../tests/data/dog.jpeg").unwrap();
 ///
 /// assert_eq!(image.cols(), 258);
 /// assert_eq!(image.rows(), 195);

--- a/crates/kornia-io/src/jpegturbo.rs
+++ b/crates/kornia-io/src/jpegturbo.rs
@@ -228,7 +228,7 @@ impl JpegTurboDecoder {
 /// use kornia_image::Image;
 /// use kornia_io::jpegturbo as F;
 ///
-/// let image: Image<u8, 3> = F::read_image_jpegturbo_rgb8("../../tests/data/dog.jpeg").unwrap();
+/// let image: Image<u8, 3, _> = F::read_image_jpegturbo_rgb8("../../tests/data/dog.jpeg").unwrap();
 ///
 /// assert_eq!(image.cols(), 258);
 /// assert_eq!(image.rows(), 195);

--- a/crates/kornia-tensor/src/lib.rs
+++ b/crates/kornia-tensor/src/lib.rs
@@ -8,15 +8,15 @@ pub mod allocator;
 #[cfg(feature = "bincode")]
 pub mod bincode;
 
-/// tensor module containing the tensor and storage implementations.
-pub mod tensor;
-
 /// serde module containing the serialization and deserialization utilities.
 #[cfg(feature = "serde")]
 pub mod serde;
 
 /// storage module containing the storage implementations.
 pub mod storage;
+
+/// tensor module containing the tensor and storage implementations.
+pub mod tensor;
 
 /// view module containing the view implementations.
 pub mod view;

--- a/crates/kornia-tensor/src/storage.rs
+++ b/crates/kornia-tensor/src/storage.rs
@@ -139,16 +139,10 @@ impl<T, A: TensorAllocator> Drop for TensorStorage<T, A> {
 impl<T, A> Clone for TensorStorage<T, A>
 where
     T: Clone,
-    A: TensorAllocator + 'static,
+    A: TensorAllocator,
 {
     fn clone(&self) -> Self {
-        let mut new_vec = Vec::<T>::with_capacity(self.len());
-
-        for i in self.as_slice() {
-            new_vec.push(i.clone());
-        }
-
-        Self::from_vec(new_vec, self.alloc.clone())
+        Self::from_vec(self.as_slice().to_vec(), self.alloc.clone())
     }
 }
 

--- a/crates/kornia-tensor/src/tensor.rs
+++ b/crates/kornia-tensor/src/tensor.rs
@@ -82,10 +82,7 @@ pub struct Tensor<T, const N: usize, A: TensorAllocator> {
     pub strides: [usize; N],
 }
 
-impl<T, const N: usize, A: TensorAllocator> Tensor<T, N, A>
-where
-    A: 'static,
-{
+impl<T, const N: usize, A: TensorAllocator> Tensor<T, N, A> {
     /// Get the data of the tensor as a slice.
     ///
     /// # Returns
@@ -724,7 +721,7 @@ where
 impl<T, const N: usize, A> Clone for Tensor<T, N, A>
 where
     T: Clone,
-    A: TensorAllocator + Clone + 'static,
+    A: TensorAllocator + Clone,
 {
     fn clone(&self) -> Self {
         Self {
@@ -738,7 +735,7 @@ where
 impl<T, const N: usize, A> std::fmt::Display for Tensor<T, N, A>
 where
     T: std::fmt::Display + std::fmt::LowerExp,
-    A: TensorAllocator + 'static,
+    A: TensorAllocator,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let width = self

--- a/crates/kornia-tensor/src/view.rs
+++ b/crates/kornia-tensor/src/view.rs
@@ -14,7 +14,7 @@ pub struct TensorView<'a, T, const N: usize, A: TensorAllocator> {
     pub strides: [usize; N],
 }
 
-impl<T, const N: usize, A: TensorAllocator + 'static> TensorView<'_, T, N, A> {
+impl<T, const N: usize, A: TensorAllocator> TensorView<'_, T, N, A> {
     /// Returns the data slice of the tensor.
     #[inline]
     pub fn as_slice(&self) -> &[T] {

--- a/examples/binarize/src/main.rs
+++ b/examples/binarize/src/main.rs
@@ -17,10 +17,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Args = argh::from_env();
 
     // read the image
-    let image: Image<u8, 3> = F::read_image_any_rgb8(args.image_path)?;
+    let image = F::read_image_any_rgb8(args.image_path)?;
 
     // binarize the image as u8
-    let mut bin = Image::<u8, 3>::from_size_val(image.size(), 0, CpuAllocator)?;
+    let mut bin = Image::<u8, 3, _>::from_size_val(image.size(), 0, CpuAllocator)?;
     imgproc::threshold::threshold_binary(&image, &mut bin, 127, 255)?;
 
     // normalize the image between 0 and 1

--- a/examples/color_detector/src/main.rs
+++ b/examples/color_detector/src/main.rs
@@ -21,19 +21,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rgb = F::read_image_any_rgb8(args.image_path)?;
 
     // cast the image to f32
-    let mut rgb_f32 = Image::<f32, 3>::from_size_val(rgb.size(), 0.0, CpuAllocator)?;
+    let mut rgb_f32 = Image::<f32, 3, _>::from_size_val(rgb.size(), 0.0, CpuAllocator)?;
     ops::cast_and_scale(&rgb, &mut rgb_f32, 1.0)?;
 
     // binarize the image as u8
-    let mut hsv = Image::<f32, 3>::from_size_val(rgb.size(), 0.0, CpuAllocator)?;
+    let mut hsv = Image::<f32, 3, _>::from_size_val(rgb.size(), 0.0, CpuAllocator)?;
     imgproc::color::hsv_from_rgb(&rgb_f32, &mut hsv)?; // convert to u8 (0-255)
 
     // create the mask for the green color
-    let mut mask = Image::<u8, 1>::from_size_val(hsv.size(), 0, CpuAllocator)?;
+    let mut mask = Image::<u8, 1, _>::from_size_val(hsv.size(), 0, CpuAllocator)?;
     imgproc::threshold::in_range(&hsv, &mut mask, &[40.0, 110.0, 50.0], &[90.0, 255.0, 255.0])?;
 
     // apply the mask to the image
-    let mut out = Image::<u8, 3>::from_size_val(mask.size(), 0, CpuAllocator)?;
+    let mut out = Image::<u8, 3, _>::from_size_val(mask.size(), 0, CpuAllocator)?;
     imgproc::core::bitwise_and(&rgb, &rgb, &mut out, &mask)?;
 
     // create a Rerun recording stream

--- a/examples/copper/src/tasks/cu_image.rs
+++ b/examples/copper/src/tasks/cu_image.rs
@@ -1,7 +1,7 @@
 use kornia::tensor::CpuAllocator;
 
-type ImageRgb8 = kornia::image::Image<u8, 3>;
-type ImageGray8 = kornia::image::Image<u8, 1>;
+type ImageRgb8 = kornia::image::Image<u8, 3, CpuAllocator>;
+type ImageGray8 = kornia::image::Image<u8, 1, CpuAllocator>;
 
 #[derive(Clone)]
 pub struct ImageRgb8Msg(pub ImageRgb8);

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -1,8 +1,6 @@
 use argh::FromArgs;
+use kornia::{image::Image, io::functional as F, tensor::CpuAllocator};
 use std::path::PathBuf;
-
-use kornia::image::Image;
-use kornia::io::functional as F;
 
 #[derive(FromArgs)]
 /// Hello world!
@@ -16,7 +14,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Args = argh::from_env();
 
     // read the image
-    let image: Image<u8, 3> = F::read_image_any_rgb8(args.image_path)?;
+    let image: Image<u8, 3, CpuAllocator> = F::read_image_any_rgb8(args.image_path)?;
 
     println!("Hello, world! 🦀");
     println!("Loaded Image size: {:?}", image.size());

--- a/examples/histogram/src/main.rs
+++ b/examples/histogram/src/main.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Args = argh::from_env();
 
     // read the image
-    let image: Image<u8, 3> = F::read_image_any_rgb8(args.image_path)?;
+    let image: Image<u8, 3, _> = F::read_image_any_rgb8(args.image_path)?;
 
     // compute the histogram per channel
     let histograms = image

--- a/examples/imgproc/src/main.rs
+++ b/examples/imgproc/src/main.rs
@@ -20,14 +20,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Args = argh::from_env();
 
     // read the image
-    let image: Image<u8, 3> = F::read_image_any_rgb8(args.image_path)?;
+    let image = F::read_image_any_rgb8(args.image_path)?;
 
     // convert the image to grayscale
-    let mut gray = Image::<u8, 1>::from_size_val(image.size(), 0, CpuAllocator)?;
+    let mut gray = Image::<u8, 1, _>::from_size_val(image.size(), 0, CpuAllocator)?;
     imgproc::color::gray_from_rgb_u8(&image, &mut gray)?;
 
     // convert to float
-    let mut gray_f32 = Image::<f32, 1>::from_size_val(gray.size(), 0.0, CpuAllocator)?;
+    let mut gray_f32 = Image::<f32, 1, _>::from_size_val(gray.size(), 0.0, CpuAllocator)?;
     ops::cast_and_scale(&gray, &mut gray_f32, 1.0 / 255.0)?;
 
     let new_size = ImageSize {
@@ -35,7 +35,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         height: 128,
     };
 
-    let mut gray_resize = Image::<f32, 1>::from_size_val(new_size, 0.0, CpuAllocator)?;
+    let mut gray_resize = Image::<f32, 1, _>::from_size_val(new_size, 0.0, CpuAllocator)?;
     imgproc::resize::resize_native(
         &gray_f32,
         &mut gray_resize,

--- a/examples/metrics/src/main.rs
+++ b/examples/metrics/src/main.rs
@@ -21,14 +21,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Args = argh::from_env();
 
     // read the image
-    let image: Image<u8, 3> = F::read_image_any_rgb8(args.image_path)?;
+    let image = F::read_image_any_rgb8(args.image_path)?;
 
     // convert the image to f32 and scale it
-    let mut image_f32 = Image::<f32, 3>::from_size_val(image.size(), 0.0, CpuAllocator)?;
+    let mut image_f32 = Image::<f32, 3, _>::from_size_val(image.size(), 0.0, CpuAllocator)?;
     ops::cast_and_scale(&image, &mut image_f32, 1.0 / 255.0)?;
 
     // modify the image to see the changes
-    let mut image_dirty = Image::<f32, 3>::from_size_val(image.size(), 0.0, CpuAllocator)?;
+    let mut image_dirty = Image::<f32, 3, _>::from_size_val(image.size(), 0.0, CpuAllocator)?;
     imgproc::flip::horizontal_flip(&image_f32, &mut image_dirty)?;
 
     // compute the mean squared error (mse) between the original and the modified image

--- a/examples/normalize/src/main.rs
+++ b/examples/normalize/src/main.rs
@@ -17,7 +17,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Args = argh::from_env();
 
     // read the image
-    let image: Image<u8, 3> = F::read_image_any_rgb8(args.image_path)?;
+    let image = F::read_image_any_rgb8(args.image_path)?;
 
     // cast the image to floating point
     let image_f32 = image.clone().cast::<f32>()?;

--- a/examples/normalize_ii/src/main.rs
+++ b/examples/normalize_ii/src/main.rs
@@ -17,17 +17,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Args = argh::from_env();
 
     // read the image
-    let image: Image<u8, 3> = F::read_image_any_rgb8(args.image_path)?;
+    let image = F::read_image_any_rgb8(args.image_path)?;
 
     // cast the image to floating point
-    let image_f32: Image<f32, 3> = image.cast_and_scale::<f32>(1.0 / 255.0)?;
+    let image_f32 = image.cast_and_scale::<f32>(1.0 / 255.0)?;
 
     // convert to grayscale
-    let mut gray = Image::<f32, 1>::from_size_val(image_f32.size(), 0.0, CpuAllocator)?;
+    let mut gray = Image::<f32, 1, _>::from_size_val(image_f32.size(), 0.0, CpuAllocator)?;
     imgproc::color::gray_from_rgb(&image_f32, &mut gray)?;
 
     // normalize the image each channel
-    let mut image_norm: Image<f32, 3> = Image::from_size_val(image_f32.size(), 0.0, CpuAllocator)?;
+    let mut image_norm = Image::<f32, 3, _>::from_size_val(image_f32.size(), 0.0, CpuAllocator)?;
     imgproc::normalize::normalize_mean_std(
         &image_f32,
         &mut image_norm,
@@ -36,7 +36,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     // normalize the grayscale image
-    let mut gray_norm = Image::<f32, 1>::from_size_val(gray.size(), 0.0, CpuAllocator)?;
+    let mut gray_norm = Image::<f32, 1, _>::from_size_val(gray.size(), 0.0, CpuAllocator)?;
     imgproc::normalize::normalize_mean_std(&gray, &mut gray_norm, &[0.5], &[0.5])?;
 
     // alternative way to normalize the image between 0 and 255

--- a/examples/onnx/src/main.rs
+++ b/examples/onnx/src/main.rs
@@ -49,7 +49,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     std::env::set_var("ORT_DYLIB_PATH", &args.ort_dylib_path);
 
     // read the image
-    let image: Image<u8, 3> = F::read_image_any_rgb8(&args.image_path)?;
+    let image = F::read_image_any_rgb8(&args.image_path)?;
 
     // read the onnx model
 

--- a/examples/rerun_viz/src/main.rs
+++ b/examples/rerun_viz/src/main.rs
@@ -1,8 +1,6 @@
 use argh::FromArgs;
+use kornia::{image::Image, io::functional as F, tensor::CpuAllocator};
 use std::path::PathBuf;
-
-use kornia::image::Image;
-use kornia::io::functional as F;
 
 #[derive(FromArgs)]
 /// Log an image to Rerun
@@ -16,7 +14,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Args = argh::from_env();
 
     // read the image
-    let image: Image<u8, 3> = F::read_image_any_rgb8(args.image_path)?;
+    let image: Image<u8, 3, CpuAllocator> = F::read_image_any_rgb8(args.image_path)?;
 
     // create a Rerun recording stream
     let rec = rerun::RecordingStreamBuilder::new("Kornia App").spawn()?;

--- a/examples/rotate/src/main.rs
+++ b/examples/rotate/src/main.rs
@@ -17,8 +17,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Args = argh::from_env();
 
     // read the image
-    let image: Image<u8, 3> = F::read_image_any_rgb8(args.image_path)?;
-    let image: Image<f32, 3> = image.cast_and_scale::<f32>(1.0 / 255.0)?;
+    let image = F::read_image_any_rgb8(args.image_path)?;
+    let image = image.cast_and_scale::<f32>(1.0 / 255.0)?;
 
     let rec = rerun::RecordingStreamBuilder::new("Kornia App").spawn()?;
 
@@ -34,7 +34,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let scale = i as f32 / 360.0;
         let rotation_matrix = imgproc::warp::get_rotation_matrix2d(center, angle, scale);
 
-        let mut output = Image::<f32, 3>::from_size_val(image.size(), 0.0, CpuAllocator)?;
+        let mut output = Image::<f32, 3, _>::from_size_val(image.size(), 0.0, CpuAllocator)?;
         let mut output_norm = output.clone();
 
         imgproc::warp::warp_affine(

--- a/examples/rtspcam/src/main.rs
+++ b/examples/rtspcam/src/main.rs
@@ -69,8 +69,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     })?;
 
     // preallocate images
-    let mut img_f32 = Image::<f32, 3>::from_size_val([640, 360].into(), 0.0, CpuAllocator)?;
-    let mut gray = Image::<f32, 1>::from_size_val(img_f32.size(), 0.0, CpuAllocator)?;
+    let mut img_f32 = Image::<f32, 3, _>::from_size_val([640, 360].into(), 0.0, CpuAllocator)?;
+    let mut gray = Image::<f32, 1, _>::from_size_val(img_f32.size(), 0.0, CpuAllocator)?;
 
     while !cancel_token.load(Ordering::SeqCst) {
         // start grabbing frames from the camera

--- a/examples/video_player/src/lib.rs
+++ b/examples/video_player/src/lib.rs
@@ -1,12 +1,15 @@
-use eframe::egui::{self, Grid};
-use eframe::egui::{CentralPanel, TextEdit};
+use eframe::egui::{self, CentralPanel, Grid, TextEdit};
 use humanize_duration::{prelude::*, Truncate};
-use kornia::image::{Image, ImageSize};
-use kornia::imgproc::resize::resize_fast;
-use kornia::io::stream::video::{ImageFormat, SeekFlags, VideoReader};
-use kornia::tensor::CpuAllocator;
-use std::path::PathBuf;
-use std::time::{Duration, Instant};
+use kornia::{
+    image::{Image, ImageSize},
+    imgproc::resize::resize_fast,
+    io::stream::video::{ImageFormat, SeekFlags, VideoReader},
+    tensor::CpuAllocator,
+};
+use std::{
+    path::PathBuf,
+    time::{Duration, Instant},
+};
 
 const SLIDER_HEIGHT: f32 = 20.;
 
@@ -19,7 +22,7 @@ pub struct MyApp {
 }
 
 struct TextureStore {
-    image: Image<u8, 3>,
+    image: Image<u8, 3, CpuAllocator>,
     texture_handle: egui::TextureHandle,
 }
 
@@ -312,7 +315,7 @@ fn render_image(app: &mut MyApp, ui: &mut eframe::egui::Ui) {
                         ts.texture_handle
                             .set(color_image, egui::TextureOptions::default());
                     } else {
-                        let mut dst: Image<u8, 3> =
+                        let mut dst: Image<u8, 3, _> =
                             Image::from_size_val(new_image_size, 0, CpuAllocator)
                                 .expect("Failed to create Image");
                         resize_fast(

--- a/kornia-py/src/color.rs
+++ b/kornia-py/src/color.rs
@@ -36,7 +36,7 @@ pub fn bgr_from_rgb(image: PyImage) -> PyResult<PyImage> {
 
 #[pyfunction]
 pub fn gray_from_rgb(image: PyImage) -> PyResult<PyImage> {
-    let image_rgb: Image<u8, 3> = Image::from_pyimage(image)
+    let image_rgb: Image<u8, 3, _> = Image::from_pyimage(image)
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("src image: {}", e)))?;
 
     let image_rgb = image_rgb.cast::<f32>().map_err(|e| {

--- a/kornia-py/src/enhance.rs
+++ b/kornia-py/src/enhance.rs
@@ -12,11 +12,11 @@ pub fn add_weighted(
     beta: f32,
     gamma: f32,
 ) -> PyResult<PyImage> {
-    let image1: Image<u8, 3> = Image::from_pyimage(src1).map_err(|e| {
+    let image1: Image<u8, 3, _> = Image::from_pyimage(src1).map_err(|e| {
         PyErr::new::<pyo3::exceptions::PyException, _>(format!("src1 image: {}", e))
     })?;
 
-    let image2: Image<u8, 3> = Image::from_pyimage(src2).map_err(|e| {
+    let image2: Image<u8, 3, _> = Image::from_pyimage(src2).map_err(|e| {
         PyErr::new::<pyo3::exceptions::PyException, _>(format!("src2 image: {}", e))
     })?;
 
@@ -29,7 +29,7 @@ pub fn add_weighted(
         PyErr::new::<pyo3::exceptions::PyException, _>(format!("src2 image: {}", e))
     })?;
 
-    let mut dst: Image<f32, 3> = Image::from_size_val(image1.size(), 0.0f32, CpuAllocator)
+    let mut dst: Image<f32, 3, _> = Image::from_size_val(image1.size(), 0.0f32, CpuAllocator)
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("dst image: {}", e)))?;
 
     enhance::add_weighted(&image1, alpha, &image2, beta, gamma, &mut dst)

--- a/kornia-py/src/image.rs
+++ b/kornia-py/src/image.rs
@@ -25,7 +25,7 @@ pub trait ToPyImageF32 {
     fn to_pyimage_f32(self) -> PyImageF32;
 }
 
-impl<const C: usize> ToPyImage for Image<u8, C> {
+impl<const C: usize> ToPyImage for Image<u8, C, CpuAllocator> {
     fn to_pyimage(self) -> PyImage {
         Python::with_gil(|py| unsafe {
             let array = PyArray::<u8, _>::new(py, [self.height(), self.width(), C], false);
@@ -36,7 +36,7 @@ impl<const C: usize> ToPyImage for Image<u8, C> {
     }
 }
 
-impl<const C: usize> ToPyImageU16 for Image<u16, C> {
+impl<const C: usize> ToPyImageU16 for Image<u16, C, CpuAllocator> {
     fn to_pyimage_u16(self) -> PyImageU16 {
         Python::with_gil(|py| unsafe {
             let array = PyArray::<u16, _>::new(py, [self.height(), self.width(), C], false);
@@ -47,7 +47,7 @@ impl<const C: usize> ToPyImageU16 for Image<u16, C> {
     }
 }
 
-impl<const C: usize> ToPyImageF32 for Image<f32, C> {
+impl<const C: usize> ToPyImageF32 for Image<f32, C, CpuAllocator> {
     fn to_pyimage_f32(self) -> PyImageF32 {
         Python::with_gil(|py| unsafe {
             let array = PyArray::<f32, _>::new(py, [self.height(), self.width(), C], false);
@@ -59,19 +59,19 @@ impl<const C: usize> ToPyImageF32 for Image<f32, C> {
 }
 /// Trait to convert a PyImage (3D numpy array of u8) to an image
 pub trait FromPyImage<const C: usize> {
-    fn from_pyimage(image: PyImage) -> Result<Image<u8, C>, ImageError>;
+    fn from_pyimage(image: PyImage) -> Result<Image<u8, C, CpuAllocator>, ImageError>;
 }
 
 pub trait FromPyImageU16<const C: usize> {
-    fn from_pyimage_u16(image: PyImageU16) -> Result<Image<u16, C>, ImageError>;
+    fn from_pyimage_u16(image: PyImageU16) -> Result<Image<u16, C, CpuAllocator>, ImageError>;
 }
 
 pub trait FromPyImageF32<const C: usize> {
-    fn from_pyimage_f32(image: PyImageF32) -> Result<Image<f32, C>, ImageError>;
+    fn from_pyimage_f32(image: PyImageF32) -> Result<Image<f32, C, CpuAllocator>, ImageError>;
 }
 
-impl<const C: usize> FromPyImage<C> for Image<u8, C> {
-    fn from_pyimage(image: PyImage) -> Result<Image<u8, C>, ImageError> {
+impl<const C: usize> FromPyImage<C> for Image<u8, C, CpuAllocator> {
+    fn from_pyimage(image: PyImage) -> Result<Image<u8, C, CpuAllocator>, ImageError> {
         Python::with_gil(|py| {
             let pyarray = image.bind(py);
 
@@ -94,8 +94,8 @@ impl<const C: usize> FromPyImage<C> for Image<u8, C> {
     }
 }
 
-impl<const C: usize> FromPyImageU16<C> for Image<u16, C> {
-    fn from_pyimage_u16(image: PyImageU16) -> Result<Image<u16, C>, ImageError> {
+impl<const C: usize> FromPyImageU16<C> for Image<u16, C, CpuAllocator> {
+    fn from_pyimage_u16(image: PyImageU16) -> Result<Image<u16, C, CpuAllocator>, ImageError> {
         Python::with_gil(|py| {
             let pyarray = image.bind(py);
             let data = match pyarray.to_vec() {
@@ -113,8 +113,8 @@ impl<const C: usize> FromPyImageU16<C> for Image<u16, C> {
     }
 }
 
-impl<const C: usize> FromPyImageF32<C> for Image<f32, C> {
-    fn from_pyimage_f32(image: PyImageF32) -> Result<Image<f32, C>, ImageError> {
+impl<const C: usize> FromPyImageF32<C> for Image<f32, C, CpuAllocator> {
+    fn from_pyimage_f32(image: PyImageF32) -> Result<Image<f32, C, CpuAllocator>, ImageError> {
         Python::with_gil(|py| {
             let pyarray = image.bind(py);
             let data = match pyarray.to_vec() {

--- a/kornia-py/src/io/jpeg.rs
+++ b/kornia-py/src/io/jpeg.rs
@@ -36,13 +36,13 @@ pub fn read_image_jpeg(file_path: &str, mode: &str) -> PyResult<PyImage> {
 pub fn write_image_jpeg(file_path: &str, image: PyImage, mode: &str, quality: u8) -> PyResult<()> {
     match mode {
         "rgb" => {
-            let image = Image::<u8, 3>::from_pyimage(image)
+            let image = Image::<u8, 3, _>::from_pyimage(image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
             J::write_image_jpeg_rgb8(file_path, &image, quality)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
         }
         "mono" => {
-            let image = Image::<u8, 1>::from_pyimage(image)
+            let image = Image::<u8, 1, _>::from_pyimage(image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
             J::write_image_jpeg_gray8(file_path, &image, quality)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
@@ -83,15 +83,17 @@ pub fn decode_image_jpeg(src: &[u8], image_shape: (usize, usize), mode: &str) ->
 
     let result = match mode {
         "rgb" => {
-            let mut output_image = Image::<u8, 3>::from_size_val(image_shape, 0, CpuAllocator)
-                .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
+            let mut output_image =
+                Image::<u8, 3, _>::from_size_val(image_shape, 0, CpuAllocator)
+                    .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
             J::decode_image_jpeg_rgb8(src, &mut output_image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
             output_image.to_pyimage()
         }
         "mono" => {
-            let mut output_image = Image::<u8, 1>::from_size_val(image_shape, 0, CpuAllocator)
-                .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
+            let mut output_image =
+                Image::<u8, 1, _>::from_size_val(image_shape, 0, CpuAllocator)
+                    .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
             J::decode_image_jpeg_mono8(src, &mut output_image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
             output_image.to_pyimage()

--- a/kornia-py/src/io/png.rs
+++ b/kornia-py/src/io/png.rs
@@ -78,19 +78,19 @@ pub fn read_image_png_u16(file_path: &str, mode: &str) -> PyResult<PyImageU16> {
 pub fn write_image_png_u8(file_path: &str, image: PyImage, mode: &str) -> PyResult<()> {
     match mode {
         "rgb" => {
-            let image = Image::<u8, 3>::from_pyimage(image)
+            let image = Image::<u8, 3, _>::from_pyimage(image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
             P::write_image_png_rgb8(file_path, &image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
         }
         "rgba" => {
-            let image = Image::<u8, 4>::from_pyimage(image)
+            let image = Image::<u8, 4, _>::from_pyimage(image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
             P::write_image_png_rgba8(file_path, &image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
         }
         "mono" => {
-            let image = Image::<u8, 1>::from_pyimage(image)
+            let image = Image::<u8, 1, _>::from_pyimage(image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
             P::write_image_png_gray8(file_path, &image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
@@ -116,19 +116,19 @@ pub fn write_image_png_u8(file_path: &str, image: PyImage, mode: &str) -> PyResu
 pub fn write_image_png_u16(file_path: &str, image: PyImageU16, mode: &str) -> PyResult<()> {
     match mode {
         "rgb" => {
-            let image = Image::<u16, 3>::from_pyimage_u16(image)
+            let image = Image::<u16, 3, _>::from_pyimage_u16(image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
             P::write_image_png_rgb16(file_path, &image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
         }
         "rgba" => {
-            let image = Image::<u16, 4>::from_pyimage_u16(image)
+            let image = Image::<u16, 4, _>::from_pyimage_u16(image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
             P::write_image_png_rgba16(file_path, &image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
         }
         "mono" => {
-            let image = Image::<u16, 1>::from_pyimage_u16(image)
+            let image = Image::<u16, 1, _>::from_pyimage_u16(image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
             P::write_image_png_gray16(file_path, &image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
@@ -178,21 +178,21 @@ pub fn decode_image_png_u8(
 
     let result = match mode {
         "rgb" => {
-            let mut image: Image<u8, 3> = Image::from_size_val(image_shape, 0, CpuAllocator)
+            let mut image: Image<u8, 3, _> = Image::from_size_val(image_shape, 0, CpuAllocator)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
             P::decode_image_png_rgb8(src, &mut image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
             image.to_pyimage()
         }
         "rgba" => {
-            let mut image: Image<u8, 4> = Image::from_size_val(image_shape, 0, CpuAllocator)
+            let mut image: Image<u8, 4, _> = Image::from_size_val(image_shape, 0, CpuAllocator)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
             P::decode_image_png_rgba8(src, &mut image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
             image.to_pyimage()
         }
         "mono" => {
-            let mut image: Image<u8, 1> = Image::from_size_val(image_shape, 0, CpuAllocator)
+            let mut image: Image<u8, 1, _> = Image::from_size_val(image_shape, 0, CpuAllocator)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
             P::decode_image_png_mono8(src, &mut image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
@@ -228,21 +228,21 @@ pub fn decode_image_png_u16(
 
     let result = match mode {
         "rgb" => {
-            let mut image: Image<u16, 3> = Image::from_size_val(image_shape, 0, CpuAllocator)
+            let mut image: Image<u16, 3, _> = Image::from_size_val(image_shape, 0, CpuAllocator)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
             P::decode_image_png_rgb16(src, &mut image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
             image.to_pyimage_u16()
         }
         "rgba" => {
-            let mut image: Image<u16, 4> = Image::from_size_val(image_shape, 0, CpuAllocator)
+            let mut image: Image<u16, 4, _> = Image::from_size_val(image_shape, 0, CpuAllocator)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
             P::decode_image_png_rgba16(src, &mut image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
             image.to_pyimage_u16()
         }
         "mono" => {
-            let mut image: Image<u16, 1> = Image::from_size_val(image_shape, 0, CpuAllocator)
+            let mut image: Image<u16, 1, _> = Image::from_size_val(image_shape, 0, CpuAllocator)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
             P::decode_image_png_mono16(src, &mut image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;

--- a/kornia-py/src/io/tiff.rs
+++ b/kornia-py/src/io/tiff.rs
@@ -95,13 +95,13 @@ pub fn read_image_tiff_f32(file_path: &str, mode: &str) -> PyResult<PyImageF32> 
 pub fn write_image_tiff_u8(file_path: &str, image: PyImage, mode: &str) -> PyResult<()> {
     match mode {
         "rgb" => {
-            let image = Image::<u8, 3>::from_pyimage(image)
+            let image = Image::<u8, 3, _>::from_pyimage(image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
             k_tiff::write_image_tiff_rgb8(file_path, &image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
         }
         "mono" => {
-            let image = Image::<u8, 1>::from_pyimage(image)
+            let image = Image::<u8, 1, _>::from_pyimage(image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
             k_tiff::write_image_tiff_mono8(file_path, &image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
@@ -126,13 +126,13 @@ pub fn write_image_tiff_u8(file_path: &str, image: PyImage, mode: &str) -> PyRes
 pub fn write_image_tiff_u16(file_path: &str, image: PyImageU16, mode: &str) -> PyResult<()> {
     match mode {
         "rgb" => {
-            let image = Image::<u16, 3>::from_pyimage_u16(image)
+            let image = Image::<u16, 3, _>::from_pyimage_u16(image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
             k_tiff::write_image_tiff_rgb16(file_path, &image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
         }
         "mono" => {
-            let image = Image::<u16, 1>::from_pyimage_u16(image)
+            let image = Image::<u16, 1, _>::from_pyimage_u16(image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
             k_tiff::write_image_tiff_mono16(file_path, &image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
@@ -156,13 +156,13 @@ pub fn write_image_tiff_u16(file_path: &str, image: PyImageU16, mode: &str) -> P
 pub fn write_image_tiff_f32(file_path: &str, image: PyImageF32, mode: &str) -> PyResult<()> {
     match mode {
         "mono" => {
-            let image = Image::<f32, 1>::from_pyimage_f32(image)
+            let image = Image::<f32, 1, _>::from_pyimage_f32(image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
             k_tiff::write_image_tiff_mono32f(file_path, &image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
         }
         "rgb" => {
-            let image = Image::<f32, 3>::from_pyimage_f32(image)
+            let image = Image::<f32, 3, _>::from_pyimage_f32(image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
             k_tiff::write_image_tiff_rgb32f(file_path, &image)
                 .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;

--- a/kornia-py/src/warp.rs
+++ b/kornia-py/src/warp.rs
@@ -15,7 +15,7 @@ pub fn warp_affine(
 ) -> PyResult<PyImage> {
     // have to add annotation Image<u8, 3>, otherwise the compiler will complain
     // NOTE: do we support images with channels != 3?
-    let image: Image<u8, 3> = Image::from_pyimage(image)
+    let image: Image<u8, 3, _> = Image::from_pyimage(image)
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
 
     let new_size = ImageSize {
@@ -59,7 +59,7 @@ pub fn warp_perspective(
     new_size: (usize, usize),
     interpolation: &str,
 ) -> PyResult<PyImage> {
-    let image: Image<u8, 3> = Image::from_pyimage(image)
+    let image: Image<u8, 3, _> = Image::from_pyimage(image)
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
 
     let new_size = ImageSize {


### PR DESCRIPTION
This pull request introduces several improvements and adjustments across the codebase, primarily focusing on enhancing type flexibility for the `Image` struct, simplifying allocator handling, and improving code clarity. The most significant changes include adding support for default allocators using the `_` wildcard, removing unnecessary `'static` lifetime constraints, and cleaning up redundant code in tensor-related modules.

### Enhancements to `Image` struct and examples:
* Updated `Image` type definitions to support default allocators using the `_` wildcard, simplifying usage in multiple files, including `README.md`, `examples/hello_world/src/main.rs`, and others. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R23) [[2]](diffhunk://#diff-d7c919b32e685719baf394dd4faedad8e3f13d3ed905d1ac09cb91ceb3b6618fL103-R101) [[3]](diffhunk://#diff-2093af58c5d9d24de9cc7325e044cbf064b15ded91079fa3f850d9f487f10da5L20-R23)
* Adjusted examples to use the new `Image` type syntax, improving consistency and readability. [[1]](diffhunk://#diff-1132ff0caae2764f6eefb3afdda9029775e412ebe2d8c1503f3c63f12f6dd101L24-R36) [[2]](diffhunk://#diff-dd835e4e15f706e7fbef1dd133f89e1ee05006221ce8749f52c460e3a0227a44L24-R31) [[3]](diffhunk://#diff-a0915096d75213eb77c97e02248086de2b5f0307513549c3ebe670ca7b7a0ee2L20-R20)

### Refactoring of allocator handling:
* Removed explicit `'static` lifetime constraints from `ImageAllocator` and related traits, making the code more flexible and less restrictive. [[1]](diffhunk://#diff-d7c919b32e685719baf394dd4faedad8e3f13d3ed905d1ac09cb91ceb3b6618fL60-R58) [[2]](diffhunk://#diff-79e99646606722ba787c4dc536950ea99c34bd2a5d075e625e7dafd02dd45ac9L85-R85) [[3]](diffhunk://#diff-6b32bf0868a15cc4d201d1640dbcf2dfe5522911bc87e2e8555f8372b3d0ac08L17-R17)
* Re-exported `CpuAllocator` in `kornia-image` for easier access and usage.

### Tensor module improvements:
* Simplified tensor cloning logic by replacing manual element-by-element cloning with a `to_vec()` call.
* Removed unnecessary `'static` constraints in tensor and tensor view implementations, improving general usability. [[1]](diffhunk://#diff-79e99646606722ba787c4dc536950ea99c34bd2a5d075e625e7dafd02dd45ac9L727-R724) [[2]](diffhunk://#diff-6b32bf0868a15cc4d201d1640dbcf2dfe5522911bc87e2e8555f8372b3d0ac08L17-R17)

### Documentation and example updates:
* Updated documentation examples to reflect changes in the `Image` struct and allocator handling. [[1]](diffhunk://#diff-81218580246ca96b6bf69f6782c7a34219e9677b18a4deb9f3bc5da962b58bb7L92-R92) [[2]](diffhunk://#diff-33e3f93dba1a64689e84a7cbc85ac88f3c184d8d05feae9bf456b8e98ba8df97L191-R191)
* Improved clarity in example code by explicitly specifying allocators where necessary. [[1]](diffhunk://#diff-28134c2561db48619a3a8e0f6c7ab73e75f87dacbb5a4403ea199e89e8102675L3-R4) [[2]](diffhunk://#diff-d3595088ee41ba12a376817a06a7b217cf194070c22a982a98b375635d2b471fL19-R17)

### Code cleanup:
* Reorganized module imports to improve readability and maintain consistency across files. [[1]](diffhunk://#diff-d7c919b32e685719baf394dd4faedad8e3f13d3ed905d1ac09cb91ceb3b6618fL1-R2) [[2]](diffhunk://#diff-657ab72ca431afd4f99e638a5313e8414a9ed0440163fb90903356ca220bc7feL11-R20)
* Removed redundant code and improved formatting in tensor-related modules. [[1]](diffhunk://#diff-79e99646606722ba787c4dc536950ea99c34bd2a5d075e625e7dafd02dd45ac9L741-R738) [[2]](diffhunk://#diff-657ab72ca431afd4f99e638a5313e8414a9ed0440163fb90903356ca220bc7feL11-R20)

These changes collectively enhance the flexibility, readability, and maintainability of the codebase while ensuring backward compatibility with existing functionality.