### PR TITLE
fix(python): include Cargo.lock in PyPI source distribution

### DIFF
--- a/kornia-py/pyproject.toml
+++ b/kornia-py/pyproject.toml
@@ -62,5 +62,13 @@ dev = [
 requires = ["maturin>=1,<2"]
 build-backend = "maturin"
 
+[tool.maturin]
+# Include the workspace Cargo.lock in the source distribution (sdist)
+# to ensure reproducible builds from the PyPI tarball.
+# See: https://github.com/kornia/kornia-rs/issues/827
+locked = true
+sdist-include = ["../Cargo.lock"]
+
+
 [tool.uv]
 extra-index-url = ["https://download.pytorch.org/whl/cpu"]


### PR DESCRIPTION
Fixes #827 
## Problem
The PyPI source tarball for `kornia_rs` was missing the `Cargo.lock` file, making builds from the sdist non-reproducible.

## Solution
Added `[tool.maturin]` configuration to `kornia-py/pyproject.toml`:

- `locked = true` -- Ensures `cargo build` uses `--locked` during sdist builds, preventing dependency resolution drift.
- - `sdist-include = ["../Cargo.lock"]` -- Explicitly includes the workspace-level `Cargo.lock` in the source distribution tarball.
## Verification
After this change, building an sdist with `maturin sdist` will include the `Cargo.lock` file.