### PR TITLE
Added documentation comments in benchmark image file

### DIFF
--- a/crates/kornia-image/benches/bench_image.rs
+++ b/crates/kornia-image/benches/bench_image.rs
@@ -1,9 +1,14 @@
+// Benchmark tests for Kornia Image operations
+// This file measures performance of cast_and_scale and scale_and_cast methods
+// Contribution by ItsmeVishwa for GSoC 2025 learning
+
 use criterion::{criterion_group, criterion_main, Criterion};
 use half::f16;
 use kornia_image::{Image, ImageSize};
 use kornia_tensor::CpuAllocator;
 use std::hint::black_box;
 
+// Creates a sample image for benchmarking
 fn sample_image() -> Image<u8, 3, CpuAllocator> {
     Image::from_size_val(
         ImageSize {
@@ -16,6 +21,7 @@ fn sample_image() -> Image<u8, 3, CpuAllocator> {
     .unwrap()
 }
 
+// Runs benchmark tests for image operations
 fn bench_image(c: &mut Criterion) {
     let mut group = c.benchmark_group("Image");
 
@@ -74,3 +80,6 @@ fn bench_image(c: &mut Criterion) {
 
 criterion_group!(benches, bench_image);
 criterion_main!(benches);
+
+
+Added documentation comments in benchmark image file


### PR DESCRIPTION
Added documentation comments to clarify benchmark tests for image operations.

## 📝 Description

**⚠️ Issue Link Required**: This PR must be linked to an approved and assigned issue. See [Contributing Guide](CONTRIBUTING.md#pull-request) for details.

**Fixes/Relates to:** # (issue number)

**Important**:
- Ensure you are assigned to the linked issue before submitting this PR
- This PR should strictly implement what the linked issue describes
- Do not include changes beyond the scope of the linked issue

---

## 🛠️ Changes Made
- [ ] Item 1
- [ ] Item 2

---

## 🧪 How Was This Tested?
- [ ] **Unit Tests:** (List new/updated tests)
- [ ] **Manual Verification:** (Describe the steps you took)
- [ ] **Performance/Edge Cases:** (How does this handle nulls, large data, etc.?)

---

## 🕵️ AI Usage Disclosure
*Check one of the following:*
- [ ] 🟢 **No AI used.**
- [ ] 🟡 **AI-assisted:** I used AI for boilerplate/refactoring but have manually reviewed and tested every line.
- [ ] 🔴 **AI-generated:** (Note: These PRs may be subject to stricter scrutiny or immediate closure if the logic is not explained).

---

## 🚦 Checklist
- [ ] I am assigned to the linked issue (required before PR submission)
- [ ] The linked issue has been approved by a maintainer
- [ ] This PR strictly implements what the linked issue describes (no scope creep)
- [ ] I have performed a **self-review** of my code (no "ghost" variables or hallucinations).
- [ ] My code follows the existing style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] (Optional) I have attached screenshots/recordings for UI changes.

---

## 💭 Additional Context
Add any other context or screenshots about the pull request here.

Added documentation comments to clarify benchmark tests for image operations.
This improves code readability.