### PR TITLE
Fix decode_gray8 to return Image<u8, 1> instead of Image<u8, 3>

### DIFF
--- a/crates/kornia-io/src/jpegturbo.rs
+++ b/crates/kornia-io/src/jpegturbo.rs
@@ -72,7 +72,7 @@ impl JpegTurboEncoder {
         let buf = turbojpeg::Image {
             pixels: image_data,
             width: image.width(),
-            pitch: 3 * image.width(),
+            pitch: C * image.width(),
             height: image.height(),
             format: turbojpeg::PixelFormat::RGB,
         };
@@ -166,8 +166,8 @@ impl JpegTurboDecoder {
     pub fn decode_gray8(
         &self,
         jpeg_data: &[u8],
-    ) -> Result<Image<u8, 3, CpuAllocator>, JpegTurboError> {
-        self.decode(jpeg_data, turbojpeg::PixelFormat::GRAY)
+    ) -> Result<Image<u8, 1, CpuAllocator>, JpegTurboError> {
+        self.decode::<1>(jpeg_data, turbojpeg::PixelFormat::GRAY)
     }
 
     fn decode<const C: usize>(
@@ -185,7 +185,7 @@ impl JpegTurboDecoder {
         let buf = turbojpeg::Image {
             pixels: pixels.as_mut_slice(),
             width: image_size.width,
-            pitch: 3 * image_size.width, // we use no padding between rows
+            pitch:  C* image_size.width, // we use no padding between rows
             height: image_size.height,
             format,
         };


### PR DESCRIPTION
Fixes #830

This PR fixes the incorrect channel count in `decode_gray8`.

Changes:
- Updated return type from `Image<u8, 3>` to `Image<u8, 1>`
- Explicitly set channel count using `decode::<1>`
- Fixed pitch calculation to use `C * width`

This ensures correct grayscale decoding consistent with `PixelFormat::GRAY`.

All tests for kornia-io pass successfully.