### PR TITLE
Replace faer by kornia_linalg::svd3 in ICP crate 

### DIFF
--- a/crates/kornia-icp/Cargo.toml
+++ b/crates/kornia-icp/Cargo.toml
@@ -17,6 +17,7 @@ version.workspace = true
 faer = { workspace = true }
 kiddo = "5.0.2"
 kornia-3d = { workspace = true }
+kornia-linalg = {workspace = true}
 log = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/kornia-linalg/src/lib.rs
+++ b/crates/kornia-linalg/src/lib.rs
@@ -3,3 +3,4 @@
 
 /// Module to calculate SVD of a 3x3 matrix
 pub mod svd;
+pub use glam::{DMat3, DVec3, Mat3};


### PR DESCRIPTION
closes: #288
Have added a layer to convert the incoming f64 to f32 for svd3 and the output of svd3 which is in f32 back to f64 for further use.
After making changes and running the tests 3 tests failed and 2 passed.
<img width="796" height="124" alt="Code_PICCIZ4Yi5" src="https://github.com/user-attachments/assets/304e6906-6bb3-4877-bb88-3d4db85e6b96" />
