### PR TITLE
incorrect sign in so2 hat function

### DIFF
--- a/crates/kornia-lie/src/so2.rs
+++ b/crates/kornia-lie/src/so2.rs
@@ -95,11 +95,11 @@ impl SO2 {
     }
 
     pub fn hat(theta: f32) -> Mat2 {
-        Mat2::from_cols_array(&[0.0, theta, theta, 0.0])
+        Mat2::from_cols_array(&[0.0, theta, -theta, 0.0])
     }
 
     pub fn vee(omega: Mat2) -> f32 {
-        omega.y_axis.x
+        omega.x_axis.y
     }
 
     /// Left Jacobian of SO(2).
@@ -296,7 +296,7 @@ mod tests {
     #[test]
     fn test_hat() {
         let theta = 0.5;
-        let expected = Mat2::from_cols_array(&[0.0, 0.5, 0.5, 0.0]);
+        let expected = Mat2::from_cols_array(&[0.0, 0.5, -0.5, 0.0]);
         let actual = SO2::hat(theta);
 
         for i in 0..2 {
@@ -309,7 +309,7 @@ mod tests {
         let hat_matrix = SO2::hat(theta);
         assert_relative_eq!(hat_matrix.x_axis.x, 0.0);
         assert_relative_eq!(hat_matrix.y_axis.y, 0.0);
-        assert_relative_eq!(hat_matrix.x_axis.y, hat_matrix.y_axis.x);
+        assert_relative_eq!(hat_matrix.x_axis.y, -hat_matrix.y_axis.x);
     }
 
     #[test]


### PR DESCRIPTION
# SO(2) Hat and Vee Functions — Changes Summary

**Original Functions:**

```rust
pub fn hat(theta: f32) -> Mat2 { 
    Mat2::from_cols_array(&[0.0, theta, theta, 0.0]) 
}

pub fn vee(omega: Mat2) -> f32 { 
    omega.y_axis.x 
}
````

**Issues Identified:**

1. `hat` had the **wrong sign** on the off-diagonal element.
   Correct SO(2) hat matrix is:

   ```
   [ 0   -θ ]
   [ θ    0 ]
   ```
2. `vee` extracted the **wrong element**, returning `-θ` instead of `θ`.

**Corrected Functions:**

```rust
pub fn hat(theta: f32) -> Mat2 {
    Mat2::from_cols_array(&[0.0, theta, -theta, 0.0])
}

pub fn vee(omega: Mat2) -> f32 {
    omega.x_axis.y
}
```

**Summary of Changes:**

* Fixed `hat` to produce a proper skew-symmetric matrix for SO(2).
* Fixed `vee` to correctly recover the angle `θ` from the skew-symmetric matrix.