### PR TITLE
feat: ORB-SLAM3 monocular parity — FAST fixes, ORB extractor parity, CheckRT, BoW vocab loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5269,6 +5269,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
 
 [[package]]
+name = "fisheye_rerun_viewer"
+version = "0.1.11"
+dependencies = [
+ "argh",
+ "kornia",
+ "rerun",
+ "serde",
+ "serde_yaml",
+]
+
+[[package]]
 name = "fixed"
 version = "1.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7960,6 +7971,25 @@ dependencies = [
  "kornia-io",
  "numpy",
  "pyo3",
+]
+
+[[package]]
+name = "kornia-slam"
+version = "0.1.11"
+dependencies = [
+ "argh",
+ "criterion",
+ "kornia-3d",
+ "kornia-algebra",
+ "kornia-image",
+ "kornia-imgproc",
+ "kornia-io",
+ "kornia-tensor",
+ "rerun",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.17",
 ]
 
 [[package]]

--- a/crates/kornia-3d/src/pose/triangulation.rs
+++ b/crates/kornia-3d/src/pose/triangulation.rs
@@ -26,6 +26,14 @@ pub struct TriangulationConfig {
     pub max_reprojection_error: f64,
     /// Minimum number of positive-depth triangulated points required.
     pub min_cheirality_count: usize,
+    /// When true, the two-view candidate check uses ORB-SLAM3's CheckRT:
+    /// pixel-space reprojection threshold `check_rt_reproj_th_sq`, points
+    /// at infinity allowed when `cosParallax >= 0.99998`, and parallax
+    /// reported at sorted index `min(50, N-1)` rather than per-point filtering.
+    pub use_orb_slam3_check_rt: bool,
+    /// Squared reprojection threshold in pixels, applied to both images,
+    /// used only when `use_orb_slam3_check_rt` is true. ORB-SLAM3 uses 4.0.
+    pub check_rt_reproj_th_sq: f64,
 }
 
 impl Default for TriangulationConfig {
@@ -35,6 +43,8 @@ impl Default for TriangulationConfig {
             max_midpoint_gap: 1.0,
             max_reprojection_error: 2.0,
             min_cheirality_count: 1,
+            use_orb_slam3_check_rt: false,
+            check_rt_reproj_th_sq: 4.0,
         }
     }
 }
@@ -121,6 +131,125 @@ pub(crate) fn triangulate_inliers(
     }
 
     (count, points, indices)
