### PR TITLE
fused preprocessor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,6 +414,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "aprilgrid"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9c681cce0390b1a3c285d04bc5fc64d92efe59af52a36f85a77d798cb5b97"
+dependencies = [
+ "faer 0.22.6",
+ "glam",
+ "image 0.25.9",
+ "imageproc",
+ "itertools 0.14.0",
+ "kiddo",
+ "rand 0.9.2",
+]
+
+[[package]]
 name = "apriltag"
 version = "0.1.11-rc.1"
 dependencies = [
@@ -421,6 +436,34 @@ dependencies = [
  "kornia",
  "kornia-apriltag",
  "rerun",
+]
+
+[[package]]
+name = "apriltag"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3278ce87faf6559bf159b5d5920de622f39dfe7c035387a6e70854e3dfcfa55"
+dependencies = [
+ "apriltag-sys",
+ "libc",
+ "measurements",
+ "noisy_float",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "apriltag-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168f741d3e5f434b54fa6fa857e35093b631900addbb3fb452715a2a67cd14c2"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cmake",
+ "glob",
+ "itertools 0.10.5",
+ "once_cell",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1235,6 +1278,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-wait"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55b94919229f2c42292fd71ffa4b75e83193bffdd77b1e858cd55fd2d0b0ea8"
+dependencies = [
+ "libc",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1525,6 +1578,20 @@ name = "base64ct"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d809780667f4410e7c41b07f52439b94d2bdf8528eeedc287fa38d3b7f95d82"
+
+[[package]]
+name = "bench_preprocessors"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "candle-core",
+ "criterion",
+ "kornia-image",
+ "kornia-imgproc",
+ "kornia-io",
+ "kornia-vlm",
+ "rayon",
+]
 
 [[package]]
 name = "bigdecimal"
@@ -2537,6 +2604,18 @@ dependencies = [
  "ryu",
  "serde",
  "static_assertions",
+]
+
+[[package]]
+name = "compare_preprocessors"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "candle-core",
+ "kornia-image",
+ "kornia-imgproc",
+ "kornia-io",
+ "kornia-vlm",
 ]
 
 [[package]]
@@ -3960,6 +4039,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6ca96b45ca70b8045e0462f191bd209fcb3c3bfe8dbfb1257ada54c4dd59169"
 
 [[package]]
+name = "defer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "930c7171c8df9fb1782bdf9b918ed9ed2d33d1d22300abb754f9085bc48bf8e8"
+
+[[package]]
 name = "delegate"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4938,6 +5023,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "faer"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fce40ad65c366fbc6cd70a99d09d1008f075280bf2455e558e163c82913a9f"
+dependencies = [
+ "bytemuck",
+ "dyn-stack 0.13.2",
+ "equator 0.4.2",
+ "faer-macros",
+ "faer-traits",
+ "gemm 0.18.2",
+ "generativity",
+ "libm",
+ "nano-gemm",
+ "npyz",
+ "num-complex",
+ "num-traits",
+ "private-gemm-x86",
+ "pulp 0.21.5",
+ "rand 0.8.5",
+ "rand_distr 0.4.3",
+ "rayon",
+ "reborrow",
+]
+
+[[package]]
 name = "faer-entity"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4949,6 +5060,35 @@ dependencies = [
  "num-complex",
  "num-traits",
  "pulp 0.18.22",
+ "reborrow",
+]
+
+[[package]]
+name = "faer-macros"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d0a255d1442b5825c61812a7eafda9034ec53d969c98555251085e148428e6a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "faer-traits"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54febfcbb90edaab562d85447a94d500f1601f11db0b30d27da87ed6542c8f91"
+dependencies = [
+ "bytemuck",
+ "dyn-stack 0.13.2",
+ "faer-macros",
+ "generativity",
+ "libm",
+ "num-complex",
+ "num-traits",
+ "pulp 0.21.5",
+ "qd",
  "reborrow",
 ]
 
@@ -7325,6 +7465,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
+name = "interpol"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb58032ba748f4010d15912a1855a8a0b1ba9eaad3395b0c171c09b3b356ae50"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "interpolate_name"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7618,7 +7769,13 @@ dependencies = [
  "approx",
  "bincode 2.0.1",
  "criterion",
- "faer",
+ "faer 0.20.1",
+ "kiddo",
+ "kornia-algebra",
+ "kornia-imgproc",
+ "log",
+ "nalgebra",
+ "rand 0.9.2",
  "serde",
  "thiserror 2.0.17",
 ]
