### PR TITLE
perf: removed SVD for a more specialized solver

### DIFF
--- a/crates/kornia-pnp/src/epnp.rs
+++ b/crates/kornia-pnp/src/epnp.rs
@@ -100,14 +100,12 @@ pub fn solve_epnp(
 
     value_index_pairs.sort_by(|a, b| a.0.total_cmp(&b.0));
 
-    let null4 = DMatrix::from_columns(
-        &value_index_pairs
-            .iter()
-            .rev()
-            .take(4)
-            .map(|&(_, idx)| eigenvectors.column(idx))
-            .collect::<Vec<_>>(),
-    );
+    let null4 = DMatrix::from_columns(&[
+        eigenvectors.column(value_index_pairs[3].1),
+        eigenvectors.column(value_index_pairs[2].1),
+        eigenvectors.column(value_index_pairs[1].1),
+        eigenvectors.column(value_index_pairs[0].1),
+    ]);
 
     // Build helper matrices for beta initialisation
     let l = build_l6x10(&null4);


### PR DESCRIPTION
# **Title: Perf: 1.46x speedup in EPnP null space by replacing SVD**

### What this PR does

This PR optimizes the 12x12 null space extraction inside the `solve_epnp` function by replacing the computationally expensive `mtm.svd()` with `mtm.symmetric_eigen()`.

### Why this change is needed

The $M^T M$ matrix (`mtm`) is symmetric, so a full SVD is unnecessary. `symmetric_eigen` is a much faster algorithm for this specific case. However, this is not a simple 1:1 replacement.

The `symmetric_eigen()` function in `nalgebra` returns **unsorted** eigenvalues. This PR introduces the necessary logic to:
1.  Pair the unsorted eigenvalues with their original indices.
2.  Manually sort the pairs to find the 4 smallest eigenvalues (the null space).
3.  Re-assemble the `null4` matrix in the specific column order `[4th_smallest, 3rd_smallest, 2nd_smallest, 1st_smallest]`. This is critical to match the order that the previous `svd()` implementation provided, which the downstream `build_l6x10` function expects.

### Performance Impact

This change results in a **1.46x speedup** (a 31.6% time reduction) for the null space extraction step, as shown by the `Null Space Extraction (12x12)` benchmark:

| Method | Time (Mean) |
| :--- | :--- |
| Original (SVD) | 17.594 µs |
| **Optimized (Eigen + Sort)** | **12.038 µs** |

---

### Benchmark Script 
The following script was used to verify correctness and measure performance.

```rust
use std::hint::black_box;
use criterion::{criterion_group, criterion_main, Criterion};
use nalgebra::DMatrix;
fn nullspace_svd(mtm: &DMatrix<f32>) -> DMatrix<f32> {
    let svd = mtm.clone().svd(true, true);
    let u = svd.u.unwrap();
    let cols = u.ncols();
    let start_col = cols - 4; // Selects last 4 columns (8, 9, 10, 11)
    u.columns(start_col, 4).into_owned()
}

fn nullspace_eigen_sort(mtm: &DMatrix<f32>) -> DMatrix<f32> {
    let eig = mtm.clone().symmetric_eigen();

    let eigenvalues = eig.eigenvalues;
    let eigenvectors = eig.eigenvectors;

    let mut value_index_pairs: Vec<(f32, usize)> = eigenvalues
        .iter()
        .cloned()
        .enumerate()
        .map(|(index, value)| (value.abs(), index)) // Pair value with its index
        .collect();

    // 2. Sort the list by the eigenvalue, from smallest to largest
    value_index_pairs.sort_by(|a, b| a.0.total_cmp(&b.0));

    // 3. Build the 12x4 null4 matrix in the order SVD provided
    DMatrix::from_columns(&[
        eigenvectors.column(value_index_pairs[3].1), // 4th smallest
        eigenvectors.column(value_index_pairs[2].1), // 3rd smallest
        eigenvectors.column(value_index_pairs[1].1), // 2nd smallest
        eigenvectors.column(value_index_pairs[0].1), // 1st smallest
    ])
}

fn setup_data() -> DMatrix<f32> {
    let m = DMatrix::<f32>::from_fn(12, 12, |_, _| rand::random::<f32>() - 0.5);
    m.transpose() * m
}

fn bench_nullspace_extraction(c: &mut Criterion) {
    let mtm = setup_data();

    let null4_svd = nullspace_svd(&mtm);
    let null4_eigen = nullspace_eigen_sort(&mtm);

    let mut all_match = true;
    for i in 0..4 {
        let col_svd = null4_svd.column(i);
        let col_eig = null4_eigen.column(i);
        
        let diff_norm = (col_svd - col_eig).norm();
        let diff_flipped_norm = (col_svd + col_eig).norm();

        if diff_norm.min(diff_flipped_norm) > 1e-3 {
            all_match = false;
            break;
        }
    }
    
    assert!(all_match, "Verification failed! The eigenvector matrices do not match.");
    println!("Verification successful: SVD and Eigen+Sort methods produce the same null space.");

    let mut group = c.benchmark_group("Null Space Extraction (12x12)");

    group.bench_function("Original (SVD)", |b| {
        b.iter(|| nullspace_svd(black_box(&mtm)))
    });

    group.bench_function("Optimized (Eigen + Manual Sort)", |b| {
        b.iter(|| nullspace_eigen_sort(black_box(&mtm)))
    });

    group.finish();
}

criterion_group!(benches, bench_nullspace_extraction);
criterion_main!(benches);