### PR TITLE
corrected Bresenham circle offsets in FAST feature detector

### DIFF
--- a/crates/kornia-imgproc/src/features/fast.rs
+++ b/crates/kornia-imgproc/src/features/fast.rs
@@ -21,23 +21,23 @@ pub fn fast_feature_detector<A: ImageAllocator>(
 
     // Precompute the offsets for the Bresenham circle
     let offsets = [
-            -3 * cols,     // 1: (0, -3)
-            -3 * cols + 1, // 2: (1, -3)
-            -2 * cols + 2, // 3: (2, -2)
-            -cols + 3,     // 4: (3, -1)
-            3,             // 5: (3, 0)
-            cols + 3,      // 6: (3, 1)
-            2 * cols + 2,  // 7: (2, 2)
-            3 * cols + 1,  // 8: (1, 3)
-            3 * cols,      // 9: (0, 3)
-            3 * cols - 1,  // 10: (-1, 3)
-            2 * cols - 2,  // 11: (-2, 2)
-            cols - 3,      // 12: (-3, 1)
-            -3,            // 13: (-3, 0)
-            -cols - 3,     // 14: (-3, -1)
-            -2 * cols - 2, // 15: (-2, -2)
-            -3 * cols - 1, // 16: (-1, -3)
-        ];
+        -3 * cols,     // 1: (0, -3)
+        -3 * cols + 1, // 2: (1, -3)
+        -2 * cols + 2, // 3: (2, -2)
+        -cols + 3,     // 4: (3, -1)
+        3,             // 5: (3, 0)
+        cols + 3,      // 6: (3, 1)
+        2 * cols + 2,  // 7: (2, 2)
+        3 * cols + 1,  // 8: (1, 3)
+        3 * cols,      // 9: (0, 3)
+        3 * cols - 1,  // 10: (-1, 3)
+        2 * cols - 2,  // 11: (-2, 2)
+        cols - 3,      // 12: (-3, 1)
+        -3,            // 13: (-3, 0)
+        -cols - 3,     // 14: (-3, -1)
+        -2 * cols - 2, // 15: (-2, -2)
+        -3 * cols - 1, // 16: (-1, -3)
+    ];
 
     // Process rows in parallel
     let keypoints = (3..rows - 3)


### PR DESCRIPTION
the old offsets were wrong; there were 2 pairs that were duplicates, namely, 5 and 6 were the same, and 1 and 16 were the same

old offsets - 

    let offsets = [
        -3 * cols,     // 1
        -3 * cols + 1, // 2
        -2 * cols + 2, // 3
        -cols + 3,     // 4
        cols + 3,      // 5
        cols + 3,      // 6
        2 * cols + 2,  // 7
        3 * cols + 1,  // 8
        3 * cols,      // 9
        3 * cols - 1,  // 10
        2 * cols - 2,  // 11
        cols - 3,      // 12
        -cols - 3,     // 13
        -2 * cols - 2, // 14
        -3 * cols - 1, // 15
        -3 * cols,     // 16
    ];

corrected offsets - 

    let offsets = [
            -3 * cols,     // 1: (0, -3)
            -3 * cols + 1, // 2: (1, -3)
            -2 * cols + 2, // 3: (2, -2)
            -cols + 3,     // 4: (3, -1)
            3,             // 5: (3, 0)
            cols + 3,      // 6: (3, 1)
            2 * cols + 2,  // 7: (2, 2)
            3 * cols + 1,  // 8: (1, 3)
            3 * cols,      // 9: (0, 3)
            3 * cols - 1,  // 10: (-1, 3)
            2 * cols - 2,  // 11: (-2, 2)
            cols - 3,      // 12: (-3, 1)
            -3,            // 13: (-3, 0)
            -cols - 3,     // 14: (-3, -1)
            -2 * cols - 2, // 15: (-2, -2)
            -3 * cols - 1, // 16: (-1, -3)
        ];


