### PR TITLE
test: add edge-case coverage for tensor and imgproc (refs #812)

### DIFF
--- a/crates/kornia-imgproc/src/crop.rs
+++ b/crates/kornia-imgproc/src/crop.rs
@@ -97,4 +97,63 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_crop_full_image() -> Result<(), ImageError> {
+        // Cropping the entire image (x=0, y=0, dst size == src size) must yield
+        // pixel-identical data to the original.
+        let image_size = ImageSize {
+            width: 3,
+            height: 2,
+        };
+
+        #[rustfmt::skip]
+        let data = vec![
+            10u8, 20, 30, 40, 50, 60,
+            70u8, 80, 90, 100, 110, 120,
+        ];
+
+        let image = Image::<_, 2, _>::new(image_size, data.clone(), CpuAllocator)?;
+        let mut dst = Image::<_, 2, _>::from_size_val(image_size, 0u8, CpuAllocator)?;
+
+        super::crop_image(&image, &mut dst, 0, 0)?;
+
+        assert_eq!(dst.as_slice(), data.as_slice());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_crop_single_pixel() -> Result<(), ImageError> {
+        // A 1x1 crop from a known location must return exactly that pixel's channels.
+        let image_size = ImageSize {
+            width: 4,
+            height: 4,
+        };
+
+        #[rustfmt::skip]
+        let image = Image::<_, 1, _>::new(
+            image_size,
+            vec![
+                 0u8,  1,  2,  3,
+                 4u8,  5,  6,  7,
+                 8u8,  9, 10, 11,
+                12u8, 13, 14, 15,
+            ],
+            CpuAllocator,
+        )?;
+
+        let crop_size = ImageSize {
+            width: 1,
+            height: 1,
+        };
+        let mut dst = Image::<_, 1, _>::from_size_val(crop_size, 0u8, CpuAllocator)?;
+
+        // Pixel at column 2, row 3 is value 14.
+        super::crop_image(&image, &mut dst, 2, 3)?;
+
+        assert_eq!(dst.as_slice(), &[14u8]);
+
+        Ok(())
+    }
 }

--- a/crates/kornia-imgproc/src/flip.rs
+++ b/crates/kornia-imgproc/src/flip.rs
@@ -180,4 +180,36 @@ mod tests {
         assert_eq!(flipped.as_slice(), &data_expected);
         Ok(())
     }
+
+    #[test]
+    fn test_horizontal_flip_single_row() -> Result<(), ImageError> {
+        // A single-row (rows=1) image flipped horizontally must reverse the pixel order.
+        // Image layout: 1 row × 4 columns × 1 channel.
+        let image_size = ImageSize {
+            width: 4,
+            height: 1,
+        };
+        let image = Image::<_, 1, _>::new(image_size, vec![10u8, 20, 30, 40], CpuAllocator)?;
+        let mut flipped = Image::<_, 1, _>::from_size_val(image_size, 0u8, CpuAllocator)?;
+        super::horizontal_flip(&image, &mut flipped)?;
+        // Columns reversed: [40, 30, 20, 10]
+        assert_eq!(flipped.as_slice(), &[40u8, 30, 20, 10]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_vertical_flip_single_column() -> Result<(), ImageError> {
+        // A single-column (cols=1) image flipped vertically must reverse the row order.
+        // Image layout: 4 rows × 1 column × 1 channel.
+        let image_size = ImageSize {
+            width: 1,
+            height: 4,
+        };
+        let image = Image::<_, 1, _>::new(image_size, vec![10u8, 20, 30, 40], CpuAllocator)?;
+        let mut flipped = Image::<_, 1, _>::from_size_val(image_size, 0u8, CpuAllocator)?;
+        super::vertical_flip(&image, &mut flipped)?;
+        // Rows reversed: [40, 30, 20, 10]
+        assert_eq!(flipped.as_slice(), &[40u8, 30, 20, 10]);
+        Ok(())
+    }
 }

--- a/crates/kornia-imgproc/src/threshold.rs
+++ b/crates/kornia-imgproc/src/threshold.rs
@@ -510,6 +510,33 @@ mod tests {
     }
 
     #[test]
+    fn test_threshold_binary_equal_to_threshold() -> Result<(), ImageError> {
+        // The implementation uses strict `>` (not `>=`), so a pixel whose value
+        // exactly equals the threshold is treated as NOT exceeding it and maps to
+        // zero rather than max_val.  Pin that boundary behaviour here.
+        let data = vec![100u8, 101, 99];
+        let image = Image::<_, 1, _>::new(
+            ImageSize {
+                width: 3,
+                height: 1,
+            },
+            data,
+            CpuAllocator,
+        )?;
+
+        let mut thresholded = Image::<_, 1, _>::from_size_val(image.size(), 0, CpuAllocator)?;
+
+        super::threshold_binary(&image, &mut thresholded, 100, 255)?;
+
+        // 100 == threshold → 0 (not strictly greater)
+        // 101 >  threshold → 255
+        // 99  <  threshold → 0
+        assert_eq!(thresholded.as_slice(), &[0u8, 255, 0]);
+
+        Ok(())
+    }
+
+    #[test]
     fn test_in_range() -> Result<(), ImageError> {
         let data = vec![100u8, 200, 50, 150, 200, 250];
         let image = Image::<_, 3, _>::new(

--- a/crates/kornia-tensor/src/allocator.rs
+++ b/crates/kornia-tensor/src/allocator.rs
@@ -207,4 +207,16 @@ mod tests {
         allocator.dealloc(ptr, layout);
         Ok(())
     }
+
+    #[test]
+    fn test_cpu_allocator_dealloc_null_noop() {
+        // The CpuAllocator::dealloc implementation has an explicit null-guard;
+        // calling it with a null pointer must be a no-op and must not panic or UB.
+        let allocator = CpuAllocator;
+        let layout = Layout::from_size_align(1024, 8).unwrap();
+        let null_ptr = std::ptr::null_mut::<u8>();
+        // If the null-guard is missing this would invoke undefined behaviour.
+        // A passing call here confirms the guard is in place.
+        allocator.dealloc(null_ptr, layout);
+    }
 }

--- a/crates/kornia-tensor/src/tensor.rs
+++ b/crates/kornia-tensor/src/tensor.rs
@@ -1616,6 +1616,68 @@ mod tests {
     }
 
     #[test]
+    fn test_from_shape_vec_shape_data_mismatch() {
+        // 2*3 = 6 elements expected but only 3 supplied — must return InvalidShape.
+        let result = Tensor::<u8, 2, _>::from_shape_vec([2, 3], vec![1, 2, 3], CpuAllocator);
+        assert!(
+            matches!(result, Err(TensorError::InvalidShape(6))),
+            "expected Err(TensorError::InvalidShape(6))"
+        );
+    }
+
+    #[test]
+    fn test_reshape_invalid_numel() -> Result<(), TensorError> {
+        // 4-element tensor cannot be reshaped to [3, 2] (= 6 elements).
+        let data: Vec<u8> = vec![1, 2, 3, 4];
+        let t = Tensor::<u8, 1, _>::from_shape_vec([4], data, CpuAllocator)?;
+        let result = t.reshape([3, 2]);
+        assert!(
+            matches!(result, Err(TensorError::DimensionMismatch(_))),
+            "expected Err(TensorError::DimensionMismatch)"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_zero_sized_tensor_roundtrip() -> Result<(), TensorError> {
+        // A 1-D tensor with zero elements must be constructable and report correct metadata.
+        let t = Tensor::<f32, 1, _>::from_shape_vec([0], vec![], CpuAllocator)?;
+        assert_eq!(t.numel(), 0);
+        assert!(t.as_slice().is_empty());
+
+        // Casting an empty tensor must also yield an empty tensor.
+        let t2 = t.cast::<f64>();
+        assert_eq!(t2.numel(), 0);
+        assert!(t2.as_slice().is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_cast_on_permuted_view() -> Result<(), TensorError> {
+        // Build a 2x3 tensor [[1,2,3],[4,5,6]] and permute (transpose) to 3x2.
+        let data: Vec<u8> = vec![1, 2, 3, 4, 5, 6];
+        let t = Tensor::<u8, 2, _>::from_shape_vec([2, 3], data, CpuAllocator)?;
+
+        // permute_axes returns a TensorView; materialise it before casting.
+        let permuted_view = t.permute_axes([1, 0]);
+        assert_eq!(permuted_view.shape, [3, 2]);
+
+        let contiguous = permuted_view.as_contiguous();
+        // as_contiguous() iterates in the view's logical order, so the flat layout
+        // of the 3x2 transposed matrix [[1,4],[2,5],[3,6]] is [1,4,2,5,3,6].
+        assert_eq!(contiguous.shape, [3, 2]);
+        assert_eq!(contiguous.as_slice(), &[1u8, 4, 2, 5, 3, 6]);
+
+        // Cast the contiguous tensor to u16 — shape and values must be preserved.
+        let casted = contiguous.cast::<u16>();
+        assert_eq!(casted.shape, [3, 2]);
+        assert_eq!(casted.as_slice(), &[1u16, 4, 2, 5, 3, 6]);
+
+        Ok(())
+    }
+
+    #[test]
     fn contiguous_tensor_is_standard_layout_true() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
         let t = Tensor::<u8, 3, CpuAllocator>::from_shape_vec([2, 2, 3], data, CpuAllocator)?;


### PR DESCRIPTION
## Summary

Adds 10 focused unit tests across `kornia-tensor` and `kornia-imgproc` as a first reviewable step toward the GPU-acceleration test coverage goal described in #812.

### New tests

**`crates/kornia-tensor/src/allocator.rs`**
- `test_cpu_allocator_dealloc_null_noop` — verifies that the null-guard in `CpuAllocator::dealloc` makes calling it with a null pointer a safe no-op

**`crates/kornia-tensor/src/tensor.rs`**
- `test_from_shape_vec_shape_data_mismatch` — `from_shape_vec([2,3], vec![1,2,3], …)` returns `Err(TensorError::InvalidShape(6))`
- `test_reshape_invalid_numel` — reshaping a 4-element tensor to `[3,2]` returns `Err(TensorError::DimensionMismatch(…))`
- `test_zero_sized_tensor_roundtrip` — `from_shape_vec([0], vec![], …)` succeeds; `numel()==0`, `as_slice().is_empty()`; casting to `f64` yields another empty tensor
- `test_cast_on_permuted_view` — permutes a 2×3 tensor, materialises via `as_contiguous()`, then casts to `u16`; pins transposed element order and shape

**`crates/kornia-imgproc/src/crop.rs`**
- `test_crop_full_image` — crop with `x=0, y=0` and dst size == src size yields pixel-identical data
- `test_crop_single_pixel` — 1×1 crop from a known location returns exactly that pixel value

**`crates/kornia-imgproc/src/flip.rs`**
- `test_horizontal_flip_single_row` — a 1-row image flipped horizontally reverses column order
- `test_vertical_flip_single_column` — a 1-column image flipped vertically reverses row order

**`crates/kornia-imgproc/src/threshold.rs`**
- `test_threshold_binary_equal_to_threshold` — pins the strict-`>` boundary: a pixel equal to the threshold maps to **zero**, not `max_val`

### Skipped / adapted

- **`test_cpu_allocator_zero_size_layout`** — skipped. `std::alloc::alloc` with a zero-size layout is undefined behaviour per the stdlib docs; there is no deterministic result to pin.
- **`test_cast_on_permuted_view`** — adapted. `cast()` is defined on `Tensor`, not `TensorView`; the test calls `permute_axes(…).as_contiguous()` first to obtain an owned `Tensor` before casting. This is the idiomatic pattern already used in `contiguous_2d`.

Refs #812