### PR TITLE
fix: resolve #[allow(dead_code)] TODOs by removing dead code

### DIFF
--- a/crates/kornia-vlm/src/smolvlm/utils.rs
+++ b/crates/kornia-vlm/src/smolvlm/utils.rs
@@ -44,8 +44,4 @@ pub enum SmolVlmError {
 
     #[error("Invalid logits detected: {0}")]
     InvalidLogits(String),
-
-    // TODO: not used right now (currently, the end token is handled via if/else, which might be preferred)
-    #[error("Cannot find the <end_of_utterance> token")]
-    EosTokenNotFound,
 }

--- a/crates/kornia-vlm/src/smolvlm2/text_processor.rs
+++ b/crates/kornia-vlm/src/smolvlm2/text_processor.rs
@@ -14,7 +14,7 @@ use tokenizers::Tokenizer;
 
 use crate::smolvlm2::{SmolVlm2Config, SmolVlm2Error};
 
-#[allow(dead_code)] // TODO: remove
+#[allow(dead_code)] // TODO: implement System role support
 #[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum Role {
@@ -23,7 +23,7 @@ pub enum Role {
     System,
 }
 
-#[allow(dead_code)] // TODO: remove
+#[allow(dead_code)] // TODO: implement Video line type support
 #[derive(Serialize, Debug, Clone)]
 #[serde(tag = "type")]
 #[serde(rename_all = "lowercase")]


### PR DESCRIPTION
## Description

Updates stale `#[allow(dead_code)]` TODO comments in `kornia-vlm` with actionable descriptions and removes an unused error variant.

Contributes to #734 / #740

## Changes Made

- **`crates/kornia-vlm/src/smolvlm2/text_processor.rs`**: Update `// TODO: remove` to `// TODO: implement System role support` on `Role` enum and `// TODO: implement Video line type support` on `Line` enum. Variants kept as planned features per maintainer.
- **`crates/kornia-vlm/src/smolvlm/utils.rs`**: Remove unused `EosTokenNotFound` variant and its stale TODO comment. Confirmed 0 usages — SmolVlm handles EOS via if/else; SmolVlm2 and Paligemma have their own error types.

## How Tested

- `cargo check -p kornia-vlm` — compiles cleanly
- `EosTokenNotFound` removal verified via grep — 0 references in smolvlm module

## Checklist

- [x] Formatted code with `cargo fmt`
- [x] Verified no regressions with `cargo check`
- [x] Addressed all maintainer review feedback