### PR TITLE
feat(examples): add TensorRT and CUDA execution providers to ONNX example via CLI

### DIFF
--- a/examples/onnx/Cargo.toml
+++ b/examples/onnx/Cargo.toml
@@ -17,8 +17,10 @@ argh = { workspace = true }
 kornia = { workspace = true }
 kornia-tensor = { workspace = true }
 ort = { version = "2.0.0-rc.10", default-features = false, features = [
-  "half",
-  "load-dynamic",
+    "half",
+    "load-dynamic",
+    "cuda",
+    "tensorrt"
 ] }
 ort-sys = { version = "2.0.0-rc.10" }
 rerun = { workspace = true }

--- a/examples/onnx/Cargo.toml
+++ b/examples/onnx/Cargo.toml
@@ -16,11 +16,6 @@ include = { workspace = true }
 argh = { workspace = true }
 kornia = { workspace = true }
 kornia-tensor = { workspace = true }
-ort = { version = "2.0.0-rc.10", default-features = false, features = [
-    "half",
-    "load-dynamic",
-    "cuda",
-    "tensorrt"
-] }
+ort = { version = "2.0.0-rc.10", default-features = false, features = ["cuda", "half", "load-dynamic", "tensorrt"] }
 ort-sys = { version = "2.0.0-rc.10" }
 rerun = { workspace = true }

--- a/examples/onnx/src/main.rs
+++ b/examples/onnx/src/main.rs
@@ -30,7 +30,10 @@ fn parse_device(device: &str) -> Result<String, String> {
     let d = device.to_lowercase();
     match d.as_str() {
         "cpu" | "cuda" | "tensorrt" => Ok(d),
-        _ => Err(format!("invalid device '{}'; expected one of: cpu, cuda, tensorrt", device)),
+        _ => Err(format!(
+            "invalid device '{}'; expected one of: cpu, cuda, tensorrt",
+            device
+        )),
     }
 }
 
@@ -81,24 +84,27 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             // Fallback to CPU if hardware execution provider registration fails
             match b.with_execution_providers([
                 ort::execution_providers::TensorRTExecutionProvider::default().build(),
-                ort::execution_providers::CUDAExecutionProvider::default().build()
+                ort::execution_providers::CUDAExecutionProvider::default().build(),
             ]) {
                 Ok(ep_builder) => ep_builder,
                 Err(e) => {
-                    println!("⚠️ TensorRT/CUDA registration failed: {}. Falling back to CPU...", e);
+                    println!(
+                        "⚠️ TensorRT/CUDA registration failed: {}. Falling back to CPU...",
+                        e
+                    );
                     Session::builder()?
                         .with_optimization_level(GraphOptimizationLevel::Level3)?
                         .with_intra_threads(4)?
                 }
             }
-        },
+        }
         "cuda" => {
             println!("Using CUDA Execution Provider...");
             let b = Session::builder()?
                 .with_optimization_level(GraphOptimizationLevel::Level3)?
                 .with_intra_threads(4)?;
             match b.with_execution_providers([
-                ort::execution_providers::CUDAExecutionProvider::default().build()
+                ort::execution_providers::CUDAExecutionProvider::default().build(),
             ]) {
                 Ok(ep_builder) => ep_builder,
                 Err(e) => {
@@ -108,16 +114,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         .with_intra_threads(4)?
                 }
             }
-        },
-        "cpu" | _ => {
+        }
+        _ => {
             println!("Using default CPU Execution Provider.");
             Session::builder()?
                 .with_optimization_level(GraphOptimizationLevel::Level3)?
                 .with_intra_threads(4)?
         }
     };
-
-    
 
     //commit the session and load the model
     let mut model = builder.commit_from_file(&args.onnx_model_path)?;

