### PR TITLE
fix: pin maturin>=1.9 to support Python 3.14t free-threaded builds

### DIFF
--- a/kornia-py/pyproject.toml
+++ b/kornia-py/pyproject.toml
@@ -59,7 +59,7 @@ dev = [
 ]
 
 [build-system]
-requires = ["maturin>=1,<2"]
+requires = ["maturin>=1.9,<2"]
 build-backend = "maturin"
 
 [tool.uv]

--- a/pixi.toml
+++ b/pixi.toml
@@ -72,7 +72,7 @@ rust-cross-test-aarch64-full = { cmd = "env -u CARGO -u RUSTC -u RUSTUP_HOME PAT
 [feature.python.dependencies]
 python = ">=3.8"
 uv = "*"
-maturin = "*"
+maturin = ">=1.9"
 pytest = "*"
 
 [feature.python.tasks]
@@ -114,7 +114,7 @@ python = "3.14.*"
 # Python 3.14t (free-threaded) - uses uv to provide Python since conda-forge doesn't have 3.14t yet
 [feature.py314t.dependencies]
 uv = "*"
-maturin = "*"
+maturin = ">=1.9"
 pytest = "*"
 
 [feature.py314t.activation]


### PR DESCRIPTION
## Summary
- Pin `maturin>=1.9` in [pixi.toml](pixi.toml) (both `python` and `py314t` features) and [kornia-py/pyproject.toml](kornia-py/pyproject.toml) build-system requires.
- Fixes the `py-build` task in the `py314t` environment failing with:
  ```
  maturin failed
    Caused by: Unsupported Python interpreter for cross-compilation: .../py314t-venv/bin/python; supported interpreters are pypy, graalpy, and python (cpython)
  ```
- Older maturin (pre-1.9) misclassifies a free-threaded CPython 3.14t venv as an unsupported cross-compilation target. Version 1.9 added proper detection for free-threaded CPython, unblocking `pixi run -e py314t py-test-threaded`.

## Test plan
- [ ] CI runs `pixi run -e py314t py-build` successfully on linux-64.
- [ ] CI runs `pixi run -e py314t py-test-threaded` successfully.
- [ ] Existing py38–py314 environments still build and test (no behavior change expected — they already satisfy `>=1.9`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)