### PR TITLE
fix(io): decode_gray8 returns Image<u8, 1> with correct pitch

### DIFF
--- a/crates/kornia-io/src/jpegturbo.rs
+++ b/crates/kornia-io/src/jpegturbo.rs
@@ -166,7 +166,7 @@ impl JpegTurboDecoder {
     pub fn decode_gray8(
         &self,
         jpeg_data: &[u8],
-    ) -> Result<Image<u8, 3, CpuAllocator>, JpegTurboError> {
+    ) -> Result<Image<u8, 1, CpuAllocator>, JpegTurboError> {
         self.decode(jpeg_data, turbojpeg::PixelFormat::GRAY)
     }
 
@@ -185,7 +185,7 @@ impl JpegTurboDecoder {
         let buf = turbojpeg::Image {
             pixels: pixels.as_mut_slice(),
             width: image_size.width,
-            pitch: 3 * image_size.width, // we use no padding between rows
+            pitch: C * image_size.width, // we use no padding between rows
             height: image_size.height,
             format,
         };
@@ -295,6 +295,17 @@ mod tests {
         assert_eq!(image.cols(), 258);
         assert_eq!(image.rows(), 195);
         assert_eq!(image.num_channels(), 3);
+        Ok(())
+    }
+
+    #[test]
+    fn image_decoder_gray8() -> Result<(), JpegTurboError> {
+        let jpeg_data = std::fs::read("../../tests/data/dog.jpeg").unwrap();
+        let image = JpegTurboDecoder::new()?.decode_gray8(&jpeg_data)?;
+        assert_eq!(image.cols(), 258);
+        assert_eq!(image.rows(), 195);
+        assert_eq!(image.num_channels(), 1);
+        assert_eq!(image.as_slice().len(), 258 * 195);
         Ok(())
     }
 

--- a/crates/kornia-io/src/jpegturbo.rs
+++ b/crates/kornia-io/src/jpegturbo.rs
@@ -24,6 +24,10 @@ pub enum JpegTurboError {
     /// Error when mutex is poisoned.
     #[error("Mutex is poisoned")]
     MutexPoisoned,
+
+    /// I/O error, e.g. when reading a JPEG file from disk.
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
 }
 
 /// A JPEG decoder using the turbojpeg library.
@@ -285,7 +289,7 @@ mod tests {
 
     #[test]
     fn image_decoder() -> Result<(), JpegTurboError> {
-        let jpeg_data = std::fs::read("../../tests/data/dog.jpeg").unwrap();
+        let jpeg_data = std::fs::read("../../tests/data/dog.jpeg")?;
         // read the header
         let image_size = JpegTurboDecoder::new()?.read_header(&jpeg_data)?;
         assert_eq!(image_size.width, 258);
@@ -300,7 +304,7 @@ mod tests {
 
     #[test]
     fn image_decoder_gray8() -> Result<(), JpegTurboError> {
-        let jpeg_data = std::fs::read("../../tests/data/dog.jpeg").unwrap();
+        let jpeg_data = std::fs::read("../../tests/data/dog.jpeg")?;
         let image = JpegTurboDecoder::new()?.decode_gray8(&jpeg_data)?;
         assert_eq!(image.cols(), 258);
         assert_eq!(image.rows(), 195);


### PR DESCRIPTION
## Summary

`JpegTurboDecoder::decode_gray8` had two bugs that contradicted its documented behaviour:

1. **Wrong return type**: The function signature declared `Image<u8, 3, CpuAllocator>` while the doc comment said it should return `Image<u8, 1>`.
2. **Wrong pitch**: The internal generic `decode<C>` helper hardcoded `pitch: 3 * image_size.width` instead of `pitch: C * image_size.width`, so decoding a single-channel GRAY image would pass an incorrect row stride to libjpeg-turbo.

## Changes

- `crates/kornia-io/src/jpegturbo.rs`:
  - `decode_gray8` return type changed from `Image<u8, 3, CpuAllocator>` to `Image<u8, 1, CpuAllocator>`.
  - `decode<C>` pitch fixed from `3 * image_size.width` to `C * image_size.width`.
  - Regression test `image_decoder_gray8` added that decodes `dog.jpeg` via `decode_gray8` and asserts `num_channels() == 1`, correct dimensions (258x195), and correct slice length.

## Breaking Change

This is a breaking API change for any caller that was relying on `decode_gray8` returning `Image<u8, 3>`. However, the previous behaviour was incorrect — callers relying on it would have been receiving a wrongly-shaped buffer — so this fix is the only sound path forward.

Fixes #830
