### PR TITLE
Add image downscaling support in AprilTag Detection

### DIFF
--- a/crates/kornia-apriltag/benches/bench_decoding.rs
+++ b/crates/kornia-apriltag/benches/bench_decoding.rs
@@ -29,7 +29,7 @@ fn bench_decoding(c: &mut Criterion) {
         .build()
         .unwrap();
 
-    apriltag_c_detector.set_decimation(1.0);
+    apriltag_c_detector.set_decimation(2.0);
 
     let kornia_detector_config = DecodeTagsConfig::new(vec![TagFamilyKind::Tag36H11]);
     let mut kornia_detector =

--- a/crates/kornia-apriltag/src/decoder.rs
+++ b/crates/kornia-apriltag/src/decoder.rs
@@ -849,6 +849,7 @@ mod tests {
     #[test]
     fn test_decode_tags() -> Result<(), Box<dyn std::error::Error>> {
         let mut config = DecodeTagsConfig::new(vec![TagFamilyKind::Tag36H11]);
+        config.downscale_factor = 1;
         let src = read_image_png_mono8("../../tests/data/apriltag.png")?;
 
         let mut bin = Image::from_size_val(src.size(), Pixel::Skip, CpuAllocator)?;

--- a/crates/kornia-apriltag/src/lib.rs
+++ b/crates/kornia-apriltag/src/lib.rs
@@ -7,7 +7,7 @@ use kornia_image::{
     allocator::{CpuAllocator, ImageAllocator},
     Image, ImageSize,
 };
-use kornia_imgproc::resize::resize_fast;
+use kornia_imgproc::resize::resize_fast_gray;
 
 use crate::{
     decoder::{decode_tags, Detection, GrayModelPair},
@@ -219,7 +219,7 @@ impl AprilTagDecoder {
             )?;
         } else {
             let downscale_img = unsafe { self.downscale_img.as_mut().unwrap_unchecked() };
-            resize_fast(
+            resize_fast_gray(
                 &src,
                 downscale_img,
                 kornia_imgproc::interpolation::InterpolationMode::Nearest,

--- a/crates/kornia-apriltag/src/lib.rs
+++ b/crates/kornia-apriltag/src/lib.rs
@@ -66,7 +66,7 @@ pub struct DecodeTagsConfig {
     pub min_tag_width: usize,
     /// Minimum difference between white and black pixels for thresholding.
     pub min_white_black_difference: u8,
-    /// TODO
+    /// Downscale factor for input images.
     pub downscale_factor: usize,
 }
 
@@ -220,7 +220,7 @@ impl AprilTagDecoder {
         } else {
             let downscale_img = unsafe { self.downscale_img.as_mut().unwrap_unchecked() };
             resize_fast_gray(
-                &src,
+                src,
                 downscale_img,
                 kornia_imgproc::interpolation::InterpolationMode::Nearest,
             )?;

--- a/crates/kornia-apriltag/src/lib.rs
+++ b/crates/kornia-apriltag/src/lib.rs
@@ -7,6 +7,7 @@ use kornia_image::{
     allocator::{CpuAllocator, ImageAllocator},
     Image, ImageSize,
 };
+use kornia_imgproc::resize::resize_fast;
 
 use crate::{
     decoder::{decode_tags, Detection, GrayModelPair},
@@ -65,11 +66,15 @@ pub struct DecodeTagsConfig {
     pub min_tag_width: usize,
     /// Minimum difference between white and black pixels for thresholding.
     pub min_white_black_difference: u8,
+    /// TODO
+    pub downscale_factor: usize,
 }
 
 impl DecodeTagsConfig {
     /// Creates a new `DecodeTagsConfig` with the given tag family kinds.
     pub fn new(tag_family_kinds: Vec<TagFamilyKind>) -> Self {
+        const DEFAULT_DOWNSCALE_FACTOR: usize = 2;
+
         let mut tag_families = Vec::with_capacity(tag_family_kinds.len());
         let mut normal_border = false;
         let mut reversed_border = false;
@@ -86,6 +91,8 @@ impl DecodeTagsConfig {
             tag_families.push(family);
         });
 
+        min_tag_width /= DEFAULT_DOWNSCALE_FACTOR;
+
         if min_tag_width < 3 {
             min_tag_width = 3;
         }
@@ -99,6 +106,7 @@ impl DecodeTagsConfig {
             reversed_border,
             min_tag_width,
             min_white_black_difference: 5,
+            downscale_factor: DEFAULT_DOWNSCALE_FACTOR,
         }
     }
 
@@ -122,6 +130,7 @@ impl DecodeTagsConfig {
 /// Decoder for AprilTag detection and decoding.
 pub struct AprilTagDecoder {
     config: DecodeTagsConfig,
+    downscale_img: Option<Image<u8, 1, CpuAllocator>>,
     bin_img: Image<Pixel, 1, CpuAllocator>,
     tile_min_max: TileMinMax,
     uf: UnionFind,
@@ -153,12 +162,27 @@ impl AprilTagDecoder {
     ///
     /// Returns a `Result` containing the new `AprilTagDecoder` or an `AprilTagError`.
     pub fn new(config: DecodeTagsConfig, img_size: ImageSize) -> Result<Self, AprilTagError> {
+        let (img_size, downscale_img) = if config.downscale_factor <= 1 {
+            (img_size, None)
+        } else {
+            let new_size = ImageSize {
+                width: img_size.width / config.downscale_factor,
+                height: img_size.height / config.downscale_factor,
+            };
+
+            (
+                new_size,
+                Some(Image::from_size_val(new_size, 0, CpuAllocator)?),
+            )
+        };
+
         let bin_img = Image::from_size_val(img_size, Pixel::Skip, CpuAllocator)?;
         let tile_min_max = TileMinMax::new(img_size, 4);
         let uf = UnionFind::new(img_size.width * img_size.height);
 
         Ok(Self {
             config,
+            downscale_img,
             bin_img,
             tile_min_max,
             uf,
@@ -185,15 +209,30 @@ impl AprilTagDecoder {
         &mut self,
         src: &Image<u8, 1, A>,
     ) -> Result<Vec<Detection>, AprilTagError> {
-        // TODO: Add support for downscaling image
+        if self.config.downscale_factor <= 1 {
+            // Step 1: Adaptive Threshold
+            adaptive_threshold(
+                src,
+                &mut self.bin_img,
+                &mut self.tile_min_max,
+                self.config.min_white_black_difference,
+            )?;
+        } else {
+            let downscale_img = unsafe { self.downscale_img.as_mut().unwrap_unchecked() };
+            resize_fast(
+                &src,
+                downscale_img,
+                kornia_imgproc::interpolation::InterpolationMode::Nearest,
+            )?;
 
-        // Step 1: Adaptive Threshold
-        adaptive_threshold(
-            src,
-            &mut self.bin_img,
-            &mut self.tile_min_max,
-            self.config.min_white_black_difference,
-        )?;
+            // Step 1: Adaptive Threshold
+            adaptive_threshold(
+                downscale_img,
+                &mut self.bin_img,
+                &mut self.tile_min_max,
+                self.config.min_white_black_difference,
+            )?;
+        }
 
         // Step 2(a): Find Connected Components
         find_connected_components(&self.bin_img, &mut self.uf)?;

--- a/crates/kornia-apriltag/src/lib.rs
+++ b/crates/kornia-apriltag/src/lib.rs
@@ -314,14 +314,14 @@ mod tests {
 
                 for (point, expected) in detection.quad.corners.iter().zip(expected_quads.iter()) {
                     assert!(
-                        (point.y - expected.y).abs() <= 0.001,
+                        (point.y - expected.y).abs() <= 0.1,
                         "Tag: {}, Got y: {}, Expected: {}",
                         file_name,
                         point.y,
                         expected.y
                     );
                     assert!(
-                        (point.x - expected.x).abs() <= 0.001,
+                        (point.x - expected.x).abs() <= 0.1,
                         "Tag: {}, Got x: {}, Expected: {}",
                         file_name,
                         point.x,

--- a/crates/kornia-apriltag/src/quad.rs
+++ b/crates/kornia-apriltag/src/quad.rs
@@ -134,7 +134,7 @@ pub fn fit_quads<A: ImageAllocator>(
             return;
         }
 
-        if let Some(quad) = fit_single_quad(
+        if let Some(mut quad) = fit_single_quad(
             src,
             cluster,
             config.min_tag_width,
@@ -142,6 +142,14 @@ pub fn fit_quads<A: ImageAllocator>(
             config.reversed_border,
             &config.fit_quad_config,
         ) {
+            if config.downscale_factor > 1 {
+                let downscale_factor = config.downscale_factor as f32;
+                quad.corners.iter_mut().for_each(|c| {
+                    c.x *= downscale_factor;
+                    c.y *= downscale_factor;
+                });
+            }
+
             quads.push(quad);
         }
     });

--- a/crates/kornia-apriltag/src/quad.rs
+++ b/crates/kornia-apriltag/src/quad.rs
@@ -811,11 +811,10 @@ mod tests {
         find_connected_components(&bin, &mut uf)?;
         find_gradient_clusters(&bin, &mut uf, &mut clusters);
 
-        let quads = fit_quads(
-            &bin,
-            &mut clusters,
-            &DecodeTagsConfig::new(vec![TagFamilyKind::Tag36H11]),
-        );
+        let mut decode_tag_config = DecodeTagsConfig::new(vec![TagFamilyKind::Tag36H11]);
+        decode_tag_config.downscale_factor = 1;
+
+        let quads = fit_quads(&bin, &mut clusters, &decode_tag_config);
 
         let expected_quad = [[[27, 3], [27, 27], [3, 27], [3, 3]]];
 

--- a/crates/kornia-image/src/error.rs
+++ b/crates/kornia-image/src/error.rs
@@ -52,4 +52,8 @@ pub enum ImageError {
     /// Error when the sigma value is invalid.
     #[error("Invalid sigma values {0} and {1}")]
     InvalidSigmaValue(f32, f32),
+
+    /// Error when the channel count is unsupported.
+    #[error("Unsupported channel count {0}")]
+    UnsupportedChannelCount(usize),
 }

--- a/crates/kornia-imgproc/benches/bench_features.rs
+++ b/crates/kornia-imgproc/benches/bench_features.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use kornia_image::Image;
 use kornia_imgproc::{
-    color::gray_from_rgb_u8, features::*, interpolation::InterpolationMode, resize::resize_fast,
+    color::gray_from_rgb_u8, features::*, interpolation::InterpolationMode, resize::resize_fast_rgb,
 };
 use kornia_io::functional as io;
 use kornia_tensor::CpuAllocator;
@@ -14,7 +14,7 @@ fn bench_fast_corner_detect(c: &mut Criterion) {
 
     let new_size = [1920, 1080].into();
     let mut img_resized = Image::from_size_val(new_size, 0, CpuAllocator).unwrap();
-    resize_fast(&img_rgb8, &mut img_resized, InterpolationMode::Bilinear).unwrap();
+    resize_fast_rgb(&img_rgb8, &mut img_resized, InterpolationMode::Bilinear).unwrap();
 
     let mut img_gray8 = Image::from_size_val(new_size, 0, CpuAllocator).unwrap();
     gray_from_rgb_u8(&img_resized, &mut img_gray8).unwrap();

--- a/crates/kornia-imgproc/benches/bench_resize.rs
+++ b/crates/kornia-imgproc/benches/bench_resize.rs
@@ -148,7 +148,7 @@ fn bench_resize(c: &mut Criterion) {
             |b, i| {
                 let (src, mut dst) = (i.0.clone(), i.1.clone());
                 b.iter(|| {
-                    resize::resize_fast(
+                    resize::resize_fast_rgb(
                         std::hint::black_box(&src),
                         std::hint::black_box(&mut dst),
                         std::hint::black_box(InterpolationMode::Nearest),

--- a/crates/kornia-imgproc/src/resize.rs
+++ b/crates/kornia-imgproc/src/resize.rs
@@ -110,7 +110,7 @@ where
 /// ```
 /// use kornia_image::{Image, ImageSize};
 /// use kornia_image::allocator::CpuAllocator;
-/// use kornia_imgproc::resize::resize_fast;
+/// use kornia_imgproc::resize::resize_fast_rgb;
 /// use kornia_imgproc::interpolation::InterpolationMode;
 ///
 /// let image = Image::<_, 3, _>::new(
@@ -130,7 +130,7 @@ where
 ///
 /// let mut image_resized = Image::<_, 3, _>::from_size_val(new_size, 0, CpuAllocator).unwrap();
 ///
-/// resize_fast(
+/// resize_fast_rgb(
 ///   &image,
 ///   &mut image_resized,
 ///   InterpolationMode::Nearest,

--- a/crates/kornia-imgproc/src/resize.rs
+++ b/crates/kornia-imgproc/src/resize.rs
@@ -145,31 +145,35 @@ where
 /// # Errors
 ///
 /// The function returns an error if the image cannot be resized.
-pub fn resize_fast<A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<u8, 3, A1>,
-    dst: &mut Image<u8, 3, A2>,
+pub fn resize_fast<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
+    src: &Image<u8, C, A1>,
+    dst: &mut Image<u8, C, A2>,
     interpolation: InterpolationMode,
 ) -> Result<(), ImageError> {
-    if dst.size() != dst.size() {
-        return Err(ImageError::InvalidImageSize(
-            src.size().width,
-            src.size().height,
-            dst.size().width,
-            dst.size().height,
-        ));
-    }
+    // if dst.size() != dst.size() {
+    //     return Err(ImageError::InvalidImageSize(
+    //         src.size().width,
+    //         src.size().height,
+    //         dst.size().width,
+    //         dst.size().height,
+    //     ));
+    // }
 
     // prepare the input image for the fast_image_resize crate
     let (src_cols, src_rows) = (src.cols(), src.rows());
     let src_data_len = src.as_slice().len();
 
-    let src_image = fr::images::ImageRef::new(
-        src_cols as u32,
-        src_rows as u32,
-        src.as_slice(),
-        fr::PixelType::U8x3,
-    )
-    .map_err(|_| ImageError::InvalidChannelShape(src_data_len, src_cols * src_rows * 3))?;
+    let pixel_type = match C {
+        4 => fr::PixelType::U8x4,
+        3 => fr::PixelType::U8x3,
+        1 => fr::PixelType::U8,
+        // TODO: Find a way to generalise it further by supporting multiple types other than u8
+        _ => panic!("Unsupported number of channels: {C}. Only 1, 3, or 4 channels are supported for resize_fast."),
+    };
+
+    let src_image =
+        fr::images::ImageRef::new(src_cols as u32, src_rows as u32, src.as_slice(), pixel_type)
+            .map_err(|_| ImageError::InvalidChannelShape(src_data_len, src_cols * src_rows * C))?;
 
     // prepare the output image for the fast_image_resize crate
     let (dst_cols, dst_rows) = (dst.cols(), dst.rows());
@@ -179,9 +183,9 @@ pub fn resize_fast<A1: ImageAllocator, A2: ImageAllocator>(
         dst_cols as u32,
         dst_rows as u32,
         dst.as_slice_mut(),
-        fr::PixelType::U8x3,
+        pixel_type,
     )
-    .map_err(|_| ImageError::InvalidChannelShape(dst_data_len, dst_cols * dst_rows * 3))?;
+    .map_err(|_| ImageError::InvalidChannelShape(dst_data_len, dst_cols * dst_rows * C))?;
 
     let mut options = fr::ResizeOptions::new();
     options.algorithm = match interpolation {

--- a/crates/kornia-imgproc/src/resize.rs
+++ b/crates/kornia-imgproc/src/resize.rs
@@ -145,7 +145,7 @@ where
 /// # Errors
 ///
 /// The function returns an error if the image cannot be resized.
-pub fn resize_fast<A1: ImageAllocator, A2: ImageAllocator>(
+pub fn resize_fast_rgb<A1: ImageAllocator, A2: ImageAllocator>(
     src: &Image<u8, 3, A1>,
     dst: &mut Image<u8, 3, A2>,
     interpolation: InterpolationMode,
@@ -171,7 +171,7 @@ pub fn resize_fast<A1: ImageAllocator, A2: ImageAllocator>(
 /// # Errors
 ///
 /// The function returns an error if the image cannot be resized.
-pub fn resize_fast_gray<A1: ImageAllocator, A2: ImageAllocator>(
+pub fn resize_fast_mono<A1: ImageAllocator, A2: ImageAllocator>(
     src: &Image<u8, 1, A1>,
     dst: &mut Image<u8, 1, A2>,
     interpolation: InterpolationMode,
@@ -193,7 +193,7 @@ fn resize_fast_impl<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
         3 => fr::PixelType::U8x3,
         1 => fr::PixelType::U8,
         // TODO: Find a way to generalise it further by supporting multiple types other than u8
-        _ => panic!("Unsupported number of channels: {C}. Only 1, 3, or 4 channels are supported for resize_fast."),
+        _ => return Err(ImageError::UnsupportedChannelCount(C)),
     };
 
     let src_image =
@@ -338,7 +338,7 @@ mod tests {
 
         let mut image_resized = Image::<_, 3, _>::from_size_val(new_size, 0, CpuAllocator)?;
 
-        super::resize_fast(
+        super::resize_fast_rgb(
             &image,
             &mut image_resized,
             super::InterpolationMode::Nearest,

--- a/crates/kornia-imgproc/src/resize.rs
+++ b/crates/kornia-imgproc/src/resize.rs
@@ -184,15 +184,6 @@ fn resize_fast_impl<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
     dst: &mut Image<u8, C, A2>,
     interpolation: InterpolationMode,
 ) -> Result<(), ImageError> {
-    // if dst.size() != dst.size() {
-    //     return Err(ImageError::InvalidImageSize(
-    //         src.size().width,
-    //         src.size().height,
-    //         dst.size().width,
-    //         dst.size().height,
-    //     ));
-    // }
-
     // prepare the input image for the fast_image_resize crate
     let (src_cols, src_rows) = (src.cols(), src.rows());
     let src_data_len = src.as_slice().len();

--- a/crates/kornia-imgproc/src/resize.rs
+++ b/crates/kornia-imgproc/src/resize.rs
@@ -145,7 +145,41 @@ where
 /// # Errors
 ///
 /// The function returns an error if the image cannot be resized.
-pub fn resize_fast<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
+pub fn resize_fast<A1: ImageAllocator, A2: ImageAllocator>(
+    src: &Image<u8, 3, A1>,
+    dst: &mut Image<u8, 3, A2>,
+    interpolation: InterpolationMode,
+) -> Result<(), ImageError> {
+    resize_fast_impl(src, dst, interpolation)
+}
+
+/// Resize a grayscale (single-channel) image to a new size using the [fast_image_resize](https://crates.io/crates/fast_image_resize) crate.
+///
+/// The function resizes a grayscale image to a new size using the specified interpolation mode.
+/// It supports only 1-channel images and u8 data type.
+///
+/// # Arguments
+///
+/// * `src` - The input grayscale image container with 1 channel.
+/// * `dst` - The output grayscale image container with 1 channel.
+/// * `interpolation` - The interpolation mode to use.
+///
+/// # Returns
+///
+/// The resized image with the new size.
+///
+/// # Errors
+///
+/// The function returns an error if the image cannot be resized.
+pub fn resize_fast_gray<A1: ImageAllocator, A2: ImageAllocator>(
+    src: &Image<u8, 1, A1>,
+    dst: &mut Image<u8, 1, A2>,
+    interpolation: InterpolationMode,
+) -> Result<(), ImageError> {
+    resize_fast_impl(src, dst, interpolation)
+}
+
+fn resize_fast_impl<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
     src: &Image<u8, C, A1>,
     dst: &mut Image<u8, C, A2>,
     interpolation: InterpolationMode,

--- a/crates/kornia-vlm/src/paligemma/mod.rs
+++ b/crates/kornia-vlm/src/paligemma/mod.rs
@@ -9,7 +9,7 @@ use kornia_image::{
     allocator::{CpuAllocator, ImageAllocator},
     Image,
 };
-use kornia_imgproc::{interpolation::InterpolationMode, resize::resize_fast};
+use kornia_imgproc::{interpolation::InterpolationMode, resize::resize_fast_rgb};
 use model::{TextGeneration, TextGenerationConfig};
 use tokenizers::Tokenizer;
 use utils::hub_load_safetensors;
@@ -132,7 +132,7 @@ impl Paligemma {
         stdout_debug: bool,
     ) -> Result<String, PaligemmaError> {
         // resize image to 224x224
-        resize_fast(image, &mut self.img_buf, InterpolationMode::Bilinear)?;
+        resize_fast_rgb(image, &mut self.img_buf, InterpolationMode::Bilinear)?;
 
         // convert to tensor with shape [1, 3, 224, 224]
         let image_t = Tensor::from_raw_buffer(

--- a/crates/kornia-vlm/src/smolvlm/preprocessor.rs
+++ b/crates/kornia-vlm/src/smolvlm/preprocessor.rs
@@ -4,7 +4,7 @@ use kornia_image::allocator::ImageAllocator;
 
 use kornia_image::{Image, ImageSize};
 use kornia_imgproc::interpolation::InterpolationMode;
-use kornia_imgproc::resize::resize_fast;
+use kornia_imgproc::resize::resize_fast_rgb;
 use kornia_tensor::allocator::CpuAllocator;
 
 // ImageNet mean and std for normalization
@@ -36,7 +36,7 @@ pub fn preprocess_image<A: ImageAllocator>(
                 img.0.storage.alloc().clone(),
             )
             .unwrap();
-            resize_fast(&img, &mut resized, InterpolationMode::Bilinear).unwrap();
+            resize_fast_rgb(&img, &mut resized, InterpolationMode::Bilinear).unwrap();
             resized
         }
     };
@@ -58,7 +58,7 @@ pub fn preprocess_image<A: ImageAllocator>(
                 img.0.storage.alloc().clone(),
             )
             .unwrap();
-            resize_fast(&img, &mut resized, InterpolationMode::Bilinear).unwrap();
+            resize_fast_rgb(&img, &mut resized, InterpolationMode::Bilinear).unwrap();
             resized
         }
     };

--- a/examples/apriltag/src/main.rs
+++ b/examples/apriltag/src/main.rs
@@ -33,6 +33,10 @@ struct Args {
     /// minimum difference between white and black for detection
     #[argh(option, short = 'm', default = "5")]
     min_white_black_difference: u8,
+
+    /// TODO
+    #[argh(option, short = 's', default = "2")]
+    downscale_factor: usize,
 }
 
 fn to_tag_family_kind(value: &str) -> Result<TagFamilyKind, String> {
@@ -65,6 +69,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     config.refine_edges_enabled = args.refine_edges_enabled;
     config.min_white_black_difference = args.min_white_black_difference;
     config.decode_sharpening = args.decode_sharpening;
+    config.downscale_factor = args.downscale_factor;
 
     let mut decoder = AprilTagDecoder::new(config, grayscale_img.size())?;
     let detections = decoder.decode(&grayscale_img)?;

--- a/examples/apriltag/src/main.rs
+++ b/examples/apriltag/src/main.rs
@@ -34,7 +34,7 @@ struct Args {
     #[argh(option, short = 'm', default = "5")]
     min_white_black_difference: u8,
 
-    /// TODO
+    /// downscale factor for detection
     #[argh(option, short = 's', default = "2")]
     downscale_factor: usize,
 }

--- a/examples/video_player/src/lib.rs
+++ b/examples/video_player/src/lib.rs
@@ -1,7 +1,7 @@
 use eframe::egui::{self, CentralPanel, Grid, TextEdit};
 use humanize_duration::{prelude::*, Truncate};
 use kornia::image::{Image, ImageSize};
-use kornia::imgproc::resize::resize_fast;
+use kornia::imgproc::resize::resize_fast_rgb;
 use kornia::io::stream::video::{ImageFormat, SeekFlags, VideoReader};
 use kornia::io::stream::GstAllocator;
 use std::path::PathBuf;
@@ -298,7 +298,7 @@ fn render_image(app: &mut MyApp, ui: &mut eframe::egui::Ui) {
                 if resize_required {
                     if let Some(ts) = texture_store {
                         let dst = &mut ts.image;
-                        resize_fast(
+                        resize_fast_rgb(
                             &image_frame,
                             dst,
                             kornia::imgproc::interpolation::InterpolationMode::Nearest,
@@ -314,7 +314,7 @@ fn render_image(app: &mut MyApp, ui: &mut eframe::egui::Ui) {
                         let mut dst: Image<u8, 3, GstAllocator> =
                             Image::from_size_val(new_image_size, 0, GstAllocator::default())
                                 .expect("Failed to create Image");
-                        resize_fast(
+                        resize_fast_rgb(
                             &image_frame,
                             &mut dst,
                             kornia::imgproc::interpolation::InterpolationMode::Nearest,

--- a/kornia-py/src/resize.rs
+++ b/kornia-py/src/resize.rs
@@ -2,7 +2,7 @@ use pyo3::prelude::*;
 
 use crate::image::{FromPyImage, PyImage, ToPyImage};
 use kornia_image::{allocator::CpuAllocator, Image, ImageSize};
-use kornia_imgproc::{interpolation::InterpolationMode, resize::resize_fast};
+use kornia_imgproc::{interpolation::InterpolationMode, resize::resize_fast_rgb};
 
 #[pyfunction]
 pub fn resize(image: PyImage, new_size: (usize, usize), interpolation: &str) -> PyResult<PyImage> {
@@ -27,7 +27,7 @@ pub fn resize(image: PyImage, new_size: (usize, usize), interpolation: &str) -> 
     let mut image_resized = Image::from_size_val(new_size, 0u8, CpuAllocator)
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
 
-    resize_fast(&image, &mut image_resized, interpolation)
+    resize_fast_rgb(&image, &mut image_resized, interpolation)
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyException, _>(format!("{}", e)))?;
 
     Ok(image_resized.to_pyimage())


### PR DESCRIPTION
## Benchmarks

1. NVIDIA Orin
    ```txt
    kornia-apriltag         time:   [11.525 ms 11.526 ms 11.528 ms]
                            change: [−68.450% −68.443% −68.436%] (p = 0.00 < 0.05)
    ```

3. AMD Ryzen 7 5800X
    ```txt
    kornia-apriltag         time:   [5.4888 ms 5.4963 ms 5.5049 ms]
                            change: [−68.551% −68.469% −68.392%] (p = 0.00 < 0.05)
    ```