### PR TITLE
reduced quickdecode memory consumption by 8x

### DIFF
--- a/crates/kornia-apriltag/src/decoder.rs
+++ b/crates/kornia-apriltag/src/decoder.rs
@@ -104,6 +104,7 @@ pub struct QuickDecodeEntry {
     pub rotation: u8,
 }
 
+/// Sentinel value used to mark unoccupied slots in the quick decode hash table.
 const SLOT_EMPTY: u16 = u16::MAX;
 
 /// A table for fast lookup of decoded tag codes and their associated metadata.


### PR DESCRIPTION
# Reduce QuickDecode table entry size from 16B to 2B

## Summary
This PR refactors the QuickDecode lookup table to store raw `u16` tag IDs instead of full `QuickDecodeEntry` structs. This change reduces the memory footprint of the hash table slots by **87.5%** (from 16 bytes to 2 bytes). This prevents memory exhaustion when working with large tag families and conserves a significant amount of resources in robotics applications.

## Motivation
The previous implementation stored a fully resolved `QuickDecodeEntry` (16 bytes) in every slot of the hash table. While this worked for small tag families, it scaled poorly for high-bit tags.

**The Problem:**
For complex tag families like **52h13**, the sheer number of valid codes and Hamming neighbors causes the lookup table to contain hundreds of millions of entries. With 16-byte slots, these tables could balloon to over **3GB** of resident memory. This massive footprint puts immense pressure on system RAM and makes it near impossible to use these larger families in simple roborics applications.

**The Solution:**
By storing only the `u16` Tag ID, we compress the storage requirement to **2 bytes** per slot. For a massive 52h13 table, this shrinks the memory requirement from ~3GB down to a manageable **~380MB**, making the system far more stable and efficient on constrained hardware.

## Implementation Details

### 1. Data Structure Changes
**Previous Memory Layout (16 bytes per slot)**

    [ rcode (8B) | id (2B) | ham (1B) | rot (1B) | pad (4B) ]

**New Memory Layout (2 bytes per slot)**

    [ id (2B) ]

 Uses `u16::MAX` as a `SLOT_EMPTY` sentinel.

### 2. Functional Equivalence
Both implementations satisfy the exact same API contract. The difference lies in how the result is derived:

* **Previous (Storage-based):** The table acted as a cache of final answers. If the observed code matched the stored code, the pre-calculated struct was returned.
* **New (Compute-based):** The table acts as a probabilistic hint.
    1. The hash maps the observed code to a candidate `id`.
    2. We fetch the "perfect" code for that `id` from the `valid_codes` slice.
    3. We calculate `delta = observed ^ perfect`.
    4. We verify `delta.count_ones() <= 2`.
    5. If valid, we construct the `QuickDecodeEntry` on the stack and return it.

### 3. Memory Analysis
| Metric | Previous Implementation | New Implementation | Improvement |
| :--- | :--- | :--- | :--- |
| **Entry Size** | 16 Bytes | 2 Bytes | **8x Smaller** |
| **52h13 Table Size** | ~3.0 GB | ~384 MB | **~2.6 GB Saved** |
| **Cache Density** | Low (4 entries/line) | High (32 entries/line) | **800% Increase** |

Additionally, from the benchmarks I've run, there is either no decrease in performance or even an increase in performance in some cases, likely due to the more efficiently packed cache line.

Solves https://github.com/kornia/kornia-rs/issues/450 in some sense ig