### PR TITLE
Add benchmark aprilgrid-rs

### DIFF
--- a/crates/kornia-apriltag/Cargo.toml
+++ b/crates/kornia-apriltag/Cargo.toml
@@ -22,6 +22,8 @@ thiserror = { workspace = true }
 kornia-io = { workspace = true }
 criterion = { workspace = true }
 apriltag = "0.4"
+aprilgrid = "0.6"
+image = "0.25"
 
 [[bench]]
 name = "bench_decoding"

--- a/crates/kornia-apriltag/benches/bench_decoding.rs
+++ b/crates/kornia-apriltag/benches/bench_decoding.rs
@@ -39,8 +39,8 @@ fn bench_decoding(c: &mut Criterion) {
     apriltag_c_detector.set_decimation(2.0);
 
     // AprilGrid-rs
-    let aprigrid_img: image::DynamicImage =
-        image::RgbImage::from_vec(img.width() as u32, img.height() as u32, img.to_vec())
+    let aprilgrid_img: image::DynamicImage =
+        image::GrayImage::from_vec(img.width() as u32, img.height() as u32, img.to_vec())
             .unwrap()
             .into();
 
@@ -59,7 +59,7 @@ fn bench_decoding(c: &mut Criterion) {
     });
 
     c.bench_function("aprilgrid-rs", |b| {
-        b.iter(|| std::hint::black_box(aprilgrid_detector.detect(&aprigrid_img)));
+        b.iter(|| std::hint::black_box(aprilgrid_detector.detect(&aprilgrid_img)));
     });
 }
 

--- a/crates/kornia-apriltag/benches/bench_decoding.rs
+++ b/crates/kornia-apriltag/benches/bench_decoding.rs
@@ -9,10 +9,17 @@ use std::path::PathBuf;
 fn bench_decoding(c: &mut Criterion) {
     let img_path =
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../tests/data/apriltags_tag36h11.jpg");
+
+    // Kornia
     let img = read_image_jpeg_rgb8(img_path).unwrap();
     let mut gray_img = Image::from_size_val(img.size(), 0, CpuAllocator).unwrap();
     gray_from_rgb_u8(&img, &mut gray_img).unwrap();
 
+    let kornia_detector_config = DecodeTagsConfig::new(vec![TagFamilyKind::Tag36H11]);
+    let mut kornia_detector =
+        AprilTagDecoder::new(kornia_detector_config, gray_img.size()).unwrap();
+
+    // AprilTag C
     let mut apriltag_c_img =
         apriltag::Image::zeros_with_stride(gray_img.width(), gray_img.height(), gray_img.width())
             .unwrap();
@@ -31,9 +38,14 @@ fn bench_decoding(c: &mut Criterion) {
 
     apriltag_c_detector.set_decimation(2.0);
 
-    let kornia_detector_config = DecodeTagsConfig::new(vec![TagFamilyKind::Tag36H11]);
-    let mut kornia_detector =
-        AprilTagDecoder::new(kornia_detector_config, gray_img.size()).unwrap();
+    // AprilGrid-rs
+    let aprigrid_img: image::DynamicImage =
+        image::RgbImage::from_vec(img.width() as u32, img.height() as u32, img.to_vec())
+            .unwrap()
+            .into();
+
+    let aprilgrid_detector =
+        aprilgrid::detector::TagDetector::new(&aprilgrid::TagFamily::T36H11, None);
 
     c.bench_function("kornia-apriltag", |b| {
         b.iter(|| {
@@ -44,6 +56,10 @@ fn bench_decoding(c: &mut Criterion) {
 
     c.bench_function("apriltag-c", |b| {
         b.iter(|| std::hint::black_box(apriltag_c_detector.detect(&apriltag_c_img)));
+    });
+
+    c.bench_function("aprilgrid-rs", |b| {
+        b.iter(|| std::hint::black_box(aprilgrid_detector.detect(&aprigrid_img)));
     });
 }
 


### PR DESCRIPTION
## Benchmarks on NVIDIA Orin

1. With downscaling factor 2
    _`aprilgrid-rs` doesn't support image downscaling yet_ 

```
kornia-apriltag         time:   [12.677 ms 12.680 ms 12.683 ms]

apriltag-c              time:   [7.9444 ms 7.9456 ms 7.9470 ms]

aprilgrid-rs            time:   [12.714 ms 12.716 ms 12.718 ms]
```

2. Without downscaling

```
kornia-apriltag         time:   [46.454 ms 46.460 ms 46.466 ms]

apriltag-c              time:   [26.419 ms 26.425 ms 26.431 ms]

aprilgrid-rs            time:   [12.714 ms 12.716 ms 12.718 ms]
```