### PR TITLE
fix: remove stale TensorError TODO from perspective.rs

### DIFF
--- a/crates/kornia-imgproc/src/warp/perspective.rs
+++ b/crates/kornia-imgproc/src/warp/perspective.rs
@@ -27,7 +27,6 @@ fn adjugate3x3(m: &[f32; 9]) -> [f32; 9] {
     ]
 }
 
-// TODO: use TensorError
 fn inverse_perspective_matrix(m: &[f32; 9]) -> Result<[f32; 9], ImageError> {
     let det = determinant3x3(m);
 


### PR DESCRIPTION
## Description

Removes a stale `// TODO: use TensorError` comment from `inverse_perspective_matrix()` in `kornia-imgproc`. The function correctly returns `ImageError` — specifically the `CannotComputeDeterminant` variant — and `TensorError` is not the appropriate error type for this crate.

Contributes to #734 / #739

## Changes Made

- **`crates/kornia-imgproc/src/warp/perspective.rs`**: Remove `// TODO: use TensorError` on `inverse_perspective_matrix()`. `ImageError` is the correct error type; the TODO was speculative and stale.

### Not changed (per maintainer feedback)
- `crates/kornia-io/src/gstreamer/error.rs`: `// TODO: support later on ImageError` retained — valid TODO with actionable path (narrow `ProcessImageFrameError` from `Box<dyn Error>` to `ImageError`).

## How Tested

- `cargo check -p kornia-imgproc` — compiles cleanly
- Comment-only change, no behavioral impact

## Checklist

- [x] Formatted code with `cargo fmt`
- [x] Verified no regressions with `cargo check`
- [x] Comment-only change — no behavioral impact