### PR TITLE
Fixed cross platform build issue.

### DIFF
--- a/.github/workflows/rust_lint.yml
+++ b/.github/workflows/rust_lint.yml
@@ -58,3 +58,21 @@ jobs:
         if: always() && matrix.needs-sccache
         run: |
           sccache --show-stats 2>&1 || echo "::warning::sccache stats unavailable - server may have exited"
+
+  cross-platform-check:
+    name: Check - ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macOS
+            runner: macos-latest
+          - os: Windows
+            runner: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - run: cargo check --workspace

--- a/.github/workflows/rust_lint.yml
+++ b/.github/workflows/rust_lint.yml
@@ -59,20 +59,27 @@ jobs:
         run: |
           sccache --show-stats 2>&1 || echo "::warning::sccache stats unavailable - server may have exited"
 
-  cross-platform-check:
-    name: Check - ${{ matrix.os }}
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: macOS
-            runner: macos-latest
-          - os: Windows
-            runner: windows-latest
+  cross-platform-check-macos:
+    name: Check - macOS
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: prefix-dev/setup-pixi@v0.9.4
+        with:
+          pixi-version: v0.40.0
+          cache: true
+
+      - name: Run cargo check
+        run: pixi run rust-check
+
+  cross-platform-check-windows:
+    name: Check - Windows
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - run: cargo check --workspace
+      - name: Run cargo check (core crates)
+        run: cargo check

--- a/examples/foxglove/Cargo.toml
+++ b/examples/foxglove/Cargo.toml
@@ -11,4 +11,7 @@ ctrlc = { workspace = true }
 env_logger = { workspace = true }
 foxglove = "0.16.1"
 kornia-image = { workspace = true }
+kornia-io = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
 kornia-io = { workspace = true, features = ["v4l"] }

--- a/examples/foxglove/src/main.rs
+++ b/examples/foxglove/src/main.rs
@@ -1,15 +1,21 @@
+#[cfg(target_os = "linux")]
 use argh::FromArgs;
+#[cfg(target_os = "linux")]
 use foxglove::{
     schemas::{CompressedImage, Timestamp},
     WebSocketServer,
 };
+#[cfg(target_os = "linux")]
 use kornia_image::ImageSize;
+#[cfg(target_os = "linux")]
 use kornia_io::v4l::{PixelFormat, V4LCameraConfig, V4lVideoCapture};
+#[cfg(target_os = "linux")]
 use std::{
     sync::atomic::{AtomicBool, Ordering},
     sync::Arc,
 };
 
+#[cfg(target_os = "linux")]
 #[derive(FromArgs)]
 /// Foxglove demo application
 struct Args {
@@ -22,6 +28,7 @@ struct Args {
     fps: u32,
 }
 
+#[cfg(target_os = "linux")]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let env = env_logger::Env::default().default_filter_or("debug");
     env_logger::init_from_env(env);
@@ -80,4 +87,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     server.stop().wait_blocking();
 
     Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("error: the foxglove example requires Video4Linux and is only supported on Linux.");
+    std::process::exit(1);
 }

--- a/examples/foxglove/src/main.rs
+++ b/examples/foxglove/src/main.rs
@@ -1,92 +1,93 @@
 #[cfg(target_os = "linux")]
-use argh::FromArgs;
-#[cfg(target_os = "linux")]
-use foxglove::{
-    schemas::{CompressedImage, Timestamp},
-    WebSocketServer,
-};
-#[cfg(target_os = "linux")]
-use kornia_image::ImageSize;
-#[cfg(target_os = "linux")]
-use kornia_io::v4l::{PixelFormat, V4LCameraConfig, V4lVideoCapture};
-#[cfg(target_os = "linux")]
-use std::{
-    sync::atomic::{AtomicBool, Ordering},
-    sync::Arc,
-};
+mod linux {
+    use argh::FromArgs;
+    use foxglove::{
+        schemas::{CompressedImage, Timestamp},
+        WebSocketServer,
+    };
+    use kornia_image::ImageSize;
+    use kornia_io::v4l::{PixelFormat, V4LCameraConfig, V4lVideoCapture};
+    use std::{
+        sync::atomic::{AtomicBool, Ordering},
+        sync::Arc,
+    };
 
-#[cfg(target_os = "linux")]
-#[derive(FromArgs)]
-/// Foxglove demo application
-struct Args {
-    /// the camera id to use
-    #[argh(option, short = 'c', default = "0")]
-    camera_id: u32,
+    #[derive(FromArgs)]
+    /// Foxglove demo application
+    struct Args {
+        /// the camera id to use
+        #[argh(option, short = 'c', default = "0")]
+        camera_id: u32,
 
-    /// the frames per second to record
-    #[argh(option, short = 'f', default = "30")]
-    fps: u32,
+        /// the frames per second to record
+        #[argh(option, short = 'f', default = "30")]
+        fps: u32,
+    }
+
+    pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+        let env = env_logger::Env::default().default_filter_or("debug");
+        env_logger::init_from_env(env);
+
+        let args: Args = argh::from_env();
+
+        // create the cancellation token
+        let cancel_token = Arc::new(AtomicBool::new(false));
+        let cancel_token_clone = Arc::clone(&cancel_token);
+
+        // register a signal handler for graceful shutdown
+        ctrlc::set_handler(move || {
+            cancel_token_clone.store(true, Ordering::SeqCst);
+            println!("Sending timer cancel signal !!");
+        })?;
+
+        // create the web socket server
+        let server = WebSocketServer::new().start_blocking()?;
+
+        // the pixel format to use
+        let pixel_format = PixelFormat::MJPG;
+
+        // start the camera capture
+        let mut camera = V4lVideoCapture::new(V4LCameraConfig {
+            device_path: format!("/dev/video{}", args.camera_id),
+            size: ImageSize {
+                width: 640,
+                height: 480,
+            },
+            fps: args.fps,
+            format: pixel_format,
+            buffer_size: 4,
+        })?;
+
+        while !cancel_token.load(Ordering::SeqCst) {
+            let Some(frame) = camera.grab_frame()? else {
+                continue;
+            };
+
+            // convert the frame to a compressed image
+            let compressed_image = CompressedImage {
+                timestamp: Some(Timestamp::new(
+                    frame.timestamp.sec as u32,
+                    frame.timestamp.usec as u32,
+                )),
+                frame_id: "camera".to_string(),
+                format: pixel_format.as_str().to_lowercase(),
+                data: frame.buffer.into_vec().into(),
+            };
+
+            // send the compressed image to the web socket server
+            foxglove::log!("/camera/compressed", compressed_image);
+        }
+
+        // wait for the server to stop
+        server.stop().wait_blocking();
+
+        Ok(())
+    }
 }
 
 #[cfg(target_os = "linux")]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let env = env_logger::Env::default().default_filter_or("debug");
