### PR TITLE
Update ONNX example to use ort 2.0.0-rc.10

### DIFF
--- a/examples/onnx/Cargo.toml
+++ b/examples/onnx/Cargo.toml
@@ -16,8 +16,8 @@ version.workspace = true
 argh = { workspace = true }
 kornia-tensor.workspace = true
 kornia.workspace = true
-ort-sys = { version = "2.0.0-rc.9" }
-ort = { version = "2.0.0-rc.9", features = [
+ort-sys = { version = "2.0.0-rc.10" }
+ort = { version = "2.0.0-rc.10", features = [
     "load-dynamic",
     "half",
 ], default-features = false }

--- a/examples/onnx/src/main.rs
+++ b/examples/onnx/src/main.rs
@@ -53,7 +53,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // read the onnx model
 
-    let model = Session::builder()?
+    let mut model = Session::builder()?
         .with_optimization_level(GraphOptimizationLevel::Level3)?
         .with_intra_threads(4)?
         .commit_from_file(&args.onnx_model_path)?;
@@ -105,13 +105,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // run the model
     let outputs = model.run(ort::inputs![
         "input" => ort_tensor,
-    ]?)?;
+    ])?;
 
     println!("time ms: {:?}", time.elapsed().as_secs_f32() * 1000.0);
 
     // get the outputs
 
-    let (out_shape, out_ort) = outputs["output"].try_extract_raw_tensor::<f32>()?;
+    let (out_shape, out_ort) = outputs["output"].try_extract_tensor::<f32>()?;
     println!("out_shape: {:?}", out_shape);
 
     let out_tensor = Tensor::<f32, 3, CpuAllocator>::from_shape_vec(


### PR DESCRIPTION
According to [Cargo Specifying Dependencies](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#pre-releases), the cargo will use the release candidate 10 for `ort` crate, this introduces breaking changes and thus making the CI fail.

Merging this PR would make the CI of #380 and #381 pass with green colors