### PR TITLE
(Optim): Refactor inputs_merger

### DIFF
--- a/crates/kornia-vlm/src/smolvlm/model.rs
+++ b/crates/kornia-vlm/src/smolvlm/model.rs
@@ -72,28 +72,11 @@ impl SmolModel {
         })
     }
 
-    /// Merges image hidden states into the text input embeddings using a boolean mask.
+    /// Interleaves image features into text embeddings at positions marked by the boolean mask.
     ///
-    /// This method combines visual and textual embeddings into a single sequence by inserting
-    /// image features at positions marked by the image token mask. This allows the language
-    /// model to process both modalities in a unified manner.
-    ///
-    /// Maps the `image_token_mask` to corresponding 0-based indices in `image_hidden_states`
-    /// using a clamped cumulative sum. To maintain a constant memory footprint, the sequence
-    /// is processed and reassembled in 1024-token chunks using zero-copy views (`.narrow()`)
-    /// and vectorized conditional selection (`.where_cond()`).
-    ///
-    /// # Complexity
-    /// * Time: `O(N)` where `N` is the total sequence length.
-    /// * Space: `O(C * D)` where `C` is the chunk size and `D` is the embedding dimension.
-    ///
-    /// # Arguments
-    /// * `image_token_mask` - A 1D tensor mapping text tokens (0.0) and image tokens (1.0).
-    /// * `image_hidden_states` - The visual features from the vision encoder.
-    /// * `inputs_embeds` - The base text embeddings from the language model.
-    ///
-    /// # Errors
-    /// Returns an error on tensor dimension mismatches, broadcasting failures, or device memory exhaustion.
+    /// Image indices are derived using a clamped cumulative sum of the mask. To maintain a
+    /// constant memory footprint, the sequence is processed and reassembled in 1024-token chunks
+    /// using zero-copy views (`.narrow()`) and vectorized conditional selection (`.where_cond()`).
     fn inputs_merger(
         image_token_mask: &Tensor,
         image_hidden_states: &Tensor,
@@ -260,7 +243,6 @@ mod tests {
         let result = SmolModel::inputs_merger(&mask, &img_embeds, &text_embeds)?;
         let result_vec = result.flatten_all()?.to_vec1::<f32>()?;
         assert_eq!(result_vec, vec![1.0, 1.0, 1.0, 1.0]);
-
         Ok(())
     }
 
@@ -270,6 +252,74 @@ mod tests {
         let result = SmolModel::inputs_merger(&mask, &img_embeds, &text_embeds)?;
         let result_vec = result.flatten_all()?.to_vec1::<f32>()?;
         assert_eq!(result_vec, vec![2.0, 1.0, 2.0, 1.0]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_alternate_embeddings_multichunk_2049() -> Result<()> {
+        let seq_len = 2049;
+        let mask_vec: Vec<u8> = (0..seq_len)
+            .map(|i| if i % 2 == 0 { 1 } else { 0 })
+            .collect();
+        let img_count = mask_vec.iter().map(|&x| x as usize).sum::<usize>();
+
+        let (mask, text_embeds, img_embeds) = create_data(mask_vec, img_count, &Device::Cpu)?;
+
+        let result = SmolModel::inputs_merger(&mask, &img_embeds, &text_embeds)?;
+        let result_vec = result.flatten_all()?.to_vec1::<f32>()?;
+        let expected_vec: Vec<f32> = (0..seq_len)
+            .map(|i| if i % 2 == 0 { 2.0 } else { 1.0 })
+            .collect();
+
+        assert_eq!(result_vec, expected_vec);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_contiguous_spanning_boundary_2049() -> Result<()> {
+        let seq_len = 2049;
+        let mut mask_vec: Vec<u8> = vec![0; seq_len]; // Start with all text (0)
+
+        mask_vec[1000..1050].fill(1);
+        mask_vec[2040..2049].fill(1);
+
+        let img_count = mask_vec.iter().map(|&x| x as usize).sum::<usize>();
+        let (mask, text_embeds, img_embeds) =
+            create_data(mask_vec, img_count, &candle_core::Device::Cpu)?;
+
+        let result = SmolModel::inputs_merger(&mask, &img_embeds, &text_embeds)?;
+        let result_vec = result.flatten_all()?.to_vec1::<f32>()?;
+
+        let expected_vec: Vec<f32> = (0..seq_len)
+            .map(|i| {
+                if (1000..1050).contains(&i) || (2040..2049).contains(&i) {
+                    2.0
+                } else {
+                    1.0
+                }
+            })
+            .collect();
+
+        assert_eq!(result_vec, expected_vec);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_out_of_bounds_image_tokens() -> Result<()> {
+        let mask_pattern = vec![1, 1, 1, 0];
+        let (mask, text_embeds, img_embeds) = create_data(mask_pattern, 2, &Device::Cpu)?;
+        let result = SmolModel::inputs_merger(&mask, &img_embeds, &text_embeds);
+        assert!(result.is_err(),);
+        Ok(())
+    }
+
+    #[test]
+    fn test_empty_sequence() -> Result<()> {
+        let (mask, text_embeds, img_embeds) = create_data(vec![], 0, &Device::Cpu)?;
+        let result = SmolModel::inputs_merger(&mask, &img_embeds, &text_embeds)?;
+        assert_eq!(result.dims2()?, (0, 1));
         Ok(())
     }
 }


### PR DESCRIPTION
## 📝 Description
Optimization: inputs_merger Refactor
- Removed Iterative Logic: Switched from a slow, token-by-token CPU loop
- Deleted merged_embeds
- uses Tensor::narrow for zero-copy slicing and a single Tensor::cat for batched GPU concatenation.
- moved core logic into a static function merge_tensors_impl for tests
- Added unit tests

**Fixes/Relates to:** #679
---

## 🧪 How Was This Tested?
- [x] **Unit Tests:** (List new/updated tests)
- [x] **Manual Verification:** (Describe the steps you took)
- [ ] **Performance/Edge Cases:** (How does this handle nulls, large data, etc.?)

---

## 🕵️ AI Usage Disclosure
*Check one of the following:*
- [ ] 🟢 **No AI used.**
- [x] 🟡 **AI-assisted:** I used AI for boilerplate/refactoring but have manually reviewed and tested every line.
- [ ] 🔴 **AI-generated:** (Note: These PRs may be subject to stricter scrutiny or immediate closure if the logic is not explained).

---

## 🚦 Checklist
- [x] I am assigned to the linked issue (required before PR submission)
- [x] The linked issue has been approved by a maintainer
- [x] This PR strictly implements what the linked issue describes (no scope creep)
- [x] I have performed a **self-review** of my code (no "ghost" variables or hallucinations).
- [x] My code follows the existing style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] (Optional) I have attached screenshots/recordings for UI changes.

---

## Benchmarking
Tested using Criterion benchmark comparing the legacy iterative approach against the new chunked implementation.
Scenario: Realistic 2048-token VLM workload with interleaved images
```
Benchmarking Inputs Merger/Iterative (Stack): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.2s, enable flat sampling, or reduce sample count to 60.
Inputs Merger/Iterative (Stack)
                        time:   [993.85 µs 996.16 µs 998.92 µs]
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) high mild
  8 (8.00%) high severe
Inputs Merger/Chunked (Narrow+Cat)
                        time:   [358.58 µs 359.21 µs 359.82 µs]
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  5 (5.00%) high severe
```

~3x increase in efficiency
