### PR TITLE
fix clippy errors

### DIFF
--- a/crates/kornia-icp/src/ops.rs
+++ b/crates/kornia-icp/src/ops.rs
@@ -44,6 +44,7 @@ pub(crate) fn fit_transformation(
     let t = dst_centroid - &rr * src_centroid;
 
     // copy results back to output
+    #[allow(clippy::needless_range_loop)]
     for i in 0..3 {
         for j in 0..3 {
             dst_r_src[i][j] = rr.read(i, j);

--- a/crates/kornia-io/src/v4l/pixel_format.rs
+++ b/crates/kornia-io/src/v4l/pixel_format.rs
@@ -3,9 +3,10 @@ use std::str::FromStr;
 use v4l::FourCC;
 
 /// Supported camera pixel formats
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum PixelFormat {
     /// YUYV 4:2:2 format (uncompressed, good quality, high bandwidth)
+    #[default]
     YUYV,
     /// UYVY 4:2:2 format (uncompressed, good quality, high bandwidth)
     UYVY,
@@ -52,12 +53,6 @@ impl PixelFormat {
             Self::MJPG => None,      // Variable compression
             Self::Custom(_) => None, // Unknown
         }
-    }
-}
-
-impl Default for PixelFormat {
-    fn default() -> Self {
-        Self::YUYV // Most compatible format
     }
 }
 

--- a/crates/kornia-pnp/src/epnp.rs
+++ b/crates/kornia-pnp/src/epnp.rs
@@ -624,6 +624,8 @@ mod solve_epnp_tests {
 
         let mut expected_x = [0.0; 12];
         let mut expected_y = [0.0; 12];
+
+        #[allow(clippy::needless_range_loop)]
         for j in 0..4 {
             let base = 3 * j;
             expected_x[base] = alphas[0][j] * fu;

--- a/crates/kornia-pnp/src/ransac.rs
+++ b/crates/kornia-pnp/src/ransac.rs
@@ -5,7 +5,6 @@ use crate::pnp::{PnPError, PnPResult};
 use crate::{solve_pnp, PnPMethod};
 use glam::{Mat3, Vec3};
 use kornia_imgproc::calibration::distortion::PolynomialDistortion;
-use log::{debug, warn};
 use rand::seq::SliceRandom;
 use rand::{rngs::StdRng, SeedableRng};
 use thiserror::Error;
@@ -142,7 +141,7 @@ pub fn solve_pnp_ransac(
 
         // Debug: prevent infinite loops
         if iter > params.max_iterations {
-            warn!("RANSAC: Emergency break after {} iterations", iter);
+            log::warn!("RANSAC: Emergency break after {iter} iterations");
             break;
         }
 
@@ -163,14 +162,14 @@ pub fn solve_pnp_ransac(
         let pose_min = match pose_maybe {
             Ok(p) => p,
             Err(_e) => {
-                debug!("EPnP failed on minimal set");
+                log::debug!("EPnP failed on minimal set");
                 continue;
             }
         };
 
         // Optional cheirality check on minimal set (all positive depths)
         if !sample_all_positive_depths(&pose_min.rotation, &pose_min.translation, &w_min) {
-            debug!("Cheirality check failed on iteration {}", iter);
+            log::debug!("Cheirality check failed on iteration {iter}");
             continue;
         }
 

--- a/examples/pnp_demo/src/main.rs
+++ b/examples/pnp_demo/src/main.rs
@@ -163,7 +163,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             world_pts.len()
         );
         if let Some(rmse) = ransac_result.pose.reproj_rmse {
-            println!("  RMSE: {:.3} px", rmse);
+            println!("  RMSE: {rmse:.3} px");
         }
         ransac_result.pose
     } else {
@@ -177,7 +177,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )?;
         println!("Direct EPnP:");
         if let Some(rmse) = direct_result.reproj_rmse {
-            println!("  RMSE: {:.3} px", rmse);
+            println!("  RMSE: {rmse:.3} px");
         }
         direct_result
     };
@@ -235,9 +235,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     .sqrt();
 
     println!("\n=== Results ===");
-    println!("Translation error: {:.3} units", trans_error);
+    println!("Translation error: {trans_error:.3} units");
     if let Some(rmse) = result.reproj_rmse {
-        println!("Reprojection RMSE: {:.3} px", rmse);
+        println!("Reprojection RMSE: {rmse:.3} px");
     }
 
     println!("\n=== Configuration ===");

--- a/justfile
+++ b/justfile
@@ -7,7 +7,10 @@
 
 # Check if the code is linting and formatted
 check:
-  @cargo check --workspace --all-targets --all-features --locked
+  @echo "🚀 Checking workspace (excluding kornia-pnp)"
+  @cargo check --workspace --exclude kornia-pnp --all-targets --all-features --locked
+  @echo "🚀 Checking kornia-pnp (without opencv_bench)"
+  @cargo check -p kornia-pnp --all-targets --locked
 
 # Check if the required binaries for the project are installed
 check-environment:
@@ -15,8 +18,10 @@ check-environment:
 
 # Run clippy with all features
 clippy:
-  @echo "🚀 Running clippy"
-  cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+  @echo "🚀 Running clippy on workspace (excluding kornia-pnp)"
+  cargo clippy --workspace --exclude kornia-pnp --all-targets --all-features --locked -- -D warnings
+  @echo "🚀 Running clippy on kornia-pnp (without opencv_bench)"
+  cargo clippy -p kornia-pnp --all-targets --locked -- -D warnings
 
 # Run clippy with default features
 clippy-default:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fix clippy warnings, derive Default for PixelFormat, switch RANSAC logs to log macros, modernize println formatting, and expand justfile tasks.
> 
> - **Lint/Code Quality**:
>   - Add `#[allow(clippy::needless_range_loop)]` in `kornia-icp/src/ops.rs` and tests in `kornia-pnp/src/epnp.rs`.
>   - Replace `debug!/warn!` imports with fully qualified `log::debug!/log::warn!` in `kornia-pnp/src/ransac.rs`.
> - **API**:
>   - Derive `Default` for `kornia-io/src/v4l/pixel_format.rs::PixelFormat` with `#[default]` on `YUYV`; remove manual `Default` impl.
> - **Examples**:
>   - Update `examples/pnp_demo/src/main.rs` to use inline formatting in `println!` (e.g., `{rmse:.3}`).
> - **Tooling**:
>   - Overhaul `justfile`:
>     - Split workspace checks/lints to exclude `kornia-pnp` and run it separately.
>     - Add `lint`, `clean`, `test`, and `test-all` recipes; improve echo messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d939bbe48fe36109179fe4ee53b3f366df16ae74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->