@@ -7640,6 +7797,8 @@ dependencies = [
 name = "kornia-apriltag"
 version = "0.1.11-rc.1"
 dependencies = [
+ "aprilgrid",
+ "apriltag 0.4.0",
  "criterion",
  "image 0.25.9",
  "kornia-image",
@@ -7657,19 +7816,6 @@ dependencies = [
  "kornia-image",
  "kornia-io",
  "paste",
-]
-
-[[package]]
-name = "kornia-icp"
-version = "0.1.11-rc.1"
-dependencies = [
- "approx",
- "faer",
- "kiddo",
- "kornia-3d",
- "log",
- "rand 0.9.2",
- "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -7721,35 +7867,6 @@ dependencies = [
  "turbojpeg",
  "v4l 0.14.0",
  "zune-jpeg 0.5.8",
-]
-
-[[package]]
-name = "kornia-linalg"
-version = "0.1.11-rc.1"
-dependencies = [
- "approx",
- "criterion",
- "faer",
- "glam",
- "nalgebra",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "kornia-pnp"
-version = "0.1.11-rc.1"
-dependencies = [
- "approx",
- "criterion",
- "glam",
- "kornia-algebra",
- "kornia-imgproc",
- "kornia-linalg",
- "log",
- "nalgebra",
- "opencv",
- "rand 0.9.2",
- "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -7807,10 +7924,12 @@ dependencies = [
  "minijinja",
  "num2words",
  "rand 0.9.2",
+ "rayon",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
  "tokenizers",
+ "wide",
 ]
 
 [[package]]
@@ -8078,6 +8197,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "loop9"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8291,6 +8423,15 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
  "digest",
+]
+
+[[package]]
+name = "measurements"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f72b38901c571007811f0483e64a7e215ac9e6e3688e9f83705a717621d81513"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -8864,6 +9005,15 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "noisy_float"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c16843be85dd410c6a12251c4eca0dd1d3ee8c5725f746c4d5e0fdcec0a864b2"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "nom"
@@ -10497,6 +10647,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "private-gemm-x86"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0af8c3e5087969c323f667ccb4b789fa0954f5aa650550e38e81cf9108be21b5"
+dependencies = [
+ "crossbeam",
+ "defer",
+ "interpol",
+ "num_cpus",
+ "raw-cpuid 11.6.0",
+ "rayon",
+ "spindle",
+ "sysctl 0.6.0",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10833,6 +10999,18 @@ dependencies = [
  "pyo3-build-config",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "qd"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff8bb755b6008c3b41bf8a0866c8dd4e1245a2f011ceaa22a13ee55c538493e2"
+dependencies = [
+ "bytemuck",
+ "libm",
+ "num-traits",
+ "pulp 0.21.5",
 ]
 
 [[package]]
@@ -14627,6 +14805,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
+name = "spindle"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aaca3d8aa5387a6eba861fbf984af5348d9df5d940c25c6366b19556fdf64"
+dependencies = [
+ "atomic-wait",
+ "crossbeam",
+ "equator 0.4.2",
+ "loom",
+ "rayon",
+]
+
+[[package]]
 name = "spirv"
 version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17311,6 +17502,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]

--- a/crates/kornia-vlm/Cargo.toml
+++ b/crates/kornia-vlm/Cargo.toml
@@ -25,10 +25,12 @@ kornia-tensor = { workspace = true }
 log = { workspace = true }
 minijinja = { version = "2.12.0", features = ["loader"] }
 num2words = "1.2.0"
+rayon.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokenizers = { workspace = true }
+wide = "0.7.33"
 
 [dev-dependencies]
 env_logger = { workspace = true }

--- a/crates/kornia-vlm/src/lib.rs
+++ b/crates/kornia-vlm/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod paligemma;
+pub mod preprocessor;
 pub mod smolvlm;
 pub mod smolvlm2;
 

--- a/crates/kornia-vlm/src/preprocessor.rs
+++ b/crates/kornia-vlm/src/preprocessor.rs
@@ -1,0 +1,661 @@
+use candle_core::{Device, Tensor};
+use kornia_image::{allocator::ImageAllocator, Image};
+use kornia_imgproc::interpolation::InterpolationMode;
+use rayon::prelude::*;
+
+// Constants
+pub const CLIP_MEAN: [f32; 3] = [0.48145466, 0.4578275, 0.40821073];
+pub const CLIP_STD: [f32; 3] = [0.26862954, 0.26130258, 0.27577711];
+pub const SIGLIP_MEAN: [f32; 3] = [0.5, 0.5, 0.5];
+pub const SIGLIP_STD: [f32; 3] = [0.5, 0.5, 0.5];
+
+#[derive(Clone, Copy, Debug)]
+pub struct Rect {
+    pub x: f32,
+    pub y: f32,
+    pub w: f32,
+    pub h: f32,
+}
+
+impl Rect {
+    pub fn full() -> Self {
+        Self {
+            x: 0.0,
+            y: 0.0,
+            w: 1.0,
+            h: 1.0,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Model {
+    Clip,
+    SmolVLM,
+    LLaVA,
+    PaliGemma,
+}
+
+#[derive(Clone, Debug)]
+pub struct PreprocessConfig {
+    pub model_type: Model,
+    pub target_size: usize,
+    pub mean: [f32; 3],
+    pub std: [f32; 3],
+    pub interpolation: InterpolationMode,
+}
+
+impl Default for PreprocessConfig {
+    fn default() -> Self {
+        Self {
+            model_type: Model::Clip,
+            target_size: 224,
+            mean: CLIP_MEAN,
+            std: CLIP_STD,
+            interpolation: InterpolationMode::Bicubic,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CropTransform {
+    pub src_roi: Rect,
+    pub dst_batch_idx: usize,
+    pub dst_valid_roi: Rect,
+    pub normalization_mean: [f32; 3],
+    pub normalization_std: [f32; 3],
+}
+
+pub struct Preprocessor {
+    config: PreprocessConfig,
+}
+
+fn get_center_crop_uv(w: u32, h: u32) -> Rect {
+    let w_f = w as f32;
+    let h_f = h as f32;
+    if w < h {
+        let crop_h = w_f / h_f;
+        Rect {
+            x: 0.0,
+            y: (1.0 - crop_h) / 2.0,
+            w: 1.0,
+            h: crop_h,
+        }
+    } else {
+        let crop_w = h_f / w_f;
+        Rect {
+            x: (1.0 - crop_w) / 2.0,
+            y: 0.0,
+            w: crop_w,
+            h: 1.0,
+        }
+    }
+}
+
+fn get_grid_tiles(w: u32, h: u32, target_size: usize) -> Vec<(Rect, Rect)> {
+    let w_f = w as f32;
+    let h_f = h as f32;
+    let target_f = target_size as f32;
+
+    let cols = (w_f / target_f).ceil() as u32;
+    let rows = (h_f / target_f).ceil() as u32;
+
+    let mut tiles = Vec::with_capacity((rows * cols) as usize);
+
+    for r in 0..rows {
+        for c in 0..cols {
+            let src_x = c as f32 * target_f;
+            let src_y = r as f32 * target_f;
+
+            let valid_w = (w_f - src_x).min(target_f);
+            let valid_h = (h_f - src_y).min(target_f);
+
+            let src_roi = Rect {
+                x: src_x / w_f,
+                y: src_y / h_f,
+                w: valid_w / w_f,
+                h: valid_h / h_f,
+            };
+
+            let dst_valid_roi = Rect {
+                x: 0.0,
+                y: 0.0,
+                w: valid_w / target_f,
+                h: valid_h / target_f,
+            };
+
+            tiles.push((src_roi, dst_valid_roi));
+        }
+    }
+    tiles
+}
+
+#[inline(always)]
+fn sinc(x: f32) -> f32 {
+    if x == 0.0 {
+        1.0
+    } else {
+        let x_pi = x * std::f32::consts::PI;
+        x_pi.sin() / x_pi
+    }
+}
+
+#[inline(always)]
+fn get_lanzcos_weight(x: f32) -> f32 {
+    const A: f32 = 3.0;
+    if x.abs() < A {
+        sinc(x) * sinc(x / A)
+    } else {
+        0.0
+    }
+}
+
+#[inline(always)]
+fn get_bilinear_weight(x: f32) -> f32 {
+    1.0 - x.abs().min(1.0)
+}
+
+#[inline(always)]
+fn get_nearest_weight(x: f32) -> f32 {
+    if x.abs() <= 0.5 {
+        1.0
+    } else {
+        0.0
+    }
+}
+
+#[inline(always)]
+fn get_cubic_weight(x: f32) -> f32 {
+    const A: f32 = -0.75;
+    if x.abs() <= 1.0 {
+        (A + 2.0) * x.abs().powi(3) - (A + 3.0) * x.abs().powi(2) + 1.0
+    } else if x.abs() < 2.0 {
+        A * x.abs().powi(3) - 5.0 * A * x.abs().powi(2) + 8.0 * A * x.abs() - 4.0 * A
+    } else {
+        0.0
+    }
+}
+
+// A reusable workspace to avoid re-allocating scratch buffers
+pub struct ResizerWorkspace {
+    pub scratch: Vec<f32>, // Intermediate planar buffer
+
+    // X-dimension map buffers
+    pub x_map_offsets: Vec<usize>,
+    pub x_map_weights: Vec<f32>,
+    pub x_map_counts: Vec<usize>,
+    pub x_map_starts: Vec<usize>,
+
+    // Y-dimension map buffers
+    pub y_map_offsets: Vec<usize>,
+    pub y_map_weights: Vec<f32>,
+    pub y_map_counts: Vec<usize>,
+    pub y_map_starts: Vec<usize>,
+}
+
+impl ResizerWorkspace {
+    pub fn new() -> Self {
+        Self {
+            scratch: Vec::new(),
+            x_map_offsets: Vec::new(),
+            x_map_weights: Vec::new(),
+            x_map_counts: Vec::new(),
+            x_map_starts: Vec::new(),
+            y_map_offsets: Vec::new(),
+            y_map_weights: Vec::new(),
+            y_map_counts: Vec::new(),
+            y_map_starts: Vec::new(),
+        }
+    }
+}
+
+struct MapMetadata<'a> {
+    offsets: &'a [usize],
+    weights: &'a [f32],
+    counts: &'a [usize],
+    starts: &'a [usize],
+    min_offset: usize,
+    max_offset: usize,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn compute_weight_map_into_workspace<'a>(
+    out_size: usize,
+    src_dim: usize,
+    src_start: f32,
+    src_roi_dim: f32,
+    stride_mul: usize,
+    interpolation: InterpolationMode,
+    offsets_buf: &'a mut Vec<usize>,
+    weights_buf: &'a mut Vec<f32>,
+    counts_buf: &'a mut Vec<usize>,
+    starts_buf: &'a mut Vec<usize>,
+) -> MapMetadata<'a> {
+    offsets_buf.clear();
+    weights_buf.clear();
+    counts_buf.clear();
+    starts_buf.clear();
+
+    let scale = (src_roi_dim * src_dim as f32) / out_size as f32;
+    let estimated_kernel = if scale > 1.0 {
+        scale.ceil() as usize + 2
+    } else {
+        match interpolation {
+            InterpolationMode::Bicubic => 4,
+            InterpolationMode::Lanczos => 6,
+            InterpolationMode::Bilinear => 2,
+            InterpolationMode::Nearest => 1,
+        }
+    };
+
+    // Reserve if needed to avoid reallocs during loop
+    offsets_buf.reserve(out_size * estimated_kernel);
+    weights_buf.reserve(out_size * estimated_kernel);
+    counts_buf.reserve(out_size);
+    starts_buf.reserve(out_size);
+
+    let mut s_pos = src_start * src_dim as f32;
+    let mut min_offset = usize::MAX;
+    let mut max_offset = 0;
+
+    for _ in 0..out_size {
+        let center = s_pos + 0.5 * scale - 0.5;
+        let start_idx = offsets_buf.len();
+        let mut count = 0;
+
+        if scale > 1.0 {
+            // --- DOWNSCALING (Area-based) ---
+            let radius = scale / 2.0;
+            let left = center - radius;
+            let right = center + radius;
+
+            let first_pixel = left.ceil() as isize;
+            let last_pixel = right.floor() as isize;
+
+            // 1. Left Partial
+            let left_weight = (first_pixel as f32) - left;
+            if left_weight > 0.001 {
+                let idx = (left.floor() as isize).clamp(0, src_dim as isize - 1) as usize;
+                let off = idx * stride_mul;
+                offsets_buf.push(off);
+                weights_buf.push(left_weight);
+                min_offset = min_offset.min(off);
+                max_offset = max_offset.max(off);
+                count += 1;
+            }
+
+            // 2. Center Full
+            for i in first_pixel..=last_pixel {
+                if (i as f32) < right {
+                    let idx = i.clamp(0, src_dim as isize - 1) as usize;
+                    let off = idx * stride_mul;
+                    offsets_buf.push(off);
+                    weights_buf.push(1.0);
+                    min_offset = min_offset.min(off);
+                    max_offset = max_offset.max(off);
+                    count += 1;
+                }
+            }
+
+            // 3. Right Partial
+            if right > (last_pixel as f32) + 0.001 {
+                let right_weight = right - (right.floor());
+                let idx = (right.floor() as isize).clamp(0, src_dim as isize - 1) as usize;
+                let off = idx * stride_mul;
+                offsets_buf.push(off);
+                weights_buf.push(right_weight);
+                min_offset = min_offset.min(off);
+                max_offset = max_offset.max(off);
+                count += 1;
+            }
+        } else {
+            // --- UPSCALING (Kernel-based) ---
+            let x_int = center.floor() as isize;
+            let dx = center - x_int as f32;
+
+            match interpolation {
+                InterpolationMode::Bicubic => {
+                    for k in 0..4 {
+                        let idx = (x_int - 1 + k as isize).clamp(0, src_dim as isize - 1) as usize;
+                        let off = idx * stride_mul;
+                        offsets_buf.push(off);
+                        weights_buf.push(get_cubic_weight((k as isize - 1) as f32 - dx));
+                        min_offset = min_offset.min(off);
+                        max_offset = max_offset.max(off);
+                        count += 1;
+                    }
+                }
+                InterpolationMode::Lanczos => {
+                    for k in 0..6 {
+                        let idx = (x_int - 2 + k as isize).clamp(0, src_dim as isize - 1) as usize;
+                        let off = idx * stride_mul;
+                        offsets_buf.push(off);
+                        weights_buf.push(get_lanzcos_weight(dx + 2.0 - k as f32));
+                        min_offset = min_offset.min(off);
+                        max_offset = max_offset.max(off);
+                        count += 1;
+                    }
+                }
+                InterpolationMode::Bilinear => {
+                    for k in 0..2 {
+                        let idx = (x_int + k as isize).clamp(0, src_dim as isize - 1) as usize;
+                        let off = idx * stride_mul;
+                        offsets_buf.push(off);
+                        weights_buf.push(get_bilinear_weight(k as f32 - dx));
+                        min_offset = min_offset.min(off);
+                        max_offset = max_offset.max(off);
+                        count += 1;
+                    }
+                }
+                InterpolationMode::Nearest => {
+                    let x_int = center.floor() as isize;
+                    let dx = center - x_int as f32;
+                    
+                    for k in 0..1 {
+                        let idx = (x_int + k as isize).clamp(0, src_dim as isize - 1) as usize;
+                        let off = idx * stride_mul;
+                        offsets_buf.push(off);
+                        weights_buf.push(get_nearest_weight(k as f32 - dx));
+                        min_offset = min_offset.min(off);
+                        max_offset = max_offset.max(off);
+                        count += 1;
+                    }
+                }
+            }
+        }
+
+        // Normalize weights slice
+        let w_slice = &mut weights_buf[start_idx..start_idx + count];
+        let w_sum: f32 = w_slice.iter().sum();
+        if w_sum > 0.0 {
+            for w in w_slice {
+                *w /= w_sum;
+            }
+        }
+
+        starts_buf.push(start_idx);
+        counts_buf.push(count);
+        s_pos += scale;
+    }
+
+    // Handle edge case where no pixels were mapped (should not happen for valid images)
+    if min_offset == usize::MAX {
+        min_offset = 0;
+        max_offset = 0;
+    }
+
+    MapMetadata {
+        offsets: offsets_buf,
+        weights: weights_buf,
+        counts: counts_buf,
+        starts: starts_buf,
+        min_offset,
+        max_offset,
+    }
+}
+
+pub fn process_transform_separable<A: ImageAllocator>(
+    image: &Image<u8, 3, A>,
+    transform: &CropTransform,
+    out_size: usize,
+    interpolation: InterpolationMode,
+    workspace: &mut ResizerWorkspace,
+    device: &Device,
+) -> Result<Tensor, candle_core::Error> {
+    // --- 1. Geometry Setup ---
+    let dst_x_min = (transform.dst_valid_roi.x * out_size as f32).round() as usize;
+    let dst_y_min = (transform.dst_valid_roi.y * out_size as f32).round() as usize;
+    let dst_w = ((transform.dst_valid_roi.w * out_size as f32).round() as usize)
+        .min(out_size.saturating_sub(dst_x_min));
+    let dst_h = ((transform.dst_valid_roi.h * out_size as f32).round() as usize)
+        .min(out_size.saturating_sub(dst_y_min));
+
+    let [mr, mg, mb] = transform.normalization_mean;
+    let [sr, sg, sb] = transform.normalization_std;
+    let fill_vals = [(0.0 - mr) / sr, (0.0 - mg) / sg, (0.0 - mb) / sb];
+
+    let plane_size = out_size * out_size;
+    let mut final_data = Vec::with_capacity(plane_size * 3);
+
+    // Fast Exit: Return full padding if crop is invalid
+    if dst_w == 0 || dst_h == 0 {
+        final_data.resize(plane_size, fill_vals[0]);
+        final_data.resize(plane_size * 2, fill_vals[1]);
+        final_data.resize(plane_size * 3, fill_vals[2]);
+        return Tensor::from_vec(final_data, (3, out_size, out_size), device);
+    }
+
+    // --- 2. Compute Maps (Using Workspace) ---
+    let x_map_data = compute_weight_map_into_workspace(
+        dst_w,
+        image.width(),
+        transform.src_roi.x,
+        transform.src_roi.w,
+        3,
+        interpolation,
+        &mut workspace.x_map_offsets,
+        &mut workspace.x_map_weights,
+        &mut workspace.x_map_counts,
+        &mut workspace.x_map_starts,
+    );
+
+    let y_map_data = compute_weight_map_into_workspace(
+        dst_h,
+        image.height(),
+        transform.src_roi.y,
+        transform.src_roi.h,
+        image.width() * 3,
+        interpolation,
+        &mut workspace.y_map_offsets,
+        &mut workspace.y_map_weights,
+        &mut workspace.y_map_counts,
+        &mut workspace.y_map_starts,
+    );
+
+    // --- 3. Intermediate Scratch Buffer Setup ---
+    let min_src_row = y_map_data.min_offset / (image.width() * 3);
+    let max_src_row = y_map_data.max_offset / (image.width() * 3);
+    let scratch_h = max_src_row - min_src_row + 1;
+    let scratch_size = scratch_h * dst_w * 3;
+
+    workspace.scratch.clear();
+    workspace.scratch.resize(scratch_size, 0.0);
+
+    let (s_r, rest) = workspace.scratch.split_at_mut(scratch_h * dst_w);
+    let (s_g, s_b) = rest.split_at_mut(scratch_h * dst_w);
+
+    let src_slice = image.as_slice();
+    let src_stride = image.width() * 3;
+
+    // LUT Init
+    let inv255 = 1.0 / 255.0;
+    let mut lut_r = [0f32; 256];
+    let mut lut_g = [0f32; 256];
+    let mut lut_b = [0f32; 256];
+    for i in 0..256 {
+        let v = i as f32 * inv255;
+        lut_r[i] = (v - mr) / sr;
+        lut_g[i] = (v - mg) / sg;
+        lut_b[i] = (v - mb) / sb;
+    }
+
+    // --- 4. PASS 1: Horizontal Resize ---
+    // Parallelize over rows using chunking to avoid capture issues
+    s_r.par_chunks_mut(dst_w)
+        .zip(s_g.par_chunks_mut(dst_w))
+        .zip(s_b.par_chunks_mut(dst_w))
+        .enumerate()
+        .for_each(|(i, ((out_r, out_g), out_b))| {
+            let src_row_ptr = unsafe { src_slice.as_ptr().add((min_src_row + i) * src_stride) };
+
+            for x in 0..dst_w {
+                let start = x_map_data.starts[x];
+                let count = x_map_data.counts[x];
+
+                let mut acc_r = 0.0;
+                let mut acc_g = 0.0;
+                let mut acc_b = 0.0;
+
+                for k in 0..count {
+                    unsafe {
+                        let off = *x_map_data.offsets.get_unchecked(start + k);
+                        let w = *x_map_data.weights.get_unchecked(start + k);
+                        let p = src_row_ptr.add(off);
+
+                        acc_r += lut_r[*p as usize] * w;
+                        acc_g += lut_g[*p.add(1) as usize] * w;
+                        acc_b += lut_b[*p.add(2) as usize] * w;
+                    }
+                }
+                out_r[x] = acc_r;
+                out_g[x] = acc_g;
+                out_b[x] = acc_b;
+            }
+        });
+
+    // --- 5. PASS 2: Vertical Resize ---
+    final_data.resize(plane_size, fill_vals[0]);
+    final_data.resize(plane_size * 2, fill_vals[1]);
+    final_data.resize(plane_size * 3, fill_vals[2]);
+
+    let (f_r, rest) = final_data.split_at_mut(plane_size);
+    let (f_g, f_b) = rest.split_at_mut(plane_size);
+
+    f_r.par_chunks_mut(out_size)
+        .zip(f_g.par_chunks_mut(out_size))
+        .zip(f_b.par_chunks_mut(out_size))
+        .skip(dst_y_min)
+        .take(dst_h)
+        .enumerate()
+        .for_each(|(y_idx, ((row_r, row_g), row_b))| {
+            let start = y_map_data.starts[y_idx];
+            let count = y_map_data.counts[y_idx];
+
+            let valid_r = &mut row_r[dst_x_min..dst_x_min + dst_w];
+            let valid_g = &mut row_g[dst_x_min..dst_x_min + dst_w];
+            let valid_b = &mut row_b[dst_x_min..dst_x_min + dst_w];
+
+            valid_r.fill(0.0);
+            valid_g.fill(0.0);
+            valid_b.fill(0.0);
+
+            for k in 0..count {
+                unsafe {
+                    let global_off = *y_map_data.offsets.get_unchecked(start + k);
+                    let w = *y_map_data.weights.get_unchecked(start + k);
+
+                    let scratch_row_idx = (global_off / src_stride) - min_src_row;
+
+                    let src_r =
+                        s_r.get_unchecked(scratch_row_idx * dst_w..(scratch_row_idx + 1) * dst_w);
+                    let src_g =
+                        s_g.get_unchecked(scratch_row_idx * dst_w..(scratch_row_idx + 1) * dst_w);
+                    let src_b =
+                        s_b.get_unchecked(scratch_row_idx * dst_w..(scratch_row_idx + 1) * dst_w);
+
+                    for x in 0..dst_w {
+                        valid_r[x] += src_r[x] * w;
+                        valid_g[x] += src_g[x] * w;
+                        valid_b[x] += src_b[x] * w;
+                    }
+                }
+            }
+        });
+
+    Tensor::from_vec(final_data, (3, out_size, out_size), device)
+}
+
+impl Preprocessor {
+    pub fn new(mut config: PreprocessConfig) -> Self {
+        if config.model_type == Model::SmolVLM {
+            config.interpolation = InterpolationMode::Lanczos;
+        }
+        Self { config }
+    }
+
+    pub fn compute_transforms(&self, image_dims: (u32, u32)) -> Vec<CropTransform> {
+        let (w, h) = image_dims;
+        let mut instructions = Vec::new();
+        match self.config.model_type {
+            Model::Clip => {
+                let roi = get_center_crop_uv(w, h);
+                instructions.push(CropTransform {
+                    src_roi: roi,
+                    dst_batch_idx: 0,
+                    dst_valid_roi: Rect::full(),
+                    normalization_mean: self.config.mean,
+                    normalization_std: self.config.std,
+                });
+            }
+            Model::SmolVLM | Model::LLaVA => {
+                let w_f = w as f32;
+                let h_f = h as f32;
+                let target_f = self.config.target_size as f32;
+
+                let global_scale = if w_f <= target_f && h_f <= target_f {
+                    1.0
+                } else {
+                    target_f / w_f.max(h_f)
+                };
+
+                instructions.push(CropTransform {
+                    src_roi: Rect::full(),
+                    dst_batch_idx: 0,
+                    dst_valid_roi: Rect {
+                        x: 0.0,
+                        y: 0.0,
+                        w: (w_f * global_scale) / target_f,
+                        h: (h_f * global_scale) / target_f,
+                    },
+                    normalization_mean: self.config.mean,
+                    normalization_std: self.config.std,
+                });
+
+                let tiles = get_grid_tiles(w, h, self.config.target_size);
+
+                for (i, (src_roi, dst_valid_roi)) in tiles.into_iter().enumerate() {
+                    instructions.push(CropTransform {
+                        src_roi,
+                        dst_batch_idx: i + 1,
+                        dst_valid_roi,
+                        normalization_mean: self.config.mean,
+                        normalization_std: self.config.std,
+                    });
+                }
+            }
+            Model::PaliGemma => {
+                instructions.push(CropTransform {
+                    src_roi: Rect::full(),
+                    dst_batch_idx: 0,
+                    dst_valid_roi: Rect::full(),
+                    normalization_mean: self.config.mean,
+                    normalization_std: self.config.std,
+                });
+            }
+        }
+        instructions
+    }
+
+    /// Process an image generating all necessary crops/tiles as specified by the model config.
+    pub fn process<A: ImageAllocator>(
+        &self,
+        image: &Image<u8, 3, A>,
+        device: &Device,
+    ) -> Result<Vec<Tensor>, candle_core::Error> {
+        let transforms = self.compute_transforms((image.width() as u32, image.height() as u32));
+        let mut workspace = ResizerWorkspace::new();
+        transforms
+            .iter()
+            .map(|t| {
+                process_transform_separable(
+                    image,
+                    t,
+                    self.config.target_size,
+                    self.config.interpolation,
+                    &mut workspace,
+                    device,
+                )
+            })
+            .collect()
+    }
+}

--- a/crates/kornia-vlm/src/smolvlm/mod.rs
+++ b/crates/kornia-vlm/src/smolvlm/mod.rs
@@ -1,6 +1,6 @@
 mod custom_rmsnorm;
 mod model;
-mod preprocessor;
+pub mod preprocessor;
 mod text_model;
 pub mod utils;
 mod vision_model;

--- a/examples/bench_preprocessors/Cargo.toml
+++ b/examples/bench_preprocessors/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "bench_preprocessors"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+candle-core = { workspace = true }
+kornia-image = { workspace = true }
+kornia-io = { workspace = true }
+kornia-vlm = { workspace = true }
+kornia-imgproc = { workspace = true }
+anyhow = "1.0"
+rayon = "1.10"
+
+[dev-dependencies]
+criterion = { workspace = true }
+
+[[bench]]
+name = "bench_preprocessors"
+harness = false

--- a/examples/bench_preprocessors/benches/bench_preprocessors.rs
+++ b/examples/bench_preprocessors/benches/bench_preprocessors.rs
@@ -1,0 +1,185 @@
+use anyhow::Result;
+use candle_core::{Device, Tensor};
+use criterion::{criterion_group, criterion_main, Criterion};
+use kornia_image::{allocator::CpuAllocator, Image, ImageSize};
+use kornia_imgproc::{interpolation::InterpolationMode, resize::resize_fast_rgb};
+use kornia_io::jpeg::read_image_jpeg_rgb8;
+use kornia_vlm::preprocessor::{Model, PreprocessConfig, Preprocessor};
+use kornia_vlm::smolvlm::preprocessor::SmolVlmImagePreprocessor;
+use std::path::Path;
+
+// Minimal normalization to match PaliGemma pipeline cost
+fn image_to_normalized_tensor(img: &Image<u8, 3, CpuAllocator>, device: &Device) -> Result<Tensor> {
+    let tensor = Tensor::from_slice(img.as_slice(), (img.height(), img.width(), 3), device)?
+        .permute((2, 0, 1))? // (H, W, C) -> (C, H, W)
+        .to_dtype(candle_core::DType::F32)? // Cast to f32
+        .affine(2. / 255., -1.)?; // Normalize 0..255 -> -1..1
+    Ok(tensor)
+}
+
+fn load_test_image() -> Image<u8, 3, CpuAllocator> {
+    let paths = [
+        "tests/data/apriltags_tag36h11.jpg",
+        "../../tests/data/apriltags_tag36h11.jpg",
+    ];
+
+    for p in paths {
+        let path = Path::new(p);
+        if path.exists() {
+            println!("Loading image from {:?}", path);
+            return read_image_jpeg_rgb8(path)
+                .expect("Failed to read image")
+                .into_inner();
+        }
+    }
+    panic!("Image not found in search paths: {:?}", paths);
+}
+
+fn bench_preprocessors(c: &mut Criterion) {
+    let image = load_test_image();
+    let device = Device::Cpu;
+
+    // --- 1. Generic SmolVLM ---
+    let config_smol = PreprocessConfig {
+        model_type: Model::SmolVLM,
+        target_size: 384,
+        mean: [0.5, 0.5, 0.5],
+        std: [0.5, 0.5, 0.5],
+        interpolation: InterpolationMode::Lanczos,
+    };
+    let preprocessor_smol = Preprocessor::new(config_smol.clone());
+
+    c.bench_function("Generic SmolVLM (Fused Bicubic + Tiling)", |b| {
+        b.iter(|| preprocessor_smol.process(&image, &device).unwrap())
+    });
+
+    // --- 2. Specific SmolVLM ---
+    let mut smol_pre = SmolVlmImagePreprocessor::new(2048, 384, &device).unwrap();
+
+    c.bench_function("Specific SmolVLM (Resize + Pad + Norm)", |b| {
+        b.iter(|| smol_pre.preprocess(&image, &device, CpuAllocator).unwrap())
+    });
+
+    // --- 3. Generic PaliGemma ---
+    let config_pali = PreprocessConfig {
+        model_type: Model::PaliGemma,
+        target_size: 224,
+        mean: [0.5, 0.5, 0.5],
+        std: [0.5, 0.5, 0.5],
+        interpolation: InterpolationMode::Bicubic,
+    };
+    let preprocessor_pali = Preprocessor::new(config_pali.clone());
+
+    c.bench_function("Generic PaliGemma (Fused Bicubic)", |b| {
+        b.iter(|| preprocessor_pali.process(&image, &device).unwrap())
+    });
+
+    // --- 4. Specific PaliGemma (Simulated) ---
+    let mut pali_specific_out = Image::from_size_val(
+        ImageSize {
+            width: 224,
+            height: 224,
+        },
+        0u8,
+        CpuAllocator,
+    )
+    .unwrap();
+
+    c.bench_function("Specific PaliGemma (Resize Bilinear + Norm)", |b| {
+        b.iter(|| {
+            resize_fast_rgb(&image, &mut pali_specific_out, InterpolationMode::Bilinear).unwrap();
+            let _t = image_to_normalized_tensor(&pali_specific_out, &device).unwrap();
+        })
+    });
+
+    // --- 5. Generic Clip ---
+    // Default config is Clip (224x224, Center Crop)
+    let config_clip = PreprocessConfig::default();
+    let preprocessor_clip = Preprocessor::new(config_clip);
+
+    c.bench_function("Generic Clip (Center Crop + Resize + Norm)", |b| {
+        b.iter(|| preprocessor_clip.process(&image, &device).unwrap())
+    });
+
+    // --- 6. Native Clip (Simulated) ---
+    // Clip native pipeline: Center Crop -> Resize -> To f32 -> Normalize
+    let (w, h) = (image.width(), image.height());
+    let crop_size = w.min(h);
+    let x = (w - crop_size) / 2;
+    let y = (h - crop_size) / 2;
+
+    use kornia_vlm::preprocessor::{CLIP_MEAN, CLIP_STD};
+
+    c.bench_function("Native Clip (Crop + Resize Bicubic + Norm)", |b| {
+        b.iter(|| {
+            // Allocate on every call
+            let mut clip_cropped = Image::<u8, 3, _>::from_size_val(
+                ImageSize {
+                    width: crop_size,
+                    height: crop_size,
+                },
+                0u8,
+                CpuAllocator,
+            )
+            .unwrap();
+
+            let mut clip_resized = Image::<u8, 3, _>::from_size_val(
+                ImageSize {
+                    width: 224,
+                    height: 224,
+                },
+                0u8,
+                CpuAllocator,
+            )
+            .unwrap();
+
+            let mut clip_f32 = Image::<f32, 3, _>::from_size_val(
+                ImageSize {
+                    width: 224,
+                    height: 224,
+                },
+                0.0,
+                CpuAllocator,
+            )
+            .unwrap();
+
+            let mut clip_normalized = Image::<f32, 3, _>::from_size_val(
+                ImageSize {
+                    width: 224,
+                    height: 224,
+                },
+                0.0,
+                CpuAllocator,
+            )
+            .unwrap();
+
+            // 1. Center Crop
+            kornia_imgproc::crop::crop_image(&image, &mut clip_cropped, x, y).unwrap();
+
+            // 2. Resize
+            resize_fast_rgb(&clip_cropped, &mut clip_resized, InterpolationMode::Bicubic).unwrap();
+
+            // 3. To f32 (scale to 0-1)
+            let inv_255 = 1.0 / 255.0;
+            clip_f32
+                .as_slice_mut()
+                .iter_mut()
+                .zip(clip_resized.as_slice().iter())
+                .for_each(|(dst, &src)| {
+                    *dst = src as f32 * inv_255;
+                });
+
+            // 4. Normalize
+            kornia_imgproc::normalize::normalize_mean_std(
+                &clip_f32,
+                &mut clip_normalized,
+                &CLIP_MEAN,
+                &CLIP_STD,
+            )
+            .unwrap();
+        })
+    });
+}
+
+criterion_group!(benches, bench_preprocessors);
+criterion_main!(benches);

--- a/examples/compare_preprocessors/Cargo.toml
+++ b/examples/compare_preprocessors/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "compare_preprocessors"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+candle-core = { workspace = true }
+kornia-image = { workspace = true }
+kornia-io = { workspace = true }
+kornia-vlm = { workspace = true }
+anyhow = "1.0"
+kornia-imgproc = { version = "0.1.11-rc.1", path = "../../crates/kornia-imgproc" }

--- a/examples/compare_preprocessors/src/main.rs
+++ b/examples/compare_preprocessors/src/main.rs
@@ -1,0 +1,203 @@
+use anyhow::Result;
+use candle_core::Device;
+use kornia_image::{allocator::CpuAllocator, Image, ImageSize};
+use kornia_imgproc::{interpolation::InterpolationMode, resize::resize_fast_rgb};
+use kornia_io::{jpeg::read_image_jpeg_rgb8, png::write_image_png_rgb8};
+use kornia_vlm::preprocessor::{Model, PreprocessConfig, Preprocessor};
+use kornia_vlm::smolvlm::preprocessor::SmolVlmImagePreprocessor;
+use std::path::Path;
+
+fn main() -> Result<()> {
+    // 1. Load Image
+    let img_path = Path::new("tests/data/apriltags_tag36h11.jpg");
+    if !img_path.exists() {
+        println!("Image not found at {:?}", img_path);
+        return Ok(());
+    }
+    println!("Loading image from {:?}", img_path);
+    let image = read_image_jpeg_rgb8(img_path)?;
+
+    let device = Device::Cpu;
+
+    // --- SMOLVLM COMPARISON ---
+    println!("\n--- SMOLVLM COMPARISON ---");
+
+    // 2. Run Generic Preprocessor (SmolVLM Config)
+    println!("Running Generic Preprocessor (SmolVLM Config)...");
+    let config_smol = PreprocessConfig {
+        model_type: Model::SmolVLM,
+        target_size: 384,
+        mean: [0.5, 0.5, 0.5], // SigLIP mean
+        std: [0.5, 0.5, 0.5],  // SigLIP std
+        interpolation: InterpolationMode::Lanczos,
+    };
+    let preprocessor_smol = Preprocessor::new(config_smol.clone());
+    let out_tensors_smol = preprocessor_smol.process(&image, &device)?;
+
+    println!(
+        "Generic Preprocessor produced {} tensors",
+        out_tensors_smol.len()
+    );
+
+    // Save generic outputs
+    for (i, tensor) in out_tensors_smol.iter().enumerate() {
+        let tensor = tensor.unsqueeze(0)?;
+        let imgs = tensor_to_images(&tensor, config_smol.mean, config_smol.std)?;
+        // Since tensor_to_images returns a Vec (handling batch dim), but here we process single images:
+        if let Some(img) = imgs.first() {
+            let path = format!("smol_generic_out_{}.png", i);
+            write_image_png_rgb8(&path, img)?;
+            println!("Saved {}", path);
+        }
+    }
+
+    // 3. Run SmolVlmImagePreprocessor
+    println!("Running SmolVlmImagePreprocessor...");
+    let mut smol_pre = SmolVlmImagePreprocessor::new(2048, 384, &device)?;
+    let (img_tensor, mask_tensor, size) = smol_pre.preprocess(&image, &device, CpuAllocator)?;
+
+    println!("SmolVLM Output Tensor Shape: {:?}", img_tensor.dims());
+    println!("SmolVLM Output Mask Shape: {:?}", mask_tensor.dims());
+    println!("SmolVLM Output Size: {:?}", size);
+
+    // Convert tensor back to images and save
+    let patches = tensor_to_images(&img_tensor, config_smol.mean, config_smol.std)?;
+    for (i, img) in patches.iter().enumerate() {
+        let path = format!("smol_specific_out_{}.png", i);
+        write_image_png_rgb8(&path, img)?;
+        println!("Saved {}", path);
+    }
+
+    // --- PALIGEMMA COMPARISON ---
+    println!("\n--- PALIGEMMA COMPARISON ---");
+
+    // 4. Run Generic Preprocessor (PaliGemma Config)
+    println!("Running Generic Preprocessor (PaliGemma Config)...");
+    let config_pali = PreprocessConfig {
+        model_type: Model::PaliGemma,
+        target_size: 224,
+        mean: [0.5, 0.5, 0.5],
+        std: [0.5, 0.5, 0.5],
+        interpolation: InterpolationMode::Bicubic,
+    };
+    let preprocessor_pali = Preprocessor::new(config_pali.clone());
+    let out_tensors_pali = preprocessor_pali.process(&image, &device)?;
+
+    println!(
+        "Generic Preprocessor produced {} tensors",
+        out_tensors_pali.len()
+    );
+
+    // Save generic outputs
+    for (i, tensor) in out_tensors_pali.iter().enumerate() {
+        let tensor = tensor.unsqueeze(0)?;
+        let imgs = tensor_to_images(&tensor, config_pali.mean, config_pali.std)?;
+        if let Some(img) = imgs.first() {
+            let path = format!("pali_generic_out_{}.png", i);
+            write_image_png_rgb8(&path, img)?;
+            println!("Saved {}", path);
+        }
+    }
+
+    // 5. Run Specific PaliGemma Logic (Resize + Bilinear)
+    println!("Running Specific PaliGemma Logic...");
+
+    // Original implementation: resize_fast_rgb(image, &mut img_buf, InterpolationMode::Bilinear)?;
+    let mut pali_specific_out = Image::from_size_val(
+        ImageSize {
+            width: 224,
+            height: 224,
+        },
+        0u8,
+        CpuAllocator,
+    )?;
+
+    resize_fast_rgb(&image, &mut pali_specific_out, InterpolationMode::Bicubic)?;
+
+    let path = "pali_specific_out_0.png";
+    write_image_png_rgb8(path, &pali_specific_out)?;
+    println!("Saved {}", path);
+
+    // --- CLIP COMPARISON ---
+    println!("\n--- CLIP COMPARISON ---");
+
+    // 6. Run Generic Preprocessor (Clip Config)
+    println!("Running Generic Preprocessor (Clip Config)...");
+    let config_clip = PreprocessConfig {
+        model_type: Model::Clip,
+        target_size: 224,
+        mean: kornia_vlm::preprocessor::CLIP_MEAN,
+        std: kornia_vlm::preprocessor::CLIP_STD,
+        interpolation: InterpolationMode::Bicubic,
+    };
+    let preprocessor_clip = Preprocessor::new(config_clip.clone());
+    let out_tensors_clip = preprocessor_clip.process(&image, &device)?;
+
+    println!(
+        "Generic Preprocessor produced {} tensors",
+        out_tensors_clip.len()
+    );
+
+    // Save generic outputs
+    for (i, tensor) in out_tensors_clip.iter().enumerate() {
+        let tensor = tensor.unsqueeze(0)?;
+        let imgs = tensor_to_images(&tensor, config_clip.mean, config_clip.std)?;
+        if let Some(img) = imgs.first() {
+            let path = format!("clip_generic_out_{}.png", i);
+            write_image_png_rgb8(&path, img)?;
+            println!("Saved {}", path);
+        }
+    }
+
+    Ok(())
+}
+
+// Helper for tensor (which is [N, 3, H, W]) -> Vec<Image>
+fn tensor_to_images(
+    tensor: &candle_core::Tensor,
+    mean: [f32; 3],
+    std: [f32; 3],
+) -> Result<Vec<Image<u8, 3, CpuAllocator>>> {
+    let (n, c, h, w) = tensor.dims4()?;
+    let mut images = Vec::new();
+
+    // Convert to Vec<f32>
+    let vec_data = tensor.flatten_all()?.to_vec1::<f32>()?;
+    let image_size = c * h * w;
+    let plane_size = h * w;
+
+    for i in 0..n {
+        let start = i * image_size;
+        let end = start + image_size;
+        let img_slice = &vec_data[start..end];
+
+        // img_slice is CHW
+        let r_plane = &img_slice[0..plane_size];
+        let g_plane = &img_slice[plane_size..2 * plane_size];
+        let b_plane = &img_slice[2 * plane_size..3 * plane_size];
+
+        let mut u8_data = vec![0u8; plane_size * 3];
+        for y in 0..h {
+            for x in 0..w {
+                let idx = y * w + x;
+                let r = r_plane[idx] * std[0] + mean[0];
+                let g = g_plane[idx] * std[1] + mean[1];
+                let b = b_plane[idx] * std[2] + mean[2];
+
+                let dst_idx = (y * w + x) * 3;
+                u8_data[dst_idx] = (r * 255.0).clamp(0.0, 255.0) as u8;
+                u8_data[dst_idx + 1] = (g * 255.0).clamp(0.0, 255.0) as u8;
+                u8_data[dst_idx + 2] = (b * 255.0).clamp(0.0, 255.0) as u8;
+            }
+        }
+        images.push(Image::new(
+            ImageSize {
+                width: w,
+                height: h,
+            },
+            u8_data,
+            CpuAllocator,
+        )?);
+    }
+    Ok(images)
+}


### PR DESCRIPTION
# perf: Add fused image preprocessing kernels for VLM

##  Summary
This PR implements fused kernels for Vision-Language Model image preprocessing (SmolVLM, PaliGemma). By fusing operations like Resizing, Padding, Tiling, and Normalisation, and permuting them into single passes, we significantly reduce memory bandwidth and execution time.

## Benchmarks
The fused implementation shows a **5.3x speedup** for the complex SmolVLM pipeline.

| Pipeline | Standard Time | **Fused Time** | Improvement |
| :--- | :--- | :--- | :--- |
| **SmolVLM** (Bicubic + Tiling) | 41.99 ms | **7.89 ms** | ** 5.3x Faster** |
| **PaliGemma** (Bicubic/Bilinear) | 993.45 µs | **914.76 µs** | ~8% Faster |
| **CLIP** (Crop + Resize + Norm) | 883.30 µs | **880.56 µs** | Equivalent |

##  Changes
- **SmolVLM:** Added a specific fused kernel for `Lancoz Interpolation + Tiling`.
- **PaliGemma:** Added fused `Bicubic` interpolation.
- **CLIP:** Added generic `Center Crop + Resize + Norm`.