### PR TITLE
Fix u8 to_f32 and from_f32 normalization logic

### DIFF
--- a/crates/kornia-imgproc/src/filter/separable_filter.rs
+++ b/crates/kornia-imgproc/src/filter/separable_filter.rs
@@ -31,11 +31,11 @@ impl FloatConversion for f64 {
 
 impl FloatConversion for u8 {
     fn to_f32(&self) -> f32 {
-        *self as f32
+        *self as f32 / 255.0
     }
 
     fn from_f32(val: f32) -> Self {
-        val.clamp(0.0, 255.0) as u8
+        (val.clamp(0.0, 1.0) * 255.0).round() as u8
     }
 }
 


### PR DESCRIPTION
I believe for f32 images generally we take values between 0 to 1, while this isn't the standard way so unsure if this fixes a logic bug. Feel free to close the PR, if this seems to be correct