-    env_logger::init_from_env(env);
-
-    let args: Args = argh::from_env();
-
-    // create the cancellation token
-    let cancel_token = Arc::new(AtomicBool::new(false));
-    let cancel_token_clone = Arc::clone(&cancel_token);
-
-    // register a signal handler for graceful shutdown
-    ctrlc::set_handler(move || {
-        cancel_token_clone.store(true, Ordering::SeqCst);
-        println!("Sending timer cancel signal !!");
-    })?;
-
-    // create the web socket server
-    let server = WebSocketServer::new().start_blocking()?;
-
-    // the pixel format to use
-    let pixel_format = PixelFormat::MJPG;
-
-    // start the camera capture
-    let mut camera = V4lVideoCapture::new(V4LCameraConfig {
-        device_path: format!("/dev/video{}", args.camera_id),
-        size: ImageSize {
-            width: 640,
-            height: 480,
-        },
-        fps: args.fps,
-        format: pixel_format,
-        buffer_size: 4,
-    })?;
-
-    while !cancel_token.load(Ordering::SeqCst) {
-        let Some(frame) = camera.grab_frame()? else {
-            continue;
-        };
-
-        // convert the frame to a compressed image
-        let compressed_image = CompressedImage {
-            timestamp: Some(Timestamp::new(
-                frame.timestamp.sec as u32,
-                frame.timestamp.usec as u32,
-            )),
-            frame_id: "camera".to_string(),
-            format: pixel_format.as_str().to_lowercase(),
-            data: frame.buffer.into_vec().into(),
-        };
-
-        // send the compressed image to the web socket server
-        foxglove::log!("/camera/compressed", compressed_image);
-    }
-
-    // wait for the server to stop
-    server.stop().wait_blocking();
-
-    Ok(())
+    linux::main()
 }
 
 #[cfg(not(target_os = "linux"))]

--- a/examples/foxglove/src/main.rs
+++ b/examples/foxglove/src/main.rs
@@ -90,7 +90,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[cfg(not(target_os = "linux"))]
-fn main() {
-    eprintln!("error: the foxglove example requires Video4Linux and is only supported on Linux.");
-    std::process::exit(1);
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    Err("the foxglove example requires Video4Linux and is only supported on Linux.".into())
 }

--- a/examples/orb_detector/Cargo.toml
+++ b/examples/orb_detector/Cargo.toml
@@ -9,5 +9,8 @@ publish = false
 [dependencies]
 argh = { workspace = true }
 ctrlc = { workspace = true }
-kornia = { workspace = true, features = ["v4l"] }
+kornia = { workspace = true }
 rerun = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+kornia = { workspace = true, features = ["v4l"] }

--- a/examples/orb_detector/src/main.rs
+++ b/examples/orb_detector/src/main.rs
@@ -1,6 +1,9 @@
+#[cfg(target_os = "linux")]
 use argh::FromArgs;
+#[cfg(target_os = "linux")]
 use std::path::PathBuf;
 
