### PR TITLE
Fix `.scale_and_cast` unit test

### DIFF
--- a/crates/kornia-image/src/image.rs
+++ b/crates/kornia-image/src/image.rs
@@ -782,8 +782,8 @@ mod tests {
             data,
             CpuAllocator,
         )?;
-        let image_f32 = image_u8.cast_and_scale::<f32>(1. / 255.0)?;
-        assert_eq!(image_f32.get([1, 0, 2]), Some(&1.0f32));
+        let image_f32 = image_u8.scale_and_cast::<f32>(1)?;
+        assert_eq!(image_f32.get([1, 0, 2]), Some(&255.0f32));
 
         Ok(())
     }


### PR DESCRIPTION
## 📝 Description

The existing unit test was actually a duplicate of the `cast_and_scale` unit test. This PR fixes that.

---

## 🛠️ Changes Made
- Actually implement a unit test for scale_and_cast

---

## 🧪 How Was This Tested?
- It is itself a unit test

---

## 🕵️ AI Usage Disclosure
*Check one of the following:*
- [x] 🟢 **No AI used.**
- [ ] 🟡 **AI-assisted:** I used AI for boilerplate/refactoring but have manually reviewed and tested every line.
- [ ] 🔴 **AI-generated:** (Note: These PRs may be subject to stricter scrutiny or immediate closure if the logic is not explained).
