### PR TITLE
fix: replace unwrap() with safe handling in tensor Display impl

### DIFF
--- a/crates/kornia-tensor/src/tensor.rs
+++ b/crates/kornia-tensor/src/tensor.rs
@@ -1027,7 +1027,7 @@ where
             .iter()
             .map(|v| format!("{v:.4}").len())
             .max()
-            .unwrap();
+            .unwrap_or(0);
 
         let scientific = width > 8;
 
@@ -1074,7 +1074,7 @@ where
             if value.is_empty() {
                 value = if scientific {
                     let num = format!("{v:.4e}");
-                    let (before, after) = num.split_once('e').unwrap();
+                    let (before, after) = num.split_once('e').ok_or(std::fmt::Error)?;
                     let after = if let Some(stripped) = after.strip_prefix('-') {
                         format!("-{:0>2}", &stripped)
                     } else {


### PR DESCRIPTION
Fixes #801

## Summary
Replaces two `unwrap()` calls in the Display trait implementation for Tensor with safe error handling, per project guidelines in AGENTS.md and CONTRIBUTING.md.

## Changes
1. **Line ~1030**: `.max().unwrap()` → `.max().unwrap_or(0)` — safely handles empty tensors without panicking
2. **Line ~1077**: `split_once('e').unwrap()` → `split_once('e').ok_or(std::fmt::Error)?` — propagates errors via `fmt::Result` instead of panicking
