### PR TITLE
fix: refactor TileIterator to safe Rust, eliminating unsafe from_raw_parts

### DIFF
--- a/crates/kornia-apriltag/src/threshold.rs
+++ b/crates/kornia-apriltag/src/threshold.rs
@@ -221,7 +221,7 @@ pub fn adaptive_threshold<A1: ImageAllocator, A2: ImageAllocator>(
         let mut local_max = 0;
 
         for row in tile.data {
-            for px in row as &[u8] {
+            for px in row {
                 if px < &local_min {
                     local_min = *px;
                 }
@@ -300,7 +300,7 @@ pub fn adaptive_threshold<A1: ImageAllocator, A2: ImageAllocator>(
             let row_index = ((tile.pos.y * tile_min_max.tile_size) + y_px) * src.width()
                 + tile.pos.x * tile_min_max.tile_size;
 
-            for (x_px, px) in (row as &[u8]).iter().enumerate() {
+            for (x_px, px) in row.iter().enumerate() {
                 dst_data[row_index + x_px] = if px > &thresh {
                     Pixel::White
                 } else {


### PR DESCRIPTION
## Description

Refactors `TileIterator` in `kornia-apriltag` to eliminate an unsound `unsafe` block. The previous implementation used a reusable `Vec<&[T]>` buffer + `std::slice::from_raw_parts` to return `&'a [&'a [T]]`, but the lifetime `'a` was a lie — the outer slice actually had iterator lifetime, not image lifetime.

Replaces it with a zero-allocation `TileView<'a, T>` struct that computes row slices on-the-fly from the underlying image data.

Fixes #738

## Changes Made

- **`crates/kornia-apriltag/src/iter.rs`**:
  - Add `TileView<'a, T>` — lightweight view with `len()`, `row(y)`, `iter()`, `Index<usize>`, `IntoIterator`, `PartialEq<&[&[T]]>`
  - Change `TileInfo.data` from `&'a [&'a [T]]` to `TileView<'a, T>`
  - Remove `buffer` field from `TileIterator`
  - Remove `unsafe { std::slice::from_raw_parts }` — construct `TileView` instead
  - Remove stale SAFETY doc comment (no longer needed)
  - Update test macro to field-by-field comparison using `PartialEq<&[&[T]]>`

- **`crates/kornia-apriltag/src/threshold.rs`**: Remove unnecessary `as &[u8]` casts (rows are now `&[u8]` directly from `TileView`)

## How Tested

- `cargo check -p kornia-apriltag` — compiles cleanly
- `cargo clippy -p kornia-apriltag -- -D warnings` — zero warnings
- `cargo test -p kornia-apriltag -- iter` — all 3 iter tests pass
- `cargo test -p kornia-apriltag -- threshold` — all 5 threshold tests + 1 doctest pass
- `grep -n "unsafe" crates/kornia-apriltag/src/iter.rs` — zero results (only in doc comment)

## Checklist

- [x] Formatted code with `cargo fmt`
- [x] Verified no regressions with `cargo test`
- [x] Zero unsafe code remaining in iter.rs
- [x] Clippy clean with `-D warnings`
- [x] All call sites in threshold.rs compile without changes (except removing redundant casts)