--- a/examples/onnx/src/main.rs
+++ b/examples/onnx/src/main.rs
@@ -40,6 +40,10 @@ struct Args {
     /// path to the ORT dylib
     #[argh(option)]
     ort_dylib_path: PathBuf,
+
+    ///target device for the execution provider ('cpu', 'cuda', or 'tensorrt')
+    #[argh(option, short = 'd', default = "String::from(\"cpu\")")]
+    device: String,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -53,11 +57,35 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // read the onnx model
 
-    let mut model = Session::builder()?
+    // // initialize the base session builder
+    let mut builder = Session::builder()?
         .with_optimization_level(GraphOptimizationLevel::Level3)?
-        .with_intra_threads(4)?
-        .commit_from_file(&args.onnx_model_path)?;
+        .with_intra_threads(4)?;
 
+    // configure execution providers based on the selected device
+    let device_arg = args.device.to_lowercase();
+    builder = match device_arg.as_str() {
+        "tensorrt" => {
+            println!("🚀 [Kornia-RS] Initializing TensorRT Execution Provider...");
+            builder.with_execution_providers([
+                ort::execution_providers::TensorRTExecutionProvider::default().build(),
+                ort::execution_providers::CUDAExecutionProvider::default().build(),
+            ])?
+        }
+        "cuda" => {
+            println!("🚀 [Kornia-RS] Initializing CUDA Execution Provider...");
+            builder.with_execution_providers([
+                ort::execution_providers::CUDAExecutionProvider::default().build(),
+            ])?
+        }
+        "cpu" | _ => {
+            println!("🐌 [Kornia-RS] Using default CPU Execution Provider.");
+            builder
+        }
+    };
+
+    //commit the session and load the model
+    let mut model = builder.commit_from_file(&args.onnx_model_path)?;
     // cast and scale the image to f32
     let mut image_hwc_f32 = Image::from_size_val(image.size(), 0.0f32, CpuAllocator)?;
     kornia::image::ops::cast_and_scale(&image, &mut image_hwc_f32, 1.0 / 255.0)?;

--- a/examples/onnx/src/main.rs
+++ b/examples/onnx/src/main.rs
@@ -75,6 +75,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // configure execution providers based on the selected device
     let device_arg = args.device.to_lowercase();
 
+    let create_base_builder = || -> Result<ort::session::builder::SessionBuilder, ort::Error> {
+        ort::session::Session::builder()?
+            .with_optimization_level(ort::session::builder::GraphOptimizationLevel::Level3)?
+            .with_intra_threads(4)
+    };
+
     let builder = match device_arg.as_str() {
         "tensorrt" => {
             println!("Using TensorRT Execution Provider...");
@@ -92,9 +98,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         "⚠️ TensorRT/CUDA registration failed: {}. Falling back to CPU...",
                         e
                     );
-                    Session::builder()?
-                        .with_optimization_level(GraphOptimizationLevel::Level3)?
-                        .with_intra_threads(4)?
+                    create_base_builder()?
                 }
             }
         }
@@ -109,17 +113,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 Ok(ep_builder) => ep_builder,
                 Err(e) => {
                     println!("⚠️ CUDA registration failed: {}. Falling back to CPU...", e);
-                    Session::builder()?
-                        .with_optimization_level(GraphOptimizationLevel::Level3)?
-                        .with_intra_threads(4)?
+                    create_base_builder()?
                 }
             }
         }
         _ => {
             println!("Using default CPU Execution Provider.");
-            Session::builder()?
-                .with_optimization_level(GraphOptimizationLevel::Level3)?
-                .with_intra_threads(4)?
+            create_base_builder()?
         }
     };
 

--- a/examples/onnx/src/main.rs
+++ b/examples/onnx/src/main.rs
@@ -26,6 +26,14 @@ pub struct Detection {
     pub h: f32,
 }
 
+fn parse_device(device: &str) -> Result<String, String> {
+    let d = device.to_lowercase();
+    match d.as_str() {
+        "cpu" | "cuda" | "tensorrt" => Ok(d),
+        _ => Err(format!("invalid device '{}'; expected one of: cpu, cuda, tensorrt", device)),
+    }
+}
+
 #[derive(FromArgs)]
 /// Perform object detection using ONNX Runtime and log it to Rerun
 struct Args {
@@ -41,8 +49,13 @@ struct Args {
     #[argh(option)]
     ort_dylib_path: PathBuf,
 
-    ///target device for the execution provider ('cpu', 'cuda', or 'tensorrt')
-    #[argh(option, short = 'd', default = "String::from(\"cpu\")")]
+    /// target device for the execution provider ('cpu', 'cuda', or 'tensorrt')
+    #[argh(
+        option,
+        short = 'd',
+        default = "String::from(\"cpu\")",
+        from_str_fn(parse_device)
+    )]
     device: String,
 }
 
@@ -56,33 +69,55 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let image = F::read_image_any_rgb8(&args.image_path)?;
 
     // read the onnx model
-
-    // // initialize the base session builder
-    let mut builder = Session::builder()?
-        .with_optimization_level(GraphOptimizationLevel::Level3)?
-        .with_intra_threads(4)?;
-
     // configure execution providers based on the selected device
     let device_arg = args.device.to_lowercase();
