### PR TITLE
perf: use memcpy instead of per pixel move in flip_v

### DIFF
--- a/crates/kornia-imgproc/src/flip.rs
+++ b/crates/kornia-imgproc/src/flip.rs
@@ -120,16 +120,13 @@ where
         ));
     }
 
+    let row_len = src.cols() * C;
+
     dst.as_slice_mut()
-        .par_chunks_exact_mut(src.cols() * C)
-        .zip_eq(src.as_slice().par_chunks_exact(src.cols() * C).rev())
+        .par_chunks_exact_mut(row_len)
+        .zip(src.as_slice().par_chunks_exact(row_len).rev())
         .for_each(|(dst_row, src_row)| {
-            dst_row
-                .chunks_exact_mut(C)
-                .zip(src_row.chunks_exact(C))
-                .for_each(|(dst_pixel, src_pixel)| {
-                    dst_pixel.copy_from_slice(src_pixel);
-                })
+            dst_row.copy_from_slice(src_row);
         });
 
     Ok(())


### PR DESCRIPTION
# Optimization: Vertical Flip using Row-wise Memcpy

## Summary
I was putting random functions into Compiler Explorer as timepass, and found that the vertical flip function generates only mov instructions, as the old code iterates over every pixel. In this PR, the `vertical_flip` operation replaces the pixel-by-pixel iteration with a row-wise `copy_from_slice`. This change enables the compiler to optimize the operation by calling memcpy. In the small test images, the change is noticeable, but for the larger ones, I suspect we hit the memory bandwidth wall

## Performance Analysis
The optimization yields massive speedups (up to **2.0x**) for small-to-medium resolutions where CPU instruction overhead was previously the bottleneck.

For high resolutions (1080p and 4K), performance remains roughly equivalent to the baseline. At these sizes, I suspect that the operation becomes **memory-bound** (limited by RAM bandwidth) rather than compute-bound.

### Benchmark Results

| Resolution | Baseline Time | Optimized (Memcpy) | Speedup | 
| :--- | :--- | :--- | :--- | 
| **256x144** | 31.0 µs | 25.7 µs | **1.2x** | 
| **512x288** | 54.8 µs | 31.8 µs | **1.7x** | 
| **1024x576** | 132.6 µs | 66.3 µs | **2.0x** | 
| **1920x1080**| 1.49 ms | 1.52 ms | ~0.9x | 
| **3840x2160**| 6.86 ms | 6.63 ms | ~1.0x | 

## BEFORE - 

<img width="488" height="596" alt="image" src="https://github.com/user-attachments/assets/5936db53-f807-440c-8b47-b21279538702" />


## AFTER - 

<img width="627" height="506" alt="image" src="https://github.com/user-attachments/assets/c0a3eab0-79ac-4ea9-b8d1-e63d67dcd6ad" />
