### PR TITLE
Fix decode_gray8 memory layout (Fixes #830)

### DIFF
--- a/crates/kornia-io/src/jpegturbo.rs
+++ b/crates/kornia-io/src/jpegturbo.rs
@@ -166,7 +166,7 @@ impl JpegTurboDecoder {
     pub fn decode_gray8(
         &self,
         jpeg_data: &[u8],
-    ) -> Result<Image<u8, 3, CpuAllocator>, JpegTurboError> {
+    ) -> Result<Image<u8, 1, CpuAllocator>, JpegTurboError> {
         self.decode(jpeg_data, turbojpeg::PixelFormat::GRAY)
     }
 
@@ -185,7 +185,7 @@ impl JpegTurboDecoder {
         let buf = turbojpeg::Image {
             pixels: pixels.as_mut_slice(),
             width: image_size.width,
-            pitch: 3 * image_size.width, // we use no padding between rows
+            pitch: C * image_size.width, // we use no padding between rows
             height: image_size.height,
             format,
         };


### PR DESCRIPTION
This PR fixes the return type of decode_gray8 and the pitch calculation in the decode function to handle grayscale images correctly. Fixed #830.