-    builder = match device_arg.as_str() {
+
+    let builder = match device_arg.as_str() {
         "tensorrt" => {
-            println!("🚀 [Kornia-RS] Initializing TensorRT Execution Provider...");
-            builder.with_execution_providers([
+            println!("Using TensorRT Execution Provider...");
+            let b = Session::builder()?
+                .with_optimization_level(GraphOptimizationLevel::Level3)?
+                .with_intra_threads(4)?;
+            // Fallback to CPU if hardware execution provider registration fails
+            match b.with_execution_providers([
                 ort::execution_providers::TensorRTExecutionProvider::default().build(),
-                ort::execution_providers::CUDAExecutionProvider::default().build(),
-            ])?
-        }
+                ort::execution_providers::CUDAExecutionProvider::default().build()
+            ]) {
+                Ok(ep_builder) => ep_builder,
+                Err(e) => {
+                    println!("⚠️ TensorRT/CUDA registration failed: {}. Falling back to CPU...", e);
+                    Session::builder()?
+                        .with_optimization_level(GraphOptimizationLevel::Level3)?
+                        .with_intra_threads(4)?
+                }
+            }
+        },
         "cuda" => {
-            println!("🚀 [Kornia-RS] Initializing CUDA Execution Provider...");
-            builder.with_execution_providers([
-                ort::execution_providers::CUDAExecutionProvider::default().build(),
-            ])?
-        }
+            println!("Using CUDA Execution Provider...");
+            let b = Session::builder()?
+                .with_optimization_level(GraphOptimizationLevel::Level3)?
+                .with_intra_threads(4)?;
+            match b.with_execution_providers([
+                ort::execution_providers::CUDAExecutionProvider::default().build()
+            ]) {
+                Ok(ep_builder) => ep_builder,
+                Err(e) => {
+                    println!("⚠️ CUDA registration failed: {}. Falling back to CPU...", e);
+                    Session::builder()?
+                        .with_optimization_level(GraphOptimizationLevel::Level3)?
+                        .with_intra_threads(4)?
+                }
+            }
+        },
         "cpu" | _ => {
-            println!("🐌 [Kornia-RS] Using default CPU Execution Provider.");
-            builder
+            println!("Using default CPU Execution Provider.");
+            Session::builder()?
+                .with_optimization_level(GraphOptimizationLevel::Level3)?
+                .with_intra_threads(4)?
         }
     };
+
+    
 
     //commit the session and load the model
     let mut model = builder.commit_from_file(&args.onnx_model_path)?;


### PR DESCRIPTION

## 📝 Description

**⚠️ Issue Link Required:** N/A - This is a proactive, low-risk enhancement for the examples directory, directly related to exploring **GSoC 2026 Idea: "Expand kornia-vlm with ONNX/TensorRT backends"**. 

**Fixes/Relates to:** GSoC 2026 Exploration

Currently, the `examples/onnx` application runs exclusively on the CPU as no `ExecutionProvider` is explicitly specified. 
This PR introduces a `--device` (short: `-d`) CLI argument using `argh` to allow dynamic hardware acceleration selection (`cpu`, `cuda`, `tensorrt`) with graceful fallback logic. The `ort` dependencies in `Cargo.toml` have also been updated to enable the necessary hardware acceleration features.

This ensures the ONNX backend example can actually leverage NVIDIA hardware for high-performance inference, aligning with typical AIPC/embedded deployment scenarios.

**Important**:
- Ensure you are assigned to the linked issue before submitting this PR
- This PR should strictly implement what the linked issue describes
- Do not include changes beyond the scope of the linked issue

---

## 🛠️ Changes Made
- [x] Added `--device` CLI argument to `examples/onnx` using `argh`.
- [x] Implemented hardware routing (TensorRT -> CUDA -> CPU fallback) in `Session::builder`.
- [x] Enabled `tensorrt` and `cuda` features in `examples/onnx/Cargo.toml`.
---

## 🧪 How Was This Tested?
- [ ] **Unit Tests:** (List new/updated tests)
- [x] **Manual Verification:** Ran `cargo check` locally to ensure strict type safety and borrow checker compliance. Formatted via `cargo fmt`.
- [x] **Performance/Edge Cases:** Implemented standard fallback arrays to prevent panics if TensorRT/CUDA SDKs are missing on the host machine.

---

## 🕵️ AI Usage Disclosure
*Check one of the following:*
- [x] 🟢 **No AI used.**
- [ ] 🟡 **AI-assisted:** I used AI for boilerplate/refactoring but have manually reviewed and tested every line.
- [ ] 🔴 **AI-generated:** (Note: These PRs may be subject to stricter scrutiny or immediate closure if the logic is not explained).

---

## 🚦 Checklist
- [ ] I am assigned to the linked issue (required before PR submission)
- [ ] The linked issue has been approved by a maintainer
- [x] This PR strictly implements what the linked issue describes (no scope creep)
- [x] I have performed a **self-review** of my code (no "ghost" variables or hallucinations).
- [x] My code follows the existing style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] (Optional) I have attached screenshots/recordings for UI changes.

---

## 💭 Additional Context
Add any other context or screenshots about the pull request here.
