### PR TITLE
docs: fix inaccuracies across markdown documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ kornia-imgproc = "0.1"
 kornia-3d = "0.1"
 kornia-apriltag = "0.1"
 kornia-vlm = "0.1"
-kornia-nn = "0.1"
+kornia-bow = "0.1"
 kornia-algebra = "0.1"
 ```
 
@@ -298,38 +298,39 @@ Before you begin, ensure you have `rust` and `python3` installed on your system.
    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
    ```
 
-2. **Install [`uv`](https://docs.astral.sh/uv/)** to manage Python dependencies:
+2. **Install [`pixi`](https://pixi.sh)** for package and environment management:
    ```bash
-   curl -LsSf https://astral.sh/uv/install.sh | sh
+   curl -fsSL https://pixi.sh/install.sh | bash
    ```
 
-3. **Install [`just`](https://github.com/casey/just)** command runner for managing development tasks:
-   ```bash
-   cargo install just
-   ```
-
-4. **Clone the repository** to your local directory:
+3. **Clone the repository** to your local directory:
    ```bash
    git clone https://github.com/kornia/kornia-rs.git
    ```
 
+4. **Install dependencies** using pixi:
+   ```bash
+   pixi install
+   ```
+
 ### Available Commands
 
-You can check all available development commands by running `just` in the root directory of the project:
+You can check all available development commands via `pixi task list`:
 
 ```bash
-$ just
-Available recipes:
-    check-environment                 # Check if the required binaries for the project are installed
-    clean                             # Clean up caches and build artifacts
-    clippy                            # Run clippy with all features
-    clippy-default                    # Run clippy with default features
-    fmt                               # Run autoformatting and linting
-    py-build py_version='3.9'         # Create virtual environment, and build kornia-py
-    py-build-release py_version='3.9' # Create virtual environment, and build kornia-py for release
-    py-install py_version='3.9'       # Create virtual environment, and install dev requirements
-    py-test                           # Test the kornia-py code with pytest
-    test name=''                      # Test the code or a specific test
+pixi run rust-check        # Check Rust compilation (all targets)
+pixi run rust-clippy       # Run clippy (all targets, warnings as errors)
+pixi run rust-fmt          # Format Rust code
+pixi run rust-fmt-check    # Check Rust formatting
+pixi run rust-lint         # Run all Rust lints (fmt + clippy + check)
+pixi run rust-test         # Run Rust tests
+pixi run rust-test-release # Run Rust tests (release mode)
+pixi run rust-clean        # Clean Rust build artifacts
+pixi run py-build          # Build kornia-py for development
+pixi run py-build-release  # Build kornia-py for release
+pixi run py-test           # Run pytest
+pixi run cpp-build         # Build C++ library (debug)
+pixi run cpp-test          # Build and run C++ tests
 ```
 ### 🐳 Development Container
 
@@ -349,19 +350,19 @@ The devcontainer includes all necessary dependencies and tools for building and 
 Compile the project and run all tests:
 
 ```bash
-just test
+pixi run rust-test
 ```
 
-To run specific tests:
+To run tests for a specific package:
 
 ```bash
-just test image
+pixi run rust-test-package <package-name>
 ```
 
 To run clippy linting:
 
 ```bash
-just clippy
+pixi run rust-clippy
 ```
 
 ### 🐍 Python Development
@@ -369,13 +370,13 @@ just clippy
 Build Python wheels using `maturin`:
 
 ```bash
-just py-build
+pixi run py-build
 ```
 
 Run Python tests:
 
 ```bash
-just py-test
+pixi run py-test
 ```
 
 ## 💜 Contributing

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -107,7 +107,7 @@ kornia-imgproc = "0.1"
 kornia-3d = "0.1"
 kornia-apriltag = "0.1"
 kornia-vlm = "0.1"
-kornia-nn = "0.1"
+kornia-bow = "0.1"
 kornia-algebra = "0.1"
 ```
 
@@ -267,14 +267,9 @@ assert resized_img.shape == (128, 128, 3)
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
-安装 [`uv`](https://docs.astral.sh/uv/) 以管理 python 依赖
+安装 [`pixi`](https://pixi.sh) 用于包管理和环境管理
 ```bash
-curl -LsSf https://astral.sh/uv/install.sh | sh
-```
-
-安装 [`just`](https://github.com/casey/just) 命令行工具，用于管理开发任务。
-```bash
-cargo install just
+curl -fsSL https://pixi.sh/install.sh | bash
 ```
 
 克隆仓库到本地目录
@@ -282,21 +277,26 @@ cargo install just
 git clone https://github.com/kornia/kornia-rs.git
 ```
 
-你可以在项目根目录下运行 `just` 查看可用命令。
+安装依赖
+```bash
+pixi install
+```
+
+可用命令：
 
 ```bash
-$ just
-Available recipes:
-    check-environment                 # 检查项目所需的二进制文件是否已安装
-    clean                             # 清理缓存和构建产物
-    clippy                            # 用所有特性运行 clippy
-    clippy-default                    # 用默认特性运行 clippy
-    fmt                               # 自动格式化和 lint
-    py-build py_version='3.9'         # 创建虚拟环境并构建 kornia-py
-    py-build-release py_version='3.9' # 创建虚拟环境并为发布构建 kornia-py
-    py-install py_version='3.9'       # 创建虚拟环境并安装开发依赖
-    py-test                           # 用 pytest 测试 kornia-py 代码
-    test name=''                      # 测试全部或指定测试
+pixi run rust-check        # 检查 Rust 编译（所有目标）
+pixi run rust-clippy       # 运行 clippy（所有目标，警告视为错误）
+pixi run rust-fmt          # 格式化 Rust 代码
+pixi run rust-lint         # 运行所有 Rust lint（fmt + clippy + check）
+pixi run rust-test         # 运行 Rust 测试
+pixi run rust-test-release # 运行 Rust 测试（release 模式）
+pixi run rust-clean        # 清理 Rust 构建产物
+pixi run py-build          # 构建 kornia-py（开发模式）
+pixi run py-build-release  # 构建 kornia-py（release 模式）
+pixi run py-test           # 运行 pytest
+pixi run cpp-build         # 构建 C++ 库（debug）
+pixi run cpp-test          # 构建并运行 C++ 测试
 ```
 ### 🐳 Devcontainer
 
@@ -319,13 +319,19 @@ Visual Studio Code 会构建容器并在其中打开项目。你可以在容器�
 编译项目并运行测试
 
 ```bash
-just test
+pixi run rust-test
 ```
 
-如需运行指定测试，可用如下命令：
+如需运行指定包的测试：
 
 ```bash
-just test image
+pixi run rust-test-package <package-name>
+```
+
+运行 clippy 检查：
+
+```bash
+pixi run rust-clippy
 ```
 
 ### 🐍 Python
@@ -333,13 +339,13 @@ just test image
 构建 Python wheel 包，需使用 `maturin` 包。使用如下命令构建 wheel：
 
 ```bash
-just py-build
+pixi run py-build
 ```
 
 运行测试：
 
 ```bash
-just py-test
+pixi run py-test
 ```
 
 ## 💜 贡献

--- a/crates/kornia-3d/README.md
+++ b/crates/kornia-3d/README.md
@@ -56,10 +56,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ## 🧩 Modules
 
 *   **`io`**: Input/Output for 3D file formats.
-*   **`transforms`**: Geometric transformations for 3D points.
+*   **`linalg`**: Linear algebra utilities.
+*   **`ops`**: Operations on 3D data processing.
 *   **`pointcloud`**: Point cloud data structures and operations.
-*   **`registration`**: Point cloud alignment (ICP).
 *   **`pnp`**: Perspective-n-Point solvers.
+*   **`pose`**: Pose estimation algorithms.
+*   **`registration`**: Point cloud alignment (ICP).
+*   **`transforms`**: Geometric transformations for 3D points.
 
 ## 💡 Related Examples
 

--- a/crates/kornia-algebra/README.md
+++ b/crates/kornia-algebra/README.md
@@ -70,11 +70,17 @@ fn main() {
 
 ## 🧩 Modules
 
-*   **`lie`**: Lie group implementations (SO2, SE2, SO3, SE3).
-*   **`vec`**: Vector types (`Vec2`, `Vec3`, `Vec4`).
-*   **`mat`**: Matrix types (`Mat2`, `Mat3`, `Mat4`).
+*   **`lie`**: Lie group implementations (SO2, SE2, SO3, SE3, RxSO3, Sim3).
+*   **`vec`**: Vector types (`Vec2`, `Vec3`, `Vec4`, and dynamic `DVec`).
+*   **`mat`**: Matrix types (`Mat2`, `Mat3`, `Mat4`, and dynamic `DMat`).
 *   **`quat`**: Quaternion types.
 *   **`linalg`**: General linear algebra helpers.
+*   **`optim`**: Factor graph optimization module.
+*   **`param`**: Parameterization utilities.
+
+### Feature Flags
+
+*   **`approx`**: Enable approximate equality comparisons for algebraic types.
 
 ## 💡 Related Examples
 

--- a/crates/kornia-apriltag/README.md
+++ b/crates/kornia-apriltag/README.md
@@ -71,10 +71,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ## 🧩 Modules
 
 *   **`decoder`**: Main decoding logic and `AprilTagDecoder` struct.
+*   **`errors`**: Error types for AprilTag detection.
 *   **`family`**: Tag family definitions.
-*   **`config`**: Configuration options for the detection pipeline.
 *   **`quad`**: Low-level quad detection algorithms.
 *   **`segmentation`**: Image segmentation and clustering.
+*   **`threshold`**: Thresholding utilities for AprilTag detection.
+*   **`union_find`**: Union-find data structure for connected components.
+*   **`utils`**: Utility functions and types.
+
+**Note:** `DecodeTagsConfig` is a struct exported from the crate root (`lib.rs`), not a separate module.
 
 ## 💡 Related Examples
 

--- a/crates/kornia-image/README.md
+++ b/crates/kornia-image/README.md
@@ -62,9 +62,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 *   **`image`**: Core `Image` struct, `ImageSize`, `ImageLayout`, and `PixelFormat`.
 *   **`allocator`**: Memory management utilities and the `ImageAllocator` trait.
+*   **`error`**: Error types for the image module.
 *   **`ops`**: Basic image operations.
 *   **`color_spaces`**: Typed wrappers for common color spaces.
-*   **`arrow`**: (Optional) Utilities for Apache Arrow integration.
+*   **`arrow`**: (Optional, feature: `arrow`) Utilities for Apache Arrow integration.
 
 ## 💡 Related Examples
 

--- a/crates/kornia-imgproc/README.md
+++ b/crates/kornia-imgproc/README.md
@@ -82,14 +82,26 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ## 🧩 Modules
 
-*   **`resize`**: Image resizing with various interpolation methods.
-*   **`color`**: Color space conversions.
-*   **`filter`**: Convolutions and blurring.
-*   **`morphology`**: Morphological opertaions.
-*   **`warp`**: Affine and perspective transformations.
 *   **`calibration`**: Lens distortion correction.
+*   **`color`**: Color space conversions.
+*   **`core`**: Basic image operations.
+*   **`crop`**: Image cropping.
+*   **`draw`**: Drawing utilities for images.
+*   **`enhance`**: Image enhancement.
+*   **`features`**: Feature detection.
+*   **`filter`**: Convolutions and blurring.
+*   **`flip`**: Image flipping operations.
 *   **`histogram`**: Histogram computation.
+*   **`interpolation`**: Interpolation utilities.
+*   **`metrics`**: Image processing metrics.
+*   **`morphology`**: Morphological operations.
 *   **`normalize`**: Image normalization utilities.
+*   **`padding`**: Image padding.
+*   **`parallel`**: Parallelization utilities.
+*   **`pyramid`**: Pyramid operations.
+*   **`resize`**: Image resizing with various interpolation methods.
+*   **`threshold`**: Image thresholding operations.
+*   **`warp`**: Affine and perspective transformations.
 
 ## 💡 Related Examples
 

--- a/crates/kornia-io/README.md
+++ b/crates/kornia-io/README.md
@@ -51,7 +51,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 *Requires `gstreamer` and `v4l` features.*
 
 ```rust
-use kornia_io::stream::{CameraCapture, V4L2CameraConfig};
+use kornia_io::gstreamer::{CameraCapture, V4L2CameraConfig};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a camera capture object
@@ -73,10 +73,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ## 🧩 Modules
 
+*   **`error`**: Error types for the I/O module.
 *   **`functional`**: High-level helper functions like `read_image_any_rgb8`.
 *   **`jpeg` / `png` / `tiff`**: Format-specific implementations.
-*   **`gstreamer`**: (Feature) Video capture and streaming via GStreamer.
-*   **`v4l`**: (Feature) Direct Video4Linux2 camera access.
+*   **`jpegturbo`**: (Feature: `turbojpeg`) High-performance JPEG encoding and decoding via TurboJPEG.
+*   **`gstreamer`**: (Feature: `gstreamer`) Video capture and streaming via GStreamer.
+*   **`v4l`**: (Feature: `v4l`, Linux only) Direct Video4Linux2 camera access.
 *   **`fps_counter`**: Utilities for measuring frame rates.
 
 ## 💡 Related Examples

--- a/crates/kornia/README.md
+++ b/crates/kornia/README.md
@@ -16,6 +16,7 @@ This crate re-exports functionality from the following specialized crates:
 
 *   **`kornia-image`**: Strongly-typed image container and memory management.
 *   **`kornia-tensor`**: N-dimensional tensor library for low-level data manipulation.
+*   **`kornia-tensor-ops`**: Tensor operations.
 *   **`kornia-io`**: Image and video reading/writing (JPEG, PNG, GStreamer, V4L2).
 *   **`kornia-imgproc`**: Image processing algorithms (resize, color, filter, warp).
 *   **`kornia-3d`**: 3D vision, point clouds, and geometry.

--- a/kornia-cpp/README.md
+++ b/kornia-cpp/README.md
@@ -25,7 +25,7 @@ Lightweight, zero-overhead C++ interface to kornia-rs. All functions are inline 
 
 int main() {
     // Read JPEG image with zero-copy data access
-    auto image = kornia::io::read_jpeg_rgb8("image.jpg");
+    auto image = kornia::io::jpeg::read_image_jpeg_rgb8("image.jpg");
 
     std::cout << "Loaded: " << image.width() << "x" << image.height()
               << " (" << image.channels() << " channels)\n";
@@ -48,16 +48,18 @@ cmake --build build
 cmake --install build --prefix ~/local  # optional
 ```
 
-### Using Just
+### Using Pixi
 
-> **Note:** If you are running commands from the `kornia-cpp` directory, use the local commands below. If running from the project root, use the `cpp-` prefixed commands (e.g., `just cpp-test`), which delegate to the local justfile.
+> **Note:** Run these commands from the project root.
 
 ```bash
-just test            # Build and run tests
-just build-examples  # Build examples
-just format          # Format code with clang-format
-just format-check    # Check format without modifying
-just clean           # Clean build artifacts
+pixi run cpp-test          # Build and run C++ tests
+pixi run cpp-build         # Build C++ library (debug)
+pixi run cpp-build-release # Build C++ library (release)
+pixi run cpp-build-examples # Build C++ examples
+pixi run cpp-fmt           # Format C++ code
+pixi run cpp-fmt-check     # Check C++ code formatting
+pixi run cpp-clean         # Clean C++ build artifacts
 ```
 
 ## API
@@ -80,7 +82,7 @@ Images can be constructed in multiple ways:
 
 ```cpp
 // 1. From I/O functions (zero-copy)
-auto image = kornia::io::jpeg::read_jpeg_rgb8("image.jpg");
+auto image = kornia::io::jpeg::read_image_jpeg_rgb8("image.jpg");
 
 // 2. Create filled with a value
 kornia::image::ImageU8C3 image(width, height, 255);  // All pixels = 255
@@ -99,7 +101,7 @@ kornia::image::ImageU8C4 image(width, height, pixels);
 All methods are `const` and thread-safe for concurrent reads:
 
 ```cpp
-auto image = kornia::io::jpeg::read_jpeg_rgb8("image.jpg");
+auto image = kornia::io::jpeg::read_image_jpeg_rgb8("image.jpg");
 
 size_t w = image.width();          // Image width in pixels
 size_t h = image.height();         // Image height in pixels
@@ -125,10 +127,10 @@ uint8_t value = data[idx];
 ```cpp
 namespace kornia::io::jpeg {
     // Read JPEG as RGB u8 (uses libjpeg-turbo)
-    ImageU8C3 read_jpeg_rgb8(const std::string& file_path);
+    ImageU8C3 read_image_jpeg_rgb8(const std::string& file_path);
 
     // Read JPEG as grayscale u8 (auto-converts if needed)
-    ImageU8C1 read_jpeg_mono8(const std::string& file_path);
+    ImageU8C1 read_image_jpeg_mono8(const std::string& file_path);
 }
 ```
 
@@ -197,7 +199,7 @@ target_link_libraries(myapp PRIVATE kornia::kornia_cpp)
 ### Move Semantics
 Image types support move but not copy:
 ```cpp
-auto img1 = kornia::io::read_jpeg_rgb8("a.jpg");
+auto img1 = kornia::io::jpeg::read_image_jpeg_rgb8("a.jpg");
 auto img2 = std::move(img1);  // ✅ OK - move
 // auto img3 = img2;           // ❌ Error - copy deleted
 ```
@@ -205,9 +207,9 @@ auto img2 = std::move(img1);  // ✅ OK - move
 ## Testing
 
 ```bash
-just cpp-test           # Run all tests (from project root)
-just test              # Run all tests (from kornia-cpp/)
-just test-sanitizers   # Run with ASAN/UBSAN enabled
+pixi run cpp-test              # Build and run C++ tests
+pixi run cpp-test-release      # Build and run C++ tests (release)
+pixi run cpp-test-sanitizers   # Run with ASAN/UBSAN enabled
 ```
 
 Tests use [Catch2](https://github.com/catchorg/Catch2) v3 framework.
@@ -272,11 +274,11 @@ See `examples/` directory for complete examples demonstrating:
 The project uses `.clang-format` (LLVM style, 100 column limit):
 
 ```bash
-just format        # Auto-format all C++ files
-just format-check  # Check format without modifying
+pixi run cpp-fmt        # Auto-format all C++ files
+pixi run cpp-fmt-check  # Check format without modifying
 ```
 
-CI enforces formatting - make sure to run `just format` before committing.
+CI enforces formatting - make sure to run `pixi run cpp-fmt` before committing.
 
 ## Design Principles
 

--- a/kornia-cpp/examples/image_api/README.md
+++ b/kornia-cpp/examples/image_api/README.md
@@ -18,12 +18,11 @@ cmake --build build
 ./build/examples/image_api/image_api_example
 ```
 
-Or use just:
+Or use pixi:
 
 ```bash
-cd kornia-cpp
-just build-examples
-./build/examples/image_api/image_api_example
+pixi run cpp-build-examples
+./kornia-cpp/build/examples/image_api/image_api_example
 ```
 
 ## Example Output

--- a/kornia-cpp/examples/read_jpeg/README.md
+++ b/kornia-cpp/examples/read_jpeg/README.md
@@ -5,9 +5,8 @@ Simple example demonstrating JPEG image reading with kornia-cpp.
 ## Building
 
 ```bash
-cd kornia-cpp
-just build-examples
-./build/examples/read_jpeg/read_jpeg_example path/to/image.jpg
+pixi run cpp-build-examples
+./kornia-cpp/build/examples/read_jpeg/read_jpeg_example path/to/image.jpg
 ```
 
 ## Usage
@@ -36,7 +35,7 @@ The example demonstrates:
 
 1. Loading a JPEG image
    ```cpp
-   auto image = kornia::io::read_jpeg_rgb8(file_path);
+   auto image = kornia::io::jpeg::read_image_jpeg_rgb8(file_path);
    ```
 
 2. Accessing image properties

--- a/kornia-py/CONTRIBUTING.md
+++ b/kornia-py/CONTRIBUTING.md
@@ -22,19 +22,18 @@
 
     Or you can use one of the dev docker images ([x86_64](../devel-x86_64.Dockerfile), [i686](../devel-i686.Dockerfile), [arch64](../devel-aarch64.Dockerfile)).
 
-    This will check and try to install if not available: [rust](https://rustup.rs/) and [uv](https://docs.astral.sh/uv/).
-    Then it will setup a `.venv` directory and install the kornia-py package
+    Then build the kornia-py package (from the project root):
     ```sh
-    just install
+    pixi run py-build
     ```
 
     Note:
-    - When setting up the kornia-py package, it will automatically build its backend, which is the kornia Rust package itself.
+    - When building the kornia-py package, it will automatically build its backend, which is the kornia Rust package itself.
 
 
 3. **Run tests to ensure everything is set up correctly:**
     ```sh
-    just test
+    pixi run py-test
     ```
 
 You are now ready to start contributing to the Kornia-py package!


### PR DESCRIPTION
## Summary

- Remove non-existent `kornia-nn` crate from install blocks, add `kornia-bow`
- Replace all `just` commands with `pixi run` equivalents (project uses `pixi.toml`, no justfile exists)
- Add missing modules to crate READMEs (kornia-imgproc, kornia-apriltag, kornia-algebra, kornia-3d, kornia-io, kornia-image)
- Fix deprecated `stream::CameraCapture` to `gstreamer::CameraCapture` in kornia-io README
- Fix C++ function names to match actual API (`read_image_jpeg_rgb8` not `read_jpeg_rgb8`)
- Add `kornia-tensor-ops` to kornia umbrella crate re-exports list

## Test plan

- [x] Grep confirms zero remaining `kornia-nn` references in `.md` files
- [x] Grep confirms zero remaining `just ` command references in `.md` files
- [x] Cross-checked each crate's `src/lib.rs` `pub mod` lines against its README module list
- [x] Verified C++ function names match `kornia-cpp/include/kornia/io/jpeg.hpp` declarations
- [x] Documentation-only changes, no code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; risk is limited to potentially misleading users if any command/API names were updated incorrectly.
> 
> **Overview**
> Aligns top-level and crate READMEs with the current project setup by replacing `just`/`uv` development instructions with `pixi` equivalents, and updating dependency snippets (remove non-existent `kornia-nn`, add `kornia-bow`).
> 
> Fixes several API/doc mismatches: corrects `kornia-io` GStreamer import path, updates C++ docs/examples to use `kornia::io::jpeg::read_image_jpeg_*` function names, expands/clarifies module lists and feature notes across multiple crate READMEs, and adds `kornia-tensor-ops` to the umbrella `kornia` crate ecosystem list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba5e962a91c5b05d37e7834a87ba075baea9445f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->