### PR TITLE
fixed bug in se2 exp

### DIFF
--- a/crates/kornia-lie/src/se2.rs
+++ b/crates/kornia-lie/src/se2.rs
@@ -8,6 +8,8 @@ pub struct SE2 {
     pub t: Vec2,
 }
 
+const SMALL_ANGLE_EPSILON: f32 = 1.0e-8;
+
 impl SE2 {
     pub const IDENTITY: Self = Self {
         r: SO2::IDENTITY,
@@ -88,10 +90,11 @@ impl SE2 {
         Self {
             r: so2,
             t: {
-                let (a, b) = if theta != 0.0 {
-                    (so2.z.y / theta, (1.0 - so2.z.x) / theta)
+                let (a, b) = if theta.abs() < SMALL_ANGLE_EPSILON {
+                    // Small-angle approximation path
+                    (1.0 - theta * theta / 6.0, theta / 2.0)
                 } else {
-                    (0.0, 0.0)
+                    (so2.z.y / theta, (1.0 - so2.z.x) / theta)
                 };
                 Vec2::new(a * v.x - b * v.y, b * v.x + a * v.y)
             },
@@ -459,8 +462,8 @@ mod tests {
 
         assert_relative_eq!(se2_zero.r.z.x, 1.0, epsilon = EPSILON);
         assert_relative_eq!(se2_zero.r.z.y, 0.0, epsilon = EPSILON);
-        assert_relative_eq!(se2_zero.t.x, 0.0, epsilon = EPSILON);
-        assert_relative_eq!(se2_zero.t.y, 0.0, epsilon = EPSILON);
+        assert_relative_eq!(se2_zero.t.x, 2.0, epsilon = EPSILON);
+        assert_relative_eq!(se2_zero.t.y, 3.0, epsilon = EPSILON);
 
         // Test exp(0) = identity
         let se2_identity = SE2::exp(Vec3A::ZERO);


### PR DESCRIPTION
## **Bug Report: `SE2::exp` Discards Translation for Zero Rotation**

**Title:** `SE2::exp` incorrectly returns an identity translation (zero vector) when the input twist has zero rotation (`theta = 0.0`).

  * The function fails for all pure translation inputs, which is a fundamental operation.
  * It also contains a numerical instability (division by near-zero) for small rotations.

-----

### **Summary**

The `SE2::exp` function is responsible for converting an $se(2)$ twist vector (representing velocity) into an $SE(2)$ transformation (representing pose).

When given a twist vector representing a **pure translation** (e.g., `[v.x, v.y, 0.0]`), the function should return an $SE(2)$ transformation with an identity rotation and a translation component equal to `[v.x, v.y]`.

The current implementation has a bug in its small-angle logic that incorrectly sets the translation component to `[0.0, 0.0]`, effectively discarding the input.

### **Problematic Code**

The bug is in the `else` block of the coefficient calculation:

```rust
// ...
            t: {
                let (a, b) = if theta != 0.0 {
                    (so2.z.y / theta, (1.0 - so2.z.x) / theta)
                } else {
                    // [!] THIS IS THE BUG
                    (0.0, 0.0) 
                };
                // This calculation...
                Vec2::new(a * v.x - b * v.y, b * v.x + a * v.y)
                // ...becomes Vec2::new(0.0, 0.0)
            },
// ...
```

### **Analysis of the Bug**

The coefficients `a` and `b` are meant to be:

  * $a = \sin(\theta) / \theta$
  * $b = (1 - \cos(\theta)) / \theta$

The code's `else` block must compute the **limit** of these functions as $\theta \to 0$.

1.  **Limit for `a`:** $\lim_{\theta \to 0} \frac{\sin(\theta)}{\theta} = 1.0$
2.  **Limit for `b`:** $\lim_{\theta \to 0} \frac{1 - \cos(\theta)}{\theta} = 0.0$

The buggy code uses `(0.0, 0.0)` instead of the correct limit `(1.0, 0.0)`. This causes the final translation calculation to become `Vec2::new(0.0 * v.x - 0.0 * v.y, ...)` which incorrectly evaluates to `[0.0, 0.0]`.

Furthermore, the `if theta != 0.0` check is numerically unstable. If `theta` is `1e-10`, the `if` block executes, leading to division by a near-zero number and catastrophic cancellation.

-----

### **The fix**

The fix is to replace the hard-coded `if theta != 0.0` check with a small-angle approximation using a Taylor series expansion. This simultaneously solves the `theta = 0` bug and the numerical instability.

```rust
// Define an epsilon for "small" angles
const SMALL_ANGLE_EPSILON: f32 = 1.0e-8;

pub fn exp(v: Vec3A) -> Self {
    let theta = v.z;
    let so2 = SO2::exp(theta); 

    Self {
        r: so2,
        t: {
            // --- FIX APPLIED HERE ---
            let (a, b) = if theta.abs() < SMALL_ANGLE_EPSILON {
                // Use Taylor series for small angles
                // a = sin(t)/t ≈ 1 - t²/6
                // b = (1-cos(t))/t ≈ t/2
                (1.0 - theta * theta / 6.0, theta / 2.0)
            } else {
                // Large-angle path (unchanged)
                (so2.z.y / theta, (1.0 - so2.z.x) / theta)
            };

            // This now correctly computes [v.x, v.y] when theta is 0
            Vec2::new(a * v.x - b * v.y, b * v.x + a * v.y)
        },
    }
}
```

### **Validation (Test Case)**

The bug was also present in the test case, which was also incorrect, letting the wrong results pass

```rust
        // Test with zero rotation
        let upsilon_zero = Vec2::new(2.0, 3.0);
        let theta_zero = 0.0;
        let se2_zero = SE2::exp(Vec3A::new(upsilon_zero.x, upsilon_zero.y, theta_zero));

        // Assert identity rotation
        assert_relative_eq!(se2_zero.r.z.x, 1.0, epsilon = EPSILON);
        assert_relative_eq!(se2_zero.r.z.y, 0.0, epsilon = EPSILON);

        // the error was here
        assert_relative_eq!(se2_zero.t.x, 0.0, epsilon = EPSILON);
        assert_relative_eq!(se2_zero.t.y, 0.0, epsilon = EPSILON);
```