### PR TITLE
 Fix test assertions for ICP algorithm using geometric metrics

### DIFF
--- a/crates/kornia-3d/src/registration/icp_vanilla.rs
+++ b/crates/kornia-3d/src/registration/icp_vanilla.rs
@@ -145,13 +145,12 @@ pub fn icp_vanilla(
 
 #[cfg(test)]
 mod tests {
-
     use super::{icp_vanilla, ICPConvergenceCriteria};
     use crate::{
-        linalg::transform_points3d, pointcloud::PointCloud,
+        linalg::transform_points3d, 
+        pointcloud::PointCloud,
         transforms::axis_angle_to_rotation_matrix,
     };
-
     #[test]
     fn test_icp_vanilla() -> Result<(), Box<dyn std::error::Error>> {
         let num_points = 100;
@@ -190,14 +189,47 @@ mod tests {
 
         println!("result: {result:?}");
 
-        // TODO: fixme
-        // for i in 0..3 {
-        //     assert_relative_eq!(result.translation[i], dst_t_src[i], epsilon = 1e-1);
-        //     for j in 0..3 {
-        //         // TODO: implement convert back to axis angle
-        //         assert_relative_eq!(result.rotation[i][j], dst_r_src[i][j], epsilon = 1e-2);
-        //     }
-        // }
+        // Compute angular rotation error
+        // R_error = R_estimated^T * R_ground_truth
+        let mut r_error = [[0.0; 3]; 3];
+        for i in 0..3 {
+            for j in 0..3 {
+                r_error[i][j] = result.rotation[0][i] * dst_r_src[0][j]
+                    + result.rotation[1][i] * dst_r_src[1][j]
+                    + result.rotation[2][i] * dst_r_src[2][j];
+            }
+        }
+
+        // Compute angle from rotation matrix: angle = acos((trace(R) - 1) / 2)
+        let trace = r_error[0][0] + r_error[1][1] + r_error[2][2];
+        let angular_error = ((trace - 1.0) / 2.0).clamp(-1.0, 1.0).acos();
+
+        // Compute L2 translation error
+        let translation_error = (
+            (result.translation[0] - dst_t_src[0]).powi(2) +
+            (result.translation[1] - dst_t_src[1]).powi(2) +
+            (result.translation[2] - dst_t_src[2]).powi(2)
+        ).sqrt();
+
+        // Assert using meaningful geometric metrics
+        assert!(
+            angular_error < 0.1,
+            "Angular rotation error too large: {} rad (expected < 0.1 rad)",
+            angular_error
+        );
+
+        assert!(
+            translation_error < 0.1,
+            "Translation error too large: {} (expected < 0.1)",
+            translation_error
+        );
+
+        // Verify convergence
+        assert!(
+            result.rmse < 1e-8,
+            "ICP did not converge to low error: RMSE = {}",
+            result.rmse
+        );
 
         Ok(())
     }


### PR DESCRIPTION
## Description
This PR improves the robustness and reliability of assertions in test_icp_vanilla by replacing brittle element-wise matrix comparisons with meaningful geometric error metrics.
Previously, the test executed the ICP algorithm but did not properly validate the correctness of the result. The assertion logic was commented out due to instability when comparing rotation matrices element-by-element.

## Changes 
Replaced element-wise matrix comparison with geometric error metrics:
1. Angular rotation error: Computed using trace(R_error) to measure actual rotational difference
2. L2 translation error: Euclidean distance between estimated and ground-truth translation
3. RMSE convergence check: Verifies algorithm convergence

This approach uses meaningful geometric metrics that directly measure transformation accuracy.

Testing -  cargo test test_icp_vanilla -- --nocapture

## Results 
<img width="1461" height="291" alt="image" src="https://github.com/user-attachments/assets/166c4371-43ab-45fc-8594-5edf527d1ec6" />

The observed RMSE is on the order of 1e-16, indicating convergence to near machine precision. Also it converges in 6 iterations. 

Fixes #674 