### PR TITLE
docs(python): add docstrings for color bindings

### DIFF
--- a/kornia-py/src/color.rs
+++ b/kornia-py/src/color.rs
@@ -4,6 +4,19 @@ use crate::image::{FromPyImage, PyImage, ToPyImage};
 use kornia_image::{allocator::CpuAllocator, Image};
 use kornia_imgproc::color;
 
+/// Converts a grayscale image to RGB.
+///
+/// # Arguments
+///
+/// * `image` - The input grayscale image (1 channel).
+///
+/// # Returns
+///
+/// * The converted RGB image (3 channels).
+///
+/// # Errors
+///
+/// * `PyException` - If the image conversion or allocation fails.
 #[pyfunction]
 pub fn rgb_from_gray(image: PyImage) -> PyResult<PyImage> {
     let image_gray = Image::from_pyimage(image)
@@ -23,6 +36,19 @@ pub fn rgb_from_gray(image: PyImage) -> PyResult<PyImage> {
     Ok(pyimage_rgb)
 }
 
+/// Converts an RGB image to BGR format.
+///
+/// # Arguments
+///
+/// * `image` - The input RGB image (3 channels).
+///
+/// # Returns
+///
+/// * The converted BGR image (3 channels).
+///
+/// # Errors
+///
+/// * `PyException` - If the image conversion or allocation fails.
 #[pyfunction]
 pub fn bgr_from_rgb(image: PyImage) -> PyResult<PyImage> {
     let image_rgb = Image::from_pyimage(image)
@@ -42,6 +68,19 @@ pub fn bgr_from_rgb(image: PyImage) -> PyResult<PyImage> {
     Ok(pyimage_bgr)
 }
 
+/// Converts an RGB image to grayscale.
+///
+/// # Arguments
+///
+/// * `image` - The input RGB image (3 channels).
+///
+/// # Returns
+///
+/// * The converted grayscale image (1 channel).
+///
+/// # Errors
+///
+/// * `PyException` - If the image conversion or allocation fails.
 #[pyfunction]
 pub fn gray_from_rgb(image: PyImage) -> PyResult<PyImage> {
     let image_rgb = Image::from_pyimage(image)
@@ -69,6 +108,20 @@ pub fn gray_from_rgb(image: PyImage) -> PyResult<PyImage> {
     Ok(pyimage_gray)
 }
 
+/// Converts an RGBA image to RGB.
+///
+/// # Arguments
+///
+/// * `image` - The input RGBA image (4 channels).
+/// * `background` - An optional RGB background color to blend with the alpha channel. Defaults to None.
+///
+/// # Returns
+///
+/// * The converted RGB image (3 channels).
+///
+/// # Errors
+///
+/// * `PyException` - If the image conversion or allocation fails.
 #[pyfunction]
 #[pyo3(signature = (image, background=None))]
 pub fn rgb_from_rgba(image: PyImage, background: Option<[u8; 3]>) -> PyResult<PyImage> {
@@ -89,6 +142,20 @@ pub fn rgb_from_rgba(image: PyImage, background: Option<[u8; 3]>) -> PyResult<Py
     Ok(pyimage_rgb)
 }
 
+/// Converts a BGRA image to RGB.
+///
+/// # Arguments
+///
+/// * `image` - The input BGRA image (4 channels).
+/// * `background` - An optional RGB background color to blend with the alpha channel. Defaults to None.
+///
+/// # Returns
+///
+/// * The converted RGB image (3 channels).
+///
+/// # Errors
+///
+/// * `PyException` - If the image conversion or allocation fails.
 #[pyfunction]
 #[pyo3(signature = (image, background=None))]
 pub fn rgb_from_bgra(image: PyImage, background: Option<[u8; 3]>) -> PyResult<PyImage> {


### PR DESCRIPTION
## 📝 Description

**⚠️ Issue Link Required**: This PR must be linked to an approved and assigned issue. See [Contributing Guide](CONTRIBUTING.md#pull-request) for details.

**Fixes/Relates to:** Fixes #593

**Important**:
- Ensure you are assigned to the linked issue before submitting this PR
- This PR should strictly implement what the linked issue describes
- Do not include changes beyond the scope of the linked issue

---

## 🛠️ Changes Made
- [x] Added Rust-style docstrings to the `color` module in `kornia-py/src/color.rs`.
- [x] Documented `rgb_from_gray`, `bgr_from_rgb`, `gray_from_rgb`, `rgb_from_rgba`, and `rgb_from_bgra` with clear argument descriptions, return types, and exception/error definitions.
- [x] Replaced `# Exceptions` with `# Errors` to comply with standard rustdoc guidelines.

---

## 🧪 How Was This Tested?
- [ ] **Unit Tests:** N/A (Documentation only)
- [x] **Manual Verification:** Code compiles and passes all linters without warnings.

**Proof of Local Execution:**
```bash
pc@PC:~/Kornia-main-repo/kornia-rs_repo$ cargo clippy -p kornia-py -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.12s
pc@PC:~/Kornia-main-repo/kornia-rs_repo$ cargo fmt --all
pc@PC:~/Kornia-main-repo/kornia-rs_repo$ 

- [ ] **Performance/Edge Cases:** N/A

---

## 🕵️ AI Usage Disclosure
*Check one of the following:*
- [ ] 🟢 **No AI used.**
- [x] 🟡 **AI-assisted:** I used AI for boilerplate formatting of the docstrings to ensure consistency across modules, but have manually reviewed and tested every line.
- [ ] 🔴 **AI-generated:** (Note: These PRs may be subject to stricter scrutiny or immediate closure if the logic is not explained).

---

## 🚦 Checklist
- [x] I am assigned to the linked issue (required before PR submission)
- [x] The linked issue has been approved by a maintainer
- [x] This PR strictly implements what the linked issue describes (no scope creep)
- [x] I have performed a **self-review** of my code.
- [x] My code follows the existing style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works. (N/A)
- [ ] (Optional) I have attached screenshots/recordings for UI changes. (N/A)

---

## 💭 Additional Context
As established in previous PRs (#778 and #583), Python code snippet examples (````python`) have been intentionally omitted from these docstrings to minimize maintenance overhead.