### PR TITLE
docs(io): scope read_image/decode_image/write_image as Python-only

### DIFF
--- a/crates/kornia-io/README.md
+++ b/crates/kornia-io/README.md
@@ -8,7 +8,7 @@
 
 ## 🚀 Overview
 
-`kornia-io` provides high-performance utilities for reading and writing images and video streams. It abstracts over common formats and libraries to provide a unified, type-safe API for getting visual data into your Rust applications. It supports standard image formats (JPEG, PNG, TIFF) and integrates with GStreamer and V4L2 for advanced video capture.
+`kornia-io` provides high-performance utilities for reading and writing images and video streams. It abstracts over common formats and libraries to provide a unified, type-safe API for getting visual data into your Rust applications. It supports standard image formats (JPEG, PNG, TIFF) and integrates with GStreamer and V4L2 for advanced video capture. The generic `read_image`/`decode_image`/`write_image` helpers exposed by the Python bindings (`kornia-py`) are Python-only; Rust users should call the typed per-format functions (`jpeg`, `png`, `tiff`) in this crate directly.
 
 ## 🔑 Key Features
 

--- a/crates/kornia-io/src/lib.rs
+++ b/crates/kornia-io/src/lib.rs
@@ -1,5 +1,13 @@
 #![deny(missing_docs)]
 #![doc = env!("CARGO_PKG_DESCRIPTION")]
+//!
+//! # Scope
+//!
+//! The generic `read_image` / `decode_image` / `write_image` entry points
+//! exposed by the `kornia-py` Python bindings are Python-only convenience
+//! helpers. This crate exposes strictly typed per-format functions under the
+//! [`jpeg`], [`png`], and [`tiff`] modules (and `jpegturbo` when enabled),
+//! plus [`functional::read_image_any_rgb8`] for a single-path RGB8 convenience.
 
 /// Module to handle the error types for the io module.
 pub mod error;

