### PR TITLE
Remove `license-file` from `smol_vlm` example

### DIFF
--- a/examples/smol_vlm/Cargo.toml
+++ b/examples/smol_vlm/Cargo.toml
@@ -7,7 +7,6 @@ edition.workspace = true
 homepage.workspace = true
 include.workspace = true
 license.workspace = true
-license-file.workspace = true
 readme.workspace = true
 repository.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
`license-file` should be used if the package uses a non-standard license.

https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields