### PR TITLE
Supporting Otsu threshold

### DIFF
--- a/crates/kornia-imgproc/src/filter/ops.rs
+++ b/crates/kornia-imgproc/src/filter/ops.rs
@@ -589,4 +589,32 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_gaussian_blur_u8() -> Result<(), ImageError> {
+        let size = ImageSize {
+            width: 5,
+            height: 5,
+        };
+
+        let img = Image::new(size, (0..25).map(|x| x as u8).collect(), CpuAllocator)?;
+
+        let mut dst = Image::<_, 1, _>::from_size_val(size, 0u8, CpuAllocator)?;
+
+        gaussian_blur(&img, &mut dst, (3, 3), (0.5, 0.5))?;
+
+        // Rounded towards 0 of the f32 outputs
+        #[rustfmt::skip]
+        assert_eq!(
+            dst.as_slice(),
+            &[
+                0, 1, 2, 3, 3,
+                4, 5, 7, 7, 7,
+                9, 10, 12, 12, 12,
+                13, 15, 17, 17, 16,
+                15, 18, 19, 20, 18,
+            ]
+        );
+        Ok(())
+    }
 }

--- a/crates/kornia-imgproc/src/threshold.rs
+++ b/crates/kornia-imgproc/src/threshold.rs
@@ -378,7 +378,6 @@ where
 pub fn threshold_otsu<A1: ImageAllocator, A2: ImageAllocator>(
     src: &Image<u8, 1, A1>,
     dst: &mut Image<u8, 1, A2>,
-    max_value: u8,
 ) -> Result<(), ImageError>
 {
     if src.size() != dst.size() {
@@ -427,7 +426,7 @@ pub fn threshold_otsu<A1: ImageAllocator, A2: ImageAllocator>(
 
     parallel::par_iter_rows_val(src, dst, |src_pixel, dst_pixel| {
         *dst_pixel = if *src_pixel > thresh {
-            max_value
+            255
         } else {
             0u8
         };

--- a/crates/kornia-imgproc/src/threshold.rs
+++ b/crates/kornia-imgproc/src/threshold.rs
@@ -3,7 +3,7 @@ use std::cmp::PartialOrd;
 
 use kornia_image::{allocator::ImageAllocator, Image, ImageError};
 
-use crate::parallel;
+use crate::{histogram::compute_histogram, parallel};
 
 /// Apply a binary threshold to an image.
 ///

--- a/crates/kornia-imgproc/src/threshold.rs
+++ b/crates/kornia-imgproc/src/threshold.rs
@@ -391,36 +391,35 @@ pub fn threshold_otsu<A1: ImageAllocator, A2: ImageAllocator>(
     let mut hist: Vec<usize>= vec![0_usize; 256];
     let _ = compute_histogram(src, &mut hist, 256).unwrap();
 
-    let total = (src.rows() * src.cols()) as f64;
+    let n = (src.rows() * src.cols()) as f64;
 
-    let mut sum_all = 0f64;
+    let mut sum = 0f64;
     for i in 0..256 {
-        sum_all += (i as f64) * (hist[i] as f64);
+        sum += (i as f64) * (hist[i] as f64);
     }
 
     let mut sum_b = 0f64;
-    let mut w_b = 0f64;
+    let mut q1 = 0f64;
     let mut var_max = 0f64;
     let mut thresh = 0u8;
 
     for t in 0..256 {
-        w_b += hist[t] as f64;
-        if w_b == 0.0 { continue; }
+        q1 += hist[t] as f64;
+        if q1 == 0.0 { continue; }
 
-        let w_f = total - w_b;
-        if w_f == 0.0 { break; }
+        let q2 = n - q1;
 
         sum_b += (t as f64) * (hist[t] as f64);
 
-        let m_b = sum_b / w_b;
-        let m_f = (sum_all - sum_b) / w_f;
+        let mu_1 = sum_b / q1;
+        let mu_2 = (sum - sum_b) / q2;
 
         // maximize inter class variance
-        let var_between = w_b * w_f * (m_b - m_f).powi(2);
+        let var_between = q1 * q2 * (mu_1 - mu_2).powi(2);
 
         if var_between > var_max {
-            var_max = var_between;
             thresh = t as u8;
+            var_max = var_between;
         }
     }
 


### PR DESCRIPTION
Added an initial version of otsu threshold. It only supports single channel u8 images.
Solves #478 
Implementation according to the algorithm given in the paper: https://www.ipol.im/pub/art/2016/158/article_lr.pdf