### PR TITLE
fix(ci): use pull_request_target and grant issues write permission 

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,12 +1,12 @@
 name: PR Validation
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 permissions:
   pull-requests: write
-  issues: read
+  issues: write
   contents: read
 
 jobs:


### PR DESCRIPTION
Switch trigger from pull_request to pull_request_target so fork PRs
get a write-capable GITHUB_TOKEN, and change issues permission from
read to write to allow posting validation comments.