### PR TITLE
feat: harden morphology kernel api

### DIFF
--- a/crates/kornia-image/src/error.rs
+++ b/crates/kornia-image/src/error.rs
@@ -49,6 +49,10 @@ pub enum ImageError {
     #[error("Invalid kernel length {0} and {1}")]
     InvalidKernelLength(usize, usize),
 
+    /// Error when the kernel shape is invalid for the requested operation.
+    #[error("Invalid kernel shape: {0}")]
+    InvalidKernelShape(String),
+
     /// Error when the sigma value is invalid.
     #[error("Invalid sigma values {0} and {1}")]
     InvalidSigmaValue(f32, f32),

--- a/crates/kornia-imgproc/README.md
+++ b/crates/kornia-imgproc/README.md
@@ -80,6 +80,36 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+### Morphological Opening
+
+```rust
+use kornia_image::{allocator::CpuAllocator, Image, ImageSize};
+use kornia_imgproc::morphology::{open, Kernel, KernelShape};
+use kornia_imgproc::padding::PaddingMode;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let src = Image::<u8, 1, _>::new(
+        ImageSize { width: 5, height: 5 },
+        vec![
+            0, 0, 0, 0, 0,
+            0, 255, 0, 0, 0,
+            0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
+        ],
+        CpuAllocator,
+    )?;
+
+    let kernel = Kernel::try_new(KernelShape::Box { size: 3 })?;
+    let mut dst = Image::<u8, 1, _>::from_size_val(src.size(), 0, CpuAllocator)?;
+
+    open(&src, &mut dst, &kernel, PaddingMode::Constant, [0])?;
+
+    assert!(dst.as_slice().iter().all(|&value| value == 0));
+    Ok(())
+}
+```
+
 ## 🧩 Modules
 
 *   **`calibration`**: Lens distortion correction.

--- a/crates/kornia-imgproc/benches/bench_morphology.rs
+++ b/crates/kornia-imgproc/benches/bench_morphology.rs
@@ -16,7 +16,7 @@ fn bench_morphology(c: &mut Criterion) {
             let image = Image::<u8, 1, _>::from_size_val(image_size, 128, CpuAllocator).unwrap();
             let dst = Image::<u8, 1, _>::from_size_val(image_size, 0, CpuAllocator).unwrap();
 
-            let kernel = Kernel::new(KernelShape::Box { size: *kernel_size });
+            let kernel = Kernel::try_new(KernelShape::Box { size: *kernel_size }).unwrap();
 
             group.bench_with_input(
                 BenchmarkId::new("dilate", &parameter_string),

--- a/crates/kornia-imgproc/src/features/responses.rs
+++ b/crates/kornia-imgproc/src/features/responses.rs
@@ -369,7 +369,7 @@ pub fn non_max_suppression<A1: ImageAllocator, A2: ImageAllocator>(
         });
 
     let mut dilated_u32: Image<u32, 1, _> = Image::from_size_val(size, 0u32, CpuAllocator)?;
-    let kernel = Kernel::new(KernelShape::Box { size: 3 });
+    let kernel = Kernel::try_new(KernelShape::Box { size: 3 })?;
     dilate(
         &src_u32,
         &mut dilated_u32,

--- a/crates/kornia-imgproc/src/morphology/kernels.rs
+++ b/crates/kornia-imgproc/src/morphology/kernels.rs
@@ -1,3 +1,5 @@
+use kornia_image::ImageError;
+
 /// Shapes of morphological `Kernels`.
 ///
 /// Defines the geometry of the kernel used in morphological operations.
@@ -51,7 +53,7 @@ pub enum KernelShape {
 /// use kornia_imgproc::morphology::{Kernel, KernelShape};
 ///
 /// // Create a 3x3 box kernel
-/// let kernel = Kernel::new(KernelShape::Box { size: 3 });
+/// let kernel = Kernel::try_new(KernelShape::Box { size: 3 }).unwrap();
 /// assert_eq!(kernel.width(), 3);
 /// assert_eq!(kernel.height(), 3);
 /// assert_eq!(kernel.pad(), (1, 1));
@@ -72,32 +74,137 @@ impl Kernel {
     /// # Returns
     ///
     /// A [`Kernel`] struct with the appropriate data.
-    pub fn new(shape: KernelShape) -> Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ImageError::InvalidKernelShape`] if the kernel dimensions are
+    /// zero, even-sized, or if the generated kernel does not contain any active
+    /// elements.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use kornia_imgproc::morphology::{Kernel, KernelShape};
+    ///
+    /// let kernel = Kernel::try_new(KernelShape::Cross { size: 3 }).unwrap();
+    /// assert_eq!(kernel.pad(), (1, 1));
+    /// ```
+    pub fn try_new(shape: KernelShape) -> Result<Self, ImageError> {
         match shape {
-            KernelShape::Box { size } => box_kernel(size),
-            KernelShape::Cross { size } => cross_kernel(size),
-            KernelShape::Ellipse { width, height } => ellipse_kernel(width, height),
+            KernelShape::Box { size } => try_box_kernel(size),
+            KernelShape::Cross { size } => try_cross_kernel(size),
+            KernelShape::Ellipse { width, height } => try_ellipse_kernel(width, height),
         }
     }
 
     /// Get a reference to the kernel data.
+    ///
+    /// # Returns
+    ///
+    /// The flattened binary mask of the structuring element.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use kornia_imgproc::morphology::{Kernel, KernelShape};
+    ///
+    /// let kernel = Kernel::try_new(KernelShape::Box { size: 3 }).unwrap();
+    /// assert_eq!(kernel.data().len(), 9);
+    /// ```
     pub fn data(&self) -> &[u8] {
         &self.data
     }
 
     /// Get the width of the kernel.
+    ///
+    /// # Returns
+    ///
+    /// The kernel width in pixels.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use kornia_imgproc::morphology::{Kernel, KernelShape};
+    ///
+    /// let kernel = Kernel::try_new(KernelShape::Box { size: 5 }).unwrap();
+    /// assert_eq!(kernel.width(), 5);
+    /// ```
     pub fn width(&self) -> usize {
         self.width
     }
 
     /// Get the height of the kernel.
+    ///
+    /// # Returns
+    ///
+    /// The kernel height in pixels.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use kornia_imgproc::morphology::{Kernel, KernelShape};
+    ///
+    /// let kernel = Kernel::try_new(KernelShape::Ellipse { width: 3, height: 5 }).unwrap();
+    /// assert_eq!(kernel.height(), 5);
+    /// ```
     pub fn height(&self) -> usize {
         self.height
     }
 
     /// Get the padding for the kernel (offset from center).
+    ///
+    /// # Returns
+    ///
+    /// The symmetric `(pad_h, pad_w)` padding required around the source image.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use kornia_imgproc::morphology::{Kernel, KernelShape};
+    ///
+    /// let kernel = Kernel::try_new(KernelShape::Box { size: 7 }).unwrap();
+    /// assert_eq!(kernel.pad(), (3, 3));
+    /// ```
     pub fn pad(&self) -> (usize, usize) {
         (self.height / 2, self.width / 2)
+    }
+
+    /// Validate that the kernel is well-formed for morphological operations.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` if the kernel can be used by morphology operators.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ImageError::InvalidKernelShape`] if the kernel has zero-sized
+    /// dimensions, even-sized dimensions, inconsistent storage, or no active
+    /// elements.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use kornia_imgproc::morphology::{Kernel, KernelShape};
+    ///
+    /// let kernel = Kernel::try_new(KernelShape::Box { size: 3 }).unwrap();
+    /// kernel.validate().unwrap();
+    /// ```
+    pub fn validate(&self) -> Result<(), ImageError> {
+        validate_kernel_dimensions(self.width, self.height)?;
+
+        if self.data.len() != self.width * self.height {
+            return Err(ImageError::InvalidKernelShape(
+                "kernel storage does not match its dimensions".to_string(),
+            ));
+        }
+
+        if !self.data.iter().any(|&value| value != 0) {
+            return Err(ImageError::InvalidKernelShape(
+                "kernel must contain at least one active element".to_string(),
+            ));
+        }
+
+        Ok(())
     }
 }
 
@@ -110,13 +217,27 @@ impl Kernel {
 /// # Returns
 ///
 /// A [`Kernel`] filled with 1s.
-pub fn box_kernel(size: usize) -> Kernel {
+///
+/// # Errors
+///
+/// Returns [`ImageError::InvalidKernelShape`] if `size` is zero or even.
+///
+/// # Example
+///
+/// ```rust
+/// use kornia_imgproc::morphology::try_box_kernel;
+///
+/// let kernel = try_box_kernel(3).unwrap();
+/// assert_eq!(kernel.data(), &[1, 1, 1, 1, 1, 1, 1, 1, 1]);
+/// ```
+pub fn try_box_kernel(size: usize) -> Result<Kernel, ImageError> {
+    validate_kernel_dimensions(size, size)?;
     let data = vec![1u8; size * size];
-    Kernel {
+    Ok(Kernel {
         data,
         width: size,
         height: size,
-    }
+    })
 }
 
 /// Create a cross structuring element.
@@ -128,7 +249,21 @@ pub fn box_kernel(size: usize) -> Kernel {
 /// # Returns
 ///
 /// A [`Kernel`] with 1s along the horizontal and vertical center lines.
-pub fn cross_kernel(size: usize) -> Kernel {
+///
+/// # Errors
+///
+/// Returns [`ImageError::InvalidKernelShape`] if `size` is zero or even.
+///
+/// # Example
+///
+/// ```rust
+/// use kornia_imgproc::morphology::try_cross_kernel;
+///
+/// let kernel = try_cross_kernel(3).unwrap();
+/// assert_eq!(kernel.data(), &[0, 1, 0, 1, 1, 1, 0, 1, 0]);
+/// ```
+pub fn try_cross_kernel(size: usize) -> Result<Kernel, ImageError> {
+    validate_kernel_dimensions(size, size)?;
     let mut data = vec![0u8; size * size];
     let mid = size / 2;
 
@@ -142,11 +277,11 @@ pub fn cross_kernel(size: usize) -> Kernel {
         data[i * size + mid] = 1;
     }
 
-    Kernel {
+    Ok(Kernel {
         data,
         width: size,
         height: size,
-    }
+    })
 }
 
 /// Create an ellipse structuring element.
@@ -159,12 +294,28 @@ pub fn cross_kernel(size: usize) -> Kernel {
 /// # Returns
 ///
 /// A [`Kernel`] with 1s inside the ellipse boundary.
-pub fn ellipse_kernel(width: usize, height: usize) -> Kernel {
+///
+/// # Errors
+///
+/// Returns [`ImageError::InvalidKernelShape`] if either dimension is zero,
+/// even-sized, or if the generated ellipse contains no active elements.
+///
+/// # Example
+///
+/// ```rust
+/// use kornia_imgproc::morphology::try_ellipse_kernel;
+///
+/// let kernel = try_ellipse_kernel(5, 5).unwrap();
+/// assert_eq!(kernel.width(), 5);
+/// assert_eq!(kernel.height(), 5);
+/// ```
+pub fn try_ellipse_kernel(width: usize, height: usize) -> Result<Kernel, ImageError> {
+    validate_kernel_dimensions(width, height)?;
     let mut data = vec![0u8; width * height];
-    let cx = width as f32 / 2.0;
-    let cy = height as f32 / 2.0;
-    let rx = width as f32 / 2.0;
-    let ry = height as f32 / 2.0;
+    let cx = (width / 2) as f32;
+    let cy = (height / 2) as f32;
+    let rx = cx.max(1.0);
+    let ry = cy.max(1.0);
 
     for i in 0..height {
         for j in 0..width {
@@ -177,9 +328,27 @@ pub fn ellipse_kernel(width: usize, height: usize) -> Kernel {
         }
     }
 
-    Kernel {
+    let kernel = Kernel {
         data,
         width,
         height,
+    };
+    kernel.validate()?;
+    Ok(kernel)
+}
+
+fn validate_kernel_dimensions(width: usize, height: usize) -> Result<(), ImageError> {
+    if width == 0 || height == 0 {
+        return Err(ImageError::InvalidKernelShape(
+            "kernel dimensions must be greater than zero".to_string(),
+        ));
     }
+
+    if width % 2 == 0 || height % 2 == 0 {
+        return Err(ImageError::InvalidKernelShape(
+            "kernel dimensions must be odd so the anchor is centered".to_string(),
+        ));
+    }
+
+    Ok(())
 }

--- a/crates/kornia-imgproc/src/morphology/ops.rs
+++ b/crates/kornia-imgproc/src/morphology/ops.rs
@@ -4,24 +4,57 @@ use kornia_image::{allocator::ImageAllocator, Image, ImageError, ImageSize};
 use kornia_tensor::CpuAllocator;
 use rayon::prelude::*;
 
+#[derive(Clone, Copy)]
+enum MorphologyOp {
+    Dilate,
+    Erode,
+}
+
 /// Dilate an image using a [`Kernel`].
 ///
-/// Dilation expands white regions in the image. Each pixel is replaced
-/// by the maximum value in the neighborhood defined by the kernel.
+/// Dilation replaces each pixel with the maximum value over the active kernel
+/// support. This expands bright regions and can connect nearby structures.
 ///
 /// # Arguments
 ///
 /// * `src` - The source image.
-/// * `dst` - The destination image (will be overwritten).
-/// * `kernel` - The morphological structuring element ([`Kernel`]).
-/// * `padding_mode` - The border handling mode ([`PaddingMode`]).
-/// * `constant_value` - The fill value for constant padding.
+/// * `dst` - The destination image. It must have the same size as `src`.
+/// * `kernel` - The structuring element defining the neighborhood to scan.
+/// * `padding_mode` - The border handling mode used before scanning.
+/// * `constant_value` - The fill value used when `padding_mode` is
+///   [`PaddingMode::Constant`].
 ///
 /// # Returns
 ///
-/// Ok(()) on success, or [`ImageError`] if shapes don't match.
+/// `Ok(())` on success.
+///
+/// # Errors
+///
+/// Returns [`ImageError::InvalidImageSize`] if `src` and `dst` sizes differ.
+/// Returns [`ImageError::InvalidKernelShape`] if `kernel` is not valid for
+/// morphology operations.
+///
+/// # Example
+///
+/// ```rust
+/// use kornia_image::{allocator::CpuAllocator, Image, ImageSize};
+/// use kornia_imgproc::morphology::{dilate, Kernel, KernelShape};
+/// use kornia_imgproc::padding::PaddingMode;
+///
+/// let src = Image::<u8, 1, _>::new(
+///     ImageSize { width: 3, height: 3 },
+///     vec![0, 0, 0, 0, 255, 0, 0, 0, 0],
+///     CpuAllocator,
+/// )?;
+/// let mut dst = Image::<u8, 1, _>::from_size_val(src.size(), 0, CpuAllocator)?;
+/// let kernel = Kernel::try_new(KernelShape::Box { size: 3 })?;
+///
+/// dilate(&src, &mut dst, &kernel, PaddingMode::Constant, [0])?;
+/// assert!(dst.as_slice().iter().all(|&value| value == 255));
+/// # Ok::<(), kornia_image::ImageError>(())
+/// ```
 pub fn dilate<
-    T: Copy + Default + Send + Sync + Ord,
+    T: Copy + Send + Sync + Ord,
     const C: usize,
     A1: ImageAllocator,
     A2: ImageAllocator,
@@ -32,88 +65,61 @@ pub fn dilate<
     padding_mode: PaddingMode,
     constant_value: [T; C],
 ) -> Result<(), ImageError> {
-    if src.size() != dst.size() {
-        return Err(ImageError::InvalidImageSize(
-            dst.width(),
-            dst.height(),
-            src.width(),
-            src.height(),
-        ));
-    }
-
-    let width = src.width();
-    let height = src.height();
-    let (pad_h, pad_w) = kernel.pad();
-    let k_height = kernel.height();
-    let k_width = kernel.width();
-    let k_data = kernel.data();
-
-    let padded_size = ImageSize {
-        width: width + 2 * pad_w,
-        height: height + 2 * pad_h,
-    };
-    let padded_buffer = vec![T::default(); padded_size.width * padded_size.height * C];
-    let mut padded = Image::new(padded_size, padded_buffer, CpuAllocator)?;
-
-    let padding = Padding2D {
-        top: pad_h,
-        bottom: pad_h,
-        left: pad_w,
-        right: pad_w,
-    };
-    spatial_padding(src, &mut padded, padding, padding_mode, constant_value)?;
-
-    // dilation
-    let dst_slice = dst.as_slice_mut();
-    let dst_chunks: Vec<_> = dst_slice.chunks_mut(width * C).collect();
-
-    dst_chunks
-        .into_par_iter()
-        .enumerate()
-        .for_each(|(h, row_chunk)| {
-            for c in 0..C {
-                for w in 0..width {
-                    let mut max_val = T::default();
-
-                    for kh in 0..k_height {
-                        for kw in 0..k_width {
-                            if k_data[kh * k_width + kw] == 1 {
-                                let px = w + kw;
-                                let py = h + kh;
-                                if let Ok(pixel) = padded.get_pixel(px, py, c) {
-                                    max_val = max_val.max(*pixel);
-                                }
-                            }
-                        }
-                    }
-
-                    let idx = w * C + c;
-                    row_chunk[idx] = max_val;
-                }
-            }
-        });
-
-    Ok(())
+    morphology_op(
+        src,
+        dst,
+        kernel,
+        padding_mode,
+        constant_value,
+        MorphologyOp::Dilate,
+    )
 }
 
 /// Erode an image using a [`Kernel`].
 ///
-/// Erosion shrinks white regions in the image. Each pixel is replaced
-/// by the minimum value in the neighborhood defined by the kernel.
+/// Erosion replaces each pixel with the minimum value over the active kernel
+/// support. This shrinks bright regions and removes isolated bright pixels.
 ///
 /// # Arguments
 ///
 /// * `src` - The source image.
-/// * `dst` - The destination image (will be overwritten).
-/// * `kernel` - The morphological structuring element ([`Kernel`]).
-/// * `padding_mode` - The border handling mode ([`PaddingMode`]).
-/// * `constant_value` - The fill value for constant padding.
+/// * `dst` - The destination image. It must have the same size as `src`.
+/// * `kernel` - The structuring element defining the neighborhood to scan.
+/// * `padding_mode` - The border handling mode used before scanning.
+/// * `constant_value` - The fill value used when `padding_mode` is
+///   [`PaddingMode::Constant`].
 ///
 /// # Returns
 ///
-/// Ok(()) on success, or [`ImageError`] if shapes don't match.
+/// `Ok(())` on success.
+///
+/// # Errors
+///
+/// Returns [`ImageError::InvalidImageSize`] if `src` and `dst` sizes differ.
+/// Returns [`ImageError::InvalidKernelShape`] if `kernel` is not valid for
+/// morphology operations.
+///
+/// # Example
+///
+/// ```rust
+/// use kornia_image::{allocator::CpuAllocator, Image, ImageSize};
+/// use kornia_imgproc::morphology::{erode, Kernel, KernelShape};
+/// use kornia_imgproc::padding::PaddingMode;
+///
+/// let src = Image::<u8, 1, _>::new(
+///     ImageSize { width: 3, height: 3 },
+///     vec![255; 9],
+///     CpuAllocator,
+/// )?;
+/// let mut dst = Image::<u8, 1, _>::from_size_val(src.size(), 0, CpuAllocator)?;
+/// let kernel = Kernel::try_new(KernelShape::Box { size: 3 })?;
+///
+/// erode(&src, &mut dst, &kernel, PaddingMode::Constant, [0])?;
+/// assert_eq!(dst.as_slice()[4], 255);
+/// # Ok::<(), kornia_image::ImageError>(())
+/// ```
 pub fn erode<
-    T: Copy + Default + Send + Sync + Ord,
+    T: Copy + Send + Sync + Ord,
     const C: usize,
     A1: ImageAllocator,
     A2: ImageAllocator,
@@ -124,90 +130,68 @@ pub fn erode<
     padding_mode: PaddingMode,
     constant_value: [T; C],
 ) -> Result<(), ImageError> {
-    if src.size() != dst.size() {
-        return Err(ImageError::InvalidImageSize(
-            dst.width(),
-            dst.height(),
-            src.width(),
-            src.height(),
-        ));
-    }
-
-    let width = src.width();
-    let height = src.height();
-    let (pad_h, pad_w) = kernel.pad();
-    let k_height = kernel.height();
-    let k_width = kernel.width();
-    let k_data = kernel.data();
-
-    let padded_size = ImageSize {
-        width: width + 2 * pad_w,
-        height: height + 2 * pad_h,
-    };
-    let padded_buffer = vec![T::default(); padded_size.width * padded_size.height * C];
-    let mut padded = Image::new(padded_size, padded_buffer, CpuAllocator)?;
-
-    let padding = Padding2D {
-        top: pad_h,
-        bottom: pad_h,
-        left: pad_w,
-        right: pad_w,
-    };
-    spatial_padding(src, &mut padded, padding, padding_mode, constant_value)?;
-
-    // erosion
-    let dst_slice = dst.as_slice_mut();
-    let dst_chunks: Vec<_> = dst_slice.chunks_mut(width * C).collect();
-
-    dst_chunks
-        .into_par_iter()
-        .enumerate()
-        .for_each(|(h, row_chunk)| {
-            for c in 0..C {
-                for w in 0..width {
-                    let mut min_val: Option<T> = None;
-
-                    for kh in 0..k_height {
-                        for kw in 0..k_width {
-                            if k_data[kh * k_width + kw] == 1 {
-                                let px = w + kw;
-                                let py = h + kh;
-                                if let Ok(pixel) = padded.get_pixel(px, py, c) {
-                                    min_val = Some(match min_val {
-                                        None => *pixel,
-                                        Some(v) => v.min(*pixel),
-                                    });
-                                }
-                            }
-                        }
-                    }
-
-                    let idx = w * C + c;
-                    row_chunk[idx] = min_val.unwrap_or_default();
-                }
-            }
-        });
-
-    Ok(())
+    morphology_op(
+        src,
+        dst,
+        kernel,
+        padding_mode,
+        constant_value,
+        MorphologyOp::Erode,
+    )
 }
 
-/// Opening: erosion followed by dilation.
+/// Apply an opening operation to an image.
 ///
-/// Removes small objects and smooths object boundaries.
+/// Opening performs erosion followed by dilation using the same structuring
+/// element. It is commonly used to remove small bright noise while preserving
+/// larger structures.
 ///
 /// # Arguments
 ///
 /// * `src` - The source image.
-/// * `dst` - The destination image (will be overwritten).
-/// * `kernel` - The morphological structuring element ([`Kernel`]).
-/// * `padding_mode` - The border handling mode ([`PaddingMode`]).
-/// * `constant_value` - The fill value for constant padding.
+/// * `dst` - The destination image. It must have the same size as `src`.
+/// * `kernel` - The structuring element defining the neighborhood to scan.
+/// * `padding_mode` - The border handling mode used before scanning.
+/// * `constant_value` - The fill value used when `padding_mode` is
+///   [`PaddingMode::Constant`].
 ///
 /// # Returns
 ///
-/// Ok(()) on success, or [`ImageError`] if shapes don't match.
+/// `Ok(())` on success.
+///
+/// # Errors
+///
+/// Returns [`ImageError::InvalidImageSize`] if `src` and `dst` sizes differ.
+/// Returns [`ImageError::InvalidKernelShape`] if `kernel` is not valid for
+/// morphology operations.
+///
+/// # Example
+///
+/// ```rust
+/// use kornia_image::{allocator::CpuAllocator, Image, ImageSize};
+/// use kornia_imgproc::morphology::{open, Kernel, KernelShape};
+/// use kornia_imgproc::padding::PaddingMode;
+///
+/// let src = Image::<u8, 1, _>::new(
+///     ImageSize { width: 5, height: 5 },
+///     vec![
+///         0, 0, 0, 0, 0,
+///         0, 255, 0, 0, 0,
+///         0, 0, 0, 0, 0,
+///         0, 0, 0, 0, 0,
+///         0, 0, 0, 0, 0,
+///     ],
+///     CpuAllocator,
+/// )?;
+/// let mut dst = Image::<u8, 1, _>::from_size_val(src.size(), 0, CpuAllocator)?;
+/// let kernel = Kernel::try_new(KernelShape::Box { size: 3 })?;
+///
+/// open(&src, &mut dst, &kernel, PaddingMode::Constant, [0])?;
+/// assert!(dst.as_slice().iter().all(|&value| value == 0));
+/// # Ok::<(), kornia_image::ImageError>(())
+/// ```
 pub fn open<
-    T: Copy + Default + Send + Sync + Ord,
+    T: Copy + Send + Sync + Ord + Default,
     const C: usize,
     A1: ImageAllocator,
     A2: ImageAllocator,
@@ -218,29 +202,65 @@ pub fn open<
     padding_mode: PaddingMode,
     constant_value: [T; C],
 ) -> Result<(), ImageError> {
+    validate_inputs(src, dst, kernel)?;
+
     let mut temp_img = Image::from_size_val(src.size(), T::default(), CpuAllocator)?;
     erode(src, &mut temp_img, kernel, padding_mode, constant_value)?;
     dilate(&temp_img, dst, kernel, padding_mode, constant_value)?;
     Ok(())
 }
 
-/// Closing: dilation followed by erosion.
+/// Apply a closing operation to an image.
 ///
-/// Fills small holes and smooths object boundaries.
+/// Closing performs dilation followed by erosion using the same structuring
+/// element. It is commonly used to fill small dark holes inside bright regions.
 ///
 /// # Arguments
 ///
 /// * `src` - The source image.
-/// * `dst` - The destination image (will be overwritten).
-/// * `kernel` - The morphological structuring element ([`Kernel`]).
-/// * `padding_mode` - The border handling mode ([`PaddingMode`]).
-/// * `constant_value` - The fill value for constant padding.
+/// * `dst` - The destination image. It must have the same size as `src`.
+/// * `kernel` - The structuring element defining the neighborhood to scan.
+/// * `padding_mode` - The border handling mode used before scanning.
+/// * `constant_value` - The fill value used when `padding_mode` is
+///   [`PaddingMode::Constant`].
 ///
 /// # Returns
 ///
-/// Ok(()) on success, or [`ImageError`] if shapes don't match.
+/// `Ok(())` on success.
+///
+/// # Errors
+///
+/// Returns [`ImageError::InvalidImageSize`] if `src` and `dst` sizes differ.
+/// Returns [`ImageError::InvalidKernelShape`] if `kernel` is not valid for
+/// morphology operations.
+///
+/// # Example
+///
+/// ```rust
+/// use kornia_image::{allocator::CpuAllocator, Image, ImageSize};
+/// use kornia_imgproc::morphology::{close, Kernel, KernelShape};
+/// use kornia_imgproc::padding::PaddingMode;
+///
+/// let src = Image::<u8, 1, _>::new(
+///     ImageSize { width: 5, height: 5 },
+///     vec![
+///         0, 0, 0, 0, 0,
+///         0, 255, 255, 255, 0,
+///         0, 255, 0, 255, 0,
+///         0, 255, 255, 255, 0,
+///         0, 0, 0, 0, 0,
+///     ],
+///     CpuAllocator,
+/// )?;
+/// let mut dst = Image::<u8, 1, _>::from_size_val(src.size(), 0, CpuAllocator)?;
+/// let kernel = Kernel::try_new(KernelShape::Box { size: 3 })?;
+///
+/// close(&src, &mut dst, &kernel, PaddingMode::Constant, [0])?;
+/// assert_eq!(dst.as_slice()[12], 255);
+/// # Ok::<(), kornia_image::ImageError>(())
+/// ```
 pub fn close<
-    T: Copy + Default + Send + Sync + Ord,
+    T: Copy + Send + Sync + Ord + Default,
     const C: usize,
     A1: ImageAllocator,
     A2: ImageAllocator,
@@ -251,20 +271,126 @@ pub fn close<
     padding_mode: PaddingMode,
     constant_value: [T; C],
 ) -> Result<(), ImageError> {
+    validate_inputs(src, dst, kernel)?;
+
     let mut temp_img = Image::from_size_val(src.size(), T::default(), CpuAllocator)?;
     dilate(src, &mut temp_img, kernel, padding_mode, constant_value)?;
     erode(&temp_img, dst, kernel, padding_mode, constant_value)?;
     Ok(())
 }
 
+fn validate_inputs<T, const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
+    src: &Image<T, C, A1>,
+    dst: &Image<T, C, A2>,
+    kernel: &Kernel,
+) -> Result<(), ImageError> {
+    if src.size() != dst.size() {
+        return Err(ImageError::InvalidImageSize(
+            src.width(),
+            src.height(),
+            dst.width(),
+            dst.height(),
+        ));
+    }
+
+    kernel.validate()
+}
+
+fn morphology_op<
+    T: Copy + Send + Sync + Ord,
+    const C: usize,
+    A1: ImageAllocator,
+    A2: ImageAllocator,
+>(
+    src: &Image<T, C, A1>,
+    dst: &mut Image<T, C, A2>,
+    kernel: &Kernel,
+    padding_mode: PaddingMode,
+    constant_value: [T; C],
+    op: MorphologyOp,
+) -> Result<(), ImageError> {
+    validate_inputs(src, dst, kernel)?;
+
+    let width = src.width();
+    let height = src.height();
+    let padded = pad_image(src, kernel, padding_mode, constant_value)?;
+    let padded_width = padded.width();
+    let padded_data = padded.as_slice();
+    let active_offsets = kernel_offsets(kernel);
+
+    dst.as_slice_mut()
+        .par_chunks_exact_mut(width * C)
+        .enumerate()
+        .for_each(|(y, row_chunk)| {
+            for x in 0..width {
+                for c in 0..C {
+                    let first = active_offsets[0];
+                    let mut acc =
+                        padded_data[((y + first.1) * padded_width + (x + first.0)) * C + c];
+
+                    for &(kx, ky) in &active_offsets[1..] {
+                        let value = padded_data[((y + ky) * padded_width + (x + kx)) * C + c];
+                        acc = match op {
+                            MorphologyOp::Dilate => acc.max(value),
+                            MorphologyOp::Erode => acc.min(value),
+                        };
+                    }
+
+                    row_chunk[x * C + c] = acc;
+                }
+            }
+        });
+
+    debug_assert_eq!(dst.height(), height);
+    Ok(())
+}
+
+fn pad_image<T: Copy + Send + Sync, const C: usize, A: ImageAllocator>(
+    src: &Image<T, C, A>,
+    kernel: &Kernel,
+    padding_mode: PaddingMode,
+    constant_value: [T; C],
+) -> Result<Image<T, C, CpuAllocator>, ImageError> {
+    let (pad_h, pad_w) = kernel.pad();
+    let padded_size = ImageSize {
+        width: src.width() + 2 * pad_w,
+        height: src.height() + 2 * pad_h,
+    };
+    let mut padded = Image::from_size_val(padded_size, constant_value[0], CpuAllocator)?;
+
+    let padding = Padding2D {
+        top: pad_h,
+        bottom: pad_h,
+        left: pad_w,
+        right: pad_w,
+    };
+    spatial_padding(src, &mut padded, padding, padding_mode, constant_value)?;
+
+    Ok(padded)
+}
+
+fn kernel_offsets(kernel: &Kernel) -> Vec<(usize, usize)> {
+    let mut offsets = Vec::new();
+
+    for y in 0..kernel.height() {
+        for x in 0..kernel.width() {
+            if kernel.data()[y * kernel.width() + x] != 0 {
+                offsets.push((x, y));
+            }
+        }
+    }
+
+    offsets
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::morphology::kernels::KernelShape;
+    use crate::morphology::kernels::{try_box_kernel, KernelShape};
 
     #[test]
     fn test_box_kernel() {
-        let kernel = Kernel::new(KernelShape::Box { size: 3 });
+        let kernel = Kernel::try_new(KernelShape::Box { size: 3 }).unwrap();
         assert_eq!(kernel.width(), 3);
         assert_eq!(kernel.height(), 3);
         assert!(kernel.data().iter().all(|&x| x == 1));
@@ -272,37 +398,46 @@ mod tests {
 
     #[test]
     fn test_cross_kernel() {
-        let kernel = Kernel::new(KernelShape::Cross { size: 3 });
+        let kernel = Kernel::try_new(KernelShape::Cross { size: 3 }).unwrap();
         let data = kernel.data();
-        // center row
         assert_eq!(data[3], 1);
         assert_eq!(data[4], 1);
         assert_eq!(data[5], 1);
-        // center column
         assert_eq!(data[1], 1);
         assert_eq!(data[7], 1);
-        // corners
         assert_eq!(data[0], 0);
     }
 
     #[test]
     fn test_ellipse_kernel() {
-        let kernel = Kernel::new(KernelShape::Ellipse {
+        let kernel = Kernel::try_new(KernelShape::Ellipse {
             width: 5,
             height: 5,
-        });
+        })
+        .unwrap();
         assert_eq!(kernel.width(), 5);
         assert_eq!(kernel.height(), 5);
-        // center
         assert_eq!(kernel.data()[12], 1);
     }
 
     #[test]
     fn test_kernel_padding() {
-        let kernel = Kernel::new(KernelShape::Box { size: 5 });
+        let kernel = Kernel::try_new(KernelShape::Box { size: 5 }).unwrap();
         let (pad_h, pad_w) = kernel.pad();
         assert_eq!(pad_h, 2);
         assert_eq!(pad_w, 2);
+    }
+
+    #[test]
+    fn test_invalid_even_kernel_size() {
+        let err = Kernel::try_new(KernelShape::Box { size: 4 }).unwrap_err();
+        assert!(matches!(err, ImageError::InvalidKernelShape(_)));
+    }
+
+    #[test]
+    fn test_invalid_zero_kernel_size() {
+        let err = try_box_kernel(0).unwrap_err();
+        assert!(matches!(err, ImageError::InvalidKernelShape(_)));
     }
 
     #[test]
@@ -315,14 +450,10 @@ mod tests {
         let src = Image::new(size, data, CpuAllocator)?;
         let mut dst = Image::new(size, vec![0u8; 9], CpuAllocator)?;
 
-        let kernel = Kernel::new(KernelShape::Box { size: 3 });
+        let kernel = Kernel::try_new(KernelShape::Box { size: 3 })?;
         dilate(&src, &mut dst, &kernel, PaddingMode::Constant, [0])?;
-        let result = dst.as_slice();
 
-        assert!(
-            result.iter().all(|&x| x == 255),
-            "All pixels should be 255 after dilation"
-        );
+        assert!(dst.as_slice().iter().all(|&x| x == 255));
         Ok(())
     }
 
@@ -335,15 +466,11 @@ mod tests {
         let src = Image::new(size, vec![255u8; 9], CpuAllocator)?;
         let mut dst = Image::new(size, vec![0u8; 9], CpuAllocator)?;
 
-        let kernel = Kernel::new(KernelShape::Box { size: 3 });
+        let kernel = Kernel::try_new(KernelShape::Box { size: 3 })?;
         erode(&src, &mut dst, &kernel, PaddingMode::Constant, [0])?;
-        let result = dst.as_slice();
 
-        assert_eq!(result[4], 255, "Center pixel should survive erosion");
-        assert_eq!(
-            result[0], 0,
-            "Corner pixel should be eroded due to zero padding"
-        );
+        assert_eq!(dst.as_slice()[4], 255);
+        assert_eq!(dst.as_slice()[0], 0);
         Ok(())
     }
 
@@ -359,14 +486,10 @@ mod tests {
         let src = Image::new(size, data, CpuAllocator)?;
         let mut dst = Image::new(size, vec![0u8; 25], CpuAllocator)?;
 
-        let kernel = Kernel::new(KernelShape::Box { size: 3 });
+        let kernel = Kernel::try_new(KernelShape::Box { size: 3 })?;
         open(&src, &mut dst, &kernel, PaddingMode::Constant, [0])?;
-        let result = dst.as_slice();
 
-        assert!(
-            result.iter().all(|&x| x == 0),
-            "Opening should remove the isolated noise pixel"
-        );
+        assert!(dst.as_slice().iter().all(|&x| x == 0));
         Ok(())
     }
 
@@ -387,16 +510,57 @@ mod tests {
         let src = Image::new(size, data, CpuAllocator)?;
         let mut dst = Image::new(size, vec![0u8; 25], CpuAllocator)?;
 
-        let kernel = Kernel::new(KernelShape::Box { size: 3 });
+        let kernel = Kernel::try_new(KernelShape::Box { size: 3 })?;
         close(&src, &mut dst, &kernel, PaddingMode::Constant, [0])?;
-        let result = dst.as_slice();
 
-        assert_eq!(
-            result[12], 255,
-            "Closing should fill the hole in the center"
-        );
-        assert_eq!(result[6], 255);
-        assert_eq!(result[18], 255);
+        assert_eq!(dst.as_slice()[12], 255);
+        assert_eq!(dst.as_slice()[6], 255);
+        assert_eq!(dst.as_slice()[18], 255);
+        Ok(())
+    }
+
+    #[test]
+    fn test_cross_kernel_dilation() -> Result<(), ImageError> {
+        let size = ImageSize {
+            width: 5,
+            height: 5,
+        };
+        let mut data = vec![0u8; 25];
+        data[12] = 255;
+
+        let src = Image::new(size, data, CpuAllocator)?;
+        let mut dst = Image::new(size, vec![0u8; 25], CpuAllocator)?;
+        let kernel = Kernel::try_new(KernelShape::Cross { size: 3 })?;
+
+        dilate(&src, &mut dst, &kernel, PaddingMode::Constant, [0])?;
+
+        let expected = [
+            0, 0, 0, 0, 0, 0, 0, 255, 0, 0, 0, 255, 255, 255, 0, 0, 0, 255, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        assert_eq!(dst.as_slice(), expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_multichannel_dilate() -> Result<(), ImageError> {
+        let src = Image::<u8, 3, _>::new(
+            ImageSize {
+                width: 3,
+                height: 3,
+            },
+            vec![
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 20, 30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            ],
+            CpuAllocator,
+        )?;
+        let mut dst = Image::<u8, 3, _>::from_size_val(src.size(), 0, CpuAllocator)?;
+        let kernel = Kernel::try_new(KernelShape::Box { size: 3 })?;
+
+        dilate(&src, &mut dst, &kernel, PaddingMode::Constant, [0, 0, 0])?;
+
+        assert_eq!(dst.get_pixel(0, 0, 0), Ok(&10));
+        assert_eq!(dst.get_pixel(0, 0, 1), Ok(&20));
+        assert_eq!(dst.get_pixel(0, 0, 2), Ok(&30));
         Ok(())
     }
 }


### PR DESCRIPTION
This PR hardens the existing morphology API in `kornia-imgproc`.

  - make kernel construction fallible with `Kernel::try_new(...)`
  - reject invalid kernel shapes early
  - refactor dilate/erode to share the same internal scan path
  - add docs and regression tests
  - update internal morphology call sites