+}
+
+/// ORB-SLAM3-style CheckRT for a single (R, t) candidate.
+///
+/// Triangulates each inlier correspondence using DLT with normalized
+/// coordinates, then filters against the exact criteria from
+/// `TwoViewReconstruction::CheckRT`:
+///
+///   1. the triangulated point is finite,
+///   2. `z1 > 0` OR `cosParallax >= 0.99998` (points at infinity allowed),
+///   3. same for `z2`,
+///   4. per-point reprojection error in image 1 ≤ `reproj_th_sq` (pixels²),
+///   5. per-point reprojection error in image 2 ≤ `reproj_th_sq` (pixels²).
+///
+/// `parallax_deg` is reported at sorted index `min(50, N-1)` of the collected
+/// cosParallax values (ascending), matching ORB-SLAM3's representative
+/// parallax heuristic.
+///
+/// `x1` / `x2` are pixel-space observations; `k1` / `k2` are the intrinsics of
+/// the corresponding cameras; `r`, `t` map points from camera 1 into camera 2.
+pub fn check_rt(
+    x1: &[Vec2F64],
+    x2: &[Vec2F64],
+    inliers: &[bool],
+    k1: &Mat3F64,
+    k2: &Mat3F64,
+    r: &Mat3F64,
+    t: &Vec3F64,
+    reproj_th_sq: f64,
+) -> (usize, Vec<Vec3F64>, Vec<usize>, f64) {
+    let k1_inv = k1.inverse();
+    let k2_inv = k2.inverse();
+
+    // Camera-1 origin is at (0,0,0). Camera-2 origin in cam1 frame is -R^T * t.
+    let o2 = -(r.transpose() * *t);
+
+    let mut points = Vec::new();
+    let mut indices = Vec::new();
+    let mut cos_values: Vec<f64> = Vec::new();
+
+    for i in 0..x1.len() {
+        if !inliers[i] {
+            continue;
+        }
+        let x1n = normalize_point(&k1_inv, &x1[i]);
+        let x2n = normalize_point(&k2_inv, &x2[i]);
+        let p3d = match triangulate_point_linear(&x1n, &x2n, r, t) {
+            Some(p) => p,
+            None => continue,
+        };
+        if !p3d.x.is_finite() || !p3d.y.is_finite() || !p3d.z.is_finite() {
+            continue;
+        }
+
+        // Parallax at the 3D point w.r.t. both camera centres.
+        let normal1 = p3d; // cam1 center is origin.
+        let dist1 = normal1.length();
+        let normal2 = p3d - o2;
+        let dist2 = normal2.length();
+        if dist1 <= 1e-12 || dist2 <= 1e-12 {
+            continue;
+        }
+        let cos_parallax = (normal1.dot(normal2) / (dist1 * dist2)).clamp(-1.0, 1.0);
+
+        // Depth in cam1 (origin frame).
+        if p3d.z <= 0.0 && cos_parallax < 0.99998 {
+            continue;
+        }
+        // Depth in cam2.
+        let p3d_c2 = *r * p3d + *t;
+        if p3d_c2.z <= 0.0 && cos_parallax < 0.99998 {
+            continue;
+        }
+
+        // Reprojection error in image 1: project p3d with K1 * [I|0].
+        if p3d.z.abs() < 1e-12 {
+            continue;
+        }
+        let k1c0 = k1.col(0);
+        let k1c1 = k1.col(1);
+        let k1c2 = k1.col(2);
+        let u1 = (k1c0.x * p3d.x + k1c1.x * p3d.y + k1c2.x * p3d.z) / p3d.z;
+        let v1 = (k1c0.y * p3d.x + k1c1.y * p3d.y + k1c2.y * p3d.z) / p3d.z;
+        let dx1 = u1 - x1[i].x;
+        let dy1 = v1 - x1[i].y;
+        if dx1 * dx1 + dy1 * dy1 > reproj_th_sq {
+            continue;
+        }
+
+        // Reprojection error in image 2.
+        if p3d_c2.z.abs() < 1e-12 {
+            continue;
+        }
+        let k2c0 = k2.col(0);
+        let k2c1 = k2.col(1);
+        let k2c2 = k2.col(2);
+        let u2 = (k2c0.x * p3d_c2.x + k2c1.x * p3d_c2.y + k2c2.x * p3d_c2.z) / p3d_c2.z;
+        let v2 = (k2c0.y * p3d_c2.x + k2c1.y * p3d_c2.y + k2c2.y * p3d_c2.z) / p3d_c2.z;
+        let dx2 = u2 - x2[i].x;
+        let dy2 = v2 - x2[i].y;
+        if dx2 * dx2 + dy2 * dy2 > reproj_th_sq {
+            continue;
+        }
+
+        cos_values.push(cos_parallax);
+        points.push(p3d);
+        indices.push(i);
+    }
+
+    let count = indices.len();
+    let parallax_deg = if cos_values.is_empty() {
+        0.0
+    } else {
+        cos_values.sort_by(|a, b| a.total_cmp(b));
+        let idx = cos_values.len().saturating_sub(1).min(50);
+        cos_values[idx].clamp(-1.0, 1.0).acos().to_degrees()
+    };
+
+    (count, points, indices, parallax_deg)
 }
 
 pub(crate) fn parallax_ok(x1: &Vec3F64, x2: &Vec3F64, min_parallax_deg: f64) -> bool {

--- a/crates/kornia-3d/src/pose/twoview.rs
+++ b/crates/kornia-3d/src/pose/twoview.rs
@@ -33,7 +33,9 @@
 //! from two views alone — this is the SE(3) → essential manifold quotient in action.
 
 use crate::pose::fundamental::{fundamental_8point, sampson_distance, FundamentalError};
-use crate::pose::triangulation::{triangulate_inliers, TriangulateParams, TriangulationConfig};
+use crate::pose::triangulation::{
+    check_rt, triangulate_inliers, TriangulateParams, TriangulationConfig,
+};
 use crate::pose::{
     decompose_essential, decompose_homography, enforce_essential_constraints,
     essential_from_fundamental, homography_4pt2d, HomographyError,
@@ -147,6 +149,38 @@ pub struct TwoViewResult {
     pub inlier_indices: Vec<usize>,
     /// Inlier mask from the selected model's RANSAC.
     pub inliers: Vec<bool>,
+}
+
+/// Per-candidate diagnostics from a two-view estimation. All counts are
+/// computed with kornia's own filters (cheirality + parallax + midpoint/reproj
+/// checks), so they do not match ORB-SLAM3's CheckRT one-to-one — but they
+/// reveal which candidate was picked and how close the runners-up were.
+#[derive(Clone, Debug)]
+pub struct TwoViewDiagnostics {
+    /// Fundamental matrix from RANSAC (always computed).
+    pub f_matrix: Mat3F64,
+    /// Homography matrix from RANSAC (always computed).
+    pub h_matrix: Mat3F64,
+    /// Inlier count from fundamental RANSAC.
+    pub f_inlier_count: usize,
+    /// Inlier count from homography RANSAC.
+    pub h_inlier_count: usize,
+    /// Inlier mask from fundamental RANSAC.
+    pub f_inliers: Vec<bool>,
+    /// Inlier mask from homography RANSAC.
+    pub h_inliers: Vec<bool>,
+    /// Per-candidate triangulation counts for the selected model
+    /// (4 entries for fundamental, 8 for homography).
+    pub candidate_ngood: Vec<usize>,
+    /// Index of the chosen candidate inside `candidate_ngood`, or `None` if
+    /// no candidate passed the minimum cheirality count.
+    pub best_candidate_idx: Option<usize>,
+    /// Second-best candidate count (used for ambiguity checks).
+    pub second_best_good: usize,
+    /// Representative parallax (degrees) of the selected candidate.
+    /// With `use_orb_slam3_check_rt` this is the ORB-SLAM3 sorted-index-50
+    /// parallax of the chosen candidate; otherwise 0.0.
+    pub best_candidate_parallax_deg: f64,
 }
 
 impl TwoViewResult {
@@ -344,6 +378,17 @@ pub fn two_view_estimate(
     k2: &Mat3F64,
     config: &TwoViewConfig,
 ) -> Result<TwoViewResult, TwoViewError> {
+    two_view_estimate_with_diagnostics(x1, x2, k1, k2, config).map(|(r, _)| r)
+}
+
+/// Same as [`two_view_estimate`] but also returns per-candidate diagnostics.
+pub fn two_view_estimate_with_diagnostics(
+    x1: &[Vec2F64],
+    x2: &[Vec2F64],
+    k1: &Mat3F64,
+    k2: &Mat3F64,
+    config: &TwoViewConfig,
+) -> Result<(TwoViewResult, TwoViewDiagnostics), TwoViewError> {
     let res_f = ransac_fundamental(x1, x2, &config.ransac_f)?;
     let res_h = ransac_homography(x1, x2, &config.ransac_h)?;
 
@@ -359,22 +404,58 @@ pub fn two_view_estimate(
         config: &config.triangulation,
     };
 
+    let mut diagnostics = TwoViewDiagnostics {
+        f_matrix: res_f.model,
+        h_matrix: res_h.model,
+        f_inlier_count: res_f.inlier_count,
+        h_inlier_count: res_h.inlier_count,
+        f_inliers: res_f.inliers.clone(),
+        h_inliers: res_h.inliers.clone(),
+        candidate_ngood: Vec::new(),
+        best_candidate_idx: None,
+        second_best_good: 0,
+        best_candidate_parallax_deg: 0.0,
+    };
+
     let mut best_pose = None;
     let mut best_count = 0usize;
     let mut best_points = Vec::new();
     let mut best_indices = Vec::new();
+    let mut best_parallax = 0.0f64;
+    let mut second_best = 0usize;
+    let mut best_candidate_idx: Option<usize> = None;
+    let mut candidate_ngood: Vec<usize> = Vec::new();
+
+    let use_check_rt = config.triangulation.use_orb_slam3_check_rt;
+    let reproj_th_sq = config.triangulation.check_rt_reproj_th_sq;
+
+    let eval_candidate =
+        |inliers: &[bool], r: &Mat3F64, t: &Vec3F64| -> (usize, Vec<Vec3F64>, Vec<usize>, f64) {
+            if use_check_rt {
+                check_rt(x1, x2, inliers, k1, k2, r, t, reproj_th_sq)
+            } else {
+                let (c, p, i) = triangulate_inliers(x1, x2, inliers, r, t, &tri_params);
+                (c, p, i, 0.0)
+            }
+        };
 
     let (model, inliers) = if use_h {
         let h = res_h.model;
         let poses = decompose_homography(&h, k1, k2);
-        for (r, t) in &poses {
-            let (count, points, indices) =
-                triangulate_inliers(x1, x2, &res_h.inliers, r, t, &tri_params);
+        candidate_ngood.reserve(poses.len());
+        for (i, (r, t)) in poses.iter().enumerate() {
+            let (count, points, indices, parallax) = eval_candidate(&res_h.inliers, r, t);
+            candidate_ngood.push(count);
             if count >= config.triangulation.min_cheirality_count && count > best_count {
+                second_best = best_count;
                 best_count = count;
                 best_pose = Some((*r, *t));
                 best_points = points;
                 best_indices = indices;
+                best_candidate_idx = Some(i);
+                best_parallax = parallax;
+            } else if count > second_best {
+                second_best = count;
             }
         }
         (TwoViewModel::Homography(h), res_h.inliers)
@@ -383,32 +464,46 @@ pub fn two_view_estimate(
         let e = essential_from_fundamental(&f, k1, k2);
         let e = enforce_essential_constraints(&e);
         let poses = decompose_essential(&e);
-        for (r, t) in &poses {
-            let (count, points, indices) =
-                triangulate_inliers(x1, x2, &res_f.inliers, r, t, &tri_params);
+        candidate_ngood.reserve(poses.len());
+        for (i, (r, t)) in poses.iter().enumerate() {
+            let (count, points, indices, parallax) = eval_candidate(&res_f.inliers, r, t);
+            candidate_ngood.push(count);
             if count >= config.triangulation.min_cheirality_count && count > best_count {
+                second_best = best_count;
                 best_count = count;
                 best_pose = Some((*r, *t));
                 best_points = points;
                 best_indices = indices;
+                best_candidate_idx = Some(i);
+                best_parallax = parallax;
+            } else if count > second_best {
+                second_best = count;
             }
         }
         (TwoViewModel::Fundamental(f), res_f.inliers)
     };
+
+    diagnostics.candidate_ngood = candidate_ngood;
+    diagnostics.best_candidate_idx = best_candidate_idx;
+    diagnostics.second_best_good = second_best;
+    diagnostics.best_candidate_parallax_deg = best_parallax;
 
     let (r, t) = match best_pose {
         Some(p) => p,
         None => return Err(TwoViewError::RansacFailure),
     };
 
-    Ok(TwoViewResult {
-        model,
-        rotation: r,
-        translation: t,
-        points3d: best_points,
-        inlier_indices: best_indices,
-        inliers,
-    })
+    Ok((
+        TwoViewResult {
+            model,
+            rotation: r,
+            translation: t,
+            points3d: best_points,
+            inlier_indices: best_indices,
+            inliers,
+        },
+        diagnostics,
+    ))
 }
 
 /// Computes the squared reprojection error for mapping `x1` to `x2` via the homography `h`.

--- a/crates/kornia-algebra/src/optim/core/factor.rs
+++ b/crates/kornia-algebra/src/optim/core/factor.rs
@@ -75,13 +75,21 @@ impl LinearizationResult {
 /// It computes the residual (error) and Jacobian for the current variable values,
 /// which are used by the optimizer to minimize the total cost.
 ///
+/// # Information matrix convention
+///
+/// The solver minimizes `Σ rᵢᵀ rᵢ` (unweighted). Factors that have a non-identity
+/// information matrix Ω must **pre-whiten** their outputs: return `L·e` and `L·J`
+/// where `Ω = LᵀL` (Cholesky). The solver then computes `(LJ)ᵀ(LJ) = JᵀΩJ`
+/// automatically. See [`super::whitening`] for helpers.
+///
 /// # Implementing Custom Factors
 ///
 /// To create a custom factor:
 /// 1. Implement this trait
 /// 2. Define the residual function `r(x)` (how to compute error from variable values)
 /// 3. Compute the Jacobian `J = ∂r/∂x` (analytically or numerically)
-/// 4. Return the residual dimension
+/// 4. If the factor has an information matrix, pre-whiten the residual and Jacobian
+/// 5. Return the residual dimension
 ///
 /// # Thread Safety
 ///

--- a/crates/kornia-algebra/src/optim/core/mod.rs
+++ b/crates/kornia-algebra/src/optim/core/mod.rs
@@ -1,6 +1,7 @@
 mod factor;
 mod problem;
 mod variable;
+pub mod whitening;
 
 pub use factor::{Factor, FactorError, FactorResult, LinearizationResult, PriorFactor};
 pub use problem::{Problem, ProblemError};

--- a/crates/kornia-algebra/src/optim/core/whitening.rs
+++ b/crates/kornia-algebra/src/optim/core/whitening.rs
@@ -1,0 +1,252 @@
+//! Utilities for pre-whitening residuals and Jacobians by an information matrix.
+//!
+//! In factor graph optimization, the cost for a factor is `eᵀ Ω e` where Ω is the
+//! information matrix (inverse covariance). Rather than modifying the solver to
+//! handle per-factor information matrices, we pre-whiten: decompose Ω = LᵀL via
+//! Cholesky, then return `L·e` and `L·J` from `linearize`. The solver then
+//! computes `(LJ)ᵀ(LJ) = JᵀLᵀLJ = JᵀΩJ` and `(LJ)ᵀ(Le) = JᵀΩe` automatically.
+//!
+//! This is the standard approach used by Ceres, GTSAM, and g2o.
+
+/// Whiten a residual and Jacobian by a scalar information weight.
+///
+/// For isotropic information `Ω = w·I`, the Cholesky factor is `L = √w·I`,
+/// so whitening is just scaling by `√w`.
+///
+/// This is the common case for visual reprojection factors where `w = 1/σ²`
+/// comes from the image pyramid octave.
+pub fn whiten_scalar(residual: &mut [f32], jacobian: &mut [f32], information_weight: f32) {
+    let sqrt_w = information_weight.sqrt();
+    for r in residual.iter_mut() {
+        *r *= sqrt_w;
+    }
+    for j in jacobian.iter_mut() {
+        *j *= sqrt_w;
+    }
+}
+
+/// Whiten a residual and Jacobian by a dense information matrix via Cholesky.
+///
+/// Given information matrix Ω (dim × dim), computes L from Ω = LᵀL, then
+/// applies `residual ← L·residual` and `jacobian ← L·jacobian`.
+///
+/// The Jacobian is stored row-major with shape (residual_dim × total_local_dim).
+///
+/// Returns `false` if the Cholesky decomposition fails (matrix not positive definite).
+pub fn whiten_matrix(
+    residual: &mut [f32],
+    jacobian: &mut [f32],
+    information: &[f32],
+    dim: usize,
+    jacobian_cols: usize,
+) -> bool {
+    // Cholesky decomposition: Ω = LᵀL (upper triangular L)
+    // We compute L such that LᵀL = Ω, then apply L to residual and Jacobian rows.
+    //
+    // We use the lower-triangular convention: Ω = L Lᵀ, then whiten with Lᵀ.
+    // Actually for whitening we need: eᵀΩe = eᵀLᵀLe = (Le)ᵀ(Le)
+    // So we need L from Ω = LᵀL (upper Cholesky), or equivalently Lᵀ from lower Cholesky.
+
+    let mut l = vec![0.0f32; dim * dim];
+
+    // Lower Cholesky: L such that L·Lᵀ = Ω
+    for j in 0..dim {
+        let mut sum = 0.0f32;
+        for k in 0..j {
+            sum += l[j * dim + k] * l[j * dim + k];
+        }
+        let diag = information[j * dim + j] - sum;
+        if diag <= 0.0 {
+            return false;
+        }
+        l[j * dim + j] = diag.sqrt();
+
+        for i in (j + 1)..dim {
+            let mut sum = 0.0f32;
+            for k in 0..j {
+                sum += l[i * dim + k] * l[j * dim + k];
+            }
+            l[i * dim + j] = (information[i * dim + j] - sum) / l[j * dim + j];
+        }
+    }
+
+    // We have L such that L·Lᵀ = Ω.
+    // We need to apply Lᵀ (upper triangular) to get whitened = Lᵀ · original.
+    // Because (Lᵀ·e)ᵀ(Lᵀ·e) = eᵀ·L·Lᵀ·e = eᵀ·Ω·e. ✓
+
+    // Whiten residual: r' = Lᵀ · r
+    let mut whitened_r = vec![0.0f32; dim];
+    for i in 0..dim {
+        let mut val = 0.0f32;
+        // Lᵀ[i,j] = L[j,i], nonzero for j >= i
+        for j in i..dim {
+            val += l[j * dim + i] * residual[j];
+        }
+        whitened_r[i] = val;
+    }
+    residual[..dim].copy_from_slice(&whitened_r);
+
+    // Whiten Jacobian rows: J'[i, :] = Σ_j Lᵀ[i,j] · J[j, :]
+    let mut whitened_j = vec![0.0f32; dim * jacobian_cols];
+    for i in 0..dim {
+        for j in i..dim {
+            let lt_ij = l[j * dim + i]; // Lᵀ[i,j] = L[j,i]
+            for c in 0..jacobian_cols {
+                whitened_j[i * jacobian_cols + c] += lt_ij * jacobian[j * jacobian_cols + c];
+            }
+        }
+    }
+    jacobian[..dim * jacobian_cols].copy_from_slice(&whitened_j);
+
+    true
+}
+
+/// Compute the inverse of a symmetric positive-definite matrix (covariance → information).
+///
+/// Uses Cholesky decomposition followed by back-substitution.
+/// Returns `None` if the matrix is not positive definite.
+pub fn invert_spd(matrix: &[f32], dim: usize) -> Option<Vec<f32>> {
+    // Lower Cholesky: L such that L·Lᵀ = matrix
+    let mut l = vec![0.0f32; dim * dim];
+
+    for j in 0..dim {
+        let mut sum = 0.0f32;
+        for k in 0..j {
+            sum += l[j * dim + k] * l[j * dim + k];
+        }
+        let diag = matrix[j * dim + j] - sum;
+        if diag <= 0.0 {
+            return None;
+        }
+        l[j * dim + j] = diag.sqrt();
+
+        for i in (j + 1)..dim {
+            let mut sum = 0.0f32;
+            for k in 0..j {
+                sum += l[i * dim + k] * l[j * dim + k];
+            }
+            l[i * dim + j] = (matrix[i * dim + j] - sum) / l[j * dim + j];
+        }
+    }
+
+    // Invert L (lower triangular)
+    let mut l_inv = vec![0.0f32; dim * dim];
+    for i in 0..dim {
+        l_inv[i * dim + i] = 1.0 / l[i * dim + i];
+        for j in (i + 1)..dim {
+            let mut sum = 0.0f32;
+            for k in i..j {
+                sum += l[j * dim + k] * l_inv[k * dim + i];
+            }
+            l_inv[j * dim + i] = -sum / l[j * dim + j];
+        }
+    }
+
+    // Ω = (LLᵀ)⁻¹ = L⁻ᵀ L⁻¹
+    let mut inv = vec![0.0f32; dim * dim];
+    for i in 0..dim {
+        for j in 0..=i {
+            let mut sum = 0.0f32;
+            for k in i..dim {
+                sum += l_inv[k * dim + i] * l_inv[k * dim + j];
+            }
+            inv[i * dim + j] = sum;
+            inv[j * dim + i] = sum;
+        }
+    }
+
+    Some(inv)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scalar_whitening_scales_by_sqrt() {
+        let mut residual = vec![2.0f32, 3.0];
+        let mut jacobian = vec![1.0f32, 0.0, 0.0, 1.0];
+        let w = 4.0; // sqrt(4) = 2
+
+        whiten_scalar(&mut residual, &mut jacobian, w);
+
+        assert!((residual[0] - 4.0).abs() < 1e-6);
+        assert!((residual[1] - 6.0).abs() < 1e-6);
+        assert!((jacobian[0] - 2.0).abs() < 1e-6);
+        assert!((jacobian[3] - 2.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn matrix_whitening_reproduces_mahalanobis() {
+        // 2x2 information matrix: Ω = [[4, 1], [1, 2]]
+        let info = vec![4.0f32, 1.0, 1.0, 2.0];
+        let e_orig = vec![1.0f32, 2.0];
+
+        let mut e = e_orig.clone();
+        // Dummy 2x1 jacobian
+        let mut j = vec![1.0f32, 0.0];
+
+        assert!(whiten_matrix(&mut e, &mut j, &info, 2, 1));
+
+        // Check: whitened eᵀe should equal eᵀΩe
+        let whitened_sq: f32 = e.iter().map(|x| x * x).sum();
+        // eᵀΩe = [1,2]·[[4,1],[1,2]]·[1,2]ᵀ = 1*4+1*1 + 2*1+2*2 = 5+6 = 12? no
+        // = 1*(4*1+1*2) + 2*(1*1+2*2) = 1*6 + 2*5 = 6+10 = 16? no wait
+        // eᵀΩe = e[0]*(Ω[0,0]*e[0]+Ω[0,1]*e[1]) + e[1]*(Ω[1,0]*e[0]+Ω[1,1]*e[1])
+        //       = 1*(4+2) + 2*(1+4) = 6 + 10 = 16
+        let expected: f32 = {
+            let oe0 = info[0] * e_orig[0] + info[1] * e_orig[1];
+            let oe1 = info[2] * e_orig[0] + info[3] * e_orig[1];
+            e_orig[0] * oe0 + e_orig[1] * oe1
+        };
+
+        assert!(
+            (whitened_sq - expected).abs() < 1e-4,
+            "whitened {whitened_sq} != expected {expected}"
+        );
+    }
+
+    #[test]
+    fn invert_spd_identity() {
+        let id = vec![1.0f32, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
+        let inv = invert_spd(&id, 3).unwrap();
+        for i in 0..3 {
+            for j in 0..3 {
+                let expected = if i == j { 1.0 } else { 0.0 };
+                assert!(
+                    (inv[i * 3 + j] - expected).abs() < 1e-6,
+                    "inv[{i},{j}] = {} != {expected}",
+                    inv[i * 3 + j]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn invert_spd_roundtrip() {
+        // Ω = [[4, 1], [1, 2]], Σ = Ω⁻¹, then Ω·Σ = I
+        let omega = vec![4.0f32, 1.0, 1.0, 2.0];
+        let sigma = invert_spd(&omega, 2).unwrap();
+
+        // Check Ω·Σ ≈ I
+        for i in 0..2 {
+            for j in 0..2 {
+                let mut sum = 0.0f32;
+                for k in 0..2 {
+                    sum += omega[i * 2 + k] * sigma[k * 2 + j];
+                }
+                let expected = if i == j { 1.0 } else { 0.0 };
+                assert!(
+                    (sum - expected).abs() < 1e-5,
+                    "product[{i},{j}] = {sum} != {expected}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn invert_spd_fails_on_non_positive_definite() {
+        let bad = vec![1.0f32, 2.0, 2.0, 1.0]; // eigenvalues: 3, -1
+        assert!(invert_spd(&bad, 2).is_none());
+    }
+}

--- a/crates/kornia-algebra/src/optim/mod.rs
+++ b/crates/kornia-algebra/src/optim/mod.rs
@@ -8,9 +8,9 @@ mod tests_l2_baseline;
 #[cfg(test)]
 mod tests_robust_losses;
 
+pub use core::whitening;
 pub use core::{Factor, FactorError, FactorResult, LinearizationResult, PriorFactor};
 pub use core::{Problem, ProblemError, Variable, VariableType};
-pub use core::whitening;
 pub use losses::{CauchyLoss, HuberLoss, IdentityLoss, RobustLoss};
 pub use solvers::{
     LevenbergMarquardt, LinearSystemBuilder, OptimizerError, OptimizerResult, OptimizerState,

--- a/crates/kornia-algebra/src/optim/mod.rs
+++ b/crates/kornia-algebra/src/optim/mod.rs
@@ -10,6 +10,7 @@ mod tests_robust_losses;
 
 pub use core::{Factor, FactorError, FactorResult, LinearizationResult, PriorFactor};
 pub use core::{Problem, ProblemError, Variable, VariableType};
+pub use core::whitening;
 pub use losses::{CauchyLoss, HuberLoss, IdentityLoss, RobustLoss};
 pub use solvers::{
     LevenbergMarquardt, LinearSystemBuilder, OptimizerError, OptimizerResult, OptimizerState,

--- a/crates/kornia-bow/src/lib.rs
+++ b/crates/kornia-bow/src/lib.rs
@@ -7,6 +7,7 @@ pub mod bow;
 pub mod constructor;
 pub mod io;
 pub mod metric;
+pub mod orb_slam3;
 
 pub use bow::{BoW, DirectIndex};
 use metric::{DistanceMetric, MetricType};

--- a/crates/kornia-bow/src/orb_slam3.rs
+++ b/crates/kornia-bow/src/orb_slam3.rs
@@ -1,0 +1,284 @@
+//! Loader for ORB-SLAM3 / DBoW2 vocabulary text files.
+//!
+//! Parses the plain-text `ORBvoc.txt` emitted by ORB-SLAM3's DBoW2 fork and
+//! reshapes it into the flat [`Vocabulary`] layout used by this crate.
+//!
+//! File format:
+//! ```text
+//! k L weighting scoring          // header
+//! parent_id is_leaf b0 b1 ... b31 weight   // one node per line, node id = line number (1-based)
+//! ```
+//!
+//! The root (id 0) is implicit — its children are the nodes with `parent_id == 0`.
+
+use std::collections::VecDeque;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+use crate::metric::{Feature, Hamming};
+use crate::{BlockCluster, BlockContent, BowError, BowResult, InternalMeta, LeafData, Vocabulary};
+
+/// Branching factor expected in ORB-SLAM3's vocabulary.
+pub const ORB_SLAM3_B: usize = 10;
+/// Number of u64 words per packed descriptor (256 bits = 4 × u64).
+pub const ORB_SLAM3_D: usize = 4;
+
+/// Packs a 32-byte ORB descriptor into 4 little-endian u64 words.
+///
+/// Use this for any query features transformed against a vocabulary loaded
+/// via [`load_orb_slam3_vocabulary`] so that byte ordering matches.
+#[inline]
+pub fn pack_orb_descriptor(bytes: &[u8; 32]) -> Feature<u64, ORB_SLAM3_D> {
+    let mut words = [0u64; ORB_SLAM3_D];
+    for (i, w) in words.iter_mut().enumerate() {
+        let mut chunk = [0u8; 8];
+        chunk.copy_from_slice(&bytes[i * 8..(i + 1) * 8]);
+        *w = u64::from_le_bytes(chunk);
+    }
+    Feature(words)
+}
+
+struct RawNode {
+    parent: u32,
+    is_leaf: bool,
+    desc: Feature<u64, ORB_SLAM3_D>,
+    weight: f32,
+}
+
+/// Loads an ORB-SLAM3 `ORBvoc.txt` file into a [`Vocabulary`].
+pub fn load_orb_slam3_vocabulary<P: AsRef<Path>>(
+    path: P,
+) -> BowResult<Vocabulary<ORB_SLAM3_B, Hamming<ORB_SLAM3_D>>> {
+    let file = File::open(path)?;
+    let mut reader = BufReader::new(file);
+
+    // Header: "k L weighting scoring"
+    let mut header = String::new();
+    reader.read_line(&mut header)?;
+    let mut hp = header.split_whitespace();
+    let k: usize = hp
+        .next()
+        .and_then(|s| s.parse().ok())
+        .ok_or(BowError::CorruptedVocabulary)?;
+    let _l: usize = hp
+        .next()
+        .and_then(|s| s.parse().ok())
+        .ok_or(BowError::CorruptedVocabulary)?;
+    // weighting and scoring are parsed but not used (we use the per-leaf weights as-is).
+    let _ = hp.next();
+    let _ = hp.next();
+
+    if k != ORB_SLAM3_B {
+        return Err(BowError::VocabularyMismatch {
+            expected_b: ORB_SLAM3_B,
+            found_b: k,
+        });
+    }
+
+    // Parse all nodes. Node id = line index (1-based).
+    let mut raw: Vec<RawNode> = Vec::with_capacity(1_200_000);
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let n = reader.read_line(&mut line)?;
+        if n == 0 {
+            break;
+        }
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let mut it = trimmed.split_ascii_whitespace();
+        let parent: u32 = it
+            .next()
+            .and_then(|s| s.parse().ok())
+            .ok_or(BowError::CorruptedVocabulary)?;
+        let is_leaf_flag: u32 = it
+            .next()
+            .and_then(|s| s.parse().ok())
+            .ok_or(BowError::CorruptedVocabulary)?;
+
+        let mut bytes = [0u8; 32];
+        for b in bytes.iter_mut() {
+            *b = it
+                .next()
+                .and_then(|s| s.parse().ok())
+                .ok_or(BowError::CorruptedVocabulary)?;
+        }
+        let weight: f32 = it
+            .next()
+            .and_then(|s| s.parse().ok())
+            .ok_or(BowError::CorruptedVocabulary)?;
+
+        raw.push(RawNode {
+            parent,
+            is_leaf: is_leaf_flag != 0,
+            desc: pack_orb_descriptor(&bytes),
+            weight,
+        });
+    }
+
+    if raw.is_empty() {
+        return Err(BowError::NoFeatures);
+    }
+
+    // Group children by parent node id. Root has id 0.
+    let n_nodes = raw.len();
+    let mut children_of: Vec<Vec<u32>> = vec![Vec::new(); n_nodes + 1];
+    for (i, r) in raw.iter().enumerate() {
+        let own_id = (i as u32) + 1;
+        let pidx = r.parent as usize;
+        if pidx > n_nodes {
+            return Err(BowError::CorruptedVocabulary);
+        }
+        children_of[pidx].push(own_id);
+    }
+
+    // BFS flatten into the crate's block layout.
+    // Block 0 holds the root's children.
+    let mut blocks: Vec<BlockCluster<ORB_SLAM3_B, Hamming<ORB_SLAM3_D>>> =
+        vec![BlockCluster::default()];
+    let mut queue: VecDeque<(u32, u32)> = VecDeque::new();
+    queue.push_back((0, 0));
+    let mut next_free: u32 = 1;
+
+    while let Some((parent_node, block_idx)) = queue.pop_front() {
+        let kids = &children_of[parent_node as usize];
+        if kids.is_empty() {
+            // Unexpected: internal node with no children. Write a dummy leaf to keep bounds valid.
+            let mut b = BlockCluster::default();
+            for d in b.descriptors.iter_mut() {
+                *d = Feature([u64::MAX; ORB_SLAM3_D]);
+            }
+            b.content = BlockContent::Leaf(LeafData {
+                weights: [0.0; ORB_SLAM3_B],
+            });
+            if block_idx as usize >= blocks.len() {
+                blocks.resize(block_idx as usize + 1, BlockCluster::default());
+            }
+            blocks[block_idx as usize] = b;
+            continue;
+        }
+
+        if kids.len() > ORB_SLAM3_B {
+            return Err(BowError::CorruptedVocabulary);
+        }
+
+        let mut block: BlockCluster<ORB_SLAM3_B, Hamming<ORB_SLAM3_D>> = BlockCluster::default();
+        for d in block.descriptors.iter_mut() {
+            *d = Feature([u64::MAX; ORB_SLAM3_D]);
+        }
+
+        let any_internal = kids.iter().any(|&c| !raw[(c - 1) as usize].is_leaf);
+
+        if !any_internal {
+            // Leaf block: every child is a leaf — fold them directly.
+            let mut weights = [0.0f32; ORB_SLAM3_B];
+            for (i, &c) in kids.iter().enumerate() {
+                let r = &raw[(c - 1) as usize];
+                block.descriptors[i] = r.desc;
+                weights[i] = r.weight;
+            }
+            // Pad unused slots with the last real descriptor so traversal's argmin
+            // can never prefer a padded slot over a real one.
+            if let Some(&last) = kids.last() {
+                let r = &raw[(last - 1) as usize];
+                for i in kids.len()..ORB_SLAM3_B {
+                    block.descriptors[i] = r.desc;
+                    weights[i] = r.weight;
+                }
+            }
+            block.content = BlockContent::Leaf(LeafData { weights });
+        } else {
+            // Internal block: allocate B child slots even if some children are leaves.
+            let children_base = next_free;
+            next_free += ORB_SLAM3_B as u32;
+            if blocks.len() < next_free as usize {
+                blocks.resize(next_free as usize, BlockCluster::default());
+            }
+            block.content = BlockContent::Internal(InternalMeta {
+                children_base_idx: children_base,
+            });
+
+            for (i, &c) in kids.iter().enumerate() {
+                let r = &raw[(c - 1) as usize];
+                block.descriptors[i] = r.desc;
+                let child_block_idx = children_base + i as u32;
+                if r.is_leaf {
+                    // Wrapper leaf block: slot 0 is the real leaf, others replicate
+                    // the same descriptor+weight so any argmin tie still returns the
+                    // correct (node_id, weight).
+                    let mut wb: BlockCluster<ORB_SLAM3_B, Hamming<ORB_SLAM3_D>> =
+                        BlockCluster::default();
+                    for d in wb.descriptors.iter_mut() {
+                        *d = r.desc;
+                    }
+                    let weights = [r.weight; ORB_SLAM3_B];
+                    wb.content = BlockContent::Leaf(LeafData { weights });
+                    blocks[child_block_idx as usize] = wb;
+                } else {
+                    queue.push_back((c, child_block_idx));
+                }
+            }
+
+            // Pad unused slots of this internal block the same way as above.
+            if let Some(&last) = kids.last() {
+                let r = &raw[(last - 1) as usize];
+                for i in kids.len()..ORB_SLAM3_B {
+                    block.descriptors[i] = r.desc;
+                    // Also dead-end these slots with a dummy leaf wrapper to keep
+                    // children_base_idx + i in bounds for traversal.
+                    let dummy_idx = children_base + i as u32;
+                    let mut db: BlockCluster<ORB_SLAM3_B, Hamming<ORB_SLAM3_D>> =
+                        BlockCluster::default();
+                    for d in db.descriptors.iter_mut() {
+                        *d = r.desc;
+                    }
+                    db.content = BlockContent::Leaf(LeafData {
+                        weights: [r.weight; ORB_SLAM3_B],
+                    });
+                    blocks[dummy_idx as usize] = db;
+                }
+            }
+        }
+
+        if block_idx as usize >= blocks.len() {
+            blocks.resize(block_idx as usize + 1, BlockCluster::default());
+        }
+        blocks[block_idx as usize] = block;
+    }
+
+    // Safety check: every Internal block must point to a valid child range.
+    for b in &blocks {
+        if let BlockContent::Internal(meta) = b.content {
+            let end = meta.children_base_idx as u64 + ORB_SLAM3_B as u64;
+            if end > blocks.len() as u64 {
+                return Err(BowError::CorruptedVocabulary);
+            }
+        }
+    }
+
+    blocks.shrink_to_fit();
+
+    Ok(Vocabulary {
+        blocks,
+        root_idx: 0,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pack_descriptor_le() {
+        let mut bytes = [0u8; 32];
+        bytes[0] = 0x01;
+        bytes[8] = 0x02;
+        let f = pack_orb_descriptor(&bytes);
+        assert_eq!(f.0[0], 0x0000_0000_0000_0001);
+        assert_eq!(f.0[1], 0x0000_0000_0000_0002);
+    }
+}

--- a/crates/kornia-imgproc/src/features/fast.rs
+++ b/crates/kornia-imgproc/src/features/fast.rs
@@ -1,5 +1,3 @@
-use std::ops::ControlFlow;
-
 use kornia_image::{allocator::ImageAllocator, Image, ImageError, ImageSize};
 use kornia_tensor::CpuAllocator;
 use rayon::prelude::*;
@@ -97,24 +95,6 @@ impl FastDetector {
                     let lower_threshold = curr_pixel - self.threshold;
                     let upper_threshold = curr_pixel + self.threshold;
 
-                    let mut speed_sum_b = 0;
-                    let mut speed_sum_d = 0;
-
-                    for &k in &[0, 4, 8, 12] {
-                        let ik =
-                            ((y as isize + RP[k]) * width as isize + (x as isize + CP[k])) as usize;
-                        let ring_pixel = src_slice[ik];
-                        if ring_pixel > upper_threshold {
-                            speed_sum_b += 1;
-                        } else if ring_pixel < lower_threshold {
-                            speed_sum_d += 1;
-                        }
-                    }
-                    if speed_sum_d < 3 && speed_sum_b < 3 {
-                        row[ix] = 0.0;
-                        continue;
-                    }
-
                     for k in 0..16 {
                         let ik =
                             ((y as isize + RP[k]) * width as isize + (x as isize + CP[k])) as usize;
@@ -168,6 +148,24 @@ impl FastDetector {
         );
         Ok(coordinates)
     }
+
+    /// Extracts raw FAST candidates before nonmax suppression.
+    pub fn extract_raw_keypoints(&self) -> Vec<[usize; 2]> {
+        let size = self.corner_response.size();
+        let width = size.width;
+        self.corner_response
+            .as_slice()
+            .iter()
+            .enumerate()
+            .filter(|&(_, &response)| response > self.threshold)
+            .map(|(i, _)| [i / width, i % width])
+            .collect()
+    }
+
+    /// Returns the last computed FAST corner response image.
+    pub fn corner_response(&self) -> &Image<f32, 1, CpuAllocator> {
+        &self.corner_response
+    }
 }
 
 fn corner_fast_response(
@@ -177,30 +175,28 @@ fn corner_fast_response(
     state: PixelType,
     n: usize,
 ) -> f32 {
-    let mut consecutive_count = 0;
-    let mut curr_response = 0.0;
-
-    if let ControlFlow::Break(_) = (0..15 + n).try_for_each(|l| {
-        if bins[l % 16] == state {
-            consecutive_count += 1;
-            if consecutive_count == n {
-                curr_response = 0.0;
-                circle_intensities.iter().for_each(|m| {
-                    curr_response += (m - curr_pixel).abs();
-                });
-
-                return ControlFlow::Break(());
+    let mut best_score = 0.0f32;
+    for start in 0..16 {
+        let mut arc_min = f32::INFINITY;
+        let mut valid_arc = true;
+        for offset in 0..n {
+            let idx = (start + offset) % 16;
+            if bins[idx] != state {
+                valid_arc = false;
+                break;
             }
-        } else {
-            consecutive_count = 0;
+            let diff = match state {
+                PixelType::Brighter => circle_intensities[idx] - curr_pixel,
+                PixelType::Darker => curr_pixel - circle_intensities[idx],
+                PixelType::Similar => 0.0,
+            };
+            arc_min = arc_min.min(diff);
         }
-
-        ControlFlow::Continue(())
-    }) {
-        return curr_response;
+        if valid_arc {
+            best_score = best_score.max(arc_min);
+        }
     }
-
-    0.0
+    best_score
 }
 
 fn get_peak_mask<A: ImageAllocator>(
@@ -208,13 +204,44 @@ fn get_peak_mask<A: ImageAllocator>(
     mask: &mut Image<bool, 1, A>,
     threshold: f32,
 ) {
+    let width = src.width();
+    let height = src.height();
     let src_slice = src.as_slice();
     let mask_slice = mask.as_slice_mut();
 
-    src_slice
-        .par_iter()
-        .zip(mask_slice)
-        .for_each(|(src, mask)| *mask = *src > threshold);
+    mask_slice.fill(false);
+
+    if width < 3 || height < 3 {
+        return;
+    }
+
+    mask_slice[width..(height - 1) * width]
+        .par_chunks_mut(width)
+        .enumerate()
+        .for_each(|(row_idx, row_mask)| {
+            let y = row_idx + 1;
+            for x in 1..width - 1 {
+                let center = src_slice[y * width + x];
+                if center <= threshold {
+                    row_mask[x] = false;
+                    continue;
+                }
+
+                let mut is_strict_max = true;
+                'neighbors: for yy in (y - 1)..=(y + 1) {
+                    for xx in (x - 1)..=(x + 1) {
+                        if yy == y && xx == x {
+                            continue;
+                        }
+                        if src_slice[yy * width + xx] >= center {
+                            is_strict_max = false;
+                            break 'neighbors;
+                        }
+                    }
+                }
+                row_mask[x] = is_strict_max;
+            }
+        });
 }
 
 fn exclude_border<A: ImageAllocator>(label: &mut Image<bool, 1, A>, border_width: usize) {
@@ -329,17 +356,19 @@ mod tests {
             [32, 86],
             [60, 75],
             [69, 184],
-            [71, 84],
+            [72, 84],
             [72, 169],
-            [109, 69],
             [109, 125],
-            [120, 64],
-            [129, 162],
+            [122, 63],
+            [125, 165],
             [134, 95],
+            [135, 161],
             [141, 121],
             [153, 104],
             [162, 148],
         ];
+
+        let legacy_keypoints = vec![[71, 84], [109, 69], [109, 125], [120, 64], [129, 162]];
 
         const THRESHOLD: f32 = 0.15;
 
@@ -350,6 +379,51 @@ mod tests {
         let expected: HashSet<[usize; 2]> = expected_keypoints.into_iter().collect();
         let actual: HashSet<[usize; 2]> = keypoints.into_iter().collect();
         assert_eq!(actual, expected);
+        let legacy: HashSet<[usize; 2]> = legacy_keypoints.into_iter().collect();
+        assert_ne!(actual, legacy);
+        Ok(())
+    }
+
+    #[test]
+    fn test_fast_9_accepts_arc_with_only_two_cardinals() -> Result<(), Box<dyn std::error::Error>> {
+        let mut img = Image::from_size_val(
+            ImageSize {
+                width: 7,
+                height: 7,
+            },
+            0.5f32,
+            CpuAllocator,
+        )?;
+
+        let center_r = 3usize;
+        let center_c = 3usize;
+        let width = img.width();
+        let ring_offsets = [
+            (0isize, 3isize),
+            (1, 3),
+            (2, 2),
+            (3, 1),
+            (3, 0),
+            (3, -1),
+            (2, -2),
+            (1, -3),
+            (0, -3),
+        ];
+
+        for (dr, dc) in ring_offsets {
+            let r = (center_r as isize + dr) as usize;
+            let c = (center_c as isize + dc) as usize;
+            img.as_slice_mut()[r * width + c] = 1.0;
+        }
+
+        let mut fast_detector = FastDetector::new(img.size(), 0.1, 9, 1)?;
+        fast_detector.compute_corner_response(&img);
+
+        let raw: HashSet<[usize; 2]> = fast_detector.extract_raw_keypoints().into_iter().collect();
+        assert!(raw.contains(&[center_r, center_c]));
+
+        let nms: HashSet<[usize; 2]> = fast_detector.extract_keypoints()?.into_iter().collect();
+        assert!(nms.contains(&[center_r, center_c]));
         Ok(())
     }
 }

--- a/crates/kornia-imgproc/src/features/orb/extractor.rs
+++ b/crates/kornia-imgproc/src/features/orb/extractor.rs
@@ -18,6 +18,8 @@ pub struct OrbFeatures {
     pub orientations: Vec<f32>,
     /// Binary descriptors (256-bit, packed as 32 bytes each).
     pub descriptors: Vec<[u8; 32]>,
+    /// Scale factor (downscale^octave) at which each keypoint was detected.
+    pub scales: Vec<f32>,
 }
 
 /// ORB (Oriented FAST and Rotated BRIEF) feature detector and descriptor extractor.
@@ -420,15 +422,22 @@ impl OrbDetector {
         let mut keypoints_xy = Vec::with_capacity(descriptors.len());
         let mut valid_orientations = Vec::with_capacity(descriptors.len());
         let mut valid_descriptors = Vec::with_capacity(descriptors.len());
+        let mut valid_scales = Vec::with_capacity(descriptors.len());
 
         // `mask` has one entry per keypoint; `descriptors` has entries only
         // for keypoints where mask is true, so we track a separate index.
         let mut desc_idx = 0;
-        for (i, ((row, col), &ori)) in kps_rc.iter().zip(orientations.iter()).enumerate() {
+        for (i, (((row, col), &ori), &sc)) in kps_rc
+            .iter()
+            .zip(orientations.iter())
+            .zip(scales.iter())
+            .enumerate()
+        {
             if mask.get(i).copied().unwrap_or(false) {
                 keypoints_xy.push([*col, *row]);
                 valid_orientations.push(ori);
                 valid_descriptors.push(descriptors[desc_idx]);
+                valid_scales.push(sc);
                 desc_idx += 1;
             }
         }
@@ -437,6 +446,7 @@ impl OrbDetector {
             keypoints_xy,
             orientations: valid_orientations,
             descriptors: valid_descriptors,
+            scales: valid_scales,
         })
     }
 }

--- a/crates/kornia-imgproc/src/features/orb/extractor.rs
+++ b/crates/kornia-imgproc/src/features/orb/extractor.rs
@@ -2,9 +2,9 @@ use kornia_image::{allocator::ImageAllocator, Image, ImageError, ImageSize};
 use kornia_tensor::CpuAllocator;
 
 use crate::{
-    features::{FastDetector, HarrisResponse},
+    features::FastDetector,
     filter::gaussian_blur,
-    resize::resize_native,
+    padding::{spatial_padding, Padding2D, PaddingMode},
 };
 
 use super::pattern::{POS0, POS1};
@@ -20,6 +20,56 @@ pub struct OrbFeatures {
     pub descriptors: Vec<[u8; 32]>,
     /// Scale factor (downscale^octave) at which each keypoint was detected.
     pub scales: Vec<f32>,
+}
+
+/// Which FAST threshold produced a debug candidate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OrbDebugThresholdKind {
+    /// Initial FAST threshold.
+    Initial,
+    /// Fallback minimum FAST threshold.
+    Minimum,
+}
+
+/// Debug record for a single ORB candidate or survivor.
+#[derive(Debug, Clone)]
+pub struct OrbDebugCandidate {
+    /// Keypoint x coordinate in original-image pixel space.
+    pub x: f32,
+    /// Keypoint y coordinate in original-image pixel space.
+    pub y: f32,
+    /// Detector response used for ranking.
+    pub response: f32,
+    /// Pyramid octave.
+    pub octave: usize,
+    /// Cell row used during cell-local FAST detection.
+    pub cell_row: i32,
+    /// Cell column used during cell-local FAST detection.
+    pub cell_col: i32,
+    /// Threshold source for this candidate.
+    pub threshold_kind: OrbDebugThresholdKind,
+}
+
+/// Debug data for a single octave.
+#[derive(Debug, Clone)]
+pub struct OrbDebugOctave {
+    /// Pyramid octave.
+    pub octave: usize,
+    /// Octave image size before padding.
+    pub image_size: ImageSize,
+    /// Raw FAST candidates before nonmax suppression.
+    pub raw_candidates: Vec<OrbDebugCandidate>,
+    /// Post-NMS FAST candidates before octree distribution.
+    pub candidates: Vec<OrbDebugCandidate>,
+    /// Final survivors after octree distribution.
+    pub survivors: Vec<OrbDebugCandidate>,
+}
+
+/// Debug data for one ORB detection pass.
+#[derive(Debug, Clone)]
+pub struct OrbDebugFrame {
+    /// Per-octave debug data.
+    pub octaves: Vec<OrbDebugOctave>,
 }
 
 /// ORB (Oriented FAST and Rotated BRIEF) feature detector and descriptor extractor.
@@ -51,10 +101,14 @@ struct OrbCandidate {
     col: usize,
     response: f32,
     angle: f32,
+    cell_row: i32,
+    cell_col: i32,
+    threshold_kind: OrbDebugThresholdKind,
 }
 
 #[derive(Clone, Debug)]
 struct ExtractorNode {
+    id: usize,
     ul: (i32, i32),
     ur: (i32, i32),
     bl: (i32, i32),
@@ -64,11 +118,14 @@ struct ExtractorNode {
 }
 
 impl ExtractorNode {
-    fn divide(&self, candidates: &[OrbCandidate]) -> [ExtractorNode; 4] {
-        let mid_x = (self.ul.0 + self.ur.0) / 2;
-        let mid_y = (self.ul.1 + self.bl.1) / 2;
+    fn divide(&self, candidates: &[OrbCandidate], next_id: &mut usize) -> [ExtractorNode; 4] {
+        let half_x = ((self.ur.0 - self.ul.0) as f32 / 2.0).ceil() as i32;
+        let half_y = ((self.br.1 - self.ul.1) as f32 / 2.0).ceil() as i32;
+        let mid_x = self.ul.0 + half_x;
+        let mid_y = self.ul.1 + half_y;
 
         let mut n1 = ExtractorNode {
+            id: alloc_node_id(next_id),
             ul: self.ul,
             ur: (mid_x, self.ul.1),
             bl: (self.ul.0, mid_y),
@@ -77,6 +134,7 @@ impl ExtractorNode {
             no_more: false,
         };
         let mut n2 = ExtractorNode {
+            id: alloc_node_id(next_id),
             ul: (mid_x, self.ul.1),
             ur: self.ur,
             bl: (mid_x, mid_y),
@@ -85,6 +143,7 @@ impl ExtractorNode {
             no_more: false,
         };
         let mut n3 = ExtractorNode {
+            id: alloc_node_id(next_id),
             ul: (self.ul.0, mid_y),
             ur: (mid_x, mid_y),
             bl: self.bl,
@@ -93,6 +152,7 @@ impl ExtractorNode {
             no_more: false,
         };
         let mut n4 = ExtractorNode {
+            id: alloc_node_id(next_id),
             ul: (mid_x, mid_y),
             ur: (self.ur.0, mid_y),
             bl: (mid_x, self.bl.1),
@@ -118,8 +178,19 @@ impl ExtractorNode {
             }
         }
 
+        n1.no_more = n1.keys.len() == 1;
+        n2.no_more = n2.keys.len() == 1;
+        n3.no_more = n3.keys.len() == 1;
+        n4.no_more = n4.keys.len() == 1;
+
         [n1, n2, n3, n4]
     }
+}
+
+fn alloc_node_id(next_id: &mut usize) -> usize {
+    let id = *next_id;
+    *next_id += 1;
+    id
 }
 
 impl Default for OrbDetector {
@@ -169,63 +240,179 @@ impl OrbDetector {
         &self,
         img: &Image<f32, 1, A>,
     ) -> Result<Vec<Image<f32, 1, CpuAllocator>>, ImageError> {
-        let img = Image::from_size_slice(img.size(), img.as_slice(), CpuAllocator)?;
+        let orig_w = img.width() as f32;
+        let orig_h = img.height() as f32;
 
-        let mut pyramid = Vec::with_capacity(self.n_scales);
-        let mut current = img.clone();
-        pyramid.push(current.clone());
+        let mut pyramid: Vec<Image<f32, 1, CpuAllocator>> = Vec::with_capacity(self.n_scales);
+        pyramid.push(Image::from_size_slice(
+            img.size(),
+            img.as_slice(),
+            CpuAllocator,
+        )?);
 
-        for _ in 1..self.n_scales {
-            let next = pyramid_reduce(&current, self.downscale)?;
-            if next.size() == current.size() {
+        for level in 1..self.n_scales {
+            let inv_scale = 1.0f32 / self.downscale.powi(level as i32);
+            let new_w = (orig_w * inv_scale).round().max(1.0) as usize;
+            let new_h = (orig_h * inv_scale).round().max(1.0) as usize;
+
+            let prev = &pyramid[level - 1];
+            if new_w == prev.width() && new_h == prev.height() {
                 break;
             }
 
-            pyramid.push(next.clone());
-            current = next;
+            let mut resized = Image::from_size_val(
+                ImageSize {
+                    width: new_w,
+                    height: new_h,
+                },
+                0.0,
+                CpuAllocator,
+            )?;
+            resize_linear_pixel_center(prev, &mut resized);
+            pyramid.push(resized);
         }
 
         Ok(pyramid)
     }
 
     #[allow(clippy::type_complexity)]
-    fn detect_octave<A: ImageAllocator>(
+    fn detect_octave_debug<A: ImageAllocator>(
         &self,
         octave_image: &Image<f32, 1, A>,
-    ) -> Result<(Vec<[usize; 2]>, Vec<f32>, Vec<f32>), ImageError> {
-        // Two-tier FAST detection: first try with higher threshold, then lower if needed.
-        // This matches ORB-SLAM3's approach of using iniThFAST then falling back to minThFAST.
-        let mut fast_detector =
-            FastDetector::new(octave_image.size(), self.ini_fast_threshold, self.fast_n, 1)?;
-        fast_detector.compute_corner_response(octave_image);
-        let mut keypoints = fast_detector.extract_keypoints()?;
+        octave: usize,
+    ) -> Result<
+        (
+            Vec<[usize; 2]>,
+            Vec<f32>,
+            Vec<f32>,
+            Vec<OrbDebugCandidate>,
+            Vec<OrbDebugCandidate>,
+        ),
+        ImageError,
+    > {
+        const EDGE_THRESHOLD: i32 = 19;
+        let cell_w = self.cell_size as i32;
+        let (min_x, max_x, min_y, max_y) = octave_bounds(octave_image);
+        let region_w = (max_x - min_x).max(0);
+        let region_h = (max_y - min_y).max(0);
+        if region_w <= 0 || region_h <= 0 {
+            return Ok((vec![], vec![], vec![], vec![], vec![]));
+        }
+        let n_cols = (region_w / cell_w).max(1) as usize;
+        let n_rows = (region_h / cell_w).max(1) as usize;
+        let w_cell = ((region_w as f32) / (n_cols as f32)).ceil() as i32;
+        let h_cell = ((region_h as f32) / (n_rows as f32)).ceil() as i32;
+        let scale = self.downscale.powi(octave as i32);
 
-        // If very few keypoints found, retry with lower threshold.
-        // ORB-SLAM3 does this per-cell; we do it globally for simplicity.
-        if keypoints.len() < 10 {
-            let mut fast_detector_low =
-                FastDetector::new(octave_image.size(), self.min_fast_threshold, self.fast_n, 1)?;
-            fast_detector_low.compute_corner_response(octave_image);
-            let keypoints_low = fast_detector_low.extract_keypoints()?;
+        let mut keypoints: Vec<[usize; 2]> = Vec::new();
+        let mut responses: Vec<f32> = Vec::new();
+        let mut raw_debug_candidates = Vec::new();
+        let mut debug_candidates = Vec::new();
+        let padded = reflect101_pad(octave_image, EDGE_THRESHOLD as usize)?;
+        for row in 0..n_rows {
+            let ini_y = min_y + row as i32 * h_cell;
+            if ini_y >= max_y - 3 {
+                continue;
+            }
+            let max_y_cell = (ini_y + h_cell + 6).min(max_y);
 
-            // Merge keypoints, avoiding duplicates (within 3 pixel radius).
-            for kp in keypoints_low {
-                let dominated = keypoints.iter().any(|&[r, c]| {
-                    let dr = (r as i32 - kp[0] as i32).abs();
-                    let dc = (c as i32 - kp[1] as i32).abs();
-                    dr <= 3 && dc <= 3
-                });
-                if !dominated {
-                    keypoints.push(kp);
+            for col in 0..n_cols {
+                let ini_x = min_x + col as i32 * w_cell;
+                if ini_x >= max_x - 6 {
+                    continue;
+                }
+                let max_x_cell = (ini_x + w_cell + 6).min(max_x);
+
+                let roi = extract_subimage(
+                    &padded,
+                    (ini_y + EDGE_THRESHOLD) as usize,
+                    (ini_x + EDGE_THRESHOLD) as usize,
+                    (max_y_cell - ini_y) as usize,
+                    (max_x_cell - ini_x) as usize,
+                )?;
+                let mut fast_ini =
+                    FastDetector::new(roi.size(), self.ini_fast_threshold, self.fast_n, 1)?;
+                fast_ini.compute_corner_response(&roi);
+                let mut raw_cell_keypoints = fast_ini.extract_raw_keypoints();
+                let mut cell_keypoints = fast_ini.extract_keypoints()?;
+                let mut threshold_kind = OrbDebugThresholdKind::Initial;
+                let mut cell_responses: Vec<f32> = cell_keypoints
+                    .iter()
+                    .map(|&[r, c]| {
+                        fast_ini.corner_response().as_slice()
+                            [fast_ini.corner_response().size().index(r, c)]
+                    })
+                    .collect();
+
+                if cell_keypoints.is_empty() {
+                    let mut fast_min =
+                        FastDetector::new(roi.size(), self.min_fast_threshold, self.fast_n, 1)?;
+                    fast_min.compute_corner_response(&roi);
+                    raw_cell_keypoints = fast_min.extract_raw_keypoints();
+                    cell_keypoints = fast_min.extract_keypoints()?;
+                    threshold_kind = OrbDebugThresholdKind::Minimum;
+                    cell_responses = cell_keypoints
+                        .iter()
+                        .map(|&[r, c]| {
+                            fast_min.corner_response().as_slice()
+                                [fast_min.corner_response().size().index(r, c)]
+                        })
+                        .collect();
+
+                    raw_debug_candidates.extend(raw_cell_keypoints.into_iter().map(|[r, c]| {
+                        let abs_r = (r as i32 + ini_y) as usize;
+                        let abs_c = (c as i32 + ini_x) as usize;
+                        OrbDebugCandidate {
+                            x: abs_c as f32 * scale,
+                            y: abs_r as f32 * scale,
+                            response: fast_min.corner_response().as_slice()
+                                [fast_min.corner_response().size().index(r, c)],
+                            octave,
+                            cell_row: row as i32,
+                            cell_col: col as i32,
+                            threshold_kind,
+                        }
+                    }));
+                } else {
+                    raw_debug_candidates.extend(raw_cell_keypoints.into_iter().map(|[r, c]| {
+                        let abs_r = (r as i32 + ini_y) as usize;
+                        let abs_c = (c as i32 + ini_x) as usize;
+                        OrbDebugCandidate {
+                            x: abs_c as f32 * scale,
+                            y: abs_r as f32 * scale,
+                            response: fast_ini.corner_response().as_slice()
+                                [fast_ini.corner_response().size().index(r, c)],
+                            octave,
+                            cell_row: row as i32,
+                            cell_col: col as i32,
+                            threshold_kind,
+                        }
+                    }));
+                }
+
+                for ([r, c], response) in cell_keypoints.into_iter().zip(cell_responses.into_iter())
+                {
+                    let abs_r = (r as i32 + ini_y) as usize;
+                    let abs_c = (c as i32 + ini_x) as usize;
+                    keypoints.push([abs_r, abs_c]);
+                    responses.push(response);
+                    debug_candidates.push(OrbDebugCandidate {
+                        x: abs_c as f32 * scale,
+                        y: abs_r as f32 * scale,
+                        response,
+                        octave,
+                        cell_row: row as i32,
+                        cell_col: col as i32,
+                        threshold_kind,
+                    });
                 }
             }
         }
 
         if keypoints.is_empty() {
-            return Ok((vec![], vec![], vec![]));
+            return Ok((vec![], vec![], vec![], vec![], raw_debug_candidates));
         }
 
-        const EDGE_THRESHOLD: i32 = 19;
         let mask = mask_border_keypoints(octave_image.size(), &keypoints, EDGE_THRESHOLD);
         let filtered_keypoints: Vec<_> = keypoints
             .iter()
@@ -234,30 +421,38 @@ impl OrbDetector {
             .collect();
 
         if filtered_keypoints.is_empty() {
-            return Ok((vec![], vec![], vec![]));
+            return Ok((vec![], vec![], vec![], vec![], raw_debug_candidates));
         }
 
-        let orientations = corner_orientations(octave_image, &keypoints);
-        let filtered_orientations: Vec<_> = keypoints
+        let padded_keypoints: Vec<_> = keypoints
             .iter()
-            .zip(orientations.iter())
+            .map(|&[r, c]| [r + EDGE_THRESHOLD as usize, c + EDGE_THRESHOLD as usize])
+            .collect();
+        let orientations = corner_orientations(&padded, &padded_keypoints);
+        let filtered_orientations: Vec<_> = orientations
+            .iter()
             .zip(mask.iter())
-            .filter_map(|((_, &ori), &m)| if m { Some(ori) } else { None })
+            .filter_map(|(&ori, &m)| if m { Some(ori) } else { None })
             .collect();
 
-        let mut response = Image::from_size_val(octave_image.size(), 0f32, CpuAllocator)?;
-        let mut harris_response = HarrisResponse::new(octave_image.size()).with_k(self.harris_k);
-        harris_response.compute(octave_image, &mut response)?;
-
-        let filtered_responses: Vec<_> = filtered_keypoints
+        let filtered_responses: Vec<_> = responses
             .iter()
-            .map(|&[r, c]| response.as_slice()[response.size().index(r, c)])
+            .zip(mask.iter())
+            .filter_map(|(&response, &m)| if m { Some(response) } else { None })
+            .collect();
+
+        let filtered_debug_candidates: Vec<_> = debug_candidates
+            .into_iter()
+            .zip(mask.iter())
+            .filter_map(|(candidate, &m)| if m { Some(candidate) } else { None })
             .collect();
 
         Ok((
             filtered_keypoints,
             filtered_orientations,
             filtered_responses,
+            filtered_debug_candidates,
+            raw_debug_candidates,
         ))
     }
 
@@ -279,7 +474,8 @@ impl OrbDetector {
         let mut responses_list = vec![];
 
         for (octave, octave_image) in pyramid.iter().enumerate() {
-            let (keypoints, orientations, responses) = self.detect_octave(octave_image)?;
+            let (keypoints, orientations, responses, _, _) =
+                self.detect_octave_debug(octave_image, octave)?;
             if keypoints.is_empty() {
                 continue;
             }
@@ -293,6 +489,9 @@ impl OrbDetector {
                     col: c,
                     response,
                     angle,
+                    cell_row: -1,
+                    cell_col: -1,
+                    threshold_kind: OrbDebugThresholdKind::Initial,
                 })
                 .collect();
 
@@ -322,6 +521,69 @@ impl OrbDetector {
             orientations_list,
             responses_list,
         ))
+    }
+
+    /// Detect ORB keypoints and return per-octave debug data.
+    pub fn detect_debug<A: ImageAllocator>(
+        &self,
+        src: &Image<f32, 1, A>,
+    ) -> Result<OrbDebugFrame, ImageError> {
+        let pyramid = self.build_pyramid(src)?;
+        let features_per_level = self.features_per_level();
+        let mut octaves = Vec::with_capacity(pyramid.len());
+
+        for (octave, octave_image) in pyramid.iter().enumerate() {
+            let (keypoints, orientations, responses, debug_candidates, raw_debug_candidates) =
+                self.detect_octave_debug(octave_image, octave)?;
+            let candidates: Vec<OrbCandidate> = keypoints
+                .iter()
+                .zip(orientations.iter())
+                .zip(responses.iter())
+                .zip(debug_candidates.iter())
+                .map(|(((&[r, c], &angle), &response), debug)| OrbCandidate {
+                    row: r,
+                    col: c,
+                    response,
+                    angle,
+                    cell_row: debug.cell_row,
+                    cell_col: debug.cell_col,
+                    threshold_kind: debug.threshold_kind,
+                })
+                .collect();
+
+            let (min_x, max_x, min_y, max_y) = octave_bounds(octave_image);
+            let distributed = distribute_octree(
+                &candidates,
+                min_x,
+                max_x,
+                min_y,
+                max_y,
+                features_per_level[octave],
+            );
+            let scale = self.downscale.powi(octave as i32);
+            let survivors = distributed
+                .into_iter()
+                .map(|cand| OrbDebugCandidate {
+                    x: cand.col as f32 * scale,
+                    y: cand.row as f32 * scale,
+                    response: cand.response,
+                    octave,
+                    cell_row: cand.cell_row,
+                    cell_col: cand.cell_col,
+                    threshold_kind: cand.threshold_kind,
+                })
+                .collect();
+
+            octaves.push(OrbDebugOctave {
+                octave,
+                image_size: octave_image.size(),
+                raw_candidates: raw_debug_candidates,
+                candidates: debug_candidates,
+                survivors,
+            });
+        }
+
+        Ok(OrbDebugFrame { octaves })
     }
 
     fn extract_octave<A: ImageAllocator>(
@@ -451,35 +713,96 @@ impl OrbDetector {
     }
 }
 
-fn pyramid_reduce<A: ImageAllocator>(
-    img: &Image<f32, 1, A>,
-    downscale: f32,
+fn reflect101_pad<A: ImageAllocator>(
+    src: &Image<f32, 1, A>,
+    border: usize,
 ) -> Result<Image<f32, 1, CpuAllocator>, ImageError> {
-    // ORB-SLAM3 builds pyramid by resizing the previous level with bilinear interpolation.
-    // We apply a small Gaussian blur to reduce aliasing.
-    let sigma = 2.0 * downscale / 6.0;
-
-    let mut smoothed = Image::from_size_val(img.size(), 0.0, CpuAllocator)?;
-    gaussian_blur(img, &mut smoothed, (0, 0), (sigma, 0.0))?;
-
-    let new_h = (smoothed.height() as f32 / downscale).ceil() as usize;
-    let new_w = (smoothed.width() as f32 / downscale).ceil() as usize;
-
-    let mut resized = Image::from_size_val(
-        ImageSize {
-            width: new_w,
-            height: new_h,
+    let size = ImageSize {
+        width: src.width() + 2 * border,
+        height: src.height() + 2 * border,
+    };
+    let mut dst = Image::from_size_val(size, 0.0f32, CpuAllocator)?;
+    spatial_padding(
+        src,
+        &mut dst,
+        Padding2D {
+            top: border,
+            bottom: border,
+            left: border,
+            right: border,
         },
-        0.0,
-        CpuAllocator,
+        PaddingMode::Reflect101,
+        [0.0f32],
     )?;
-    resize_native(
-        &smoothed,
-        &mut resized,
-        crate::interpolation::InterpolationMode::Bilinear,
-    )?;
+    Ok(dst)
+}
 
-    Ok(resized)
+fn extract_subimage<A: ImageAllocator>(
+    src: &Image<f32, 1, A>,
+    top: usize,
+    left: usize,
+    height: usize,
+    width: usize,
+) -> Result<Image<f32, 1, CpuAllocator>, ImageError> {
+    let mut dst = Image::from_size_val(ImageSize { width, height }, 0.0f32, CpuAllocator)?;
+    for row in 0..height {
+        let src_row = top + row;
+        let dst_offset = row * width;
+        let src_offset = src_row * src.width() + left;
+        dst.as_slice_mut()[dst_offset..dst_offset + width]
+            .copy_from_slice(&src.as_slice()[src_offset..src_offset + width]);
+    }
+    Ok(dst)
+}
+
+fn resize_linear_pixel_center<A: ImageAllocator>(
+    src: &Image<f32, 1, A>,
+    dst: &mut Image<f32, 1, CpuAllocator>,
+) {
+    let src_w = src.width();
+    let src_h = src.height();
+    let dst_w = dst.width();
+    let dst_h = dst.height();
+
+    if src_w == dst_w && src_h == dst_h {
+        dst.as_slice_mut().copy_from_slice(src.as_slice());
+        return;
+    }
+
+    let sx_ratio = src_w as f32 / dst_w as f32;
+    let sy_ratio = src_h as f32 / dst_h as f32;
+    let sx_max = (src_w - 1) as i32;
+    let sy_max = (src_h - 1) as i32;
+
+    let src_slice = src.as_slice();
+    let dst_slice = dst.as_slice_mut();
+
+    for row in 0..dst_h {
+        let sy = (row as f32 + 0.5) * sy_ratio - 0.5;
+        let y0f = sy.floor();
+        let wy = sy - y0f;
+        let y0 = (y0f as i32).clamp(0, sy_max) as usize;
+        let y1 = ((y0f as i32) + 1).clamp(0, sy_max) as usize;
+        let row0 = y0 * src_w;
+        let row1 = y1 * src_w;
+
+        for col in 0..dst_w {
+            let sx = (col as f32 + 0.5) * sx_ratio - 0.5;
+            let x0f = sx.floor();
+            let wx = sx - x0f;
+            let x0 = (x0f as i32).clamp(0, sx_max) as usize;
+            let x1 = ((x0f as i32) + 1).clamp(0, sx_max) as usize;
+
+            let p00 = src_slice[row0 + x0];
+            let p01 = src_slice[row0 + x1];
+            let p10 = src_slice[row1 + x0];
+            let p11 = src_slice[row1 + x1];
+
+            let top = p00 + wx * (p01 - p00);
+            let bot = p10 + wx * (p11 - p10);
+            dst_slice[row * dst_w + col] = top + wy * (bot - top);
+        }
+    }
 }
 
 fn mask_border_keypoints(size: ImageSize, keypoints: &[[usize; 2]], distance: i32) -> Vec<bool> {
@@ -529,6 +852,7 @@ fn distribute_octree(
     }
     let h_x = width / n_ini as f32;
 
+    let mut next_node_id = 0usize;
     let mut nodes: Vec<ExtractorNode> = Vec::with_capacity(n_ini);
     for i in 0..n_ini {
         let ul = (min_x + (h_x * i as f32) as i32, min_y);
@@ -536,6 +860,7 @@ fn distribute_octree(
         let bl = (ul.0, max_y);
         let br = (ur.0, max_y);
         nodes.push(ExtractorNode {
+            id: alloc_node_id(&mut next_node_id),
             ul,
             ur,
             bl,
@@ -561,69 +886,71 @@ fn distribute_octree(
         }
     }
 
-    while nodes.len() < n_features {
-        let expandable: Vec<usize> = nodes
+    let mut finished = false;
+    while !finished {
+        let prev_size = nodes.len();
+        let mut n_to_expand = 0usize;
+        let mut size_and_node_ids: Vec<(usize, i32, usize)> = Vec::new();
+        let to_expand: Vec<usize> = nodes
             .iter()
-            .enumerate()
-            .filter(|(_, n)| !n.no_more && n.keys.len() > 1)
-            .map(|(i, _)| i)
+            .filter(|n| !n.no_more && n.keys.len() > 1)
+            .map(|n| n.id)
             .collect();
 
-        if expandable.is_empty() {
-            break;
+        for node_id in to_expand {
+            let Some(pos) = nodes.iter().position(|n| n.id == node_id) else {
+                continue;
+            };
+
+            let node = nodes.remove(pos);
+            let children = node.divide(candidates, &mut next_node_id);
+            for child in children {
+                if child.keys.is_empty() {
+                    continue;
+                }
+                if child.keys.len() > 1 {
+                    n_to_expand += 1;
+                    size_and_node_ids.push((child.keys.len(), child.ul.0, child.id));
+                }
+                nodes.insert(0, child);
+            }
         }
 
-        if nodes.len() + expandable.len() * 3 <= n_features {
-            let mut new_nodes = Vec::new();
-            let mut to_remove = Vec::new();
-            for idx in expandable {
-                let node = nodes[idx].clone();
-                let children = node.divide(candidates);
-                for mut child in children {
-                    if child.keys.is_empty() {
-                        continue;
-                    }
-                    child.no_more = child.keys.len() == 1;
-                    new_nodes.push(child);
-                }
-                to_remove.push(idx);
-            }
-            to_remove.sort_unstable_by(|a, b| b.cmp(a));
-            for idx in to_remove {
-                nodes.swap_remove(idx);
-            }
-            nodes.extend(new_nodes);
-        } else {
-            let mut expandable_sorted: Vec<(usize, usize)> = nodes
-                .iter()
-                .enumerate()
-                .filter(|(_, n)| !n.no_more && n.keys.len() > 1)
-                .map(|(i, n)| (i, n.keys.len()))
-                .collect();
-            expandable_sorted.sort_by_key(|(_, s)| *s);
+        if nodes.len() >= n_features || nodes.len() == prev_size {
+            finished = true;
+        } else if nodes.len() + n_to_expand * 3 > n_features {
+            while !finished {
+                let prev_size = nodes.len();
+                let mut prev = size_and_node_ids.clone();
+                size_and_node_ids.clear();
 
-            let mut new_nodes = Vec::new();
-            let mut to_remove = Vec::new();
-            for (idx, _) in expandable_sorted.into_iter().rev() {
-                let node = nodes[idx].clone();
-                let children = node.divide(candidates);
-                for mut child in children {
-                    if child.keys.is_empty() {
+                prev.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+                for (_, _, node_id) in prev.into_iter().rev() {
+                    let Some(pos) = nodes.iter().position(|n| n.id == node_id) else {
                         continue;
+                    };
+
+                    let node = nodes.remove(pos);
+                    let children = node.divide(candidates, &mut next_node_id);
+                    for child in children {
+                        if child.keys.is_empty() {
+                            continue;
+                        }
+                        if child.keys.len() > 1 {
+                            size_and_node_ids.push((child.keys.len(), child.ul.0, child.id));
+                        }
+                        nodes.insert(0, child);
                     }
-                    child.no_more = child.keys.len() == 1;
-                    new_nodes.push(child);
+
+                    if nodes.len() >= n_features {
+                        break;
+                    }
                 }
-                to_remove.push(idx);
-                if nodes.len() - to_remove.len() + new_nodes.len() >= n_features {
-                    break;
+
+                if nodes.len() >= n_features || nodes.len() == prev_size {
+                    finished = true;
                 }
             }
-            to_remove.sort_unstable_by(|a, b| b.cmp(a));
-            for idx in to_remove {
-                nodes.swap_remove(idx);
-            }
-            nodes.extend(new_nodes);
         }
     }
 
@@ -671,47 +998,78 @@ fn corner_orientations<A: ImageAllocator>(
     src: &Image<f32, 1, A>,
     corners: &[[usize; 2]],
 ) -> Vec<f32> {
-    const M_SIZE: usize = 31; // NOTE: This must be uneven
+    const HALF_PATCH_SIZE: i32 = 15;
     let src_slice = src.as_slice();
-
-    let mrows2 = (M_SIZE as i32 - 1) / 2;
-    let mcols2 = (M_SIZE as i32 - 1) / 2;
-    let radius2 = mrows2 * mrows2;
-
     let height = src.height() as i32;
     let width = src.width() as i32;
+    let umax = orb_umax();
 
     let mut orientations = Vec::with_capacity(corners.len());
 
     for &[r0, c0] in corners {
         let mut m01 = 0f32;
         let mut m10 = 0f32;
+        let row = r0 as i32;
+        let col = c0 as i32;
 
-        for r in 0..M_SIZE as i32 {
-            let mut m01_tmp = 0f32;
+        for u in -HALF_PATCH_SIZE..=HALF_PATCH_SIZE {
+            let rr = row;
+            let cc = col + u;
+            if rr >= 0 && rr < height && cc >= 0 && cc < width {
+                let curr = src_slice[src.size().index(rr as usize, cc as usize)];
+                m10 += u as f32 * curr;
+            }
+        }
 
-            for c in 0..M_SIZE as i32 {
-                let dr = r - mrows2;
-                let dc = c - mcols2;
-                if dr * dr + dc * dc > radius2 {
-                    continue;
-                }
-
-                let rr = r0 as i32 + dr;
-                let cc = c0 as i32 + dc;
-                if rr >= 0 && rr < height && cc >= 0 && cc < width {
-                    let curr_pixel = src_slice[src.size().index(rr as usize, cc as usize)];
-                    m10 += curr_pixel * dc as f32;
-                    m01_tmp += curr_pixel;
+        for v in 1..=HALF_PATCH_SIZE {
+            let mut v_sum = 0f32;
+            let d = umax[v as usize];
+            for u in -d..=d {
+                let rr_plus = row + v;
+                let rr_minus = row - v;
+                let cc = col + u;
+                if rr_plus >= 0
+                    && rr_plus < height
+                    && rr_minus >= 0
+                    && rr_minus < height
+                    && cc >= 0
+                    && cc < width
+                {
+                    let val_plus = src_slice[src.size().index(rr_plus as usize, cc as usize)];
+                    let val_minus = src_slice[src.size().index(rr_minus as usize, cc as usize)];
+                    v_sum += val_plus - val_minus;
+                    m10 += u as f32 * (val_plus + val_minus);
                 }
             }
-
-            m01 += m01_tmp * (r - mrows2) as f32;
+            m01 += v as f32 * v_sum;
         }
         orientations.push(m01.atan2(m10));
     }
 
     orientations
+}
+
+fn orb_umax() -> [i32; 16] {
+    const HALF_PATCH_SIZE: i32 = 15;
+    let mut umax = [0i32; 16];
+    let vmax = ((HALF_PATCH_SIZE as f32) * std::f32::consts::SQRT_2 / 2.0 + 1.0).floor() as i32;
+    let vmin = ((HALF_PATCH_SIZE as f32) * std::f32::consts::SQRT_2 / 2.0).ceil() as i32;
+    let hp2 = (HALF_PATCH_SIZE * HALF_PATCH_SIZE) as f32;
+
+    for v in 0..=vmax {
+        umax[v as usize] = (hp2 - (v * v) as f32).sqrt().round() as i32;
+    }
+
+    let mut v0 = 0;
+    for v in (vmin..=HALF_PATCH_SIZE).rev() {
+        while umax[v0 as usize] == umax[(v0 + 1) as usize] {
+            v0 += 1;
+        }
+        umax[v as usize] = v0;
+        v0 += 1;
+    }
+
+    umax
 }
 
 /// Compute ORB descriptors packed into 32 bytes (256 bits) per keypoint.

--- a/crates/kornia-imgproc/src/features/orb/mod.rs
+++ b/crates/kornia-imgproc/src/features/orb/mod.rs
@@ -2,7 +2,10 @@ mod extractor;
 mod matcher;
 mod pattern;
 
-pub use extractor::{OrbDetector, OrbFeatures};
+pub use extractor::{
+    OrbDebugCandidate, OrbDebugFrame, OrbDebugOctave, OrbDebugThresholdKind, OrbDetector,
+    OrbFeatures,
+};
 pub use matcher::{match_orb_descriptors, OrbMatchConfig};
 
 #[cfg(all(test, feature = "opencv_bench"))]


### PR DESCRIPTION
## Context

These changes are the upstream library half of a module-by-module effort to match ORB-SLAM3's monocular SLAM output on EuRoC MH_01_easy. The SLAM-side orchestration lives in `kornia-slam`; this PR contains the low-level fixes that `kornia-slam` depends on.

## FAST detector (`kornia-imgproc`)

Three independent bugs were causing kornia's raw FAST output to be a strict subset of OpenCV FAST on the same image:

**1. Invalid 4-point speed test** — `compute_corner_response` checked ring positions `{0, 4, 8, 12}` and required ≥3 brighter or darker before running the full arc check. This gate is not valid for FAST-9: a legal 9-pixel arc can pass through only 2 of those 4 cardinal positions, so real corners were being silently dropped. Removing the gate brought raw overlap from ~67% to ~100% of OpenCV's output on a single EuRoC frame.

**2. Wrong FAST score** — the old score summed absolute differences over all 16 ring pixels once an arc was found. Replaced with the threshold-margin score: maximum over all valid arcs of the minimum per-pixel contrast in that arc. This matches OpenCV's FAST ranking, which determines which corner survives NMS when two are adjacent.

**3. No real NMS** — `get_peak_mask` only checked `response > threshold`. Added strict 3×3 local maximum check, matching `cv::FAST(..., nonmax_suppression=true)`.

Together these bring kornia's FAST output to bit-exact overlap with OpenCV FAST on the tested frames.

## ORB extractor (`kornia-imgproc`)

Fixes to match ORB-SLAM3's `ORBextractor`:

- **Pyramid size rounding**: level sizes now computed from original dimensions as `round(orig × invScale^L)` instead of iterative `ceil(prev / scale)` — eliminates 1–3px drift per level past L=2
- **Pixel-center bilinear resize**: replaces `pyramid_reduce` (which applied a σ=0.4 pre-blur); matches OpenCV `INTER_LINEAR` pixel-center sampling convention
- **`DistributeOctTree` split geometry**: `ExtractorNode::divide` now uses `ceil((width)/2)` / `ceil((height)/2)` half-extents matching ORB-SLAM3's C++ implementation
- **Stable node IDs**: required for the correct fixed-snapshot outer-pass logic (without this, freshly inserted child nodes were re-expanded in the same pass, causing a major regression)
- **Debug types** (`OrbDebugFrame/Octave/Candidate`): expose per-octave raw/NMS/survivor candidates for the parity harness without affecting production paths

End-to-end Module 1 result after all fixes: **~92% spatial match rate vs ORB-SLAM3** (1px), same-octave agreement 90%, median Hamming 2–3, median |Δθ| 0.02°.

## Two-view reconstruction (`kornia-3d`)

- **`check_rt()`**: port of `TwoViewReconstruction::CheckRT` — DLT triangulation in normalized coordinates, cheirality check with points-at-infinity allowance (`cosParallax ≥ 0.99998`), per-point pixel-space reprojection gate, and parallax reported at sorted index `min(50, N-1)`. Opt-in via `use_orb_slam3_check_rt` config flag.
- **`TwoViewDiagnostics`** + **`two_view_estimate_with_diagnostics()`**: per-candidate `ngood` counts, best/second-best indices, and representative parallax — used by `kornia-slam`'s trace writer for numerical comparison against ORB-SLAM3.

## BoW vocabulary loader (`kornia-bow`)

New `orb_slam3` module:
- `load_orb_slam3_vocabulary()`: parses ORB-SLAM3's `ORBvoc.txt` (DBoW2 plain-text format) into `kornia-bow`'s `Vocabulary` layout
- `pack_orb_descriptor()`: packs a 32-byte ORB descriptor into 4×`u64` little-endian words for querying against the loaded vocabulary

This is the prerequisite for BoW-accelerated matching paths in `kornia-slam` (loop closure, `SearchForTriangulation`, relocalisation).