### PR TITLE
fix: make So2 hat matrix skew symmetric

### DIFF
--- a/crates/kornia-lie/src/so2.rs
+++ b/crates/kornia-lie/src/so2.rs
@@ -75,11 +75,11 @@ impl SO2 {
     }
 
     pub fn hat(theta: f32) -> Mat2 {
-        Mat2::from_cols_array(&[0.0, theta, theta, 0.0])
+        Mat2::from_cols_array(&[0.0, -theta, theta, 0.0])
     }
 
     pub fn vee(omega: Mat2) -> f32 {
-        omega.x_axis.y
+        omega.y_axis.x
     }
 }
 
@@ -246,7 +246,7 @@ mod tests {
     #[test]
     fn test_hat() {
         let theta = 0.5;
-        let expected = Mat2::from_cols_array(&[0.0, 0.5, 0.5, 0.0]);
+        let expected = Mat2::from_cols_array(&[0.0, -0.5, 0.5, 0.0]);
         let actual = SO2::hat(theta);
 
         for i in 0..2 {
@@ -255,11 +255,11 @@ mod tests {
             }
         }
 
-        // Test hat structure (symmetric, not skew-symmetric in SO2 case)
+        // Test hat structure
         let hat_matrix = SO2::hat(theta);
         assert_relative_eq!(hat_matrix.x_axis.x, 0.0);
         assert_relative_eq!(hat_matrix.y_axis.y, 0.0);
-        assert_relative_eq!(hat_matrix.x_axis.y, hat_matrix.y_axis.x);
+        assert_relative_eq!(hat_matrix.x_axis.y, -hat_matrix.y_axis.x);
     }
 
     #[test]


### PR DESCRIPTION
I noticed that the So2 hat operation returns a symmetric matrix rather than a skew symmetric one which seems to be wrong. The python impl has the same bug as well.

ref: (micro lie thoery)
![image](https://github.com/user-attachments/assets/29eccfd8-6b06-4ad1-bdc5-a8b8df9d7c46)

