### PR TITLE
separate internal conv bit functions

### DIFF
--- a/crates/kornia-io/src/conv_utils.rs
+++ b/crates/kornia-io/src/conv_utils.rs
@@ -1,0 +1,27 @@
+/// Utility function to convert 16-bit `Vec<u8>` to `Vec<u16>`
+pub fn convert_buf_u8_u16(buf: Vec<u8>) -> Vec<u16> {
+    let mut buf_u16 = Vec::with_capacity(buf.len() / 2);
+    for chunk in buf.chunks_exact(2) {
+        buf_u16.push(u16::from_be_bytes([chunk[0], chunk[1]]));
+    }
+
+    buf_u16
+}
+
+// This function expects the size of output to be input.len() / 2;
+pub fn convert_buf_u8_u16_into_slice(input: &[u8], output: &mut [u16]) {
+    for (i, chunk) in input.chunks_exact(2).enumerate() {
+        output[i] = u16::from_be_bytes([chunk[0], chunk[1]]);
+    }
+}
+
+pub fn convert_buf_u16_u8(buf: &[u16]) -> Vec<u8> {
+    let mut buf_u8: Vec<u8> = Vec::with_capacity(buf.len() * 2);
+
+    for byte in buf {
+        let be_bytes = byte.to_be_bytes();
+        buf_u8.extend_from_slice(&be_bytes);
+    }
+
+    buf_u8
+}

--- a/crates/kornia-io/src/jpegturbo.rs
+++ b/crates/kornia-io/src/jpegturbo.rs
@@ -1,4 +1,4 @@
-use crate::IoError;
+use crate::error::IoError;
 use kornia_image::{
     allocator::{CpuAllocator, ImageAllocator},
     Image, ImageError, ImageSize,

--- a/crates/kornia-io/src/jpegturbo.rs
+++ b/crates/kornia-io/src/jpegturbo.rs
@@ -290,7 +290,7 @@ pub fn write_image_jpegturbo_rgb8<A: ImageAllocator>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::IoError;
+    use crate::error::IoError;
 
     #[test]
     fn image_decoder() -> Result<(), JpegTurboError> {

--- a/crates/kornia-io/src/lib.rs
+++ b/crates/kornia-io/src/lib.rs
@@ -36,32 +36,5 @@ pub mod tiff;
 #[cfg(feature = "v4l")]
 pub mod v4l;
 
-pub use crate::error::IoError;
-
-/// Utility function to convert 16-bit `Vec<u8>` to `Vec<u16>`
-pub(crate) fn convert_buf_u8_u16(buf: Vec<u8>) -> Vec<u16> {
-    let mut buf_u16 = Vec::with_capacity(buf.len() / 2);
-    for chunk in buf.chunks_exact(2) {
-        buf_u16.push(u16::from_be_bytes([chunk[0], chunk[1]]));
-    }
-
-    buf_u16
-}
-
-// This function expects the size of output to be input.len() / 2;
-pub(crate) fn convert_buf_u8_u16_into_slice(input: &[u8], output: &mut [u16]) {
-    for (i, chunk) in input.chunks_exact(2).enumerate() {
-        output[i] = u16::from_be_bytes([chunk[0], chunk[1]]);
-    }
-}
-
-pub(crate) fn convert_buf_u16_u8(buf: &[u16]) -> Vec<u8> {
-    let mut buf_u8: Vec<u8> = Vec::with_capacity(buf.len() * 2);
-
-    for byte in buf {
-        let be_bytes = byte.to_be_bytes();
-        buf_u8.extend_from_slice(&be_bytes);
-    }
-
-    buf_u8
-}
+/// Internal utility functions for image bit depth conversion.
+mod conv_utils;

--- a/crates/kornia-io/src/png.rs
+++ b/crates/kornia-io/src/png.rs
@@ -1,14 +1,13 @@
-use std::{fs, fs::File, path::Path};
-
+use crate::{
+    conv_utils::{convert_buf_u16_u8, convert_buf_u8_u16, convert_buf_u8_u16_into_slice},
+    error::IoError,
+};
 use kornia_image::{
     allocator::{CpuAllocator, ImageAllocator},
     Image, ImageSize,
 };
 use png::{BitDepth, ColorType, Decoder, Encoder};
-
-use crate::{
-    convert_buf_u16_u8, convert_buf_u8_u16, convert_buf_u8_u16_into_slice, error::IoError,
-};
+use std::{fs, fs::File, path::Path};
 
 /// Read a PNG image with a single channel (mono8).
 ///


### PR DESCRIPTION
This pull request refactors the utility functions for image bit depth conversion by moving them into a dedicated `conv_utils` module, improving code organization and maintainability. Additionally, it updates imports across several files to reflect this change and fixes a minor import path issue for `IoError`.

### Refactoring and Code Organization:

* Moved utility functions for converting between `Vec<u8>` and `Vec<u16>` (`convert_buf_u8_u16`, `convert_buf_u8_u16_into_slice`, and `convert_buf_u16_u8`) from `lib.rs` to a new `conv_utils` module. This change centralizes these utilities and enhances modularity. (`[[1]](diffhunk://#diff-fe761de759d7a083eac9e0a809ebe8b4de3267a5af96e388ab36bd443f49208eL34-R35)`, `[[2]](diffhunk://#diff-541f4f938469940dba70f6f4e582b682568788b109a04bf776df184a3f46aca8R1-R27)`)

* Updated the `png.rs` file to import the conversion functions from the new `conv_utils` module, ensuring consistency with the refactored structure. (`[crates/kornia-io/src/png.rsL1-R10](diffhunk://#diff-43934078ed200c0714b1a1aab3d5061ba41b5dd46ba488a6e092b74c3a0c2f3eL1-R10)`)

### Bug Fix:

* Corrected the import path for `IoError` in `jpegturbo.rs` to use `crate::error::IoError` instead of `crate::IoError`, resolving a potential namespace conflict. (`[crates/kornia-io/src/jpegturbo.rsL1-R1](diffhunk://#diff-66b29b681b0ff0485470b26e88f8cee0296e06aae99fcf9af24892a31ee80b35L1-R1)`)