### PR TITLE
feat(image): added is_contiguous and to_contiguous for Image solving kornia-py/image.rs todo

### DIFF
--- a/crates/kornia-image/src/image.rs
+++ b/crates/kornia-image/src/image.rs
@@ -382,7 +382,7 @@ impl<T, const C: usize, A: ImageAllocator> Image<T, C, A> {
     }
 
     /// Copy Image data into contiguous memory if not already
-    pub fn to_contiguous(&self) -> Vec<T> 
+    pub fn to_contiguous(&self, alloc: A) -> Self 
     where
         T: Clone,
     {
@@ -390,7 +390,11 @@ impl<T, const C: usize, A: ImageAllocator> Image<T, C, A> {
         let mut flat = Vec::with_capacity(self.shape.iter().product());
         let data = self.as_slice();
         if self.is_contiguous() {
-            return data[..total_eles].to_vec();
+            return Self(Tensor3::from_shape_vec(
+                self.shape,
+                data[..total_eles].to_vec(),
+                alloc,
+            ).unwrap());
         }
 
         let mut idx = [0usize; C];
@@ -414,7 +418,12 @@ impl<T, const C: usize, A: ImageAllocator> Image<T, C, A> {
             }
         }
 
-        flat
+        
+        Self(Tensor3::from_shape_vec(
+                self.shape,
+                flat,
+                alloc,
+            ).unwrap())
     }
 
     /// Cast the pixel data to a different type and scale it.