+#[cfg(target_os = "linux")]
 use kornia::{
     image::{Image, ImageSize},
     imgproc::{
@@ -12,9 +15,11 @@ use kornia::{
     tensor::CpuAllocator,
 };
 
+#[cfg(target_os = "linux")]
 use kornia::io::v4l::{PixelFormat, V4LCameraConfig, V4lVideoCapture};
 
 /// ORB detector webcam demo: match a reference image against live webcam frames.
+#[cfg(target_os = "linux")]
 #[derive(FromArgs)]
 struct Args {
     /// path to the reference image
@@ -22,6 +27,7 @@ struct Args {
     image_path: PathBuf,
 }
 
+#[cfg(target_os = "linux")]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Args = argh::from_env();
 
@@ -159,6 +165,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 }
 
+#[cfg(target_os = "linux")]
 fn join_images_inplace(
     image1: &Image<u8, 1, CpuAllocator>,
     image2: &Image<u8, 1, CpuAllocator>,
@@ -194,6 +201,7 @@ fn join_images_inplace(
     }
 }
 
+#[cfg(target_os = "linux")]
 fn u8_to_f32_image(src: &Image<u8, 1, CpuAllocator>, dst: &mut Image<f32, 1, CpuAllocator>) {
     src.as_slice()
         .iter()
@@ -201,4 +209,12 @@ fn u8_to_f32_image(src: &Image<u8, 1, CpuAllocator>, dst: &mut Image<f32, 1, Cpu
         .for_each(|(&s, d)| {
             *d = s as f32 / 255.0;
         });
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!(
+        "error: the orb_detector example requires Video4Linux and is only supported on Linux."
+    );
+    std::process::exit(1);
 }

--- a/examples/orb_detector/src/main.rs
+++ b/examples/orb_detector/src/main.rs
@@ -212,9 +212,6 @@ fn u8_to_f32_image(src: &Image<u8, 1, CpuAllocator>, dst: &mut Image<f32, 1, Cpu
 }
 
 #[cfg(not(target_os = "linux"))]
-fn main() {
-    eprintln!(
-        "error: the orb_detector example requires Video4Linux and is only supported on Linux."
-    );
-    std::process::exit(1);
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    Err("the orb_detector example requires Video4Linux and is only supported on Linux.".into())
 }

--- a/examples/orb_detector/src/main.rs
+++ b/examples/orb_detector/src/main.rs
@@ -1,214 +1,215 @@
 #[cfg(target_os = "linux")]
-use argh::FromArgs;
-#[cfg(target_os = "linux")]
-use std::path::PathBuf;
+mod linux {
+    use argh::FromArgs;
+    use std::path::PathBuf;
 
-#[cfg(target_os = "linux")]
-use kornia::{
-    image::{Image, ImageSize},
-    imgproc::{
-        self,
-        color::gray_from_rgb_u8,
-        features::{match_descriptors, OrbDetector},
-    },
-    io::{functional::read_image_any_rgb8, jpeg},
-    tensor::CpuAllocator,
-};
+    use kornia::{
+        image::{Image, ImageSize},
+        imgproc::{
+            self,
+            color::gray_from_rgb_u8,
+            features::{match_descriptors, OrbDetector},
+        },
+        io::{functional::read_image_any_rgb8, jpeg},
+        tensor::CpuAllocator,
+    };
 
-#[cfg(target_os = "linux")]
-use kornia::io::v4l::{PixelFormat, V4LCameraConfig, V4lVideoCapture};
+    use kornia::io::v4l::{PixelFormat, V4LCameraConfig, V4lVideoCapture};
 
-/// ORB detector webcam demo: match a reference image against live webcam frames.
-#[cfg(target_os = "linux")]
-#[derive(FromArgs)]
-struct Args {
-    /// path to the reference image
-    #[argh(positional)]
-    image_path: PathBuf,
+    /// ORB detector webcam demo: match a reference image against live webcam frames.
+    #[derive(FromArgs)]
+    struct Args {
+        /// path to the reference image
+        #[argh(positional)]
+        image_path: PathBuf,
+    }
+
+    pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+        let args: Args = argh::from_env();
+
+        println!("{}", args.image_path.to_string_lossy());
+
+        // start the recording stream
+        let rec = rerun::RecordingStreamBuilder::new("Kornia Fast Detector App").spawn()?;
+
+        let webcam_size = ImageSize {
+            width: 640,
+            height: 480,
+        };
+        let mut webcam = V4lVideoCapture::new(V4LCameraConfig {
+            size: webcam_size,
+            ..Default::default()
+        })?;
+
+        let mut webcam_frame = Image::from_size_val(webcam_size, 0, CpuAllocator)?;
+        let mut webcam_frame_gray = Image::from_size_val(webcam_size, 0, CpuAllocator)?;
+        let mut webcam_frame_grayf32 = Image::from_size_val(webcam_size, 0.0, CpuAllocator)?;
+
+        let webcam_orb_detector = OrbDetector::new();
+
+        println!("Webcam done");
+
+        // read the image
+        let img_rgb = read_image_any_rgb8(args.image_path)?;
+
+        let mut img_gray = Image::from_size_val(img_rgb.size(), 0, CpuAllocator)?;
+        let mut img_grayf32 = Image::from_size_val(img_rgb.size(), 0.0, CpuAllocator)?;
+        gray_from_rgb_u8(&img_rgb, &mut img_gray)?;
+        u8_to_f32_image(&img_gray, &mut img_grayf32);
+
+        let mut joined_image = Image::from_size_val(
+            ImageSize {
+                width: webcam_size.width + img_rgb.width(),
+                height: webcam_size.height.max(img_rgb.height()),
+            },
+            0,
+            CpuAllocator,
+        )?;
+
+        let img_orb_detector = OrbDetector::new();
+        let img_detection = img_orb_detector.detect(&img_grayf32)?;
+        let img_extract = img_orb_detector.extract(
+            &img_grayf32,
+            &img_detection.0,
+            &img_detection.1,
+            &img_detection.2,
+        )?;
+
+        // Filter keypoints to only those with valid descriptors (border-filtered).
+        // extract() returns fewer descriptors than input keypoints; the mask tells us which survived.
+        let img_valid_kps: Vec<_> = img_detection
+            .0
+            .iter()
+            .zip(&img_extract.1)
+            .filter_map(|(&kp, &valid)| if valid { Some(kp) } else { None })
+            .collect();
+
+        loop {
+            let Some(frame) = webcam.grab_frame()? else {
+                continue;
+            };
+
+            let buf = frame.buffer.as_slice();
+            match frame.pixel_format {
+                PixelFormat::YUYV => {
+                    imgproc::color::convert_yuyv_to_rgb_u8(
+                        buf,
+                        &mut webcam_frame,
+                        imgproc::color::YuvToRgbMode::Bt601Full,
+                    )?;
+                }
+                PixelFormat::MJPG => {
+                    jpeg::decode_image_jpeg_rgb8(buf, &mut webcam_frame)?;
+                }
+                _ => return Err(format!("Unsupported format: {}", frame.pixel_format).into()),
+            }
+
+            gray_from_rgb_u8(&webcam_frame, &mut webcam_frame_gray)?;
+            u8_to_f32_image(&webcam_frame_gray, &mut webcam_frame_grayf32);
+
+            join_images_inplace(&webcam_frame_gray, &img_gray, &mut joined_image);
+
+            rec.log(
+                "image",
+                &rerun::Image::from_elements(
+                    joined_image.as_slice(),
+                    joined_image.size().into(),
+                    rerun::ColorModel::L,
+                ),
+            )?;
+
+            let webcam_detection = webcam_orb_detector.detect(&webcam_frame_grayf32)?;
+            let webcam_extraction = webcam_orb_detector.extract(
+                &webcam_frame_grayf32,
+                &webcam_detection.0,
+                &webcam_detection.1,
+                &webcam_detection.2,
+            )?;
+
+            // Filter webcam keypoints to match descriptor indices
+            let webcam_valid_kps: Vec<_> = webcam_detection
+                .0
+                .iter()
+                .zip(&webcam_extraction.1)
+                .filter_map(|(&kp, &valid)| if valid { Some(kp) } else { None })
+                .collect();
+
+            let matches = match_descriptors(&webcam_extraction.0, &img_extract.0, None, true, None);
+
+            // Converting keypoint coordinates to (W, H) for drawing match lines
+            let mut coords = Vec::new();
+            for &(i1, i2) in matches.iter() {
+                let kp1 = &webcam_valid_kps[i1];
+                let kp2 = &img_valid_kps[i2];
+
+                let coords1 = (kp1.1, kp1.0);
+                let coords2 = (kp2.1 + webcam_frame_grayf32.width() as f32, kp2.0);
+
+                coords.push([coords1, coords2]);
+            }
+
+            rec.log("image/matches", &rerun::LineStrips2D::new(coords))?;
+
+            let keypoints1: Vec<[f32; 2]> =
+                webcam_valid_kps.iter().map(|kp| [kp.1, kp.0]).collect();
+            let keypoints2: Vec<[f32; 2]> = img_valid_kps
+                .iter()
+                .map(|kp| [kp.1 + webcam_frame.width() as f32, kp.0])
+                .collect();
+
+            rec.log("image/keypoints1", &rerun::Points2D::new(&keypoints1))?;
+            rec.log("image/keypoints2", &rerun::Points2D::new(&keypoints2))?;
+        }
+    }
+
+    fn join_images_inplace(
+        image1: &Image<u8, 1, CpuAllocator>,
+        image2: &Image<u8, 1, CpuAllocator>,
+        out: &mut Image<u8, 1, CpuAllocator>,
+    ) {
+        let width1 = image1.width();
+        let width2 = image2.width();
+        let height = image1.height();
+
+        assert_eq!(image1.height(), image2.height());
+        assert_eq!(out.width(), width1 + width2);
+        assert_eq!(out.height(), height);
+
+        let row_len1 = width1;
+        let row_len2 = width2;
+        let out_row_len = width1 + width2;
+
+        let src1 = image1.as_slice();
+        let src2 = image2.as_slice();
+        let dst = out.as_slice_mut();
+
+        for row in 0..height {
+            let src1_start = row * row_len1;
+            let src2_start = row * row_len2;
+            let dst_start = row * out_row_len;
+
+            // Copy first image row
+            dst[dst_start..dst_start + row_len1]
+                .copy_from_slice(&src1[src1_start..src1_start + row_len1]);
+            // Copy second image row
+            dst[dst_start + row_len1..dst_start + row_len1 + row_len2]
+                .copy_from_slice(&src2[src2_start..src2_start + row_len2]);
+        }
+    }
+
+    fn u8_to_f32_image(src: &Image<u8, 1, CpuAllocator>, dst: &mut Image<f32, 1, CpuAllocator>) {
+        src.as_slice()
+            .iter()
+            .zip(dst.as_slice_mut())
+            .for_each(|(&s, d)| {
+                *d = s as f32 / 255.0;
+            });
+    }
 }
 
 #[cfg(target_os = "linux")]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let args: Args = argh::from_env();
-
-    println!("{}", args.image_path.to_string_lossy());
-
-    // start the recording stream
-    let rec = rerun::RecordingStreamBuilder::new("Kornia Fast Detector App").spawn()?;
-
-    let webcam_size = ImageSize {
-        width: 640,
-        height: 480,
-    };
-    let mut webcam = V4lVideoCapture::new(V4LCameraConfig {
-        size: webcam_size,
-        ..Default::default()
-    })?;
-
-    let mut webcam_frame = Image::from_size_val(webcam_size, 0, CpuAllocator)?;
-    let mut webcam_frame_gray = Image::from_size_val(webcam_size, 0, CpuAllocator)?;
-    let mut webcam_frame_grayf32 = Image::from_size_val(webcam_size, 0.0, CpuAllocator)?;
-
-    let webcam_orb_detector = OrbDetector::new();
-
-    println!("Webcam done");
-
-    // read the image
-    let img_rgb = read_image_any_rgb8(args.image_path)?;
-
-    let mut img_gray = Image::from_size_val(img_rgb.size(), 0, CpuAllocator)?;
-    let mut img_grayf32 = Image::from_size_val(img_rgb.size(), 0.0, CpuAllocator)?;
-    gray_from_rgb_u8(&img_rgb, &mut img_gray)?;
-    u8_to_f32_image(&img_gray, &mut img_grayf32);
-
-    let mut joined_image = Image::from_size_val(
-        ImageSize {
-            width: webcam_size.width + img_rgb.width(),
-            height: webcam_size.height.max(img_rgb.height()),
-        },
-        0,
-        CpuAllocator,
-    )?;
-
-    let img_orb_detector = OrbDetector::new();
-    let img_detection = img_orb_detector.detect(&img_grayf32)?;
-    let img_extract = img_orb_detector.extract(
-        &img_grayf32,
-        &img_detection.0,
-        &img_detection.1,
-        &img_detection.2,
-    )?;
-
-    // Filter keypoints to only those with valid descriptors (border-filtered).
-    // extract() returns fewer descriptors than input keypoints; the mask tells us which survived.
-    let img_valid_kps: Vec<_> = img_detection
-        .0
-        .iter()
-        .zip(&img_extract.1)
-        .filter_map(|(&kp, &valid)| if valid { Some(kp) } else { None })
-        .collect();
-
-    loop {
-        let Some(frame) = webcam.grab_frame()? else {
-            continue;
-        };
-
-        let buf = frame.buffer.as_slice();
-        match frame.pixel_format {
-            PixelFormat::YUYV => {
-                imgproc::color::convert_yuyv_to_rgb_u8(
-                    buf,
-                    &mut webcam_frame,
-                    imgproc::color::YuvToRgbMode::Bt601Full,
-                )?;
-            }
-            PixelFormat::MJPG => {
-                jpeg::decode_image_jpeg_rgb8(buf, &mut webcam_frame)?;
-            }
-            _ => return Err(format!("Unsupported format: {}", frame.pixel_format).into()),
-        }
-
-        gray_from_rgb_u8(&webcam_frame, &mut webcam_frame_gray)?;
-        u8_to_f32_image(&webcam_frame_gray, &mut webcam_frame_grayf32);
-
-        join_images_inplace(&webcam_frame_gray, &img_gray, &mut joined_image);
-
-        rec.log(
-            "image",
-            &rerun::Image::from_elements(
-                joined_image.as_slice(),
-                joined_image.size().into(),
-                rerun::ColorModel::L,
-            ),
-        )?;
-
-        let webcam_detection = webcam_orb_detector.detect(&webcam_frame_grayf32)?;
-        let webcam_extraction = webcam_orb_detector.extract(
-            &webcam_frame_grayf32,
-            &webcam_detection.0,
-            &webcam_detection.1,
-            &webcam_detection.2,
-        )?;
-
-        // Filter webcam keypoints to match descriptor indices
-        let webcam_valid_kps: Vec<_> = webcam_detection
-            .0
-            .iter()
-            .zip(&webcam_extraction.1)
-            .filter_map(|(&kp, &valid)| if valid { Some(kp) } else { None })
-            .collect();
-
-        let matches = match_descriptors(&webcam_extraction.0, &img_extract.0, None, true, None);
-
-        // Converting keypoint coordinates to (W, H) for drawing match lines
-        let mut coords = Vec::new();
-        for &(i1, i2) in matches.iter() {
-            let kp1 = &webcam_valid_kps[i1];
-            let kp2 = &img_valid_kps[i2];
-
-            let coords1 = (kp1.1, kp1.0);
-            let coords2 = (kp2.1 + webcam_frame_grayf32.width() as f32, kp2.0);
-
-            coords.push([coords1, coords2]);
-        }
-
-        rec.log("image/matches", &rerun::LineStrips2D::new(coords))?;
-
-        let keypoints1: Vec<[f32; 2]> = webcam_valid_kps.iter().map(|kp| [kp.1, kp.0]).collect();
-        let keypoints2: Vec<[f32; 2]> = img_valid_kps
-            .iter()
-            .map(|kp| [kp.1 + webcam_frame.width() as f32, kp.0])
-            .collect();
-
-        rec.log("image/keypoints1", &rerun::Points2D::new(&keypoints1))?;
-        rec.log("image/keypoints2", &rerun::Points2D::new(&keypoints2))?;
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn join_images_inplace(
-    image1: &Image<u8, 1, CpuAllocator>,
-    image2: &Image<u8, 1, CpuAllocator>,
-    out: &mut Image<u8, 1, CpuAllocator>,
-) {
-    let width1 = image1.width();
-    let width2 = image2.width();
-    let height = image1.height();
-
-    assert_eq!(image1.height(), image2.height());
-    assert_eq!(out.width(), width1 + width2);
-    assert_eq!(out.height(), height);
-
-    let row_len1 = width1;
-    let row_len2 = width2;
-    let out_row_len = width1 + width2;
-
-    let src1 = image1.as_slice();
-    let src2 = image2.as_slice();
-    let dst = out.as_slice_mut();
-
-    for row in 0..height {
-        let src1_start = row * row_len1;
-        let src2_start = row * row_len2;
-        let dst_start = row * out_row_len;
-
-        // Copy first image row
-        dst[dst_start..dst_start + row_len1]
-            .copy_from_slice(&src1[src1_start..src1_start + row_len1]);
-        // Copy second image row
-        dst[dst_start + row_len1..dst_start + row_len1 + row_len2]
-            .copy_from_slice(&src2[src2_start..src2_start + row_len2]);
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn u8_to_f32_image(src: &Image<u8, 1, CpuAllocator>, dst: &mut Image<f32, 1, CpuAllocator>) {
-    src.as_slice()
-        .iter()
-        .zip(dst.as_slice_mut())
-        .for_each(|(&s, d)| {
-            *d = s as f32 / 255.0;
-        });
+    linux::main()
 }
 
 #[cfg(not(target_os = "linux"))]

--- a/examples/ros-z-nodes/Cargo.toml
+++ b/examples/ros-z-nodes/Cargo.toml
@@ -27,8 +27,8 @@ serde = { workspace = true, features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 zenoh = { version = "1.7", features = ["shared-memory"] }
 
-[target.'cfg(target_os = "linux")'.dependencies]
-kornia-io = { workspace = true, features = ["v4l"] }
-
 [build-dependencies]
 prost-build = "0.14.1"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+kornia-io = { workspace = true, features = ["v4l"] }

--- a/examples/ros-z-nodes/Cargo.toml
+++ b/examples/ros-z-nodes/Cargo.toml
@@ -15,7 +15,7 @@ flume = "0.12"
 foxglove = "0.16.1"
 kornia-image = { workspace = true }
 kornia-imgproc = { workspace = true }
-kornia-io = { workspace = true, features = ["v4l"] }
+kornia-io = { workspace = true }
 log = { workspace = true }
 nix = { version = "0.30.1", features = ["time"] }
 prost = "0.14.1"
@@ -26,6 +26,9 @@ ros-z = { git = "https://github.com/ZettaScaleLabs/ros-z.git", branch = "main", 
 serde = { workspace = true, features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 zenoh = { version = "1.7", features = ["shared-memory"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+kornia-io = { workspace = true, features = ["v4l"] }
 
 [build-dependencies]
 prost-build = "0.14.1"

--- a/examples/ros-z-nodes/src/bin/ros-z-camera.rs
+++ b/examples/ros-z-nodes/src/bin/ros-z-camera.rs
@@ -1,12 +1,17 @@
+#[cfg(target_os = "linux")]
 use argh::FromArgs;
+#[cfg(target_os = "linux")]
 use ros_z::{context::ZContextBuilder, Builder, Result as ZResult};
+#[cfg(target_os = "linux")]
 use std::sync::Arc;
 
+#[cfg(target_os = "linux")]
 use ros_z_nodes::{
     camera_node::V4lCameraNode, compute_node::ComputeNode, decoder_node::DecoderNode,
     foxglove_node::FoxgloveNode, logger_node::LoggerNode,
 };
 
+#[cfg(target_os = "linux")]
 #[derive(FromArgs)]
 /// ROS2-style camera publisher using ros-z
 struct Args {
@@ -23,6 +28,7 @@ struct Args {
     fps: u32,
 }
 
+#[cfg(target_os = "linux")]
 #[tokio::main]
 async fn main() -> ZResult<()> {
     let env = env_logger::Env::default().default_filter_or("info");
@@ -68,4 +74,12 @@ async fn main() -> ZResult<()> {
     }
 
     Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!(
+        "error: the ros-z-camera example requires Video4Linux and is only supported on Linux."
+    );
+    std::process::exit(1);
 }

--- a/examples/ros-z-nodes/src/bin/ros-z-camera.rs
+++ b/examples/ros-z-nodes/src/bin/ros-z-camera.rs
@@ -77,9 +77,6 @@ async fn main() -> ZResult<()> {
 }
 
 #[cfg(not(target_os = "linux"))]
-fn main() {
-    eprintln!(
-        "error: the ros-z-camera example requires Video4Linux and is only supported on Linux."
-    );
-    std::process::exit(1);
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    Err("the ros-z-camera example requires Video4Linux and is only supported on Linux.".into())
 }

--- a/examples/ros-z-nodes/src/bin/ros-z-camera.rs
+++ b/examples/ros-z-nodes/src/bin/ros-z-camera.rs
@@ -1,79 +1,82 @@
 #[cfg(target_os = "linux")]
-use argh::FromArgs;
-#[cfg(target_os = "linux")]
-use ros_z::{context::ZContextBuilder, Builder, Result as ZResult};
-#[cfg(target_os = "linux")]
-use std::sync::Arc;
+mod linux {
+    use argh::FromArgs;
+    use ros_z::{context::ZContextBuilder, Builder, Result as ZResult};
+    use std::sync::Arc;
 
-#[cfg(target_os = "linux")]
-use ros_z_nodes::{
-    camera_node::V4lCameraNode, compute_node::ComputeNode, decoder_node::DecoderNode,
-    foxglove_node::FoxgloveNode, logger_node::LoggerNode,
-};
+    use ros_z_nodes::{
+        camera_node::V4lCameraNode, compute_node::ComputeNode, decoder_node::DecoderNode,
+        foxglove_node::FoxgloveNode, logger_node::LoggerNode,
+    };
 
-#[cfg(target_os = "linux")]
-#[derive(FromArgs)]
-/// ROS2-style camera publisher using ros-z
-struct Args {
-    /// camera name for topics (e.g., "front", "back")
-    #[argh(option, short = 'n', default = "String::from(\"front\")")]
-    camera_name: String,
+    #[derive(FromArgs)]
+    /// ROS2-style camera publisher using ros-z
+    struct Args {
+        /// camera name for topics (e.g., "front", "back")
+        #[argh(option, short = 'n', default = "String::from(\"front\")")]
+        camera_name: String,
 
-    /// V4L device ID (e.g., 0 for /dev/video0)
-    #[argh(option, short = 'd', default = "0")]
-    device_id: u32,
+        /// V4L device ID (e.g., 0 for /dev/video0)
+        #[argh(option, short = 'd', default = "0")]
+        device_id: u32,
 
-    /// frames per second
-    #[argh(option, short = 'f', default = "30")]
-    fps: u32,
+        /// frames per second
+        #[argh(option, short = 'f', default = "30")]
+        fps: u32,
+    }
+
+    #[tokio::main]
+    pub async fn main() -> ZResult<()> {
+        let env = env_logger::Env::default().default_filter_or("info");
+        env_logger::init_from_env(env);
+
+        let args: Args = argh::from_env();
+
+        log::info!(
+            "Starting camera '{}' (device: /dev/video{}, fps: {})",
+            args.camera_name,
+            args.device_id,
+            args.fps
+        );
+
+        let shutdown_tx = tokio::sync::watch::Sender::new(());
+
+        ctrlc::set_handler({
+            let shutdown_tx = shutdown_tx.clone();
+            move || {
+                log::info!("Received Ctrl+C, shutting down gracefully...");
+                shutdown_tx.send(()).ok();
+            }
+        })?;
+
+        let ctx = Arc::new(ZContextBuilder::default().build()?);
+
+        let camera_node =
+            V4lCameraNode::new(ctx.clone(), &args.camera_name, args.device_id, args.fps)?;
+        let compute_node = ComputeNode::new(ctx.clone(), &args.camera_name)?;
+        let decoder_node = DecoderNode::new(ctx.clone(), &args.camera_name)?;
+        let foxglove_node = FoxgloveNode::new(ctx.clone(), &args.camera_name)?;
+        let logger_node = LoggerNode::new(ctx.clone(), &args.camera_name)?;
+
+        let nodes = vec![
+            tokio::spawn(camera_node.run(shutdown_tx.clone())),
+            tokio::spawn(compute_node.run(shutdown_tx.clone())),
+            tokio::spawn(decoder_node.run(shutdown_tx.clone())),
+            tokio::spawn(logger_node.run(shutdown_tx.clone())),
+            tokio::spawn(foxglove_node.run(shutdown_tx.clone())),
+        ];
+
+        for node in nodes {
+            node.await??;
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(target_os = "linux")]
-#[tokio::main]
-async fn main() -> ZResult<()> {
-    let env = env_logger::Env::default().default_filter_or("info");
-    env_logger::init_from_env(env);
-
-    let args: Args = argh::from_env();
-
-    log::info!(
-        "Starting camera '{}' (device: /dev/video{}, fps: {})",
-        args.camera_name,
-        args.device_id,
-        args.fps
-    );
-
-    let shutdown_tx = tokio::sync::watch::Sender::new(());
-
-    ctrlc::set_handler({
-        let shutdown_tx = shutdown_tx.clone();
-        move || {
-            log::info!("Received Ctrl+C, shutting down gracefully...");
-            shutdown_tx.send(()).ok();
-        }
-    })?;
-
-    let ctx = Arc::new(ZContextBuilder::default().build()?);
-
-    let camera_node = V4lCameraNode::new(ctx.clone(), &args.camera_name, args.device_id, args.fps)?;
-    let compute_node = ComputeNode::new(ctx.clone(), &args.camera_name)?;
-    let decoder_node = DecoderNode::new(ctx.clone(), &args.camera_name)?;
-    let foxglove_node = FoxgloveNode::new(ctx.clone(), &args.camera_name)?;
-    let logger_node = LoggerNode::new(ctx.clone(), &args.camera_name)?;
-
-    let nodes = vec![
-        tokio::spawn(camera_node.run(shutdown_tx.clone())),
-        tokio::spawn(compute_node.run(shutdown_tx.clone())),
-        tokio::spawn(decoder_node.run(shutdown_tx.clone())),
-        tokio::spawn(logger_node.run(shutdown_tx.clone())),
-        tokio::spawn(foxglove_node.run(shutdown_tx.clone())),
-    ];
-
-    for node in nodes {
-        node.await??;
-    }
-
-    Ok(())
+fn main() -> ros_z::Result<()> {
+    linux::main()
 }
 
 #[cfg(not(target_os = "linux"))]

--- a/examples/ros-z-nodes/src/lib.rs
+++ b/examples/ros-z-nodes/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(target_os = "linux")]
 pub mod camera_node;
 pub mod compute_node;
 pub mod decoder_node;

--- a/examples/smol_vlm2_video/Cargo.toml
+++ b/examples/smol_vlm2_video/Cargo.toml
@@ -12,12 +12,15 @@ env_logger = { workspace = true }
 gstreamer = "0.23.5"
 gstreamer-app = "0.23.5"
 gstreamer-video = "0.23.5"
-kornia = { workspace = true, features = ["v4l"] }
+kornia = { workspace = true }
 kornia-image = { workspace = true }
 kornia-tensor = { workspace = true }
 kornia-vlm = { workspace = true }
 reqwest = { version = "0.12.15", features = ["blocking"] }
 rerun = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+kornia = { workspace = true, features = ["v4l"] }
 
 [features]
 cuda = ["kornia/cuda"]

--- a/examples/smol_vlm2_video/src/main.rs
+++ b/examples/smol_vlm2_video/src/main.rs
@@ -1,3 +1,4 @@
+#[cfg(target_os = "linux")]
 mod video_demo;
 mod video_file_demo;
 
@@ -46,6 +47,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if args.video_file.is_some() {
         video_file_demo::video_file_demo(&args)
     } else {
-        video_demo::video_demo(&args)
+        #[cfg(target_os = "linux")]
+        {
+            video_demo::video_demo(&args)
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            eprintln!(
+                "error: webcam capture (camera_id={}, fps={}) requires Video4Linux and is only supported on Linux.",
+                args.camera_id, args.fps
+            );
+            eprintln!("hint: use --video-file to process a video file instead.");
+            std::process::exit(1);
+        }
     }
 }

--- a/examples/smol_vlm2_video/src/main.rs
+++ b/examples/smol_vlm2_video/src/main.rs
@@ -53,12 +53,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         #[cfg(not(target_os = "linux"))]
         {
-            eprintln!(
-                "error: webcam capture (camera_id={}, fps={}) requires Video4Linux and is only supported on Linux.",
+            Err(format!(
+                "webcam capture (camera_id={}, fps={}) requires Video4Linux and is only supported on Linux. \
+                 Hint: use --video-file to process a video file instead.",
                 args.camera_id, args.fps
-            );
-            eprintln!("hint: use --video-file to process a video file instead.");
-            std::process::exit(1);
+            ).into())
         }
     }
 }

--- a/examples/smol_vlm_video/Cargo.toml
+++ b/examples/smol_vlm_video/Cargo.toml
@@ -12,10 +12,13 @@ gstreamer = "0.21"
 gstreamer-app = "0.21"
 gstreamer-video = "0.21"
 image = "0.24"
-kornia = { workspace = true, features = ["v4l"] }
+kornia = { workspace = true }
 kornia-vlm = { workspace = true }
 reqwest = { version = "0.12.15", features = ["blocking"] }
 rerun = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+kornia = { workspace = true, features = ["v4l"] }
 
 [features]
 cuda = ["kornia/cuda"]

--- a/examples/smol_vlm_video/src/main.rs
+++ b/examples/smol_vlm_video/src/main.rs
@@ -1,3 +1,4 @@
+#[cfg(target_os = "linux")]
 mod video_demo;
 mod video_file_demo;
 
@@ -44,6 +45,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if args.video_file.is_some() {
         video_file_demo::video_file_demo(&args)
     } else {
-        video_demo::video_demo(&args)
+        #[cfg(target_os = "linux")]
+        {
+            video_demo::video_demo(&args)
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            eprintln!(
+                "error: webcam capture (camera_id={}, fps={}) requires Video4Linux and is only supported on Linux.",
+                args.camera_id, args.fps
+            );
+            eprintln!("hint: use --video-file to process a video file instead.");
+            std::process::exit(1);
+        }
     }
 }

--- a/examples/smol_vlm_video/src/main.rs
+++ b/examples/smol_vlm_video/src/main.rs
@@ -51,12 +51,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         #[cfg(not(target_os = "linux"))]
         {
-            eprintln!(
-                "error: webcam capture (camera_id={}, fps={}) requires Video4Linux and is only supported on Linux.",
+            Err(format!(
+                "webcam capture (camera_id={}, fps={}) requires Video4Linux and is only supported on Linux. \
+                 Hint: use --video-file to process a video file instead.",
                 args.camera_id, args.fps
-            );
-            eprintln!("hint: use --video-file to process a video file instead.");
-            std::process::exit(1);
+            ).into())
         }
     }
 }


### PR DESCRIPTION
## 📝 Description
Five examples (foxglove, orb_detector, ros-z-nodes, smol_vlm_video, smol_vlm2_video) unconditionally import V4L (Video4Linux) types, causing the workspace to fail compilation on macOS and Windows.
This PR gates the V4L usage in each example behind #[cfg(target_os = "linux")] at both the Cargo.toml dependency level and the source level. On non-Linux platforms, affected binaries print a clear error message and exit. For smol_vlm_video and smol_vlm2_video, only the webcam capture path is gated - the --video-file path remains fully cross-platform.
No changes to core crates, CI configuration, or pixi tasks were needed.
**⚠️ Issue Link Required**: This PR must be linked to an approved and assigned issue. See [Contributing Guide](CONTRIBUTING.md#pull-request) for details.
https://github.com/kornia/kornia-rs/issues/813
**Fixes/Relates to:** #813

**Important**:
- Ensure you are assigned to the linked issue before submitting this PR
- This PR should strictly implement what the linked issue describes
- Do not include changes beyond the scope of the linked issue

---

## 🛠️ Changes Made

- Gate V4L-dependent examples behind #[cfg(target_os = "linux")] to fix compilation on macOS/Windows
-  Move V4L feature deps to [target.'cfg(target_os = "linux")'.dependencies] in example Cargo.toml files
-  Add helpful non-Linux stub main() functions with clear error messages
-  For smol_vlm_video/smol_vlm2_video, preserve the --video-file path cross-platform while gating only the webcam (V4L) path
-  Gate camera_node module in ros-z-nodes/src/lib.rs behind cfg(target_os = "linux")
- Add macOS cross-platform CI check to [rust_lint.yml](cci:7://file:///Users/namangupta/Documents/GitHub/kornia-rs/.github/workflows/rust_lint.yml:0:0-0:0) using pixi (full workspace check)
- Add Windows cross-platform CI check to [rust_lint.yml](cci:7://file:///Users/namangupta/Documents/GitHub/kornia-rs/.github/workflows/rust_lint.yml:0:0-0:0) using plain `cargo check` (core crates)

Affected examples:

- examples/foxglove — full main gated
- examples/orb_detector — full main gated
- examples/ros-z-nodes — camera_node module + ros-z-camera binary gated
- examples/smol_vlm_video — video_demo module + webcam branch gated, video_file_demo remains cross-platform
- examples/smol_vlm2_video — video_demo module + webcam branch gated, video_file_demo remains cross-platform

---

## 🧪 How Was This Tested?
- [ ] **Unit Tests:** (List new/updated tests)
- [ ] **Manual Verification:** 
1. cargo fmt --all -- --check — passes (zero formatting issues)
2. cargo clippy --workspace --no-deps --all-targets --features ci -- -D warnings  passes (zero warnings)
3. cargo check --workspace --all-targets --features ci  - passes on macOS (zero warnings)
4. cargo test --features ci  - all tests pass

- [ ] **Performance/Edge Cases:** No runtime performance impact  changes are purely compile-time cfg gates
---

## 🕵️ AI Usage Disclosure
*Check one of the following:*
- [ ] 🟢 **No AI used.**
- [x] 🟡 **AI-assisted:** I used AI for boilerplate/refactoring but have manually reviewed and tested every line.
- [ ] 🔴 **AI-generated:** (Note: These PRs may be subject to stricter scrutiny or immediate closure if the logic is not explained).

---

## 🚦 Checklist
- [x] I am assigned to the linked issue (required before PR submission)
- [x] The linked issue has been approved by a maintainer
- [x] This PR strictly implements what the linked issue describes (no scope creep)
- [x] I have performed a **self-review** of my code (no "ghost" variables or hallucinations).
- [x] My code follows the existing style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] (Optional) I have attached screenshots/recordings for UI changes.

---

## 💭 Additional Context
The kornia-io crate already correctly gates V4L behind `#[cfg(all(feature = "v4l", target_os = "linux"))]`, but the example crates were importing V4L types unconditionally. Since CI runs exclusively on ubuntu-latest, this was never caught. These changes ensure the entire workspace compiles cleanly on macOS and Windows.
No changes were needed to kornia/Cargo.toml (ci feature) or pixi.toml - Cargo correctly handles platform-gated optional dependencies, so --features ci (which includes v4l) works on all platforms without issues.

CI improvements :
- macOS : Uses pixi + `pixi run rust-check` → full `cargo check --workspace --all-targets --features ci`. Catches any unconditional Linux-only imports across the entire workspace.
- Windows : Uses `cargo check` (core crates via `default-members`). pixi doesn't support Windows in this project, so this validates core library crates only.