### PR TITLE
Parser fix for allowing pcd without rgb values

### DIFF
--- a/crates/kornia-3d/src/io/pcd/parser.rs
+++ b/crates/kornia-3d/src/io/pcd/parser.rs
@@ -45,6 +45,7 @@ impl PcdLayout {
             .ok_or(PcdError::UnsupportedProperty)
     }
 }
+
 /// Read a little-endian f32 from a byte buffer
 #[inline]
 fn read_f32(buf: &[u8], offset: usize) -> Result<f32, PcdError> {
@@ -53,6 +54,7 @@ fn read_f32(buf: &[u8], offset: usize) -> Result<f32, PcdError> {
     bytes.copy_from_slice(slice);
     Ok(f32::from_le_bytes(bytes))
 }
+
 /// Read a little-endian u32 from a byte buffer
 #[inline]
 fn read_u32(buf: &[u8], offset: usize) -> Result<u32, PcdError> {


### PR DESCRIPTION
This PR is a revision of my previous PR (#592), with revision made based on reviewer and copilot comments.
While parsing a pointcloud in .pcd binary format without any rgb values for points, I got this error
Error: Deserialize(InvalidIntegerType { expected: U32, found: U64 })

This was happening because the size of the point was expected to be fixed, causing issues during binary parsing since the original code was accounting for size of rgb and normal values which don't necessarity exist. This patch fixes that and allows general binaries to be read.
