### PR TITLE
Fix kornia-io docs.rs not building

### DIFF
--- a/crates/kornia-io/Cargo.toml
+++ b/crates/kornia-io/Cargo.toml
@@ -12,6 +12,7 @@ version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
+features = ["gstreamer/v1_28"]
 rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 


### PR DESCRIPTION
Fixes #370 

For some reason the docs.rs builds completely fine on my locally when using `v1_28` feature of gstreamer 