--- a/crates/kornia-image/src/image.rs
+++ b/crates/kornia-image/src/image.rs
@@ -381,16 +381,15 @@ impl<T, const C: usize, A: ImageAllocator> Image<T, C, A> {
     /// use kornia_image::{Image, ImageSize};
     /// use kornia_image::allocator::CpuAllocator;
     ///
-    /// let image = Image::<f32, 2, _>::from_size_val(
-    ///   ImageSize {
-    ///    width: 10,
-    ///   height: 20,
-    /// },
-    /// 0.0f32,
-    /// CpuAllocator).unwrap();
-    ///
-    /// let channels = image.split_channels().unwrap();
-    /// assert_eq!(channels.len(), 2);
+    /// let image_u8 = Image::<u8, 1, CpuAllocator>::new(
+    ///     ImageSize {
+    ///         height: 2,
+    ///         width: 1,
+    ///     },
+    ///     vec![0, 128],
+    ///     CpuAllocator,
+    /// ).unwrap();
+    /// assert!(image_u8.is_contiguous());
     /// ```
     pub fn is_contiguous(&self) -> bool {
         let mut expected_stride = 1;
@@ -404,6 +403,31 @@ impl<T, const C: usize, A: ImageAllocator> Image<T, C, A> {
     }
 
     /// Copy Image data into contiguous memory if not already
+    ///
+    /// # Returns
+    ///
+    /// A new Image with contiguous data
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use kornia_image::{Image, ImageSize};
+    /// use kornia_image::allocator::CpuAllocator;
+    /// let mut image = Image::<u8, 3, CpuAllocator>::new(
+    ///     ImageSize {
+    ///         width: 10,
+    ///        height: 20,
+    ///     },
+    ///     vec![0u8; 10 * 20 * 3],
+    ///     CpuAllocator,
+    /// ).unwrap();
+    /// // Manually break the stride to simulate non-contiguous layout
+    /// image.strides[0] = 10;
+    /// assert!(!image.is_contiguous());
+    /// let contiguous = image.to_contiguous(CpuAllocator);
+    /// assert!(contiguous.is_contiguous());
+    /// assert_eq!(contiguous.as_slice(), &vec![0u8; 10 * 20 * 3]);
+    /// ```
     pub fn to_contiguous(&self, alloc: A) -> Self 
     where
         T: Clone,

--- a/crates/kornia-image/src/image.rs
+++ b/crates/kornia-image/src/image.rs
@@ -390,10 +390,8 @@ impl<T, const C: usize, A: ImageAllocator> Image<T, C, A> {
         let mut flat = Vec::with_capacity(self.shape.iter().product());
         let data = self.as_slice();
         if self.is_contiguous() {
-            println!("here");
             return data[..total_eles].to_vec();
         }
-        println!("here2");
 
         let mut idx = [0usize; C];
         for _ in 0..total_eles {

--- a/kornia-py/src/image.rs
+++ b/kornia-py/src/image.rs
@@ -29,7 +29,7 @@ impl<const C: usize> ToPyImage for Image<u8, C, CpuAllocator> {
     fn to_pyimage(self) -> PyImage {
         Python::with_gil(|py| unsafe {
             let array = PyArray::<u8, _>::new(py, [self.height(), self.width(), C], false);
-            // TODO: verify that the data is contiguous, otherwise iterate over the image and copy
+            self.to_contiguous(); 
             std::ptr::copy_nonoverlapping(self.as_ptr(), array.data(), self.numel());
             array.unbind()
         })
@@ -40,7 +40,7 @@ impl<const C: usize> ToPyImageU16 for Image<u16, C, CpuAllocator> {
     fn to_pyimage_u16(self) -> PyImageU16 {
         Python::with_gil(|py| unsafe {
             let array = PyArray::<u16, _>::new(py, [self.height(), self.width(), C], false);
-            // TODO: verify that the data is contiguous, otherwise iterate over the image and copy
+            self.to_contiguous(); 
             std::ptr::copy_nonoverlapping(self.as_ptr(), array.data(), self.numel());
             array.unbind()
         })
@@ -51,7 +51,7 @@ impl<const C: usize> ToPyImageF32 for Image<f32, C, CpuAllocator> {
     fn to_pyimage_f32(self) -> PyImageF32 {
         Python::with_gil(|py| unsafe {
             let array = PyArray::<f32, _>::new(py, [self.height(), self.width(), C], false);
-            // TODO: verify that the data is contiguous, otherwise iterate over the image and copy
+            self.to_contiguous(); 
             std::ptr::copy_nonoverlapping(self.as_ptr(), array.data(), self.numel());
             array.unbind()
         })

--- a/kornia-py/src/image.rs
+++ b/kornia-py/src/image.rs
@@ -29,7 +29,7 @@ impl<const C: usize> ToPyImage for Image<u8, C, CpuAllocator> {
     fn to_pyimage(self) -> PyImage {
         Python::with_gil(|py| unsafe {
             let array = PyArray::<u8, _>::new(py, [self.height(), self.width(), C], false);
-            let contiguous_data = self.to_contiguous().as_ptr(); 
+            let contiguous_data = self.to_contiguous(CpuAllocator).as_ptr(); 
             std::ptr::copy_nonoverlapping(contiguous_data, array.data(), self.numel());
             array.unbind()
         })
@@ -40,7 +40,7 @@ impl<const C: usize> ToPyImageU16 for Image<u16, C, CpuAllocator> {
     fn to_pyimage_u16(self) -> PyImageU16 {
         Python::with_gil(|py| unsafe {
             let array = PyArray::<u16, _>::new(py, [self.height(), self.width(), C], false);
-            let contiguous_data = self.to_contiguous().as_ptr(); 
+            let contiguous_data = self.to_contiguous(CpuAllocator).as_ptr(); 
             std::ptr::copy_nonoverlapping(contiguous_data, array.data(), self.numel());
             array.unbind()
         })
@@ -51,7 +51,7 @@ impl<const C: usize> ToPyImageF32 for Image<f32, C, CpuAllocator> {
     fn to_pyimage_f32(self) -> PyImageF32 {
         Python::with_gil(|py| unsafe {
             let array = PyArray::<f32, _>::new(py, [self.height(), self.width(), C], false);
-            let contiguous_data = self.to_contiguous().as_ptr(); 
+            let contiguous_data = self.to_contiguous(CpuAllocator).as_ptr(); 
             std::ptr::copy_nonoverlapping(contiguous_data, array.data(), self.numel());
             array.unbind()
         })

--- a/kornia-py/src/image.rs
+++ b/kornia-py/src/image.rs
@@ -29,8 +29,8 @@ impl<const C: usize> ToPyImage for Image<u8, C, CpuAllocator> {
     fn to_pyimage(self) -> PyImage {
         Python::with_gil(|py| unsafe {
             let array = PyArray::<u8, _>::new(py, [self.height(), self.width(), C], false);
-            self.to_contiguous(); 
-            std::ptr::copy_nonoverlapping(self.as_ptr(), array.data(), self.numel());
+            let contiguous_data = self.to_contiguous().as_ptr(); 
+            std::ptr::copy_nonoverlapping(contiguous_data, array.data(), self.numel());
             array.unbind()
         })
     }
@@ -40,8 +40,8 @@ impl<const C: usize> ToPyImageU16 for Image<u16, C, CpuAllocator> {
     fn to_pyimage_u16(self) -> PyImageU16 {
         Python::with_gil(|py| unsafe {
             let array = PyArray::<u16, _>::new(py, [self.height(), self.width(), C], false);
-            self.to_contiguous(); 
-            std::ptr::copy_nonoverlapping(self.as_ptr(), array.data(), self.numel());
+            let contiguous_data = self.to_contiguous().as_ptr(); 
+            std::ptr::copy_nonoverlapping(contiguous_data, array.data(), self.numel());
             array.unbind()
         })
     }
@@ -51,8 +51,8 @@ impl<const C: usize> ToPyImageF32 for Image<f32, C, CpuAllocator> {
     fn to_pyimage_f32(self) -> PyImageF32 {
         Python::with_gil(|py| unsafe {
             let array = PyArray::<f32, _>::new(py, [self.height(), self.width(), C], false);
-            self.to_contiguous(); 
-            std::ptr::copy_nonoverlapping(self.as_ptr(), array.data(), self.numel());
+            let contiguous_data = self.to_contiguous().as_ptr(); 
+            std::ptr::copy_nonoverlapping(contiguous_data, array.data(), self.numel());
             array.unbind()
         })
     }


### PR DESCRIPTION
Added is_contiguous and to_contiguous for Image that solve [kornia-py/image.rs line 32, 43, 54 todos](https://github.com/kornia/kornia-rs/blob/0995adf0b516dfe61a2e98c331af56fd9fc4cf15/kornia-py/src/image.rs#L32)

`is_contiguous` function checks if the actual stride matches what a tightly packed layout would require
`to_contiguous` function if not already contiguous converts the data from Image to contiguous and returns a new Image

also added test cases and docs for is_contiguous and to_contiguous 