### PR TITLE
Rtsp example test fixes

### DIFF
--- a/crates/kornia-io/src/stream/rtsp.rs
+++ b/crates/kornia-io/src/stream/rtsp.rs
@@ -102,7 +102,7 @@ impl Default for RTSPCameraConfig {
 /// A GStreamer pipeline description
 pub fn rtsp_camera_pipeline_description(url: &str, latency: u32) -> String {
     format!(
-        "rtspsrc location={} latency={} ! rtph264depay ! h264parse ! avdec_h264 ! videoconvert ! video/x-raw,format=RGB ! appsink name=sink",
+        "rtspsrc location={} latency={} ! rtph264depay ! avdec_h264 ! videoconvert ! video/x-raw,format=RGB ! appsink name=sink",
         url, latency,
     )
 }

--- a/examples/rtspcam/README.md
+++ b/examples/rtspcam/README.md
@@ -3,16 +3,22 @@ An example showing how to use the RTSP camera with the `kornia_io` module with t
 NOTE: This example requires the gstremer backend to be enabled. To enable the gstreamer backend, use the `gstreamer` feature flag when building the `kornia` crate and its dependencies.
 
 ```bash
-Usage: rtspcam [OPTIONS] --username <USERNAME> --password <PASSWORD> --camera-ip <CAMERA_IP> --camera-port <CAMERA_PORT> --stream <STREAM>
+Usage: rtspcam [-r <rtsp-url>] [-u <username>] [-p <password>] [--camera-ip <camera-ip>] [--camera-port <camera-port>] [-s <stream>]
+
+RTSP Camera Capture and stream to ReRun
 
 Options:
-  -u, --username <USERNAME>
-  -p, --password <PASSWORD>
-      --camera-ip <CAMERA_IP>
-      --camera-port <CAMERA_PORT>
-  -s, --stream <STREAM>
-  -d, --duration <DURATION>
-  -h, --help                       Print help
+  -r, --rtsp-url    the full RTSP URL (e.g., rtsp://user:pass@ip:port/stream)
+  -u, --username    the username to access the camera
+  -p, --password    the password to access the camera
+  --camera-ip       the camera ip address
+  --camera-port     the camera port
+  -s, --stream      the camera stream
+  --help, help      display usage information
 ```
+
+NOTE: You can also pass the rtsp url as an argument to the program. For example, you can use the following testing url: `rtsp://rtspstream:4j_U0tJ6fGtiaKREnuVnH@zephyr.rtsp.stream/movie`
+
+Or check out the [RTSP Streams](https://www.rtsp.stream/) website for more streams to try more streams.
 
 ![Screenshot from 2024-08-28 18-30-11](https://github.com/user-attachments/assets/2a9a80f4-4933-4614-930a-061ec2463227)

--- a/examples/rtspcam/src/main.rs
+++ b/examples/rtspcam/src/main.rs
@@ -90,10 +90,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         // initialize images lazily
         let img_f32_ref = img_f32.get_or_insert_with(|| {
-            Image::<f32, 3, _>::from_size_val(img.size(), 0.0, CpuAllocator).unwrap()
+            Image::<f32, 3, _>::from_size_val(img.size(), 0.0, CpuAllocator)
+                .expect("Failed to create image")
         });
         let gray_ref = gray.get_or_insert_with(|| {
-            Image::<f32, 1, _>::from_size_val(img.size(), 0.0, CpuAllocator).unwrap()
+            Image::<f32, 1, _>::from_size_val(img.size(), 0.0, CpuAllocator)
+                .expect("Failed to create image")
         });
 
         // cast the image to floating point and convert to grayscale

--- a/examples/rtspcam/src/main.rs
+++ b/examples/rtspcam/src/main.rs
@@ -13,25 +13,29 @@ use std::sync::{
 #[derive(FromArgs)]
 /// RTSP Camera Capture and stream to ReRun
 struct Args {
+    /// the full RTSP URL (e.g., rtsp://user:pass@ip:port/stream)
+    #[argh(option, short = 'r')]
+    rtsp_url: Option<String>,
+
     /// the username to access the camera
     #[argh(option, short = 'u')]
-    username: String,
+    username: Option<String>,
 
     /// the password to access the camera
     #[argh(option, short = 'p')]
-    password: String,
+    password: Option<String>,
 
     /// the camera ip address
     #[argh(option)]
-    camera_ip: String,
+    camera_ip: Option<String>,
 
     /// the camera port
     #[argh(option)]
-    camera_port: u16,
+    camera_port: Option<u16>,
 
     /// the camera stream
     #[argh(option, short = 's')]
-    stream: String,
+    stream: Option<String>,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -40,16 +44,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // start the recording stream
     let rec = rerun::RecordingStreamBuilder::new("Kornia Rtsp Stream Capture App").spawn()?;
 
-    //// create a stream capture object
-    let mut capture = RTSPCameraConfig::new()
-        .with_settings(
-            &args.username,
-            &args.password,
-            &args.camera_ip,
-            &args.camera_port,
-            &args.stream,
-        )
-        .build()?;
+    // create a stream capture object
+    let capture = RTSPCameraConfig::new();
+
+    let mut capture = if let Some(url) = &args.rtsp_url {
+        capture.with_url(url).build()?
+    } else {
+        capture
+            .with_settings(
+                &args.username.as_ref().ok_or("Username required")?,
+                &args.password.as_ref().ok_or("Password required")?,
+                &args.camera_ip.as_ref().ok_or("Camera IP required")?,
+                &args.camera_port.ok_or("Camera port required")?,
+                &args.stream.as_ref().ok_or("Stream name required")?,
+            )
+            .build()?
+    };
 
     // start the stream capture
     capture.start()?;
@@ -69,8 +79,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     })?;
 
     // preallocate images
-    let mut img_f32 = Image::<f32, 3, _>::from_size_val([640, 360].into(), 0.0, CpuAllocator)?;
-    let mut gray = Image::<f32, 1, _>::from_size_val(img_f32.size(), 0.0, CpuAllocator)?;
+    let mut img_f32 = None;
+    let mut gray = None;
 
     while !cancel_token.load(Ordering::SeqCst) {
         // start grabbing frames from the camera
@@ -78,9 +88,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             continue;
         };
 
+        // initialize images lazily
+        let img_f32_ref = img_f32.get_or_insert_with(|| {
+            Image::<f32, 3, _>::from_size_val(img.size(), 0.0, CpuAllocator).unwrap()
+        });
+        let gray_ref = gray.get_or_insert_with(|| {
+            Image::<f32, 1, _>::from_size_val(img.size(), 0.0, CpuAllocator).unwrap()
+        });
+
         // cast the image to floating point and convert to grayscale
-        ops::cast_and_scale(&img, &mut img_f32, 1.0 / 255.0)?;
-        imgproc::color::gray_from_rgb(&img_f32, &mut gray)?;
+        ops::cast_and_scale(&img, img_f32_ref, 1.0 / 255.0)?;
+        imgproc::color::gray_from_rgb(img_f32_ref, gray_ref)?;
 
         // update the fps counter
         fps_counter.update();
@@ -94,7 +112,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // log the grayscale image
         rec.log_static(
             "gray",
-            &rerun::Image::from_elements(gray.as_slice(), gray.size().into(), rerun::ColorModel::L),
+            &rerun::Image::from_elements(
+                gray_ref.as_slice(),
+                gray_ref.size().into(),
+                rerun::ColorModel::L,
+            ),
         )?;
 
         rec.log_static("fps", &rerun::Scalars::new([fps_counter.fps() as f64]))?;


### PR DESCRIPTION
This pull request introduces several enhancements and modifications to the RTSP camera streaming functionality in the `kornia_io` module. The changes improve flexibility in handling RTSP URLs, streamline image processing, and update documentation for better usability. Key updates include support for optional RTSP URL arguments, lazy initialization of image buffers, and updates to the example usage guide.

### Enhancements to RTSP URL handling:
* [`examples/rtspcam/src/main.rs`](diffhunk://#diff-6e3aa130805ec86c1a27b8a401ff5021b6be0b9da40acf97f38007fbe2477903R16-R38): Added support for optional RTSP URL arguments (`rtsp_url`) in the `Args` struct, allowing users to specify a full RTSP URL or provide individual components such as username, password, IP, port, and stream.
* [`examples/rtspcam/src/main.rs`](diffhunk://#diff-6e3aa130805ec86c1a27b8a401ff5021b6be0b9da40acf97f38007fbe2477903L43-R62): Updated the stream capture logic to prioritize the `rtsp_url` argument if provided, falling back to individual settings otherwise. Improved error handling for missing required fields.

### Image processing improvements:
* [`examples/rtspcam/src/main.rs`](diffhunk://#diff-6e3aa130805ec86c1a27b8a401ff5021b6be0b9da40acf97f38007fbe2477903L72-R103): Implemented lazy initialization for `img_f32` and `gray` image buffers to allocate resources only when frames are available, reducing unnecessary memory usage.
* [`examples/rtspcam/src/main.rs`](diffhunk://#diff-6e3aa130805ec86c1a27b8a401ff5021b6be0b9da40acf97f38007fbe2477903L97-R121): Updated grayscale image logging to use lazily initialized buffers, ensuring proper handling of dynamic image sizes.

### Documentation updates:
* [`examples/rtspcam/README.md`](diffhunk://#diff-f74157d82f935b5d1907c491a6caf89bce2575f99dc2fca82064fd1d89ea688cL6-R23): Revised the example usage guide to reflect the new argument structure and added an example RTSP URL for testing. Included links to external resources for additional RTSP streams.

### Pipeline simplification:
* [`crates/kornia-io/src/stream/rtsp.rs`](diffhunk://#diff-b6ab118e8ff6f6fd80716d8002696dc745ff5c1c363a58e6c0ad43af254a1556L105-R105): Simplified the GStreamer pipeline description by removing the `h264parse` element, optimizing the pipeline for RTSP streaming.