### PR TITLE
fix(imgproc): support u8 for gaussian_blur and box_blur

### DIFF
--- a/crates/kornia-imgproc/benches/bench_filters.rs
+++ b/crates/kornia-imgproc/benches/bench_filters.rs
@@ -1,22 +1,11 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
-use kornia_image::{Image, ImageError};
-use kornia_imgproc::filter::{box_blur_fast, gaussian_blur, kernels, separable_filter};
+use kornia_image::Image;
+use kornia_imgproc::filter::{box_blur_fast, gaussian_blur};
 
 use image::RgbImage;
 use imageproc::filter::gaussian_blur_f32;
 use kornia_tensor::CpuAllocator;
-
-fn gaussian_blur_u8<const C: usize>(
-    src: &Image<u8, C, CpuAllocator>,
-    dst: &mut Image<u8, C, CpuAllocator>,
-    kernel_size: usize,
-    sigma: f32,
-) -> Result<(), ImageError> {
-    let kernel_x = kernels::gaussian_kernel_1d(kernel_size, sigma);
-    let kernel_y = kernels::gaussian_kernel_1d(kernel_size, sigma);
-    separable_filter(src, dst, &kernel_x, &kernel_y)
-}
 
 fn bench_filters(c: &mut Criterion) {
     let mut group = c.benchmark_group("Gaussian Blur");
@@ -63,7 +52,12 @@ fn bench_filters(c: &mut Criterion) {
                 |b, i| {
                     let (src, mut dst) = (i.0, i.1.clone());
                     b.iter(|| {
-                        std::hint::black_box(gaussian_blur_u8(src, &mut dst, *kernel_size, 1.5))
+                        std::hint::black_box(gaussian_blur(
+                            src,
+                            &mut dst,
+                            (*kernel_size, *kernel_size),
+                            (1.5, 1.5),
+                        ))
                     })
                 },
             );


### PR DESCRIPTION
Fixes/Relates to: #461

 This PR strictly implements what the linked issue describes
  No changes outside the scope of the issue are included

  Changes Made
    Extended `gaussian_blur` to support `u8` images by making the API generic over pixel type
    Applied the same generic handling to `box_blur` for consistency
    Updated benchmarks to use the unified generic API
    Added a regression test to validate `u8` gaussian blur behavior

How Was This Tested?
    Unit Tests:
    Added `test_gaussian_blur_u8` to verify correct output and clamping behavior for `u8` inputs
    All existing image processing tests pass

Manual Verification:
    Ran `cargo test` locally
    Verified that previous `f32` use cases remain unaffected

 Performance / Edge Cases:
      Relies on the existing `FloatConversion` trait used by `separable_filter`
       Handles conversion, clamping, and round-trip safely for `u8` inputs without changing algorithmic           
        behaviour

     AI Usage Disclosure
        AI-assisted: AI was used for discussion and clarification, but all code, tests, and design decisions             were manually written, reviewed, and verified.

 Checklist
       The linked issue has been approved by a maintainer
       This PR strictly implements what the linked issue describes (no scope creep)
       I have performed a self-review of my code
       My code follows the existing style guidelines of this project
       I have added tests that prove the fix is effective

 Additional Context:
    The underlying `separable_filter` already supports multiple pixel types internally. This change exposes that capability at the     public API level, making it easier to work with common `u8` image pipelines without introducing special-case wrappers.