--- a/kornia-py/src/io/functional.rs
+++ b/kornia-py/src/io/functional.rs
@@ -56,6 +56,14 @@ pub fn read_image_any_deprecated(
 /// * `ValueError`: If the file extension is unsupported or decoding fails.
 /// * `IOError`: If an error occurs reading the file from disk.
 /// * `Exception`: If an unexpected error occurs while decoding the image or converting it into a Python tensor.
+///
+/// # Scope
+///
+/// This is a Python-only convenience helper provided by the `kornia-py` bindings.
+/// It is intentionally not part of the Rust public API of `kornia-io`. Rust
+/// consumers should use the typed per-format functions in
+/// `kornia_io::{jpeg, png, tiff}` directly, or `kornia_io::functional::read_image_any_rgb8`
+/// for a single generic RGB8 path.
 #[pyfunction]
 pub fn read_image(file_path: Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
     // Attempt to obtain a path-like object via PEP 519 (`__fspath__`)

--- a/kornia-py/src/io/jpeg.rs
+++ b/kornia-py/src/io/jpeg.rs
@@ -69,6 +69,8 @@ pub fn read_image_jpeg(file_path: &str, mode: &str) -> PyResult<PyImage> {
 /// # Exceptions
 /// * `ValueError`: If the mode is unsupported, the image shape mismatches the mode,
 ///   or the file fails to write.
+///
+/// *Python-only helper; not part of kornia-io's Rust API.*
 #[pyfunction]
 pub fn write_image_jpeg(file_path: &str, image: PyImage, mode: &str, quality: u8) -> PyResult<()> {
     match mode {
@@ -110,6 +112,8 @@ pub fn write_image_jpeg(file_path: &str, image: PyImage, mode: &str, quality: u8
 /// # Exceptions
 /// * `ValueError`: If the byte data is invalid, decoding fails, or the
 ///   number of channels is unsupported.
+///
+/// *Python-only helper; not part of kornia-io's Rust API.*
 #[pyfunction]
 pub fn decode_image_jpeg(src: &[u8]) -> PyResult<PyImage> {
     let layout = J::decode_image_jpeg_layout(src)

--- a/kornia-py/src/io/jpegturbo.rs
+++ b/kornia-py/src/io/jpegturbo.rs
@@ -152,6 +152,8 @@ impl PyImageEncoder {
 /// # Exceptions
 /// * `FileExistsError`: If the read operation fails (Note: mapped from upstream error).
 /// * `Exception`: If the image fails to convert.
+///
+/// *Python-only helper; not part of kornia-io's Rust API.*
 #[pyfunction]
 pub fn read_image_jpegturbo(file_path: &str) -> PyResult<PyImage> {
     let image = read_image_jpegturbo_rgb8(file_path)
@@ -171,6 +173,8 @@ pub fn read_image_jpegturbo(file_path: &str) -> PyResult<PyImage> {
 ///
 /// # Exceptions
 /// * `Exception`: If writing or encoding fails.
+///
+/// *Python-only helper; not part of kornia-io's Rust API.*
 #[pyfunction]
 pub fn write_image_jpegturbo(file_path: &str, image: PyImage, quality: u8) -> PyResult<()> {
     let image = Image::from_pyimage(image)
@@ -193,6 +197,8 @@ pub fn write_image_jpegturbo(file_path: &str, image: PyImage, quality: u8) -> Py
 /// # Exceptions
 /// * `ValueError`: If the mode is unsupported (case-sensitive).
 /// * `Exception`: If decoding or image conversion fails.
+///
+/// *Python-only helper; not part of kornia-io's Rust API.*
 #[pyfunction]
 pub fn decode_image_jpegturbo(jpeg_data: &[u8], mode: &str) -> PyResult<PyImage> {
     let image = match mode {

--- a/kornia-py/src/io/png.rs
+++ b/kornia-py/src/io/png.rs
@@ -151,6 +151,8 @@ pub fn read_image_png_u16(file_path: &str, mode: &str) -> PyResult<PyImageU16> {
 /// # Exceptions
 /// * `ValueError`: If the mode is unsupported (case-sensitive).
 /// * `Exception`: If the image format is incompatible or writing fails.
+///
+/// *Python-only helper; not part of kornia-io's Rust API.*
 #[pyfunction]
 pub fn write_image_png_u8(file_path: &str, image: PyImage, mode: &str) -> PyResult<()> {
     match mode {
@@ -200,6 +202,8 @@ pub fn write_image_png_u8(file_path: &str, image: PyImage, mode: &str) -> PyResu
 /// # Exceptions
 /// * `ValueError`: If the mode is unsupported (case-sensitive).
 /// * `Exception`: If the image format is incompatible or writing fails.
+///
+/// *Python-only helper; not part of kornia-io's Rust API.*
 #[pyfunction]
 pub fn write_image_png_u16(file_path: &str, image: PyImageU16, mode: &str) -> PyResult<()> {
     match mode {
@@ -253,6 +257,8 @@ pub fn write_image_png_u16(file_path: &str, image: PyImageU16, mode: &str) -> Py
 /// # Exceptions
 /// * `ValueError`: If the mode is unsupported (case-sensitive) or decoding fails.
 /// * `Exception`: If the image fails to convert to a Python tensor.
+///
+/// *Python-only helper; not part of kornia-io's Rust API.*
 #[pyfunction]
 pub fn decode_image_png_u8(
     src: &[u8],
@@ -336,6 +342,8 @@ pub fn decode_image_png_u8(
 /// # Exceptions
 /// * `ValueError`: If the mode is unsupported (case-sensitive) or decoding fails.
 /// * `Exception`: If the image fails to convert to a Python tensor.
+///
+/// *Python-only helper; not part of kornia-io's Rust API.*
 #[pyfunction]
 pub fn decode_image_png_u16(
     src: &[u8],

--- a/kornia-py/src/io/tiff.rs
+++ b/kornia-py/src/io/tiff.rs
@@ -177,6 +177,8 @@ pub fn read_image_tiff_f32(file_path: &str, mode: &str) -> PyResult<PyImageF32> 
 /// # Exceptions
 /// * `ValueError`: If the mode is unsupported (case-sensitive).
 /// * `Exception`: If the image format is incompatible or writing fails.
+///
+/// *Python-only helper; not part of kornia-io's Rust API.*
 #[pyfunction]
 pub fn write_image_tiff_u8(file_path: &str, image: PyImage, mode: &str) -> PyResult<()> {
     match mode {
@@ -219,6 +221,8 @@ pub fn write_image_tiff_u8(file_path: &str, image: PyImage, mode: &str) -> PyRes
 /// # Exceptions
 /// * `ValueError`: If the mode is unsupported (case-sensitive).
 /// * `Exception`: If the image format is incompatible or writing fails.
+///
+/// *Python-only helper; not part of kornia-io's Rust API.*
 #[pyfunction]
 pub fn write_image_tiff_u16(file_path: &str, image: PyImageU16, mode: &str) -> PyResult<()> {
     match mode {
@@ -260,6 +264,8 @@ pub fn write_image_tiff_u16(file_path: &str, image: PyImageU16, mode: &str) -> P
 /// # Exceptions
 /// * `ValueError`: If the mode is unsupported (case-sensitive).
 /// * `Exception`: If the image format is incompatible or writing fails.
+///
+/// *Python-only helper; not part of kornia-io's Rust API.*
 #[pyfunction]
 pub fn write_image_tiff_f32(file_path: &str, image: PyImageF32, mode: &str) -> PyResult<()> {
     match mode {

--- a/kornia-py/src/lib.rs
+++ b/kornia-py/src/lib.rs
@@ -305,7 +305,16 @@ pub fn kornia_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     image_mod.add_class::<PyImageLayout>()?;
     m.add_submodule(&image_mod)?;
 
-    // IO submodule
+    // ---------------------------------------------------------------------------
+    // IO submodule (Python-only)
+    //
+    // The helpers registered below (`kornia_rs.io.read_image`, `decode_image_*`,
+    // `write_image_*`) are Python-only convenience APIs. They are intentionally
+    // NOT part of the Rust public API of `kornia-io`. Rust consumers should use
+    // the typed per-format functions in `kornia_io::{jpeg, png, tiff}` directly,
+    // or `kornia_io::functional::read_image_any_rgb8` for a single generic RGB8
+    // path. See https://github.com/kornia/kornia-rs/issues/637.
+    // ---------------------------------------------------------------------------
     let io_mod = PyModule::new(py, "io")?;
 
     // NOTE:


### PR DESCRIPTION
## Summary

Closes / addresses #637.

This is a docs-only change (no functional code modified) that clarifies the scope of the generic image I/O helpers exposed by the `kornia-py` Python bindings.

- **`kornia-py/src/io/functional.rs`**: Extended the `read_image` pyfunction doc comment with a `# Scope` section explaining it is a Python-only convenience helper and directing Rust consumers to the typed per-format functions in `kornia_io::{jpeg, png, tiff}` or `kornia_io::functional::read_image_any_rgb8`.

- **`kornia-py/src/io/{png,jpeg,tiff,jpegturbo}.rs`**: Added one-line Python-only notes to each `decode_image_*` and `write_image_*` pyfunction.

- **`kornia-py/src/lib.rs`**: Added a comment block above the IO submodule registration block explaining the Python-only scope and referencing the issue.

- **`crates/kornia-io/src/lib.rs`**: Added a `# Scope` section to the crate-level `//!` doc comment clarifying that the generic `read_image`/`decode_image`/`write_image` names are Python-only and that Rust users should use the typed per-format module functions.

- **`crates/kornia-io/README.md`**: Added one sentence in the overview clarifying the Python-only nature of the generic helpers.

## Test plan

- [ ] `cargo check -p kornia-io` passes (verified locally)
- [ ] `cargo doc -p kornia-io --no-deps` emits no unresolved-link warnings (verified locally)
- [ ] `cargo fmt` applied (no changes after fmt)
- [ ] No functional code changed