### PR TITLE
SmolVLM2: Image encoder & image validations (clean)

### DIFF
--- a/crates/kornia-vlm/Cargo.toml
+++ b/crates/kornia-vlm/Cargo.toml
@@ -14,6 +14,8 @@ version = { workspace = true }
 [dependencies]
 log = { workspace = true }
 serde_json = { workspace = true }
+serde = { workspace = true }
+minijinja = { version = "2.12.0", features = ["loader"] }
 thiserror = { workspace = true }
 
 kornia-image = { workspace = true }
@@ -30,6 +32,7 @@ tokenizers = { workspace = true }
 
 [dev-dependencies]
 rand = "0.9.0"
+env_logger = { workspace = true }
 
 [features]
 cuda = ["candle-core/cuda", "candle-transformers/cuda", "candle-nn/cuda"]

--- a/crates/kornia-vlm/src/lib.rs
+++ b/crates/kornia-vlm/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod paligemma;
 pub mod smolvlm;
+pub mod smolvlm2;
 
 mod context;

--- a/crates/kornia-vlm/src/smolvlm2/image_processor.rs
+++ b/crates/kornia-vlm/src/smolvlm2/image_processor.rs
@@ -1,0 +1,710 @@
+use crate::smolvlm2::{text_processor::TextProcessor, utils::SmolVlm2Error};
+use candle_core::{DType, Device, Shape, Tensor};
+use kornia_image::{allocator::ImageAllocator, Image, ImageSize};
+use kornia_imgproc::{interpolation::InterpolationMode, resize::resize_fast_rgb};
+use log::info;
+use std::borrow::Cow;
+
+pub struct ImageProcessorConfig {
+    pub size_longest_edge: u32,           // max size
+    pub max_image_size_longest_edge: u32, // outer patch size
+    pub image_mean: [f32; 3],
+    pub image_std: [f32; 3],
+    pub rescale_factor: f32,
+    pub image_token: &'static str,
+}
+
+/// Image preprocessor for SmolVLM model
+pub struct ImageProcessor<A: ImageAllocator> {
+    config: ImageProcessorConfig,
+
+    // buffers for resizing images
+    buf_resize: Option<Image<u8, 3, A>>,
+    buf_global_resize: Option<Image<u8, 3, A>>,
+
+    // buffers for padding images
+    buf_padded_img: Option<Image<u8, 3, A>>,
+    buf_padded_mask: Option<Image<u8, 1, A>>,
+    buf_global_padded_img: Option<Image<u8, 3, A>>,
+    buf_global_padded_mask: Option<Image<u8, 1, A>>,
+
+    // buffers for tensors
+    buf_mask_tensor: Tensor,
+    buf_mean_tensor: Tensor,
+    buf_std_tensor: Tensor,
+
+    image_tag_len: usize,
+    processed_images: Vec<(Tensor, Tensor)>,
+    image_token_tensor: Option<Tensor>,
+}
+
+impl<A: ImageAllocator> ImageProcessor<A> {
+    /// Create a new SmolVLM image preprocessor
+    pub fn new(
+        config: ImageProcessorConfig,
+        device: &Device,
+        txt_processor: &TextProcessor,
+    ) -> Result<Self, SmolVlm2Error> {
+        let image_token_tensor = if let Err(SmolVlm2Error::MissingTokenizer) =
+            txt_processor.encode(config.image_token)
+        {
+            None
+        } else {
+            let image_token = txt_processor.encode(config.image_token)?;
+            Some(Tensor::from_slice(&[image_token], &[1], device)?)
+        };
+        Ok(Self {
+            buf_resize: None,
+            buf_global_resize: None,
+            buf_padded_img: None,
+            buf_padded_mask: None,
+            buf_global_padded_img: None,
+            buf_global_padded_mask: None,
+            buf_mask_tensor: (Tensor::ones((2048, 2048), DType::F32, device)? * 255.0)?,
+            buf_mean_tensor: Tensor::from_slice(&config.image_mean, (3, 1, 1), device)?,
+            buf_std_tensor: Tensor::from_slice(&config.image_std, (3, 1, 1), device)?,
+
+            image_tag_len: config.image_token.len(),
+            processed_images: vec![],
+            image_token_tensor,
+
+            config,
+        })
+    }
+
+    /// given prompt and images, it modifies the prompt to facilitate image inputs while
+    /// storing the images themselves as processed images for later use
+    pub fn binding_images_to_prompt(
+        &mut self,
+        prompt: &mut String,
+        images: Vec<Image<u8, 3, A>>,
+        device: &Device,
+        alloc: A,
+    ) -> Result<(), SmolVlm2Error> {
+        let cloned_prompt = prompt.clone();
+        let image_tags_pos = cloned_prompt
+            .match_indices(&self.config.image_token)
+            .collect::<Vec<_>>();
+        let mut offset = 0;
+
+        if image_tags_pos.len() != images.len() {
+            return Err(SmolVlm2Error::MismatchedImageCount {
+                tags: image_tags_pos.len(),
+                images: images.len(),
+            });
+        }
+
+        for ((start, _), image) in image_tags_pos.iter().zip(images.into_iter()) {
+            let (img_patches, mask_patches, size) =
+                self.preprocess(&image, device, alloc.clone())?;
+            self.processed_images.push((img_patches, mask_patches));
+
+            let img_token = get_prompt_split_image(81, size);
+            prompt.replace_range(
+                &(start + offset)..&(start + offset + self.image_tag_len),
+                &img_token,
+            );
+
+            offset += img_token.len() - self.image_tag_len;
+        }
+
+        Ok(())
+    }
+
+    pub fn get_image_token_mask(&self, input: &Tensor) -> Result<Tensor, SmolVlm2Error> {
+        Ok(input.broadcast_eq(
+            self.image_token_tensor
+                .as_ref()
+                .ok_or(SmolVlm2Error::MissingTokenizer)?,
+        )?)
+    }
+
+    pub fn get_processed_images(&self) -> Vec<(&Tensor, &Tensor)> {
+        self.processed_images.iter().map(|(a, b)| (a, b)).collect()
+    }
+
+    pub fn clear_processed_images(&mut self) {
+        self.processed_images.clear();
+    }
+
+    /// Preprocess an image for SmolVLM model inference
+    pub fn preprocess(
+        &mut self,
+        img: &Image<u8, 3, A>,
+        device: &Device,
+        alloc: A,
+    ) -> Result<(Tensor, Tensor, ImageSize), SmolVlm2Error> {
+        {
+            info!(
+                "Image size: {}x{} w/ Max size: {}",
+                img.width(),
+                img.height(),
+                self.config.size_longest_edge
+            );
+
+            let img_resized = Self::resize_image_with_buffer(
+                img,
+                &mut self.buf_resize,
+                self.config.size_longest_edge,
+                alloc.clone(),
+            )?;
+            match img_resized {
+                Cow::Borrowed(img_ref) => {
+                    Self::pad_image_in_place(
+                        img_ref,
+                        &mut self.buf_padded_img,
+                        &mut self.buf_padded_mask,
+                        self.config.max_image_size_longest_edge,
+                        alloc.clone(),
+                    )?;
+                }
+                Cow::Owned(img_owned) => {
+                    Self::pad_image_in_place(
+                        &img_owned,
+                        &mut self.buf_padded_img,
+                        &mut self.buf_padded_mask,
+                        self.config.max_image_size_longest_edge,
+                        alloc.clone(),
+                    )?;
+                }
+            }
+        }
+
+        {
+            info!(
+                "Image size: {}x{} w/ Max size: {}",
+                img.width(),
+                img.height(),
+                self.config.max_image_size_longest_edge
+            );
+
+            let global_resized = Self::resize_image_with_buffer(
+                img,
+                &mut self.buf_global_resize,
+                self.config.max_image_size_longest_edge,
+                alloc.clone(),
+            )?;
+            match global_resized {
+                Cow::Borrowed(img_ref) => {
+                    Self::pad_image_in_place(
+                        img_ref,
+                        &mut self.buf_global_padded_img,
+                        &mut self.buf_global_padded_mask,
+                        self.config.max_image_size_longest_edge,
+                        alloc.clone(),
+                    )?;
+                }
+                Cow::Owned(img_owned) => {
+                    Self::pad_image_in_place(
+                        &img_owned,
+                        &mut self.buf_global_padded_img,
+                        &mut self.buf_global_padded_mask,
+                        self.config.max_image_size_longest_edge,
+                        alloc.clone(),
+                    )?;
+                }
+            }
+        }
+
+        let img_padded = self
+            .buf_padded_img
+            .take()
+            .expect("Tried taking a None image");
+        let mask = self
+            .buf_padded_mask
+            .take()
+            .expect("Tried taking a None mask");
+        let global_img = self
+            .buf_global_padded_img
+            .take()
+            .expect("Tried taking a None global image");
+        let global_mask = self
+            .buf_global_padded_mask
+            .take()
+            .expect("Tried taking a None global mask");
+
+        // convert to tensors and normalize
+        let mask_tensor = self.mask_to_tensor(mask, device)?;
+        let global_mask_tensor = self.mask_to_tensor(global_mask, device)?;
+
+        let img_tensor = self.image_to_normalized_tensor(img_padded, device)?;
+        let global_img_tensor = self.image_to_normalized_tensor(global_img, device)?;
+
+        // create patches and concatenate with global image
+        let (img_patches, mask_patches, size) = self.create_patches_with_global(
+            &img_tensor,
+            &mask_tensor,
+            &global_img_tensor,
+            &global_mask_tensor,
+        )?;
+
+        Ok((img_patches, mask_patches, size))
+    }
+
+    /// Single resize function that takes buffer by value and returns it (lazy init)
+    fn resize_image_with_buffer<'a>(
+        img: &'a Image<u8, 3, A>,
+        buffer: &'a mut Option<Image<u8, 3, A>>,
+        target_size: u32,
+        alloc: A,
+    ) -> Result<Cow<'a, Image<u8, 3, A>>, SmolVlm2Error> {
+        let (width, height) = (img.width() as u32, img.height() as u32);
+        let longest_edge = width.max(height);
+
+        if longest_edge <= target_size {
+            Ok(Cow::Borrowed(unsafe {
+                std::mem::transmute::<&Image<u8, 3, A>, &Image<u8, 3, A>>(img)
+            }))
+        } else {
+            let scale_factor = target_size as f32 / longest_edge as f32;
+            let new_width = (width as f32 * scale_factor) as usize;
+            let new_height = (height as f32 * scale_factor) as usize;
+
+            let needs_resize = buffer.as_ref().map_or(true, |buf| {
+                buf.width() != new_width || buf.height() != new_height
+            });
+
+            if needs_resize {
+                *buffer = Some(Image::<u8, 3, A>::from_size_val(
+                    ImageSize {
+                        width: new_width,
+                        height: new_height,
+                    },
+                    0,
+                    alloc,
+                )?);
+            }
+
+            let buf = buffer
+                .as_mut()
+                .expect("Tried to resize a None image buffer");
+            resize_fast_rgb(img, buf, InterpolationMode::Lanczos)?;
+
+            Ok(Cow::Borrowed(buf))
+        }
+    }
+
+    /// Pad image to be multiples of outer_patch_size and create corresponding mask
+    /// Returns references to the internal buffers to avoid copying
+    fn pad_image_in_place(
+        img: &Image<u8, 3, A>,
+        img_buffer: &mut Option<Image<u8, 3, A>>,
+        mask_buffer: &mut Option<Image<u8, 1, A>>,
+        outer_patch_size: u32,
+        alloc: A,
+    ) -> Result<(), SmolVlm2Error> {
+        let (width, height) = (img.width(), img.height());
+
+        info!(
+            "Patch blocks (HxW): {:?}x{:?}",
+            (height as u32).div_ceil(outer_patch_size),
+            (width as u32).div_ceil(outer_patch_size),
+        );
+
+        let new_width = (width as u32).div_ceil(outer_patch_size) * outer_patch_size;
+        let new_height = (height as u32).div_ceil(outer_patch_size) * outer_patch_size;
+
+        // Lazy init buffers only if size changed
+        let needs_resize = img_buffer.as_ref().map_or(true, |buf| {
+            buf.width() != new_width as usize || buf.height() != new_height as usize
+        });
+
+        if needs_resize {
+            *img_buffer = Some(Image::<u8, 3, A>::from_size_val(
+                ImageSize {
+                    width: new_width as usize,
+                    height: new_height as usize,
+                },
+                0,
+                alloc.clone(),
+            )?);
+        }
+
+        let needs_mask_resize = mask_buffer.as_ref().map_or(true, |buf| {
+            buf.width() != new_width as usize || buf.height() != new_height as usize
+        });
+
+        if needs_mask_resize {
+            *mask_buffer = Some(Image::<u8, 1, A>::from_size_val(
+                ImageSize {
+                    width: new_width as usize,
+                    height: new_height as usize,
+                },
+                255,
+                alloc.clone(),
+            )?);
+        }
+
+        let padded_img = img_buffer
+            .as_mut()
+            .expect("Tried to pad a None image buffer");
+
+        padded_img.as_slice_mut().fill(0);
+
+        let img_slice = img.as_slice();
+        let padded_img_slice = padded_img.as_slice_mut();
+
+        // copy image data row by row
+        for y in 0..height {
+            let src_offset = y * width * 3;
+            let dst_offset = y * new_width as usize * 3;
+            let row_bytes = width * 3;
+
+            padded_img_slice[dst_offset..dst_offset + row_bytes]
+                .copy_from_slice(&img_slice[src_offset..src_offset + row_bytes]);
+        }
+        Ok(())
+    }
+
+    /// Convert image to normalized tensor
+    fn image_to_normalized_tensor(
+        &self,
+        img: Image<u8, 3, A>, // Take ownership
+        device: &Device,
+    ) -> Result<Tensor, SmolVlm2Error> {
+        let (width, height) = (img.width(), img.height());
+        let img_data = img.into_vec(); // No clone, take ownership
+
+        let mut tensor = Tensor::from_vec(img_data, Shape::from_dims(&[height, width, 3]), device)?
+            .permute(vec![2, 0, 1])?
+            .to_dtype(candle_core::DType::F32)?;
+
+        // Normalize: scale to [0,1]
+        tensor = tensor.broadcast_mul(&Tensor::from_slice(
+            &[self.config.rescale_factor],
+            &[1],
+            device,
+        )?)?;
+
+        tensor = tensor
+            .broadcast_sub(&self.buf_mean_tensor)?
+            .broadcast_div(&self.buf_std_tensor)?;
+
+        Ok(tensor)
+    }
+
+    /// Convert mask to tensor
+    fn mask_to_tensor(
+        &mut self,
+        mask: Image<u8, 1, A>, // Take ownership of the mask
+        device: &Device,
+    ) -> Result<Tensor, SmolVlm2Error> {
+        let (width, height) = (mask.width(), mask.height());
+
+        let (buf_height, buf_width) = self.buf_mask_tensor.dims2()?;
+
+        if height == buf_height && width == buf_width {
+            // No resize needed
+            Ok(self.buf_mask_tensor.clone())
+        } else if height > buf_height || width > buf_width {
+            // Resize the buffer if needed
+
+            let mask_data = mask.into_vec();
+
+            self.buf_mask_tensor =
+                Tensor::from_vec(mask_data, Shape::from_dims(&[height, width]), device)?
+                    .to_dtype(DType::F32)?;
+
+            Ok(self.buf_mask_tensor.clone())
+        } else {
+            // Slice the buffer to the required size
+            Ok(self
+                .buf_mask_tensor
+                .narrow(0, 0, height)?
+                .narrow(1, 0, width)?)
+        }
+    }
+
+    /// Create patches from image and mask, then concatenate with global image
+    fn create_patches_with_global(
+        &self,
+        img: &Tensor,
+        mask: &Tensor,
+        global_img: &Tensor,
+        global_mask: &Tensor,
+    ) -> Result<(Tensor, Tensor, ImageSize), SmolVlm2Error> {
+        let (c, h, w) = img.dims3()?;
+        let cols = w / self.config.max_image_size_longest_edge as usize;
+        let rows = h / self.config.max_image_size_longest_edge as usize;
+
+        // Split image into patches
+        let img_patches = img
+            .unsqueeze(2)?
+            .unsqueeze(4)?
+            .reshape(&[
+                c,
+                rows,
+                self.config.max_image_size_longest_edge as usize,
+                cols,
+                self.config.max_image_size_longest_edge as usize,
+            ])?
+            .permute([1, 3, 0, 2, 4])?
+            .reshape(&[
+                rows * cols,
+                c,
+                self.config.max_image_size_longest_edge as usize,
+                self.config.max_image_size_longest_edge as usize,
+            ])?;
+
+        // Split mask into patches
+        let mask_patches = mask
+            .unsqueeze(1)?
+            .unsqueeze(3)?
+            .reshape(&[
+                rows,
+                self.config.max_image_size_longest_edge as usize,
+                cols,
+                self.config.max_image_size_longest_edge as usize,
+            ])?
+            .permute([0, 2, 1, 3])?
+            .reshape(&[
+                rows * cols,
+                self.config.max_image_size_longest_edge as usize,
+                self.config.max_image_size_longest_edge as usize,
+            ])?;
+
+        // Concatenate global image with patches
+        let img_patches = Tensor::cat(&[&img_patches, &global_img.unsqueeze(0)?], 0)?;
+        let mask_patches = Tensor::cat(&[&mask_patches, &global_mask.unsqueeze(0)?], 0)?;
+
+        Ok((
+            img_patches,
+            mask_patches,
+            ImageSize {
+                width: cols,
+                height: rows,
+            },
+        ))
+    }
+}
+
+pub fn get_prompt_split_image(img_seq_len: usize, size: ImageSize) -> String {
+    let mut s = String::new();
+
+    for h in 0..size.height {
+        for w in 0..size.width {
+            s += &format!(
+                "<fake_token_around_image><row_{}_col_{}>{}",
+                h + 1,
+                w + 1,
+                "<image>".repeat(img_seq_len)
+            );
+        }
+        s += "\n";
+    }
+
+    s += &format!(
+        "\n<fake_token_around_image><global-img>{}<fake_token_around_image>",
+        "<image>".repeat(img_seq_len)
+    );
+
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle_core::Device;
+    use kornia_image::allocator::CpuAllocator;
+
+    #[test]
+    fn test_smolvlm_preprocessor_basic() -> Result<(), SmolVlm2Error> {
+        // Create a simple test image (64x64, RGB)
+        let img = Image::<u8, 3, CpuAllocator>::from_size_val(
+            ImageSize {
+                width: 64,
+                height: 64,
+            },
+            128, // gray value
+            CpuAllocator,
+        )?;
+
+        let device = Device::Cpu;
+        let mut preprocessor = ImageProcessor::new(
+            ImageProcessorConfig {
+                size_longest_edge: 512,
+                max_image_size_longest_edge: 32,
+                image_mean: [0.5, 0.5, 0.5],
+                image_std: [0.5, 0.5, 0.5],
+                rescale_factor: 1.0 / 255.0,
+                image_token: "<image>",
+            },
+            &device,
+            &TextProcessor::default(),
+        )?;
+
+        let (img_patches, mask_patches, size) =
+            preprocessor.preprocess(&img, &device, CpuAllocator)?;
+
+        // Check that we got the expected dimensions
+        assert_eq!(img_patches.dims().len(), 4); // [patches, channels, height, width]
+        assert_eq!(mask_patches.dims().len(), 3); // [patches, height, width]
+
+        // Should have patch dimensions + 1 global image
+        let expected_patches = (size.width * size.height) + 1;
+        assert_eq!(img_patches.dims()[0], expected_patches);
+        assert_eq!(mask_patches.dims()[0], expected_patches);
+
+        // Check patch size
+        assert_eq!(img_patches.dims()[2], 32); // patch height
+        assert_eq!(img_patches.dims()[3], 32); // patch width
+        assert_eq!(mask_patches.dims()[1], 32); // patch height
+        assert_eq!(mask_patches.dims()[2], 32); // patch width
+
+        // Check channels
+        assert_eq!(img_patches.dims()[1], 3); // RGB
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_resize_image_to_fit() -> Result<(), SmolVlm2Error> {
+        let img = Image::<u8, 3, CpuAllocator>::from_size_val(
+            ImageSize {
+                width: 100,
+                height: 200,
+            },
+            0,
+            CpuAllocator,
+        )?;
+
+        // Test no resize needed
+        let mut buffer = None;
+        let result =
+            ImageProcessor::resize_image_with_buffer(&img, &mut buffer, 300, CpuAllocator)?;
+        assert_eq!(result.width(), 100);
+        assert_eq!(result.height(), 200);
+
+        // Test resize needed
+        let mut buffer = None;
+        let result =
+            ImageProcessor::resize_image_with_buffer(&img, &mut buffer, 100, CpuAllocator)?;
+        assert_eq!(result.width(), 50); // scaled down proportionally
+        assert_eq!(result.height(), 100); // longest edge = 100
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_small_image_explicit_values() -> Result<(), SmolVlm2Error> {
+        // Create a small 6x4 image with explicit RGB values
+        let mut img_data = vec![0u8; 6 * 4 * 3]; // 6 width x 4 height x 3 channels
+
+        // Set explicit pixel values in a pattern (R, G, B)
+        // Top row: Red gradient
+        for x in 0..6 {
+            let offset = x * 3;
+            img_data[offset] = (x * 40) as u8; // R: 0, 40, 80, 120, 160, 200
+            img_data[offset + 1] = 0; // G: 0
+            img_data[offset + 2] = 0; // B: 0
+        }
+
+        // Second row: Green gradient
+        for x in 0..6 {
+            let offset = (6 + x) * 3;
+            img_data[offset] = 0; // R: 0
+            img_data[offset + 1] = (x * 40) as u8; // G: 0, 40, 80, 120, 160, 200
+            img_data[offset + 2] = 0; // B: 0
+        }
+
+        // Third row: Blue gradient
+        for x in 0..6 {
+            let offset = (12 + x) * 3;
+            img_data[offset] = 0; // R: 0
+            img_data[offset + 1] = 0; // G: 0
+            img_data[offset + 2] = (x * 40) as u8; // B: 0, 40, 80, 120, 160, 200
+        }
+
+        // Fourth row: Mixed colors
+        for x in 0..6 {
+            let offset = (18 + x) * 3;
+            img_data[offset] = (x * 20) as u8; // R: 0, 20, 40, 60, 80, 100
+            img_data[offset + 1] = (x * 30) as u8; // G: 0, 30, 60, 90, 120, 150
+            img_data[offset + 2] = (x * 10) as u8; // B: 0, 10, 20, 30, 40, 50
+        }
+
+        let img = Image::<u8, 3, CpuAllocator>::new(
+            ImageSize {
+                width: 6,
+                height: 4,
+            },
+            img_data.clone(),
+            CpuAllocator,
+        )?;
+
+        let device = Device::Cpu;
+        let mut preprocessor = ImageProcessor::new(
+            ImageProcessorConfig {
+                size_longest_edge: 8,
+                max_image_size_longest_edge: 4,
+                image_mean: [0.5, 0.5, 0.5],
+                image_std: [0.5, 0.5, 0.5],
+                rescale_factor: 1.0 / 255.0,
+                image_token: "<image>",
+            },
+            &device,
+            &TextProcessor::default(),
+        )?;
+
+        // First, test just the padding to verify it works correctly
+        let mut img_buffer = None;
+        let mut mask_buffer = None;
+        ImageProcessor::pad_image_in_place(
+            &img,
+            &mut img_buffer,
+            &mut mask_buffer,
+            4,
+            CpuAllocator,
+        )?;
+
+        let padded_img_data = img_buffer
+            .as_ref()
+            .expect("Failed to get padded image data")
+            .as_slice();
+        let original_img_data = img.as_slice();
+
+        // Check each row
+        for y in 0..4 {
+            let original_row_start = y * 6 * 3;
+            let padded_row_start = y * 8 * 3;
+
+            // Verify original data is intact
+            assert_eq!(
+                &padded_img_data[padded_row_start..padded_row_start + 6 * 3],
+                &original_img_data[original_row_start..original_row_start + 6 * 3]
+            );
+
+            // Verify padding columns are zero
+            assert_eq!(
+                &padded_img_data[padded_row_start + 6 * 3..padded_row_start + 8 * 3],
+                &[0u8; 2 * 3]
+            );
+        }
+
+        // Now test the full preprocessing pipeline
+        let (img_patches, mask_patches, size) =
+            preprocessor.preprocess(&img, &device, CpuAllocator)?;
+
+        // Verify basic structure
+        assert_eq!(img_patches.dims().len(), 4); // [patches, channels, height, width]
+        assert_eq!(mask_patches.dims().len(), 3); // [patches, height, width]
+
+        // Should have 2x1 patches (8x4 padded image / 4x4 patches) + 1 global = 3 total
+        let expected_patches = (size.width * size.height) + 1;
+        assert_eq!(img_patches.dims()[0], expected_patches);
+        assert_eq!(mask_patches.dims()[0], expected_patches);
+        assert_eq!(size.width, 2); // 8 / 4 = 2 patches wide
+        assert_eq!(size.height, 1); // 4 / 4 = 1 patch tall
+
+        // Check patch dimensions
+        assert_eq!(img_patches.dims()[2], 4); // patch height
+        assert_eq!(img_patches.dims()[3], 4); // patch width
+        assert_eq!(mask_patches.dims()[1], 4); // patch height
+        assert_eq!(mask_patches.dims()[2], 4); // patch width
+
+        // Check channels
+        assert_eq!(img_patches.dims()[1], 3); // RGB
+
+        Ok(())
+    }
+}

--- a/crates/kornia-vlm/src/smolvlm2/mod.rs
+++ b/crates/kornia-vlm/src/smolvlm2/mod.rs
@@ -1,0 +1,309 @@
+mod model;
+pub(super) mod text_processor;
+
+use log::debug;
+use std::io::Write;
+use std::time::Instant;
+
+use candle_core::{DType, Device, Tensor};
+use candle_nn::VarBuilder;
+use hf_hub::api::sync::Api;
+use kornia_image::{allocator::ImageAllocator, Image};
+
+use crate::smolvlm2::text_processor::{Line, Message, Role, TextProcessor};
+
+/// Utilities for the SmolVLM2 module.
+#[derive(thiserror::Error, Debug)]
+pub enum SmolVlm2Error {
+    #[error(transparent)]
+    FailedToLoadModel(#[from] hf_hub::api::sync::ApiError),
+
+    #[error(transparent)]
+    CandleError(#[from] candle_core::Error),
+
+    #[error(transparent)]
+    ImageError(#[from] kornia_image::ImageError),
+
+    #[error(transparent)]
+    TokenizerError(#[from] tokenizers::Error),
+
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
+
+    #[error(transparent)]
+    JinjaError(#[from] minijinja::Error),
+
+    #[error(transparent)]
+    SerializationError(#[from] serde_json::Error),
+
+    #[error("Invalid logits detected: {0}")]
+    InvalidLogits(String),
+
+    #[error("Invalid encoding detected: {0}")]
+    InvalidEncoding(String),
+
+    #[error("Missing chat template: {0}")]
+    MissingChatTemplate(String),
+
+    #[error("Message history mistmatch: {0}")]
+    MessageHistoryMismatch(String),
+
+    #[error("Cannot find the <end_of_utterance> token")]
+    EosTokenNotFound,
+
+    #[error("Mismatched image count: tags = {tags}, images = {images}")]
+    MismatchedImageCount { tags: usize, images: usize },
+}
+
+/// Configuration for the SmolVLM2 model
+
+#[derive(Clone, Copy)]
+pub struct SmolVlm2Config {
+    pub seed: u64,
+    pub temp: f64,
+    pub top_p: f64,
+    pub repeat_penalty: f32,
+    pub do_sample: bool,
+    pub repeat_last_n: usize,
+}
+
+impl Default for SmolVlm2Config {
+    fn default() -> Self {
+        Self {
+            seed: 42,
+            temp: 1.0,
+            top_p: 0.8,
+            repeat_penalty: 1.0,
+            do_sample: true,
+            repeat_last_n: 64,
+        }
+    }
+}
+
+pub struct SmolVlm2 {
+    model: model::Model,
+    _config: SmolVlm2Config,
+    device: Device,
+    index_pos: usize, // index of the next token to be processed
+
+    txt_processor: TextProcessor,
+    response: String,
+}
+
+impl SmolVlm2 {
+    const MODEL_IDENTIFIER: &'static str = "HuggingFaceTB/SmolVLM2-2.2B-Instruct";
+
+    pub fn new(config: SmolVlm2Config) -> Result<Self, SmolVlm2Error> {
+        #[cfg(feature = "cuda")]
+        let (device, dtype) = match Device::cuda_if_available(0) {
+            Ok(device) => (device, DType::F32),
+            Err(e) => {
+                log::warn!("CUDA not available, defaulting to CPU: {e:?}");
+                (Device::Cpu, DType::F32)
+            }
+        };
+
+        #[cfg(not(feature = "cuda"))]
+        let (device, dtype) = (Device::Cpu, DType::F32);
+
+        let (model, txt_processor) = Self::load_model(config, dtype, &device)?;
+
+        Ok(Self {
+            model,
+            txt_processor,
+            _config: config,
+            device,
+            index_pos: 0,
+
+            response: String::new(),
+        })
+    }
+
+    pub fn clear_context(&mut self) -> Result<(), SmolVlm2Error> {
+        self.model.clear_context()?;
+        self.txt_processor.clear_history();
+
+        self.index_pos = 0;
+        Ok(())
+    }
+
+    /// Run the inference of the SmolVLM2 model with previous context added.
+    /// Run the inference of the SmolVLM2 model with default prompt formatting.
+    ///
+    /// # Arguments
+    ///
+    /// * `prompt` - The user prompt string to generate a caption for
+    /// * `image` - Optional RGB image (`Image<u8, 3, A>`) to use for captioning
+    /// * `sample_len` - The maximum number of tokens to generate
+    /// * `alloc` - The image allocator to use
+    /// * `debug` - Whether to enable debug output
+    ///
+    /// # Returns
+    ///
+    /// * `Result<String, SmolVlm2Error>` - The generated caption or error
+    pub fn inference<A: ImageAllocator>(
+        &mut self,
+        prompt: &str, // TODO: should it be structured?
+        image: Option<Image<u8, 3, A>>,
+        sample_len: usize, // per prompt
+        alloc: A,
+        debug: bool,
+    ) -> Result<String, SmolVlm2Error> {
+        let full_prompt = self.txt_processor.reformat_with_additional_prompts(
+            vec![Message {
+                role: Role::User,
+                content: vec![Line::Text {
+                    text: prompt.to_string(),
+                }],
+            }],
+            true,
+        )?;
+
+        let images = if let Some(img) = image {
+            vec![img]
+        } else {
+            vec![]
+        };
+
+        let response = self.inference_raw(&full_prompt, images, sample_len, alloc, debug)?;
+
+        Ok(response)
+    }
+
+    /// Run the inference of the SmolVLM2 model without the default prompt formatting.
+    ///
+    /// # Arguments
+    ///
+    /// * `full_prompt` - The fully formatted prompt string (should include <image> tags if images are provided)
+    /// * `images` - Vector of RGB images (`Vec<Image<u8, 3, A>>`) to use for captioning
+    /// * `sample_len` - The maximum number of tokens to generate
+    /// * `_alloc` - The image allocator to use (unused)
+    /// * `debug` - Whether to enable debug output
+    ///
+    /// # Returns
+    ///
+    /// * `Result<String, SmolVlm2Error>` - The generated caption or error
+    pub fn inference_raw<A: ImageAllocator>(
+        &mut self,
+        full_prompt: &str,
+        images: Vec<Image<u8, 3, A>>,
+        sample_len: usize, // per prompt
+        _alloc: A,
+        debug: bool,
+    ) -> Result<String, SmolVlm2Error> {
+        if debug {
+            std::io::stdout().flush()?;
+        }
+
+        self.response.clear();
+
+        let image_tags_pos: Vec<_> = full_prompt.match_indices("<image>").collect();
+
+        if image_tags_pos.len() != images.len() {
+            return Err(SmolVlm2Error::MismatchedImageCount {
+                tags: image_tags_pos.len(),
+                images: images.len(),
+            });
+        }
+
+        let mut delta_token = self.txt_processor.encode_all(full_prompt)?;
+
+        if debug {
+            debug!("Initial tokens: {delta_token:?}");
+        }
+        let start_gen = if debug { Some(Instant::now()) } else { None };
+        let mut generated_tokens = 0usize;
+
+        for _i in 0..sample_len {
+            let input = Tensor::from_slice(&delta_token, &[delta_token.len()], &self.device)?;
+            let logits = self.model.forward(&input, self.index_pos)?;
+            let out_token = self.txt_processor.sample_logits(&logits)?;
+
+            self.index_pos += delta_token.len();
+            delta_token.clear();
+            delta_token.push(out_token);
+
+            let token_output = self.txt_processor.decode(out_token)?;
+            self.txt_processor
+                .update_last_textual_response(token_output.clone())?;
+
+            if !self.txt_processor.is_eos(token_output.as_str()) {
+                self.response += &token_output;
+
+                if debug {
+                    generated_tokens += 1;
+                    print!("{token_output}");
+                    std::io::stdout().flush()?;
+                }
+            } else {
+                if debug {
+                    println!();
+                    std::io::stdout().flush()?;
+                }
+                break;
+            }
+        }
+
+        if debug {
+            if let Some(start_gen) = start_gen {
+                let dt = start_gen.elapsed();
+                println!(
+                    "\n{generated_tokens} tokens generated ({:.2} token/s)",
+                    generated_tokens as f64 / dt.as_secs_f64(),
+                );
+
+                debug!("Generated text: {:?}", self.response);
+            }
+        }
+
+        self.txt_processor.add_textual_response(&self.response)?;
+
+        Ok(self.response.clone())
+    }
+
+    fn load_model(
+        config: SmolVlm2Config,
+        dtype: DType,
+        device: &Device,
+    ) -> Result<(model::Model, TextProcessor), SmolVlm2Error> {
+        let txt_processor = TextProcessor::new(Self::MODEL_IDENTIFIER.into(), config)?;
+
+        let api = Api::new()?;
+        let repo = api.model(Self::MODEL_IDENTIFIER.to_string());
+
+        let w1 = repo.get("model-00001-of-00002.safetensors")?;
+        let w2 = repo.get("model-00002-of-00002.safetensors")?;
+
+        let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[w1, w2], dtype, device)? };
+
+        model::Model::load(vb, dtype, device)
+            .map_err(SmolVlm2Error::CandleError)
+            .map(|m| (m, txt_processor))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use kornia_tensor::CpuAllocator;
+
+    use super::*;
+
+    // cargo test -p kornia-vlm test_smolvlm2_text_inference --features cuda -- --nocapture --ignored
+    #[test]
+    #[ignore = "Requires CUDA"]
+    fn test_smolvlm2_text_inference() {
+        let config = SmolVlm2Config {
+            seed: 42,
+            do_sample: false,
+            ..Default::default()
+        };
+        let mut model = SmolVlm2::new(config).unwrap();
+
+        let prompt = "What is life?";
+        let sample_len = 500;
+
+        let _response = model
+            .inference(prompt, None, sample_len, CpuAllocator, true)
+            .expect("Inference failed");
+    }
+}

--- a/crates/kornia-vlm/src/smolvlm2/model.rs
+++ b/crates/kornia-vlm/src/smolvlm2/model.rs
@@ -1,0 +1,227 @@
+use candle_core::{DType, Device, IndexOp, Result, Tensor};
+use candle_nn::{Linear, Module, VarBuilder};
+use candle_transformers::models::{
+    llama::{self, Cache},
+    siglip,
+};
+use log::debug;
+
+use crate::context::InferenceContext;
+
+pub struct Connector {
+    modality_proj: Linear,
+}
+
+impl Connector {
+    const SCALE_FACTOR: usize = 3;
+    const HEIGHT: usize = 27;
+    const WIDTH: usize = 27;
+
+    fn pixel_shuffle(&self, x: &Tensor) -> Result<Tensor> {
+        let (batch, patches, embed_dim) = x.dims3()?; // patches == HEIGHT*WIDTH
+
+        // B,P,E => B,H,W,E => B,H/S,S,W/S,S,E => B,H/S,W/S,S,S,E => B,P/S^2,S^2*E
+        x.reshape(&[batch, Self::HEIGHT, Self::WIDTH, embed_dim])?
+            .reshape(&[
+                batch,
+                Self::HEIGHT / Self::SCALE_FACTOR,
+                Self::SCALE_FACTOR,
+                Self::WIDTH / Self::SCALE_FACTOR,
+                Self::SCALE_FACTOR,
+                embed_dim,
+            ])?
+            .permute([0, 1, 3, 2, 4, 5])?
+            .reshape(&[
+                batch,
+                patches / (Self::SCALE_FACTOR * Self::SCALE_FACTOR),
+                embed_dim * Self::SCALE_FACTOR * Self::SCALE_FACTOR,
+            ])
+    }
+
+    pub fn forward(&self, image_hidden_states: &Tensor) -> Result<Tensor> {
+        let image_hidden_states = self.pixel_shuffle(image_hidden_states)?;
+        self.modality_proj.forward(&image_hidden_states)
+    }
+}
+
+pub struct Model {
+    text_model: candle_transformers::models::llama::Llama,
+    connector: Connector,
+    vision_model: candle_transformers::models::siglip::VisionModel,
+
+    // TODO: move these caching into inference context
+    cache_dtype: DType,
+    cache_device: Device,
+    cache: Cache,
+
+    merged_embeds: Vec<Tensor>, // cache results
+}
+
+impl Model {
+    const HIDDEN_SIZE: usize = 2048;
+    const VOCAB_SIZE: usize = 49280;
+    const TEXT_CONFIG: llama::Config = llama::Config {
+        vocab_size: Self::VOCAB_SIZE,
+        max_position_embeddings: 16384,
+        num_attention_heads: 32,
+        num_hidden_layers: 24,
+        intermediate_size: 8192,
+        hidden_size: Self::HIDDEN_SIZE,
+        num_key_value_heads: 32,
+        use_flash_attn: false,
+        rms_norm_eps: 1e-5,
+        rope_theta: 273768.0,
+        bos_token_id: None,
+        eos_token_id: None,
+        rope_scaling: None,
+        tie_word_embeddings: false,
+    };
+    const VISION_CONFIG: siglip::VisionConfig = siglip::VisionConfig {
+        hidden_size: 1152,
+        intermediate_size: 4304,
+        num_hidden_layers: 27,
+        num_attention_heads: 16,
+        num_channels: 3,
+        image_size: 384,
+        patch_size: 14,
+        hidden_act: candle_nn::Activation::GeluPytorchTanh,
+        layer_norm_eps: 1e-6,
+    };
+
+    pub fn load(vb: VarBuilder, dtype: DType, device: &Device) -> Result<Self> {
+        let vb = vb.rename_f(|f: &str| {
+            if let Some(rest) = f.strip_prefix("model.text_model.model") {
+                // exact `model.text_model.model` -> `model.text_model`
+                if rest.is_empty() {
+                    return "model.text_model".to_string();
+                }
+                // keep the leading dot from rest (e.g. ".layers.0...")
+                if rest.starts_with('.') {
+                    return format!("model.text_model{}", rest);
+                }
+            }
+
+            if f == "model.text_model.lm_head.weight" {
+                return "lm_head.weight".to_string();
+            }
+
+            f.to_string()
+        });
+
+        Ok(Self {
+            text_model: candle_transformers::models::llama::Llama::load(
+                vb.pp("model.text_model"),
+                &Self::TEXT_CONFIG,
+            )?,
+            connector: Connector {
+                modality_proj: candle_nn::linear_no_bias(
+                    10368,
+                    Self::HIDDEN_SIZE,
+                    vb.pp("model.connector.modality_projection.proj"),
+                )?,
+            },
+            vision_model: candle_transformers::models::siglip::VisionModel::new(
+                &Self::VISION_CONFIG,
+                false,
+                vb.pp("model.vision_model"),
+            )?,
+            cache_device: device.clone(),
+            cache_dtype: dtype,
+            cache: Cache::new(true, dtype, &Self::TEXT_CONFIG, device)?,
+
+            merged_embeds: Vec::new(),
+        })
+    }
+
+    fn inputs_merger(
+        &mut self,
+        image_token_mask: &Tensor,
+        image_hidden_states: &Tensor,
+        inputs_embeds: &Tensor,
+    ) -> Result<Tensor> {
+        let total_length = image_token_mask.dims1()?;
+
+        self.merged_embeds.clear();
+        if self.merged_embeds.capacity() < total_length {
+            self.merged_embeds
+                .reserve(total_length - self.merged_embeds.capacity());
+        }
+
+        let mut c = 0;
+        // TODO: is there a better way to do this? (scatter assignment? cuda kernel?)
+        for (i, mask) in image_token_mask.to_vec1::<u8>()?.into_iter().enumerate() {
+            self.merged_embeds.push(if mask != 0 {
+                c += 1;
+                image_hidden_states.i(c - 1)?
+            } else {
+                inputs_embeds.i(i)?
+            });
+        }
+
+        let merged_embeds = Tensor::stack(&self.merged_embeds, 0)?;
+
+        Ok(merged_embeds)
+    }
+
+    pub fn forward(
+        &mut self,
+        xs: &Tensor,
+        index_pos: usize,
+        image_token_mask: &Tensor,
+        image_data: Vec<(&Tensor, &Tensor)>,
+        ctx: &mut InferenceContext,
+    ) -> Result<Tensor> {
+        let input_embeds = self.text_model.embed(xs)?;
+
+        let mut agg_image_hidden_states = vec![];
+        for (pixel_values, _pixel_attention_masks) in image_data {
+            let image_hidden_states = self.vision_model.forward(pixel_values)?;
+
+            let image_hidden_states = self.connector.forward(&image_hidden_states)?;
+            let image_hidden_states = image_hidden_states.flatten(0, 1)?;
+            agg_image_hidden_states.push(image_hidden_states);
+
+            if ctx.debug {
+                debug!(
+                    "[Sub-image] image_hidden_states length: {}",
+                    if let Some(el) = agg_image_hidden_states.last() {
+                        format!("{}", el.dims2()?.0)
+                    } else {
+                        "<No hidden image states>".to_string()
+                    }
+                );
+            }
+
+            ctx.vis_introspector.increment_batch_pos();
+        }
+
+        let input_embeds = if !agg_image_hidden_states.is_empty() {
+            let image_hidden = Tensor::cat(&agg_image_hidden_states, 0)?;
+            self.inputs_merger(image_token_mask, &image_hidden, &input_embeds)?
+                .unsqueeze(0)?
+        } else {
+            // No images to process, return original embeddings
+            input_embeds.unsqueeze(0)?
+        };
+
+        let out = self
+            .text_model
+            .forward_input_embed(&input_embeds, index_pos, &mut self.cache)?;
+
+        if out.dims().len() == 3 {
+            Ok(out.squeeze(0)?)
+        } else {
+            Ok(out)
+        }
+    }
+
+    pub fn clear_context(&mut self) -> Result<()> {
+        self.cache = Cache::new(
+            true,
+            self.cache_dtype,
+            &Self::TEXT_CONFIG,
+            &self.cache_device,
+        )?;
+        Ok(())
+    }
+}

--- a/crates/kornia-vlm/src/smolvlm2/text_processor.rs
+++ b/crates/kornia-vlm/src/smolvlm2/text_processor.rs
@@ -1,0 +1,547 @@
+/*
+    To convert a user-friendly structured input into raw tokens for direct model usage.
+    This version of text preprocessing uses a more widely used and flexible approach: Jinja2 templating.
+*/
+
+use std::fs;
+
+use candle_core::{DType, IndexOp, Tensor};
+use candle_transformers::generation::{LogitsProcessor, Sampling};
+use hf_hub::api::sync::Api;
+use minijinja::{context, AutoEscape, Environment};
+use serde::Serialize;
+use tokenizers::Tokenizer;
+
+use crate::smolvlm2::{SmolVlm2Config, SmolVlm2Error};
+
+#[allow(dead_code)] // TODO: remove
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum Role {
+    User,      // prompt
+    Assistant, // the model's response
+    System,
+}
+
+#[allow(dead_code)] // TODO: remove
+#[derive(Serialize, Debug, Clone)]
+#[serde(tag = "type")]
+#[serde(rename_all = "lowercase")]
+pub enum Line {
+    Text { text: String },
+    Image,
+}
+
+#[derive(Serialize, Debug, Clone)]
+pub struct Message {
+    pub role: Role,
+    pub content: Vec<Line>,
+}
+
+pub struct TextProcessor {
+    tokenizer: Tokenizer,
+
+    env: Environment<'static>,
+    message_history: Vec<Message>,
+    formatted_history: String, // result of applying messages onto a template
+    token_history: Vec<u32>,   // stores the history of generated tokens
+    // note: refreshes at every add new message, and updates for every new logits sampled
+    config: SmolVlm2Config,
+    logits_processor: LogitsProcessor,
+    previously_added_generation_prompt: bool, // assumes add generation prompt pre-emptively adds an assistant prompt
+
+    eos_token: String,
+}
+
+impl TextProcessor {
+    pub fn new(identifier: String, config: SmolVlm2Config) -> Result<Self, SmolVlm2Error> {
+        let logits_processor = if config.do_sample {
+            LogitsProcessor::new(config.seed, Some(config.temp), Some(config.top_p))
+        } else {
+            LogitsProcessor::from_sampling(config.seed, Sampling::ArgMax)
+        };
+
+        let api = Api::new()?;
+        let repo = api.model(identifier.clone());
+
+        let path = repo.get("tokenizer_config.json")?;
+        let data = fs::read_to_string(path.clone())?;
+        let tokenizer_config = serde_json::from_str::<serde_json::Value>(&data)?;
+        let template_str = tokenizer_config["chat_template"]
+            .as_str()
+            .ok_or(SmolVlm2Error::MissingChatTemplate(
+                path.to_string_lossy().into_owned(),
+            ))?
+            .to_owned();
+
+        let mut env = Environment::new();
+
+        // disable auto-escaping (we're producing a plain text prompt, not HTML)
+        env.set_auto_escape_callback(|_| AutoEscape::None);
+        env.add_template_owned("chat", template_str)?;
+
+        let eos_token = tokenizer_config["eos_token"]
+            .as_str()
+            .ok_or(SmolVlm2Error::EosTokenNotFound)?
+            .to_string();
+
+        Ok(Self {
+            tokenizer: Tokenizer::from_pretrained(identifier, None)?,
+
+            env,
+            message_history: Vec::new(),
+            formatted_history: String::new(),
+            token_history: Vec::new(),
+            config,
+            logits_processor,
+            previously_added_generation_prompt: false,
+
+            eos_token,
+        })
+    }
+
+    pub fn is_eos(&self, token: &str) -> bool {
+        token == self.eos_token
+    }
+
+    /// Add prompts (enable generation prompt) to the history, format them using the template,
+    /// and return the formatted string.
+    pub fn reformat_with_additional_prompts(
+        &mut self,
+        additional_messages: Vec<Message>,
+        delta: bool,
+    ) -> Result<String, SmolVlm2Error> {
+        self.reformat_with_additional_raw_messages(additional_messages, true, delta)
+    }
+
+    /// Record the generated text into the message history from text-only assistant response.
+    pub fn add_textual_response<S: Into<String>>(
+        &mut self,
+        textual_response: S,
+    ) -> Result<(), SmolVlm2Error> {
+        self.reformat_with_additional_raw_messages(
+            vec![Message {
+                role: Role::Assistant,
+                content: vec![Line::Text {
+                    text: textual_response.into(),
+                }],
+            }],
+            false,
+            false,
+        )
+        .map(|_| ())
+    }
+
+    /// Record the generated text a set of token by a set of token into the message
+    /// history from text-only assistant response.
+    pub fn update_last_textual_response<S: Into<String> + Clone>(
+        &mut self,
+        textual_response: S,
+    ) -> Result<(), SmolVlm2Error> {
+        if let Some(Message {
+            role: Role::Assistant,
+            content,
+        }) = self.message_history.last_mut()
+        {
+            if let Some(Line::Text { text }) = content.last_mut() {
+                text.push_str(&textual_response.clone().into());
+            } else {
+                content.push(Line::Text {
+                    text: textual_response.clone().into(),
+                });
+            }
+
+            let tokens = self.encode_all(&textual_response.clone().into())?;
+
+            self.formatted_history.push_str(&textual_response.into());
+            self.token_history.extend(tokens);
+        } else {
+            self.add_textual_response(textual_response)?;
+        }
+
+        self.previously_added_generation_prompt = false;
+
+        Ok(())
+    }
+
+    /// Generalized method to add and return the formatted tokenized messages.
+    /// # Arguments
+    ///
+    /// * `additional_messages` - The messages to add
+    /// * `add_generation_prompt` - Whether to add the generation prompt at the end (note: )
+    /// * `delta` - Whether to return only the newly added part of the formatted string
+    pub fn reformat_with_additional_raw_messages(
+        &mut self,
+        additional_messages: Vec<Message>,
+        add_generation_prompt: bool,
+        delta: bool,
+    ) -> Result<String, SmolVlm2Error> {
+        if let Some(Message { role, content: _ }) = additional_messages.last() {
+            if let Role::Assistant = role {
+            } else if self.previously_added_generation_prompt {
+                // if the last message is not from the assistant yet we supposedly added a generation prompt?
+                return Err(SmolVlm2Error::MessageHistoryMismatch(
+                    "Cannot add non-assistant message after adding a (generation) prompt"
+                        .to_string(),
+                ));
+            }
+        }
+
+        let template = self.env.get_template("chat")?;
+
+        self.message_history.extend(additional_messages);
+
+        let formatted = template.render(context! {
+            messages => &self.message_history,
+            add_generation_prompt => add_generation_prompt,
+        })?;
+        self.previously_added_generation_prompt = add_generation_prompt;
+
+        let tokens = self.encode_all(&formatted)?;
+
+        let formatted_old_end_ind = self.formatted_history.len();
+
+        self.formatted_history.clear();
+        self.formatted_history.push_str(&formatted);
+        self.token_history.clear();
+        self.token_history.extend(tokens);
+
+        if delta {
+            let new_formatted = self.formatted_history[formatted_old_end_ind..].to_string();
+            Ok(new_formatted)
+        } else {
+            Ok(self.formatted_history.clone())
+        }
+    }
+
+    pub fn decode(&self, encoding: u32) -> Result<String, SmolVlm2Error> {
+        self.decode_all(vec![encoding])
+    }
+
+    pub fn encode_all(&self, text: &str) -> Result<Vec<u32>, SmolVlm2Error> {
+        let encoding = self.tokenizer.encode(text, true)?;
+        Ok(encoding.get_ids().to_vec())
+    }
+
+    pub fn decode_all(&self, encodings: Vec<u32>) -> Result<String, SmolVlm2Error> {
+        Ok(self.tokenizer.decode(&encodings, false)?)
+    }
+
+    pub fn clear_history(&mut self) {
+        self.message_history.clear();
+        self.formatted_history.clear();
+    }
+
+    pub fn sample_logits(&mut self, raw_logits: &Tensor) -> Result<u32, SmolVlm2Error> {
+        let (s, _embed_dim) = raw_logits.dims2()?;
+        let last_logit = raw_logits.i((s - 1, ..))?;
+
+        let output_logit = if self.config.do_sample {
+            let start_at = self
+                .token_history
+                .len()
+                .saturating_sub(self.config.repeat_last_n);
+            candle_transformers::utils::apply_repeat_penalty(
+                &last_logit,
+                self.config.repeat_penalty,
+                &self.token_history[start_at..],
+            )?
+        } else {
+            last_logit
+        };
+
+        if self.has_non_finite(&output_logit)? {
+            Err(SmolVlm2Error::InvalidLogits(
+                "Non-finite values (NaN or +/-Inf) found in logits".to_string(),
+            ))
+        } else {
+            let out_token = self.logits_processor.sample(&output_logit)?;
+
+            Ok(out_token)
+        }
+    }
+
+    /// Return true if any element in `logits` is not finite (NaN or +/-Inf).
+    fn has_non_finite(&self, logits: &Tensor) -> Result<bool, SmolVlm2Error> {
+        let logits_vec = logits.to_dtype(DType::F32)?.to_vec1::<f32>()?;
+        Ok(logits_vec.iter().any(|&v| !v.is_finite()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[ignore = "Requires downloading config files from HuggingFace"]
+    fn test_text_rendering() {
+        let mut preprocessor = TextProcessor::new(
+            "HuggingFaceTB/SmolVLM2-2.2B-Instruct".to_string(),
+            SmolVlm2Config {
+                do_sample: false,
+                seed: 42,
+                temp: 1.0,
+                top_p: 0.9,
+                repeat_penalty: 1.0,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let formatted = preprocessor
+            .reformat_with_additional_prompts(
+                vec![Message {
+                    role: Role::User,
+                    content: vec![Line::Text {
+                        text: "What is life?".to_string(),
+                    }],
+                }],
+                true,
+            )
+            .unwrap();
+        preprocessor.add_textual_response("").unwrap();
+
+        assert_eq!(
+            formatted,
+            "<|im_start|>User: What is life?<end_of_utterance>\nAssistant:"
+        );
+
+        let formatted = preprocessor
+            .reformat_with_additional_prompts(
+                vec![Message {
+                    role: Role::User,
+                    content: vec![
+                        Line::Image,
+                        Line::Text {
+                            text: "Describe the image.".to_string(),
+                        },
+                    ],
+                }],
+                true,
+            )
+            .unwrap();
+        preprocessor.add_textual_response("").unwrap();
+
+        assert_eq!(
+            formatted,
+            "User:<image>Describe the image.<end_of_utterance>\nAssistant:"
+        );
+
+        let formatted = preprocessor
+            .reformat_with_additional_prompts(
+                vec![Message {
+                    role: Role::User,
+                    content: vec![
+                        Line::Image,
+                        Line::Image,
+                        Line::Image,
+                        Line::Text {
+                            text: "Describe the images.".to_string(),
+                        },
+                    ],
+                }],
+                true,
+            )
+            .unwrap();
+        preprocessor.add_textual_response("").unwrap();
+
+        assert_eq!(
+            formatted,
+            "User:<image><image><image>Describe the images.<end_of_utterance>\nAssistant:"
+        );
+
+        let formatted = preprocessor
+            .reformat_with_additional_prompts(
+                vec![
+                    Message {
+                        role: Role::User,
+                        content: vec![
+                            Line::Image,
+                            Line::Text {
+                                text: "Describe the images.".to_string(),
+                            },
+                        ],
+                    },
+                    Message {
+                        role: Role::Assistant,
+                        content: vec![Line::Text {
+                            text: "The image is beautiful!".to_string(),
+                        }],
+                    },
+                    Message {
+                        role: Role::User,
+                        content: vec![Line::Text {
+                            text: "How so?".to_string(),
+                        }],
+                    },
+                ],
+                true,
+            )
+            .unwrap();
+        preprocessor.add_textual_response("").unwrap();
+
+        assert_eq!(
+            formatted,
+            "User:<image>Describe the images.<end_of_utterance>\nAssistant: The image is beautiful!<end_of_utterance>\nUser: How so?<end_of_utterance>\nAssistant:"
+        );
+
+        preprocessor.clear_history();
+
+        let formatted = preprocessor
+            .reformat_with_additional_prompts(
+                vec![Message {
+                    role: Role::User,
+                    content: vec![
+                        Line::Image,
+                        Line::Text {
+                            text: "Misc".to_string(),
+                        },
+                    ],
+                }],
+                true,
+            )
+            .unwrap();
+
+        assert_eq!(
+            formatted,
+            "<|im_start|>User:<image>Misc<end_of_utterance>\nAssistant:"
+        );
+
+        preprocessor.clear_history();
+
+        let formatted = preprocessor
+            .reformat_with_additional_prompts(
+                vec![
+                    Message {
+                        role: Role::User,
+                        content: vec![
+                            Line::Image,
+                            Line::Text {
+                                text: "Misc".to_string(),
+                            },
+                        ],
+                    },
+                    Message {
+                        role: Role::User,
+                        content: vec![
+                            Line::Image,
+                            Line::Text {
+                                text: "Misc again.".to_string(),
+                            },
+                        ],
+                    },
+                ],
+                true,
+            )
+            .unwrap();
+
+        assert_eq!(
+            formatted,
+            "<|im_start|>User:<image>Misc<end_of_utterance>\nUser:<image>Misc again.<end_of_utterance>\nAssistant:"
+        );
+    }
+
+    #[test]
+    #[ignore = "Requires downloading config files from HuggingFace"]
+    fn test_add_generation_prompt_after_assistant() {
+        let mut preprocessor = TextProcessor::new(
+            "HuggingFaceTB/SmolVLM2-2.2B-Instruct".to_string(),
+            SmolVlm2Config {
+                seed: 42,
+                temp: 1.0,
+                top_p: 0.9,
+                repeat_penalty: 1.0,
+                do_sample: false,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let formatted = preprocessor
+            .reformat_with_additional_prompts(
+                vec![Message {
+                    role: Role::Assistant,
+                    content: vec![Line::Text {
+                        text: "This is a wonderful world!".to_string(),
+                    }],
+                }],
+                true,
+            )
+            .unwrap();
+
+        assert_eq!(
+            formatted,
+            "<|im_start|>Assistant: This is a wonderful world!<end_of_utterance>\nAssistant:"
+        );
+    }
+
+    #[test]
+    #[ignore = "Requires downloading config files from HuggingFace"]
+    fn test_add_no_message() {
+        let mut preprocessor = TextProcessor::new(
+            "HuggingFaceTB/SmolVLM2-2.2B-Instruct".to_string(),
+            SmolVlm2Config {
+                seed: 42,
+                temp: 1.0,
+                top_p: 0.9,
+                repeat_penalty: 1.0,
+                do_sample: false,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let formatted = preprocessor
+            .reformat_with_additional_prompts(vec![], true)
+            .unwrap();
+
+        assert_eq!(formatted, "<|im_start|>Assistant:");
+    }
+
+    #[test]
+    #[ignore = "Requires downloading config files from HuggingFace"]
+    fn test_add_non_assistant_after_generation_prompt() {
+        let mut preprocessor = TextProcessor::new(
+            "HuggingFaceTB/SmolVLM2-2.2B-Instruct".to_string(),
+            SmolVlm2Config {
+                seed: 42,
+                temp: 1.0,
+                top_p: 0.9,
+                repeat_penalty: 1.0,
+                do_sample: false,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let formatted = preprocessor
+            .reformat_with_additional_prompts(
+                vec![Message {
+                    role: Role::User,
+                    content: vec![Line::Text {
+                        text: "What a beautiful day!".to_string(),
+                    }],
+                }],
+                true,
+            )
+            .unwrap();
+
+        assert_eq!(
+            formatted,
+            "<|im_start|>User: What a beautiful day!<end_of_utterance>\nAssistant:"
+        );
+        let err = preprocessor
+            .reformat_with_additional_prompts(
+                vec![Message {
+                    role: Role::User,
+                    content: vec![Line::Text {
+                        text: "This should fail.".to_string(),
+                    }],
+                }],
+                true,
+            )
+            .unwrap_err();
+
+        assert!(matches!(err, SmolVlm2Error::MessageHistoryMismatch(_)));
+    }
+}


### PR DESCRIPTION
Has the similiar numerical precision issue from the original SmolVLM. Will make a fine first implementation in Rust.

Initial validation results:
MMStar      | Kornia                 | Python 
-----------------------|  ------------------- |  -----
Overall        |           0.43133333333333335 |  0.456
coarse perception    |     0.616       |           0.624
fine-grained perception  | 0.364    |              0.364
instance reasoning  |      0.532            |      0.556
logical reasoning     |    0.464          |        0.428
math                   |   0.36              |     0.436
science & technology   |   0.252    |             0.328


Old: #500 