### PR TITLE
Implement undistort points

### DIFF
--- a/crates/kornia-imgproc/Cargo.toml
+++ b/crates/kornia-imgproc/Cargo.toml
@@ -18,8 +18,6 @@ kornia-image = { workspace = true }
 num-traits = { workspace = true }
 rayon = "1.10"
 thiserror = { workspace = true }
-anyhow = "1.0.99"
-ndarray = "0.15"
 
 [dev-dependencies]
 criterion = { workspace = true }


### PR DESCRIPTION
Closes #466

## Description

This pull request implements the `undistort_points_polynomial` function to correct for lens distortion on a set of 2D points. The implementation is vectorized for performance and has been integrated into the existing calibration module as requested in the code review.

### Key Changes:

- **Core Logic:** The `undistort_points_polynomial` function has been added to `crates/kornia-imgproc/src/calibration/distortion.rs`.
- **Testing:**
    - Included a robust Rust unit test that validates the function's correctness using a round-trip check (`undistort(distort(point))`).
    - Added a Python integration test to ensure the bindings work as expected.

All Rust and Python tests are passing. This PR addresses the feedback from the initial review and is ready for another look.