### PR TITLE
feat(kornia-py): add tag_families getter to DecodeTagsConfig

### DIFF
--- a/kornia-py/src/apriltag.rs
+++ b/kornia-py/src/apriltag.rs
@@ -47,7 +47,17 @@ impl PyDecodeTagsConfig {
         })
     }
 
-    // TODO: Add getter for tag_families
+    #[getter]
+    pub fn get_tag_families(&self) -> PyResult<Vec<Py<family::PyTagFamilyKind>>> {
+        Python::attach(|py| {
+            let mut out = Vec::with_capacity(self.0.tag_families.len());
+            for family in &self.0.tag_families {
+                let kind = TagFamilyKind::Custom(Box::new(family.clone()));
+                out.push(Py::new(py, family::PyTagFamilyKind(kind))?);
+            }
+            Ok(out)
+        })
+    }
 
     #[getter]
     pub fn get_fit_quad_config(&self) -> PyFitQuadConfig {

--- a/kornia-py/tests/test_apriltag.py
+++ b/kornia-py/tests/test_apriltag.py
@@ -106,3 +106,13 @@ def test_apriltag_decoder():
     for (ax, ay), (ex, ey) in zip(detection[0].quad.corners, expected_quad):
         assert ax == pytest.approx(ex, abs=1e-3)
         assert ay == pytest.approx(ey, abs=1e-3)
+
+
+def test_decode_tags_config_tag_families_getter():
+    kinds = [TagFamilyKind("tag36_h11"), TagFamilyKind("tag16_h5")]
+    config = K.apriltag.DecodeTagsConfig(kinds)
+    families = config.tag_families
+    assert len(families) == 2
+    for f in families:
+        assert isinstance(f.name, str)
+        assert len(f.name) > 0


### PR DESCRIPTION
## Summary

Adds a `tag_families` property getter to the `DecodeTagsConfig` Python binding, resolving #798.

- Implements `get_tag_families` on `PyDecodeTagsConfig` in `kornia-py/src/apriltag.rs`
- Each stored `TagFamily` is wrapped as `TagFamilyKind::Custom` since the original variant discriminant (e.g. `Tag36H11`) is not preserved after construction — only the resolved `TagFamily` struct is stored
- Returns `Vec<PyTagFamilyKind>`, consistent with how the `::all()` static method returns family kinds
- Uses `Python::attach` and `Py::new`, matching the existing style throughout the file
- Adds a Python test in `kornia-py/tests/test_apriltag.py` verifying the getter returns the correct count and that each element has a non-empty `name`

## Notes

- `cargo check -p kornia-py` could not complete locally due to missing system libraries (libturbojpeg/Visual Studio), but `cargo check -p kornia-apriltag` and `cargo fmt` both pass cleanly. The Rust syntax is straightforward and follows the existing patterns in the file.
- `pixi run py-test` was not run locally for the same environment reason; the Python test is written to match the style and imports of the existing tests in the file.

Closes #798