### PR TITLE
fix: fixes broken c++ CI/CD tests

### DIFF
--- a/kornia-cpp/CMakeLists.txt
+++ b/kornia-cpp/CMakeLists.txt
@@ -25,7 +25,7 @@ endif()
 
 # --- 2. Build Rust ---
 add_custom_target(cargo_build ALL
-    COMMAND ${CARGO_CMD}
+    COMMAND ${CMAKE_COMMAND} -E env CARGO_TARGET_DIR=${CMAKE_CURRENT_SOURCE_DIR}/target ${CARGO_CMD}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMENT "Building Kornia C++ Rust Crate..."
     BYPRODUCTS "${RUST_TARGET_DIR}/${RUST_LIB_NAME}"


### PR DESCRIPTION
### What changes

This PR updates `kornia-cpp/CMakeLists.txt` to explicitly set the `CARGO_TARGET_DIR` environment variable to `${CMAKE_CURRENT_SOURCE_DIR}/target` during the Cargo build step.

### Why

The build was failing during the `cpp-test` task with an error in the `copy_if_different` command.

* **The Issue:** Because `kornia-cpp` is part of a Cargo workspace, running `cargo build` defaults to outputting artifacts (including generated CXX headers) into the **workspace root** `target` directory.
* **The Conflict:** The CMake configuration explicitly expects these artifacts to exist in the **local** `kornia-cpp/target` directory.
* **The Fix:** forcing `CARGO_TARGET_DIR` ensures the artifacts are generated exactly where CMake looks for them, resolving the missing `lib.rs.h` file error.