### PR TITLE
optimized union find with path halving

### DIFF
--- a/crates/kornia-apriltag/src/union_find.rs
+++ b/crates/kornia-apriltag/src/union_find.rs
@@ -13,28 +13,18 @@ impl UnionFind {
         }
     }
 
-    /// Returns the representative (root) of the set containing `id`, with path compression.
+    /// Returns the representative (root) of the set containing `id`, with path halving.
     pub fn get_representative(&mut self, mut id: usize) -> usize {
-        let mut root = self.parent[id];
-
-        if root == usize::MAX {
+        if self.parent[id] == usize::MAX {
             self.parent[id] = id;
             return id;
         }
 
-        // Chase down the root
-        while self.parent[root] != root {
-            root = self.parent[root];
+        while self.parent[id] != id {
+            self.parent[id] = self.parent[self.parent[id]];
+            id = self.parent[id];
         }
-
-        // Go back and collapse the tree
-        while self.parent[id] != root {
-            let tmp = self.parent[id];
-            self.parent[id] = root;
-            id = tmp;
-        }
-
-        root
+        id
     }
 
     /// Returns the size of the set containing `id`.


### PR DESCRIPTION
replaced the two pass path compression in the union find with single pass path halving, inspired by this pr in the apriltag repo https://github.com/AprilRobotics/apriltag/pull/404 , gives about a 25% speedup in union find operations

UnionFind Comparison/Original (Full Compression)
                        time:   **4.0414 ms** 
 UnionFind Comparison/Optimized (Path Halving)
                        time:   **3.1310 ms**

this was the script i used to benchmark the changes

```
use criterion::{criterion_group, criterion_main, Criterion, BatchSize};
use rand::prelude::*;

// ==========================================
// 1. ORIGINAL IMPLEMENTATION (Full Compression)
// ==========================================
pub struct UnionFindOriginal {
    parent: Vec<usize>,
    size: Vec<usize>,
}

impl UnionFindOriginal {
    pub fn new(len: usize) -> Self {
        Self {
            parent: vec![usize::MAX; len],
            size: vec![1; len],
        }
    }

    pub fn get_representative(&mut self, mut id: usize) -> usize {
        let mut root = self.parent[id];
        if root == usize::MAX {
            self.parent[id] = id;
            return id;
        }
        // Pass 1: Find root
        while self.parent[root] != root {
            root = self.parent[root];
        }
        // Pass 2: Path compression
        while self.parent[id] != root {
            let tmp = self.parent[id];
            self.parent[id] = root;
            id = tmp;
        }
        root
    }

    pub fn connect(&mut self, aid: usize, bid: usize) {
        let aroot = self.get_representative(aid);
        let broot = self.get_representative(bid);

        if aroot == broot { return; }

        if self.size[aroot] > self.size[broot] {
            self.parent[broot] = aroot;
            self.size[aroot] += self.size[broot];
        } else {
            self.parent[aroot] = broot;
            self.size[broot] += self.size[aroot];
        }
    }
}

// ==========================================
// 2. OPTIMIZED IMPLEMENTATION (Path Halving)
// ==========================================
pub struct UnionFindOptimized {
    parent: Vec<usize>,
    size: Vec<usize>,
}

impl UnionFindOptimized {
    pub fn new(len: usize) -> Self {
        Self {
            parent: vec![usize::MAX; len],
            size: vec![1; len],
        }
    }

    /// Returns the representative (root) of the set containing `id`, with path halving.
    pub fn get_representative(&mut self, mut id: usize) -> usize {
        if self.parent[id] == usize::MAX {
            self.parent[id] = id;
            return id;
        }

        while self.parent[id] != id {
            self.parent[id] = self.parent[self.parent[id]];
            id = self.parent[id];
        }
        id
    }

    pub fn connect(&mut self, aid: usize, bid: usize) {
        let mut root_a = self.get_representative(aid);
        let mut root_b = self.get_representative(bid);

        if root_a == root_b { return; }

        if self.size[root_a] < self.size[root_b] {
            std::mem::swap(&mut root_a, &mut root_b);
        }

        self.parent[root_b] = root_a;
        self.size[root_a] += self.size[root_b];
    }
}

// ==========================================
// 3. BENCHMARK LOGIC
// ==========================================

fn bench_union_find(c: &mut Criterion) {
    let mut group = c.benchmark_group("UnionFind Comparison");
    
    // Benchmark Parameters
    let size = 100_000;
    let num_ops = 200_000;
    
    // Pre-generate random operations so both implementations process the exact same data.
    // We use a mix of Unions and Finds (Connectivity checks).
    let mut rng = StdRng::seed_from_u64(42);
    let mut ops = Vec::with_capacity(num_ops);
    
    for _ in 0..num_ops {
        let u = rng.gen_range(0..size);
        let v = rng.gen_range(0..size);
        // 0 = connect, 1 = get_representative (find)
        let op_type = rng.gen_bool(0.7); // 70% unions, 30% finds
        ops.push((op_type, u, v));
    }

    // Benchmark Original
    group.bench_function("Original (Full Compression)", |b| {
        b.iter_batched(
            || UnionFindOriginal::new(size), // Setup (not timed)
            |mut uf| {                       // Routine (timed)
                for &(is_union, u, v) in &ops {
                    if is_union {
                        uf.connect(u, v);
                    } else {
                        uf.get_representative(u);
                    }
                }
            },
            BatchSize::LargeInput,
        );
    });

    // Benchmark Optimized
    group.bench_function("Optimized (Path Halving)", |b| {
        b.iter_batched(
            || UnionFindOptimized::new(size), // Setup (not timed)
            |mut uf| {                        // Routine (timed)
                for &(is_union, u, v) in &ops {
                    if is_union {
                        uf.connect(u, v);
                    } else {
                        uf.get_representative(u);
                    }
                }
            },
            BatchSize::LargeInput,
        );
    });

    group.finish();
}

criterion_group!(benches, bench_union_find);
criterion_main!(benches);
```