### PR TITLE
Bug: fix capacity calculation math in apriltag quickdecode hashtable

### DIFF
--- a/crates/kornia-apriltag/src/decoder.rs
+++ b/crates/kornia-apriltag/src/decoder.rs
@@ -137,7 +137,7 @@ impl QuickDecode {
         let ncodes = code_data.len();
         let capacity = ncodes // Hamming 0
             + nbits * ncodes // Hamming 1
-            + ncodes * nbits * (nbits - 1); // Hamming 2
+            + ncodes * nbits * (nbits - 1) / 2; // Hamming 2
 
         let mut quick_decode = Self(vec![
             QuickDecodeEntry {


### PR DESCRIPTION
## Bug: Double-counting in Hamming 2 capacity calculation

**The Bug**
The capacity calculation for Hamming distance 2 used `nbits * (nbits - 1)`, which calculates permutations instead of combinations. This resulted in allocating memory for both `(bit_a, bit_b)` and `(bit_b, bit_a)`.

**The Fix**
Updated the formula to use the binomial coefficient `n(n-1)/2` to count unique pairs only.

**Impact**
Drastically reduces vector pre-allocation. For a standard **36h11 AprilTag** (36 bits), this removes **630 redundant slots per code**, reducing the memory overhead for the Hamming 2 layer by **50%**.