### PR TITLE
fix: replace mutex lock().expect() with proper error handling

### DIFF
--- a/crates/kornia-io/src/gstreamer/capture.rs
+++ b/crates/kornia-io/src/gstreamer/capture.rs
@@ -241,8 +241,9 @@ impl StreamCapture {
 }
 
 impl Drop for StreamCapture {
-    /// Ensures that the StreamCapture is properly closed when dropped.
     fn drop(&mut self) {
-        self.close().expect("Failed to close StreamCapture");
+        if let Err(e) = self.close() {
+            eprintln!("Failed to close StreamCapture: {e}");
+        }
     }
 }

--- a/crates/kornia-io/src/jpegturbo.rs
+++ b/crates/kornia-io/src/jpegturbo.rs
@@ -20,6 +20,10 @@ pub enum JpegTurboError {
     /// Error to create the image.
     #[error("Failed to create image")]
     ImageCreationError(#[from] ImageError),
+
+    /// Error when a mutex lock is poisoned.
+    #[error("Mutex lock was poisoned")]
+    MutexPoisoned,
 }
 
 /// A JPEG decoder using the turbojpeg library.
@@ -53,10 +57,6 @@ impl JpegTurboEncoder {
     /// # Returns
     ///
     /// A new `ImageEncoder` instance.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the compressor cannot be created.
     pub fn new() -> Result<Self, JpegTurboError> {
         let compressor = turbojpeg::Compressor::new()?;
         Ok(Self(Mutex::new(compressor)))
@@ -91,7 +91,7 @@ impl JpegTurboEncoder {
         Ok(self
             .0
             .lock()
-            .expect("Failed to lock the compressor")
+            .map_err(|_| JpegTurboError::MutexPoisoned)?
             .compress_to_vec(buf)?)
     }
 
@@ -104,7 +104,7 @@ impl JpegTurboEncoder {
         Ok(self
             .0
             .lock()
-            .expect("Failed to lock the compressor")
+            .map_err(|_| JpegTurboError::MutexPoisoned)?
             .set_quality(quality)?)
     }
 }
@@ -130,16 +130,12 @@ impl JpegTurboDecoder {
     /// # Returns
     ///
     /// The image size.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the header cannot be read.
     pub fn read_header(&self, jpeg_data: &[u8]) -> Result<ImageSize, JpegTurboError> {
         // read the JPEG header with image size
         let header = self
             .0
             .lock()
-            .expect("Failed to lock the decompressor")
+            .map_err(|_| JpegTurboError::MutexPoisoned)?
             .read_header(jpeg_data)?;
 
         Ok(ImageSize {
@@ -203,7 +199,7 @@ impl JpegTurboDecoder {
         // decompress the JPEG data
         self.0
             .lock()
-            .expect("Failed to lock the decompressor")
+            .map_err(|_| JpegTurboError::MutexPoisoned)?
             .decompress(jpeg_data, buf)?;
 
         Ok(Image::new(image_size, pixels, CpuAllocator)?)


### PR DESCRIPTION
## Summary

- Replace 4 `.lock().expect()` calls in `jpegturbo.rs` with `.map_err(|_| JpegTurboError::MutexPoisoned)?` so callers get a recoverable `Err` instead of an unrecoverable panic on mutex poisoning
- Add `MutexPoisoned` variant to `JpegTurboError` (follows the same pattern already used by `StreamCaptureError::MutexPoisonError` in the gstreamer module)
- Replace panicking `Drop` impl in `gstreamer/capture.rs` with best-effort cleanup (`if let Err`) to prevent double-panic aborts during stack unwinding
- Remove stale `# Panics` doc comments on methods that return `Result`

Closes #727

## Changes

| File | What changed |
|------|-------------|
| `crates/kornia-io/src/jpegturbo.rs` | Add `MutexPoisoned` error variant, replace 4 `.expect()` with `.map_err()`, remove stale docs |
| `crates/kornia-io/src/gstreamer/capture.rs` | Replace panicking `Drop` with `if let Err` |

## Test results

```
running 25 tests
test fps_counter::tests::test_fps_counter ... ok
test jpeg::tests::test_decode_jpeg_size ... ok
test jpeg::tests::test_encode_jpeg_gray8_with_buffer ... ok
test metadata::tests::test_missing_exif_returns_none ... ok
test metadata::tests::test_all_orientation_values ... ok
test functional::tests::test_read_any_rgb8 ... ok
test jpeg::tests::test_decode_jpeg ... ok
test metadata::tests::test_write_and_read_orientation_values ... ok
test jpeg::tests::test_read_jpeg ... ok
test tiff::tests::decode_tiff_rgb16 ... ok
test tiff::tests::decode_tiff_rgb32f ... ok
test png::tests::read_write_png_rgb16 ... ok
test png::tests::read_png_mono8 ... ok
test tiff::tests::decode_tiff_rgb8 ... ok
test tiff::tests::synthetic_write_tiff_mono16 ... ok
test tiff::tests::synthetic_write_tiff_mono8 ... ok
test tiff::tests::synthetic_write_tiff_monof32 ... ok
test png::tests::decode_png ... ok
test tiff::tests::synthetic_write_tiff_rgb16 ... ok
test tiff::tests::synthetic_write_tiff_rgb8 ... ok
test tiff::tests::synthetic_write_tiff_rgbf32 ... ok
test jpeg::tests::test_encode_jpeg_buffer_reuse ... ok
test jpeg::tests::test_encode_jpeg_rgb8_with_buffer ... ok
test jpeg::tests::test_read_write_jpeg ... ok
test png::tests::read_write_png_rgb8 ... ok

test result: ok. 25 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

Doc-tests kornia_io

running 5 tests
test jpeg::encode_image_jpeg_bgra8 - compile ... ok
test metadata::read_image_metadata - compile ... ok
test jpeg::encode_image_jpeg_rgb8 ... ok
test fps_counter::FpsCounter ... ok
test functional::read_image_any_rgb8 ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Test plan

- [x] `cargo check -p kornia-io` compiles clean
- [x] `cargo test -p kornia-io` — all 30 tests pass (25 unit + 5 doc-tests)
- [x] `grep -rn 'lock().*expect' crates/kornia-io/src/` returns zero matches
- [x] No changes to public API signatures — only error variant addition (non-breaking)