### PR TITLE
feat(io,py): in-memory PNG encoders + PIL-style Image with uint16 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,14 +248,54 @@ img: np.ndarray = K.read_image_jpeg("dog.jpeg")
 K.write_image_jpeg("dog_copy.jpeg", img)
 ```
 
-### Encoding and Decoding
+### `Image` — PIL-style class with uint8 + uint16 support
 
-Encode or decode image streams using the `turbojpeg` backend:
+`kornia_rs.image.Image` is the recommended high-level API for image I/O,
+encode/decode and transit. It mirrors the parts of PIL most projects use
+(`fromarray`, `save`, `open`-equivalent `load`, `decode`) and natively
+holds **`uint16`** for depth maps and scientific imagery — JPEG would
+corrupt object-edge discontinuities, so 16-bit data must travel through
+lossless PNG-16:
+
+```python
+import io
+import numpy as np
+from kornia_rs.image import Image
+
+# Wrap a numpy array (zero-copy when contiguous). Bit depth is auto-detected.
+rgb   = np.random.randint(0, 255, (480, 640, 3), dtype=np.uint8)
+depth = np.full((480, 640), 1500, dtype=np.uint16)            # mm
+
+rgb_img   = Image.fromarray(rgb)         # mode="RGB",  dtype=uint8
+depth_img = Image.fromarray(depth)       # mode="I;16", dtype=uint16
+
+# Encode to bytes for transit (Zenoh / MCAP / gRPC) — no temp file.
+jpeg_bytes  = rgb_img.encode("jpeg", quality=90)
+png16_bytes = depth_img.encode("png")    # PNG-16, lossless on uint16
+
+# Or save through PIL's file-or-file-like contract.
+buf = io.BytesIO()
+depth_img.save(buf, format="png")        # in-memory
+rgb_img.save("dog.png")                  # to disk (format from extension)
+
+# Decode the other side: PNG IHDR is peeked to choose uint8 vs uint16.
+back = Image.decode(png16_bytes, mode="L")
+assert back.dtype == np.uint16
+assert np.array_equal(np.array(back).reshape(480, 640), depth)
+```
+
+JPEG-on-uint16 raises `ValueError` rather than silently downcasting; 8-bit-only
+imgproc methods (`resize`, `flip_*`, `adjust_*`, `to_grayscale`, …) raise
+`NotImplementedError` on a uint16 Image with a clear remediation hint.
+
+### Encoding and Decoding (legacy, jpeg-only)
+
+The original `ImageEncoder`/`ImageDecoder` pair is still available for
+JPEG-only workflows that want the explicit `turbojpeg` backend object:
 
 ```python
 import kornia_rs as K
 
-# load image with kornia-rs
 img = K.read_image_jpeg("dog.jpeg")
 
 # encode the image with jpeg
@@ -267,9 +307,11 @@ img_encoded: list[int] = image_encoder.encode(img)
 
 # decode back the image
 image_decoder = K.ImageDecoder()
-
 decoded_img: np.ndarray = image_decoder.decode(bytes(img_encoded))
 ```
+
+For new code, prefer the `Image` class above — it covers PNG (incl.
+PNG-16), JPEG, and file-like targets in one consistent surface.
 
 ### Image Resizing
 

--- a/README.md
+++ b/README.md
@@ -250,43 +250,33 @@ K.write_image_jpeg("dog_copy.jpeg", img)
 
 ### `Image` — PIL-style class with uint8 + uint16 support
 
-`kornia_rs.image.Image` is the recommended high-level API for image I/O,
-encode/decode and transit. It mirrors the parts of PIL most projects use
-(`fromarray`, `save`, `open`-equivalent `load`, `decode`) and natively
-holds **`uint16`** for depth maps and scientific imagery — JPEG would
-corrupt object-edge discontinuities, so 16-bit data must travel through
-lossless PNG-16:
+`kornia_rs.image.Image` mirrors PIL's `fromarray` / `save` / `load` / `decode`
+and natively holds **`uint16`** for depth maps and scientific imagery
+(lossless via PNG-16):
 
 ```python
 import io
 import numpy as np
 from kornia_rs.image import Image
 
-# Wrap a numpy array (zero-copy when contiguous). Bit depth is auto-detected.
+# Bit depth is auto-detected from the numpy dtype.
 rgb   = np.random.randint(0, 255, (480, 640, 3), dtype=np.uint8)
 depth = np.full((480, 640), 1500, dtype=np.uint16)            # mm
 
-rgb_img   = Image.fromarray(rgb)         # mode="RGB",  dtype=uint8
-depth_img = Image.fromarray(depth)       # mode="I;16", dtype=uint16
+rgb_img   = Image.fromarray(rgb)
+depth_img = Image.fromarray(depth)
 
-# Encode to bytes for transit (Zenoh / MCAP / gRPC) — no temp file.
-jpeg_bytes  = rgb_img.encode("jpeg", quality=90)
-png16_bytes = depth_img.encode("png")    # PNG-16, lossless on uint16
+# In-memory encode for transit (Zenoh / MCAP / gRPC).
+png16_bytes = depth_img.encode("png")    # lossless on uint16
 
-# Or save through PIL's file-or-file-like contract.
-buf = io.BytesIO()
-depth_img.save(buf, format="png")        # in-memory
-rgb_img.save("dog.png")                  # to disk (format from extension)
+# Save to disk (format from extension), or to any file-like (PIL parity).
+rgb_img.save("dog.png")
+buf = io.BytesIO(); rgb_img.save(buf, format="jpeg")
 
-# Decode the other side: PNG IHDR is peeked to choose uint8 vs uint16.
+# Decode auto-detects bit depth from the file header.
 back = Image.decode(png16_bytes, mode="L")
 assert back.dtype == np.uint16
-assert np.array_equal(np.array(back).reshape(480, 640), depth)
 ```
-
-JPEG-on-uint16 raises `ValueError` rather than silently downcasting; 8-bit-only
-imgproc methods (`resize`, `flip_*`, `adjust_*`, `to_grayscale`, …) raise
-`NotImplementedError` on a uint16 Image with a clear remediation hint.
 
 ### Encoding and Decoding (legacy, jpeg-only)
 
@@ -298,20 +288,13 @@ import kornia_rs as K
 
 img = K.read_image_jpeg("dog.jpeg")
 
-# encode the image with jpeg
 image_encoder = K.ImageEncoder()
-image_encoder.set_quality(95)  # set the encoding quality
-
-# get the encoded stream
+image_encoder.set_quality(95)
 img_encoded: list[int] = image_encoder.encode(img)
 
-# decode back the image
 image_decoder = K.ImageDecoder()
 decoded_img: np.ndarray = image_decoder.decode(bytes(img_encoded))
 ```
-
-For new code, prefer the `Image` class above — it covers PNG (incl.
-PNG-16), JPEG, and file-like targets in one consistent surface.
 
 ### Image Resizing
 

--- a/crates/kornia-io/README.md
+++ b/crates/kornia-io/README.md
@@ -13,6 +13,7 @@
 ## 🔑 Key Features
 
 *   **Image I/O:** Read and write support for JPEG, PNG, and TIFF formats.
+*   **In-memory encode + decode:** Symmetric `encode_image_{jpeg,png}_*` ↔ `decode_image_{jpeg,png}_*` for round-tripping pixels through `Vec<u8>` without touching disk — including lossless PNG-16 (`encode_image_png_gray16`) for depth maps.
 *   **TurboJPEG Support:** Optional integration with `turbojpeg` for high-performance JPEG encoding and decoding.
 *   **Video Capture (GStreamer):** Access generic video streams (files, IP cameras, webcams) via GStreamer integration.
 *   **Camera Access (V4L2):** Direct low-latency access to V4L2 devices on Linux.

--- a/crates/kornia-io/src/png.rs
+++ b/crates/kornia-io/src/png.rs
@@ -11,7 +11,7 @@ use png::{BitDepth, ColorType, Decoder, Encoder};
 use std::{
     fs,
     fs::File,
-    io::{BufReader, Cursor},
+    io::{BufReader, Cursor, Write},
     path::Path,
 };
 
@@ -432,17 +432,20 @@ pub fn write_image_png_gray16<A: ImageAllocator>(
     )
 }
 
-fn write_png_impl(
-    file_path: impl AsRef<Path>,
+/// Writes PNG-encoded image data into any `Write` target — used by both the
+/// file-path `write_image_png_*` API and the in-memory `encode_image_png_*` API.
+///
+/// Callers are responsible for matching `depth`/`color_type` to the layout of
+/// `image_data` (e.g. 16-bit data must be passed as big-endian byte pairs and
+/// `BitDepth::Sixteen`).
+fn write_png_into<W: Write>(
+    writer: W,
     image_data: &[u8],
     image_size: ImageSize,
-    // Make sure you set `depth` correctly
     depth: BitDepth,
     color_type: ColorType,
 ) -> Result<(), IoError> {
-    let file = File::create(file_path)?;
-
-    let mut encoder = Encoder::new(file, image_size.width as u32, image_size.height as u32);
+    let mut encoder = Encoder::new(writer, image_size.width as u32, image_size.height as u32);
     encoder.set_color(color_type);
     encoder.set_depth(depth);
 
@@ -453,6 +456,128 @@ fn write_png_impl(
         .write_image_data(image_data)
         .map_err(|e| IoError::PngEncodingError(e.to_string()))?;
     Ok(())
+}
+
+fn write_png_impl(
+    file_path: impl AsRef<Path>,
+    image_data: &[u8],
+    image_size: ImageSize,
+    depth: BitDepth,
+    color_type: ColorType,
+) -> Result<(), IoError> {
+    let file = File::create(file_path)?;
+    write_png_into(file, image_data, image_size, depth, color_type)
+}
+
+// ----------------------------------------------------------------------
+// In-memory encode (returns PNG bytes via a caller-owned `Vec<u8>`)
+// ----------------------------------------------------------------------
+//
+// The buffer-based signature mirrors `encode_image_jpeg_*` in `jpeg.rs` and
+// lets callers reuse a single allocation across many encodes (e.g. a streaming
+// recorder doing one encode per frame).
+//
+// 16-bit variants serialize the source `&[u16]` to big-endian byte pairs (the
+// PNG spec's wire format) — same conversion as the file-path 16-bit writers.
+
+/// Encodes an RGB8 image as PNG bytes into `buffer`.
+///
+/// # Arguments
+///
+/// - `image` - The Rgb8 image to encode.
+/// - `buffer` - Destination buffer. Encoded data is appended (call
+///   `buffer.clear()` first if you want to reuse the buffer fresh).
+pub fn encode_image_png_rgb8<A: ImageAllocator>(
+    image: &Image<u8, 3, A>,
+    buffer: &mut Vec<u8>,
+) -> Result<(), IoError> {
+    write_png_into(
+        buffer,
+        image.as_slice(),
+        image.size(),
+        BitDepth::Eight,
+        ColorType::Rgb,
+    )
+}
+
+/// Encodes an RGBA8 image as PNG bytes into `buffer`.
+pub fn encode_image_png_rgba8<A: ImageAllocator>(
+    image: &Image<u8, 4, A>,
+    buffer: &mut Vec<u8>,
+) -> Result<(), IoError> {
+    write_png_into(
+        buffer,
+        image.as_slice(),
+        image.size(),
+        BitDepth::Eight,
+        ColorType::Rgba,
+    )
+}
+
+/// Encodes a grayscale 8-bit image as PNG bytes into `buffer`.
+pub fn encode_image_png_gray8<A: ImageAllocator>(
+    image: &Image<u8, 1, A>,
+    buffer: &mut Vec<u8>,
+) -> Result<(), IoError> {
+    write_png_into(
+        buffer,
+        image.as_slice(),
+        image.size(),
+        BitDepth::Eight,
+        ColorType::Grayscale,
+    )
+}
+
+/// Encodes an RGB16 image as PNG bytes into `buffer`.
+pub fn encode_image_png_rgb16<A: ImageAllocator>(
+    image: &Image<u16, 3, A>,
+    buffer: &mut Vec<u8>,
+) -> Result<(), IoError> {
+    let image_size = image.size();
+    let image_buf = convert_buf_u16_u8(image.as_slice());
+    write_png_into(
+        buffer,
+        &image_buf,
+        image_size,
+        BitDepth::Sixteen,
+        ColorType::Rgb,
+    )
+}
+
+/// Encodes an RGBA16 image as PNG bytes into `buffer`.
+pub fn encode_image_png_rgba16<A: ImageAllocator>(
+    image: &Image<u16, 4, A>,
+    buffer: &mut Vec<u8>,
+) -> Result<(), IoError> {
+    let image_size = image.size();
+    let image_buf = convert_buf_u16_u8(image.as_slice());
+    write_png_into(
+        buffer,
+        &image_buf,
+        image_size,
+        BitDepth::Sixteen,
+        ColorType::Rgba,
+    )
+}
+
+/// Encodes a grayscale 16-bit image as PNG bytes into `buffer`.
+///
+/// This is the variant used for depth recording: PNG-16 is lossless on the
+/// uint16 mm values, and works in-memory so the bytes go straight to the wire
+/// (Zenoh / MCAP) without a temporary file.
+pub fn encode_image_png_gray16<A: ImageAllocator>(
+    image: &Image<u16, 1, A>,
+    buffer: &mut Vec<u8>,
+) -> Result<(), IoError> {
+    let image_size = image.size();
+    let image_buf = convert_buf_u16_u8(image.as_slice());
+    write_png_into(
+        buffer,
+        &image_buf,
+        image_size,
+        BitDepth::Sixteen,
+        ColorType::Grayscale,
+    )
 }
 
 #[cfg(test)]
@@ -517,6 +642,121 @@ mod tests {
         assert_eq!(image.rows(), 195);
         assert_eq!(image.num_channels(), 3);
 
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------
+    // In-memory encode round-trips: encode → decode equals the source.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn encode_decode_png_rgb8_roundtrip() -> Result<(), IoError> {
+        let src = read_image_png_rgb8("../../tests/data/dog-rgb8.png")?;
+        let mut buffer = Vec::new();
+        encode_image_png_rgb8(&src, &mut buffer)?;
+        assert!(!buffer.is_empty());
+        // PNG magic header
+        assert_eq!(&buffer[..8], b"\x89PNG\r\n\x1a\n");
+
+        let mut decoded = Rgb8::from_size_val(src.size(), 0, CpuAllocator)?;
+        decode_image_png_rgb8(&buffer, &mut decoded)?;
+        assert_eq!(decoded.size(), src.size());
+        assert_eq!(decoded.as_slice(), src.as_slice());
+        Ok(())
+    }
+
+    #[test]
+    fn encode_decode_png_rgba8_roundtrip() -> Result<(), IoError> {
+        // Synthesize an RGBA8 image (no fixture in tests/data for this layout).
+        let mut data = vec![0u8; 16 * 16 * 4];
+        for (i, b) in data.iter_mut().enumerate() {
+            *b = (i % 251) as u8;
+        }
+        let src = Rgba8::from_size_vec([16, 16].into(), data, CpuAllocator)?;
+
+        let mut buffer = Vec::new();
+        encode_image_png_rgba8(&src, &mut buffer)?;
+        assert_eq!(&buffer[..8], b"\x89PNG\r\n\x1a\n");
+
+        let mut decoded = Rgba8::from_size_val(src.size(), 0, CpuAllocator)?;
+        decode_image_png_rgba8(&buffer, &mut decoded)?;
+        assert_eq!(decoded.as_slice(), src.as_slice());
+        Ok(())
+    }
+
+    #[test]
+    fn encode_decode_png_gray8_roundtrip() -> Result<(), IoError> {
+        let src = read_image_png_mono8("../../tests/data/dog.png")?;
+        let mut buffer = Vec::new();
+        encode_image_png_gray8(&src, &mut buffer)?;
+        assert_eq!(&buffer[..8], b"\x89PNG\r\n\x1a\n");
+
+        let mut decoded = Gray8::from_size_val(src.size(), 0, CpuAllocator)?;
+        decode_image_png_mono8(&buffer, &mut decoded)?;
+        assert_eq!(decoded.as_slice(), src.as_slice());
+        Ok(())
+    }
+
+    #[test]
+    fn encode_decode_png_rgb16_roundtrip() -> Result<(), IoError> {
+        let src = read_image_png_rgb16("../../tests/data/rgb16.png")?;
+        let mut buffer = Vec::new();
+        encode_image_png_rgb16(&src, &mut buffer)?;
+        assert_eq!(&buffer[..8], b"\x89PNG\r\n\x1a\n");
+
+        let mut decoded = Rgb16::from_size_val(src.size(), 0, CpuAllocator)?;
+        decode_image_png_rgb16(&buffer, &mut decoded)?;
+        assert_eq!(decoded.as_slice(), src.as_slice());
+        Ok(())
+    }
+
+    #[test]
+    fn encode_decode_png_gray16_roundtrip() -> Result<(), IoError> {
+        // Depth-style synthetic data: smooth gradient + a sharp object, in mm.
+        let (w, h) = (64usize, 48usize);
+        let mut data = vec![0u16; w * h];
+        for y in 0..h {
+            for x in 0..w {
+                data[y * w + x] = 1000 + (x as u16) * 8 + (y as u16) * 4;
+            }
+        }
+        // Object discontinuity — the kind of edge that JPEG would smear.
+        for y in 10..20 {
+            for x in 20..40 {
+                data[y * w + x] = 500;
+            }
+        }
+        let src = Gray16::from_size_vec([w, h].into(), data, CpuAllocator)?;
+
+        let mut buffer = Vec::new();
+        encode_image_png_gray16(&src, &mut buffer)?;
+        assert_eq!(&buffer[..8], b"\x89PNG\r\n\x1a\n");
+        // Lossless u16 round-trip is the whole point of this codec for depth.
+        let mut decoded = Gray16::from_size_val(src.size(), 0, CpuAllocator)?;
+        decode_image_png_mono16(&buffer, &mut decoded)?;
+        assert_eq!(decoded.as_slice(), src.as_slice());
+        Ok(())
+    }
+
+    #[test]
+    fn encode_png_buffer_reuse() -> Result<(), IoError> {
+        // A streaming caller (e.g. a recorder) reuses one buffer across many
+        // encodes — verify two back-to-back encodes into the same Vec produce
+        // independently-decodable PNGs after `clear()`.
+        let src = read_image_png_rgb8("../../tests/data/dog-rgb8.png")?;
+        let mut buffer = Vec::with_capacity(64 * 1024);
+
+        encode_image_png_rgb8(&src, &mut buffer)?;
+        let cap_after_first = buffer.capacity();
+
+        buffer.clear();
+        encode_image_png_rgb8(&src, &mut buffer)?;
+
+        // Capacity should not have grown on the second encode (allocation reuse).
+        assert!(buffer.capacity() <= cap_after_first.max(buffer.len()));
+        let mut decoded = Rgb8::from_size_val(src.size(), 0, CpuAllocator)?;
+        decode_image_png_rgb8(&buffer, &mut decoded)?;
+        assert_eq!(decoded.as_slice(), src.as_slice());
         Ok(())
     }
 }

--- a/crates/kornia-io/src/png.rs
+++ b/crates/kornia-io/src/png.rs
@@ -469,16 +469,9 @@ fn write_png_impl(
     write_png_into(file, image_data, image_size, depth, color_type)
 }
 
-// ----------------------------------------------------------------------
-// In-memory encode (returns PNG bytes via a caller-owned `Vec<u8>`)
-// ----------------------------------------------------------------------
-//
-// The buffer-based signature mirrors `encode_image_jpeg_*` in `jpeg.rs` and
-// lets callers reuse a single allocation across many encodes (e.g. a streaming
-// recorder doing one encode per frame).
-//
-// 16-bit variants serialize the source `&[u16]` to big-endian byte pairs (the
-// PNG spec's wire format) — same conversion as the file-path 16-bit writers.
+// In-memory encoders. Buffer is appended to (caller clears for fresh encode,
+// or reuses the allocation across frames). 16-bit variants serialize `&[u16]`
+// to big-endian byte pairs as required by the PNG wire format.
 
 /// Encodes an RGB8 image as PNG bytes into `buffer`.
 ///
@@ -491,6 +484,7 @@ pub fn encode_image_png_rgb8<A: ImageAllocator>(
     image: &Image<u8, 3, A>,
     buffer: &mut Vec<u8>,
 ) -> Result<(), IoError> {
+    buffer.reserve(image.as_slice().len() / 2);
     write_png_into(
         buffer,
         image.as_slice(),
@@ -505,6 +499,7 @@ pub fn encode_image_png_rgba8<A: ImageAllocator>(
     image: &Image<u8, 4, A>,
     buffer: &mut Vec<u8>,
 ) -> Result<(), IoError> {
+    buffer.reserve(image.as_slice().len() / 2);
     write_png_into(
         buffer,
         image.as_slice(),
@@ -519,6 +514,7 @@ pub fn encode_image_png_gray8<A: ImageAllocator>(
     image: &Image<u8, 1, A>,
     buffer: &mut Vec<u8>,
 ) -> Result<(), IoError> {
+    buffer.reserve(image.as_slice().len() / 2);
     write_png_into(
         buffer,
         image.as_slice(),
@@ -535,6 +531,7 @@ pub fn encode_image_png_rgb16<A: ImageAllocator>(
 ) -> Result<(), IoError> {
     let image_size = image.size();
     let image_buf = convert_buf_u16_u8(image.as_slice());
+    buffer.reserve(image_buf.len() / 2);
     write_png_into(
         buffer,
         &image_buf,
@@ -551,6 +548,7 @@ pub fn encode_image_png_rgba16<A: ImageAllocator>(
 ) -> Result<(), IoError> {
     let image_size = image.size();
     let image_buf = convert_buf_u16_u8(image.as_slice());
+    buffer.reserve(image_buf.len() / 2);
     write_png_into(
         buffer,
         &image_buf,
@@ -561,16 +559,13 @@ pub fn encode_image_png_rgba16<A: ImageAllocator>(
 }
 
 /// Encodes a grayscale 16-bit image as PNG bytes into `buffer`.
-///
-/// This is the variant used for depth recording: PNG-16 is lossless on the
-/// uint16 mm values, and works in-memory so the bytes go straight to the wire
-/// (Zenoh / MCAP) without a temporary file.
 pub fn encode_image_png_gray16<A: ImageAllocator>(
     image: &Image<u16, 1, A>,
     buffer: &mut Vec<u8>,
 ) -> Result<(), IoError> {
     let image_size = image.size();
     let image_buf = convert_buf_u16_u8(image.as_slice());
+    buffer.reserve(image_buf.len() / 2);
     write_png_into(
         buffer,
         &image_buf,

--- a/kornia-py/src/augmentations.rs
+++ b/kornia-py/src/augmentations.rs
@@ -1,4 +1,4 @@
-use numpy::{PyArray, PyArrayMethods};
+use numpy::{PyArray, PyArray3, PyArrayMethods};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use rand::prelude::*;
@@ -484,8 +484,15 @@ impl PyColorJitter {
 
         self.last_params = Some(Self::params_to_dict(py, b, c, s, h, &order)?);
 
-        let arr = img.data(py);
-        let bound = arr.bind(py);
+        // ColorJitter operates on u8 pixels; extract the typed array
+        // (errors on a uint16 Image — those don't go through this op).
+        let arr_any = img.data(py);
+        let typed: Py<PyArray3<u8>> = arr_any.extract(py).map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyNotImplementedError, _>(
+                "ColorJitter requires a uint8 Image; got uint16",
+            )
+        })?;
+        let bound = typed.bind(py);
         let (src, height, width, channels) = pyarray_data(bound);
         let npixels = height * width;
         let order_f32: Vec<(u8, f32)> = order.iter().map(|&(op, v)| (op, v as f32)).collect();
@@ -628,11 +635,9 @@ impl PyRandomHorizontalFlip {
         if flip {
             img.flip_horizontal(py)
         } else {
-            Ok(PyImageApi::wrap(
-                py,
-                img.data(py),
-                Some(img.mode().to_string()),
-            ))
+            // Pass-through: deep-copy preserves the dtype variant (u8/u16)
+            // through the Image enum without us hand-dispatching here.
+            img.copy(py)
         }
     }
 
@@ -690,11 +695,8 @@ impl PyRandomVerticalFlip {
         if flip {
             img.flip_vertical(py)
         } else {
-            Ok(PyImageApi::wrap(
-                py,
-                img.data(py),
-                Some(img.mode().to_string()),
-            ))
+            // Pass-through deep copy — preserves dtype variant.
+            img.copy(py)
         }
     }
 

--- a/kornia-py/src/augmentations.rs
+++ b/kornia-py/src/augmentations.rs
@@ -615,9 +615,9 @@ impl PyRandomHorizontalFlip {
     fn __call__(
         &mut self,
         py: Python<'_>,
-        img: PyRef<'_, PyImageApi>,
+        img: Py<PyImageApi>,
         params: Option<&Bound<'_, PyDict>>,
-    ) -> PyResult<PyImageApi> {
+    ) -> PyResult<Py<PyImageApi>> {
         let flip = match params {
             Some(p) => dict_get::<bool>(p, "flip")?,
             None => with_rng(|rng| rng.random::<f64>() < self.p),
@@ -625,13 +625,11 @@ impl PyRandomHorizontalFlip {
 
         self.last_params = Some(dict_single(py, "flip", flip)?);
 
-        if flip {
-            img.flip_horizontal(py)
-        } else {
-            // Pass-through: deep-copy preserves the dtype variant (u8/u16)
-            // through the Image enum without us hand-dispatching here.
-            img.copy(py)
+        if !flip {
+            return Ok(img);
         }
+        let flipped = img.borrow(py).flip_horizontal(py)?;
+        Py::new(py, flipped)
     }
 
     fn __repr__(&self) -> String {
@@ -675,9 +673,9 @@ impl PyRandomVerticalFlip {
     fn __call__(
         &mut self,
         py: Python<'_>,
-        img: PyRef<'_, PyImageApi>,
+        img: Py<PyImageApi>,
         params: Option<&Bound<'_, PyDict>>,
-    ) -> PyResult<PyImageApi> {
+    ) -> PyResult<Py<PyImageApi>> {
         let flip = match params {
             Some(p) => dict_get::<bool>(p, "flip")?,
             None => with_rng(|rng| rng.random::<f64>() < self.p),
@@ -685,12 +683,11 @@ impl PyRandomVerticalFlip {
 
         self.last_params = Some(dict_single(py, "flip", flip)?);
 
-        if flip {
-            img.flip_vertical(py)
-        } else {
-            // Pass-through deep copy — preserves dtype variant.
-            img.copy(py)
+        if !flip {
+            return Ok(img);
         }
+        let flipped = img.borrow(py).flip_vertical(py)?;
+        Py::new(py, flipped)
     }
 
     fn __repr__(&self) -> String {

--- a/kornia-py/src/augmentations.rs
+++ b/kornia-py/src/augmentations.rs
@@ -1,4 +1,4 @@
-use numpy::{PyArray, PyArray3, PyArrayMethods};
+use numpy::{PyArray, PyArrayMethods};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use rand::prelude::*;
@@ -484,14 +484,7 @@ impl PyColorJitter {
 
         self.last_params = Some(Self::params_to_dict(py, b, c, s, h, &order)?);
 
-        // ColorJitter operates on u8 pixels; extract the typed array
-        // (errors on a uint16 Image — those don't go through this op).
-        let arr_any = img.data(py);
-        let typed: Py<PyArray3<u8>> = arr_any.extract(py).map_err(|_| {
-            PyErr::new::<pyo3::exceptions::PyNotImplementedError, _>(
-                "ColorJitter requires a uint8 Image; got uint16",
-            )
-        })?;
+        let typed = img.require_u8("ColorJitter")?;
         let bound = typed.bind(py);
         let (src, height, width, channels) = pyarray_data(bound);
         let npixels = height * width;

--- a/kornia-py/src/image.rs
+++ b/kornia-py/src/image.rs
@@ -258,7 +258,12 @@ impl From<PyPixelFormat> for PixelFormat {
 /// * `image_size` - The dimensions of the image.
 /// * `channels` - The number of channels (e.g., 3 for RGB).
 /// * `pixel_format` - The data type of the pixels.
-#[pyclass(name = "ImageLayout", frozen, from_py_object, module = "kornia_rs.image")]
+#[pyclass(
+    name = "ImageLayout",
+    frozen,
+    from_py_object,
+    module = "kornia_rs.image"
+)]
 #[derive(Clone)]
 pub struct PyImageLayout {
     inner: ImageLayout,
@@ -726,22 +731,15 @@ fn adjust_hue_into_pyarray(
     }
 }
 
-fn mode_from_channels(channels: usize) -> String {
+/// PIL-style mode string. u16 paths get the `;16` suffix (with `I` instead
+/// of `L` for single-channel, mirroring PIL's `"I;16"`).
+fn mode_from_channels(channels: usize, is_u16: bool) -> String {
+    let (gray, suffix) = if is_u16 { ("I", ";16") } else { ("L", "") };
     match channels {
-        1 => "L".to_string(),
-        3 => "RGB".to_string(),
-        4 => "RGBA".to_string(),
-        c => format!("{}ch", c),
-    }
-}
-
-/// PIL-style mode for a 16-bit grayscale image. Mirrors PIL's `"I;16"`.
-fn mode_from_channels_u16(channels: usize) -> String {
-    match channels {
-        1 => "I;16".to_string(),
-        3 => "RGB;16".to_string(),
-        4 => "RGBA;16".to_string(),
-        c => format!("{}ch;16", c),
+        1 => format!("{}{}", gray, suffix),
+        3 => format!("RGB{}", suffix),
+        4 => format!("RGBA{}", suffix),
+        c => format!("{}ch{}", c, suffix),
     }
 }
 
@@ -795,6 +793,31 @@ impl ImageData {
     fn is_u16(&self) -> bool {
         matches!(self, ImageData::U16(_))
     }
+
+    /// Bumps the underlying numpy array's refcount and returns it as `Py<PyAny>`.
+    /// Drives `data` getter, `__array__`, `__getstate__`, `__reduce__`.
+    fn as_pyany(&self, py: Python<'_>) -> Py<PyAny> {
+        match self {
+            ImageData::U8(a) => a.clone_ref(py).into_any(),
+            ImageData::U16(a) => a.clone_ref(py).into_any(),
+        }
+    }
+
+    /// numpy dtype descriptor for the variant — drives the `dtype` getter.
+    fn dtype_obj(&self, py: Python<'_>) -> Py<PyAny> {
+        match self {
+            ImageData::U8(a) => a.bind(py).dtype().clone().unbind().into_any(),
+            ImageData::U16(a) => a.bind(py).dtype().clone().unbind().into_any(),
+        }
+    }
+
+    /// Raw `*mut PyObject` for the buffer protocol.
+    fn as_ptr(&self, py: Python<'_>) -> *mut pyo3::ffi::PyObject {
+        match self {
+            ImageData::U8(a) => a.bind(py).as_ptr(),
+            ImageData::U16(a) => a.bind(py).as_ptr(),
+        }
+    }
 }
 
 /// A high-level image object backed by numpy arrays and Rust operations.
@@ -838,7 +861,7 @@ impl PyImageApi {
     /// derived from channel count.
     pub fn wrap(py: Python<'_>, data: Py<PyArray3<u8>>, mode: Option<String>) -> Self {
         let channels = data.bind(py).shape()[2];
-        let mode = mode.unwrap_or_else(|| mode_from_channels(channels));
+        let mode = mode.unwrap_or_else(|| mode_from_channels(channels, false));
         Self {
             data: ImageData::U8(data),
             mode,
@@ -848,7 +871,7 @@ impl PyImageApi {
     /// Wrap a 16-bit numpy array. Mode defaults to `"I;16"`/`"RGB;16"`/etc.
     pub fn wrap_u16(py: Python<'_>, data: Py<PyArray3<u16>>, mode: Option<String>) -> Self {
         let channels = data.bind(py).shape()[2];
-        let mode = mode.unwrap_or_else(|| mode_from_channels_u16(channels));
+        let mode = mode.unwrap_or_else(|| mode_from_channels(channels, true));
         Self {
             data: ImageData::U16(data),
             mode,
@@ -868,7 +891,7 @@ impl PyImageApi {
 
     /// Returns the u8 backing array, or a `NotImplementedError` if the Image
     /// is u16. Used by 8-bit-only imgproc methods after their early gate.
-    fn require_u8<'a>(&'a self, method: &str) -> PyResult<&'a Py<PyArray3<u8>>> {
+    pub(crate) fn require_u8<'a>(&'a self, method: &str) -> PyResult<&'a Py<PyArray3<u8>>> {
         match &self.data {
             ImageData::U8(a) => Ok(a),
             ImageData::U16(_) => Err(u16_imgproc_unsupported(method)),
@@ -1169,7 +1192,12 @@ impl PyImageApi {
             "RGB" => "rgb",
             "RGBA" => "rgba",
             "L" => "mono",
-            _ => "rgb",
+            other => {
+                return Err(value_err(format!(
+                    "decode: unsupported mode {:?}; expected \"RGB\", \"RGBA\", or \"L\"",
+                    other
+                )))
+            }
         };
 
         // JPEG: always 8-bit per channel.
@@ -1181,31 +1209,31 @@ impl PyImageApi {
             return Ok(Self::wrap(py, arr, Some(mode.to_string())));
         }
 
-        // PNG: parse dimensions + bit depth from IHDR (length 13 starting at byte 16
-        // after the 8-byte signature + 4 length + 4 type bytes). IHDR layout:
-        //   width(4) height(4) bit_depth(1) color_type(1) compression(1) filter(1) interlace(1)
         if data.len() >= 4 && &data[0..4] == b"\x89PNG" {
-            if data.len() < 26 {
-                return Err(value_err("Data too short to be a valid PNG"));
-            }
-            let width = u32::from_be_bytes([data[16], data[17], data[18], data[19]]) as usize;
-            let height = u32::from_be_bytes([data[20], data[21], data[22], data[23]]) as usize;
-            let bit_depth = data[24];
-
-            return if bit_depth == 16 {
-                let arr =
-                    crate::io::png::decode_image_png_u16(data, (height, width), native_mode)?;
-                let mode_u16 = match mode {
-                    "RGB" => "RGB;16".to_string(),
-                    "RGBA" => "RGBA;16".to_string(),
-                    "L" => "I;16".to_string(),
-                    other => other.to_string(),
-                };
-                Ok(Self::wrap_u16(py, arr, Some(mode_u16)))
-            } else {
-                let arr =
-                    crate::io::png::decode_image_png_u8(data, (height, width), native_mode)?;
-                Ok(Self::wrap(py, arr, Some(mode.to_string())))
+            let layout = kornia_io::png::decode_image_png_layout(data)
+                .map_err(|e| value_err(format!("decode: invalid PNG: {}", e)))?;
+            let (height, width) = (layout.image_size.height, layout.image_size.width);
+            return match layout.pixel_format {
+                PixelFormat::U16 => {
+                    let arr =
+                        crate::io::png::decode_image_png_u16(data, (height, width), native_mode)?;
+                    let channels = match mode {
+                        "RGB" => 3,
+                        "RGBA" => 4,
+                        "L" => 1,
+                        _ => unreachable!("native_mode validated above"),
+                    };
+                    Ok(Self::wrap_u16(
+                        py,
+                        arr,
+                        Some(mode_from_channels(channels, true)),
+                    ))
+                }
+                _ => {
+                    let arr =
+                        crate::io::png::decode_image_png_u8(data, (height, width), native_mode)?;
+                    Ok(Self::wrap(py, arr, Some(mode.to_string())))
+                }
             };
         }
 
@@ -1248,10 +1276,7 @@ impl PyImageApi {
 
     #[getter]
     fn dtype(&self, py: Python<'_>) -> Py<PyAny> {
-        match &self.data {
-            ImageData::U8(a) => a.bind(py).dtype().clone().unbind().into_any(),
-            ImageData::U16(a) => a.bind(py).dtype().clone().unbind().into_any(),
-        }
+        self.data.dtype_obj(py)
     }
 
     /// The underlying numpy array. Returns ``Py<PyAny>`` because the dtype
@@ -1259,10 +1284,7 @@ impl PyImageApi {
     /// numpy directly or test ``img.dtype`` to branch.
     #[getter]
     pub fn data(&self, py: Python<'_>) -> Py<PyAny> {
-        match &self.data {
-            ImageData::U8(a) => a.clone_ref(py).into_any(),
-            ImageData::U16(a) => a.clone_ref(py).into_any(),
-        }
+        self.data.as_pyany(py)
     }
 
     #[getter]
@@ -1304,11 +1326,18 @@ impl PyImageApi {
             Some(f) => f.to_lowercase(),
             None => {
                 let path = path_str.as_deref().ok_or_else(|| {
-                    value_err(
-                        "save: format= is required when target is a file-like object",
-                    )
+                    value_err("save: format= is required when target is a file-like object")
                 })?;
-                path.rsplit('.').next().unwrap_or("").to_lowercase()
+                std::path::Path::new(path)
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .ok_or_else(|| {
+                        value_err(format!(
+                            "save: could not determine format from path {:?}; pass format=",
+                            path
+                        ))
+                    })?
+                    .to_lowercase()
             }
         };
 
@@ -1501,8 +1530,7 @@ impl PyImageApi {
         let data = self.require_u8("box_blur")?;
         let c = data.bind(py).shape()[2];
         if c == 3 {
-            let result =
-                crate::blur::box_blur(py, data.clone_ref(py), (kernel_size, kernel_size))?;
+            let result = crate::blur::box_blur(py, data.clone_ref(py), (kernel_size, kernel_size))?;
             Ok(Self::wrap(py, result, Some(self.mode.clone())))
         } else {
             self.copy(py)
@@ -1688,8 +1716,7 @@ impl PyImageApi {
         let tx = (cx - cos_a as f64 * cx + sin_a as f64 * cy) as f32;
         let ty = (cy - sin_a as f64 * cx - cos_a as f64 * cy) as f32;
         let m = [cos_a, -sin_a, tx, sin_a, cos_a, ty];
-        let result =
-            crate::warp::warp_affine(py, data.clone_ref(py), m, (h, w), "bilinear", None)?;
+        let result = crate::warp::warp_affine(py, data.clone_ref(py), m, (h, w), "bilinear", None)?;
         Ok(Self::wrap(py, result, Some(self.mode.clone())))
     }
 
@@ -1699,10 +1726,7 @@ impl PyImageApi {
         let cls = Self::type_object(py).unbind().into_any();
         // Pickle as (numpy_array, mode) — `frombuffer` will auto-detect the
         // dtype on reconstruction, so we don't need to thread an extra tag.
-        let arr_any: Py<PyAny> = match &self.data {
-            ImageData::U8(a) => a.clone_ref(py).into_any(),
-            ImageData::U16(a) => a.clone_ref(py).into_any(),
-        };
+        let arr_any = self.data.as_pyany(py);
         let args = pyo3::types::PyTuple::new(
             py,
             [
@@ -1715,11 +1739,7 @@ impl PyImageApi {
     }
 
     fn __getstate__(&self, py: Python<'_>) -> (Py<PyAny>, String) {
-        let arr_any: Py<PyAny> = match &self.data {
-            ImageData::U8(a) => a.clone_ref(py).into_any(),
-            ImageData::U16(a) => a.clone_ref(py).into_any(),
-        };
-        (arr_any, self.mode.clone())
+        (self.data.as_pyany(py), self.mode.clone())
     }
 
     fn __setstate__(&mut self, py: Python<'_>, state: (Py<PyAny>, String)) -> PyResult<()> {
@@ -1791,16 +1811,10 @@ impl PyImageApi {
         dtype: Option<&str>,
         copy: Option<bool>,
     ) -> PyResult<Py<PyAny>> {
-        let arr_any: Py<PyAny> = match &self.data {
-            ImageData::U8(a) => a.clone_ref(py).into_any(),
-            ImageData::U16(a) => a.clone_ref(py).into_any(),
-        };
+        let arr_any = self.data.as_pyany(py);
         let bound = arr_any.bind(py);
         if let Some(dt) = dtype {
-            Ok(bound
-                .call_method1("astype", (dt,))?
-                .call_method0("copy")?
-                .unbind())
+            Ok(bound.call_method1("astype", (dt,))?.unbind())
         } else if copy.unwrap_or(false) {
             Ok(bound.call_method0("copy")?.unbind())
         } else {
@@ -1823,10 +1837,7 @@ impl PyImageApi {
         flags: std::os::raw::c_int,
     ) -> PyResult<()> {
         let py = slf.py();
-        let arr_ptr = match &slf.data {
-            ImageData::U8(a) => a.bind(py).as_ptr(),
-            ImageData::U16(a) => a.bind(py).as_ptr(),
-        };
+        let arr_ptr = slf.data.as_ptr(py);
         let ret = unsafe { pyo3::ffi::PyObject_GetBuffer(arr_ptr, view, flags) };
         if ret != 0 {
             Err(PyErr::fetch(py))

--- a/kornia-py/src/image.rs
+++ b/kornia-py/src/image.rs
@@ -455,6 +455,23 @@ pub(crate) fn vec_to_pyarray(
     }
 }
 
+/// Create a `PyArray3<u16>` from a Vec with given dimensions. Sister of
+/// `vec_to_pyarray`; lets the u16 IO paths (PNG-16 decode, `frombytes` u16)
+/// land into a typed numpy view without a numpy round-trip.
+pub(crate) fn vec_to_pyarray_u16(
+    py: Python<'_>,
+    data: Vec<u16>,
+    h: usize,
+    w: usize,
+    c: usize,
+) -> Py<PyArray3<u16>> {
+    unsafe {
+        let arr = PyArray::<u16, _>::new(py, [h, w, c], false);
+        std::ptr::copy_nonoverlapping(data.as_ptr(), arr.data(), data.len());
+        arr.unbind()
+    }
+}
+
 /// Apply brightness using saturating integer add/sub.
 /// Compiles to NEON uqadd/uqsub — processes 16 bytes per instruction.
 /// Works for both src→dst and in-place (pass same slice as both args).
@@ -718,16 +735,84 @@ fn mode_from_channels(channels: usize) -> String {
     }
 }
 
+/// PIL-style mode for a 16-bit grayscale image. Mirrors PIL's `"I;16"`.
+fn mode_from_channels_u16(channels: usize) -> String {
+    match channels {
+        1 => "I;16".to_string(),
+        3 => "RGB;16".to_string(),
+        4 => "RGBA;16".to_string(),
+        c => format!("{}ch;16", c),
+    }
+}
+
+/// Internal storage variant. The two variants are mutually exclusive — the
+/// backing dtype is part of the Image's identity (a uint16 image cannot be
+/// silently downcast on access without a copy).
+#[derive(Debug)]
+pub enum ImageData {
+    U8(Py<PyArray3<u8>>),
+    U16(Py<PyArray3<u16>>),
+}
+
+impl ImageData {
+    /// `(height, width, channels)` for either variant, without copying.
+    fn shape3(&self, py: Python<'_>) -> [usize; 3] {
+        match self {
+            ImageData::U8(a) => {
+                let s = a.bind(py).shape();
+                [s[0], s[1], s[2]]
+            }
+            ImageData::U16(a) => {
+                let s = a.bind(py).shape();
+                [s[0], s[1], s[2]]
+            }
+        }
+    }
+
+    fn channels(&self, py: Python<'_>) -> usize {
+        self.shape3(py)[2]
+    }
+
+    /// dtype name as exposed by numpy. Used for `Image.dtype.name` parity.
+    fn dtype_name(&self) -> &'static str {
+        match self {
+            ImageData::U8(_) => "uint8",
+            ImageData::U16(_) => "uint16",
+        }
+    }
+
+    /// Element size in bytes — 1 for u8, 2 for u16. Used by `nbytes` and
+    /// the buffer protocol.
+    fn itemsize(&self) -> usize {
+        match self {
+            ImageData::U8(_) => 1,
+            ImageData::U16(_) => 2,
+        }
+    }
+
+    /// True for 16-bit storage. Used by 8-bit-only methods to fail fast with
+    /// a clear `NotImplementedError`.
+    fn is_u16(&self) -> bool {
+        matches!(self, ImageData::U16(_))
+    }
+}
+
 /// A high-level image object backed by numpy arrays and Rust operations.
 ///
-/// Always stores data as HWC (height, width, channels) numpy arrays.
-/// RGB color order by default.
+/// Always stores data as HWC (height, width, channels) numpy arrays. Supports
+/// both 8-bit (`uint8`) and 16-bit (`uint16`) bit depths — the latter is
+/// required for depth maps and scientific imagery where lossy transit codecs
+/// (JPEG) would corrupt object-edge discontinuities.
+///
+/// Imgproc methods (resize, flip, blur, color conversions, …) currently only
+/// support 8-bit images. Calling them on a 16-bit Image raises
+/// `NotImplementedError` with a clear remediation message.
 ///
 /// Thread-safe and serialization-friendly for use with Ray Data,
 /// multiprocessing, and other parallel execution frameworks.
 #[pyclass(name = "Image", weakref)]
 pub struct PyImageApi {
-    data: Py<PyArray3<u8>>,
+    data: ImageData,
     mode: String,
 }
 
@@ -736,14 +821,43 @@ fn value_err<M: Into<String>>(msg: M) -> PyErr {
     PyErr::new::<pyo3::exceptions::PyValueError, _>(msg.into())
 }
 
+/// Shared error for 8-bit-only methods called on a 16-bit Image. We surface
+/// a clear remediation path so users hit a known gap, not a mystery type
+/// mismatch deep inside an imgproc kernel.
+fn u16_imgproc_unsupported(method: &str) -> PyErr {
+    PyErr::new::<pyo3::exceptions::PyNotImplementedError, _>(format!(
+        "Image.{}() is not yet implemented for uint16 images. \
+         Convert to uint8 first via `np.array(img).astype('uint8')` and \
+         re-wrap with `Image.fromarray()`.",
+        method
+    ))
+}
+
 impl PyImageApi {
+    /// Wrap an 8-bit numpy array. Mode defaults to `"L"`/`"RGB"`/`"RGBA"`
+    /// derived from channel count.
     pub fn wrap(py: Python<'_>, data: Py<PyArray3<u8>>, mode: Option<String>) -> Self {
         let channels = data.bind(py).shape()[2];
         let mode = mode.unwrap_or_else(|| mode_from_channels(channels));
-        Self { data, mode }
+        Self {
+            data: ImageData::U8(data),
+            mode,
+        }
     }
 
-    /// Wrap a Vec<u8> result as a new `PyImageApi` with the current mode.
+    /// Wrap a 16-bit numpy array. Mode defaults to `"I;16"`/`"RGB;16"`/etc.
+    pub fn wrap_u16(py: Python<'_>, data: Py<PyArray3<u16>>, mode: Option<String>) -> Self {
+        let channels = data.bind(py).shape()[2];
+        let mode = mode.unwrap_or_else(|| mode_from_channels_u16(channels));
+        Self {
+            data: ImageData::U16(data),
+            mode,
+        }
+    }
+
+    /// Wrap a Vec<u8> result as a new u8 `PyImageApi` with the current mode.
+    /// Imgproc methods produce these — the result must be u8 because all
+    /// imgproc kernels currently operate on u8.
     fn wrap_vec(&self, py: Python<'_>, out: Vec<u8>, h: usize, w: usize, c: usize) -> Self {
         Self::wrap(
             py,
@@ -751,27 +865,112 @@ impl PyImageApi {
             Some(self.mode.clone()),
         )
     }
+
+    /// Returns the u8 backing array, or a `NotImplementedError` if the Image
+    /// is u16. Used by 8-bit-only imgproc methods after their early gate.
+    fn require_u8<'a>(&'a self, method: &str) -> PyResult<&'a Py<PyArray3<u8>>> {
+        match &self.data {
+            ImageData::U8(a) => Ok(a),
+            ImageData::U16(_) => Err(u16_imgproc_unsupported(method)),
+        }
+    }
+
+    /// Single canonical encode path used by both `encode()` and `save()`.
+    /// Dispatches on (format, dtype, channel count) and returns PNG/JPEG
+    /// bytes. JPEG is u8-only by spec; PNG handles u8 (1/3/4 ch) and u16
+    /// (1/3/4 ch).
+    fn encode_to_bytes(&self, py: Python<'_>, format: &str, quality: u8) -> PyResult<Vec<u8>> {
+        let c = self.data.channels(py);
+        let is_u16 = self.data.is_u16();
+
+        match format {
+            "jpg" | "jpeg" => {
+                if is_u16 {
+                    return Err(value_err(
+                        "JPEG cannot encode 16-bit images (lossy DCT corrupts \
+                         object-edge discontinuities). Use \"png\" instead.",
+                    ));
+                }
+                if c != 3 {
+                    return Err(value_err(format!(
+                        "JPEG requires 3-channel RGB image, got {} channels",
+                        c
+                    )));
+                }
+                let arr = match &self.data {
+                    ImageData::U8(a) => a.clone_ref(py),
+                    ImageData::U16(_) => unreachable!("checked is_u16 above"),
+                };
+                crate::io::jpeg::encode_image_jpeg(arr, quality)
+            }
+            "png" => {
+                let mut buffer = Vec::new();
+                match (&self.data, c) {
+                    (ImageData::U8(a), 3) => {
+                        let img = Image::<u8, 3, _>::from_pyimage(a.clone_ref(py))
+                            .map_err(|e| value_err(e.to_string()))?;
+                        kornia_io::png::encode_image_png_rgb8(&img, &mut buffer)
+                            .map_err(|e| value_err(e.to_string()))?;
+                    }
+                    (ImageData::U8(a), 4) => {
+                        let img = Image::<u8, 4, _>::from_pyimage(a.clone_ref(py))
+                            .map_err(|e| value_err(e.to_string()))?;
+                        kornia_io::png::encode_image_png_rgba8(&img, &mut buffer)
+                            .map_err(|e| value_err(e.to_string()))?;
+                    }
+                    (ImageData::U8(a), 1) => {
+                        let img = Image::<u8, 1, _>::from_pyimage(a.clone_ref(py))
+                            .map_err(|e| value_err(e.to_string()))?;
+                        kornia_io::png::encode_image_png_gray8(&img, &mut buffer)
+                            .map_err(|e| value_err(e.to_string()))?;
+                    }
+                    (ImageData::U16(a), 3) => {
+                        let img = Image::<u16, 3, _>::from_pyimage_u16(a.clone_ref(py))
+                            .map_err(|e| value_err(e.to_string()))?;
+                        kornia_io::png::encode_image_png_rgb16(&img, &mut buffer)
+                            .map_err(|e| value_err(e.to_string()))?;
+                    }
+                    (ImageData::U16(a), 4) => {
+                        let img = Image::<u16, 4, _>::from_pyimage_u16(a.clone_ref(py))
+                            .map_err(|e| value_err(e.to_string()))?;
+                        kornia_io::png::encode_image_png_rgba16(&img, &mut buffer)
+                            .map_err(|e| value_err(e.to_string()))?;
+                    }
+                    (ImageData::U16(a), 1) => {
+                        let img = Image::<u16, 1, _>::from_pyimage_u16(a.clone_ref(py))
+                            .map_err(|e| value_err(e.to_string()))?;
+                        kornia_io::png::encode_image_png_gray16(&img, &mut buffer)
+                            .map_err(|e| value_err(e.to_string()))?;
+                    }
+                    _ => {
+                        return Err(value_err(format!(
+                            "PNG requires 1/3/4-channel image, got {} channels (dtype={})",
+                            c,
+                            self.data.dtype_name()
+                        )))
+                    }
+                };
+                Ok(buffer)
+            }
+            other => Err(value_err(format!(
+                "Unsupported format {:?}. Supported: \"jpeg\"/\"jpg\", \"png\"",
+                other
+            ))),
+        }
+    }
 }
 
 #[pymethods]
 impl PyImageApi {
     /// Create an Image from a numpy array.
+    ///
+    /// Auto-detects the bit depth: ``uint8`` arrays produce an 8-bit Image,
+    /// ``uint16`` arrays produce a 16-bit Image (depth maps, scientific data).
+    /// 2D shapes are treated as single-channel and reshaped to ``(H, W, 1)``.
     #[new]
     #[pyo3(signature = (data, mode=None))]
     fn new(py: Python<'_>, data: &Bound<'_, PyAny>, mode: Option<String>) -> PyResult<Self> {
-        let shape: Vec<usize> = data.getattr("shape")?.extract()?;
-        let arr = if shape.len() == 2 {
-            data.call_method1("reshape", ((shape[0], shape[1], 1usize),))?
-                .extract::<Py<PyArray3<u8>>>()?
-        } else if shape.len() == 3 {
-            data.extract::<Py<PyArray3<u8>>>()?
-        } else {
-            return Err(value_err(format!(
-                "Expected 2D or 3D array, got {}D",
-                shape.len()
-            )));
-        };
-        Ok(Self::wrap(py, arr, mode))
+        Self::frombuffer(py, data, mode)
     }
 
     // --- Static constructors ---
@@ -779,36 +978,60 @@ impl PyImageApi {
     /// Create a zero-copy Image from a numpy array or array-like object.
     ///
     /// The Image shares memory with the input array — mutations to either
-    /// are visible in both. Accepts 2D (H, W) or 3D (H, W, C) arrays.
+    /// are visible in both. Accepts 2D (H, W) or 3D (H, W, C) arrays. Bit
+    /// depth is inferred from the array's dtype: ``uint8`` is the default
+    /// path, ``uint16`` is the depth-map path.
     ///
     /// Args:
-    ///     data: numpy array (uint8), 2D or 3D in HWC layout.
-    ///     mode: color mode string (e.g. "RGB", "L"). Auto-inferred if omitted.
+    ///     data: numpy array (``uint8`` or ``uint16``), 2D or 3D in HWC layout.
+    ///     mode: color mode string. Auto-inferred from channels + bit depth
+    ///         when omitted (`"RGB"` / `"L"` for u8, `"RGB;16"` / `"I;16"` for u16).
     ///
     /// Returns:
-    ///     Image wrapping the array data without copying.
+    ///     Image wrapping the array data without copying (when contiguous).
     #[staticmethod]
     #[pyo3(signature = (data, mode=None))]
     fn frombuffer(py: Python<'_>, data: &Bound<'_, PyAny>, mode: Option<String>) -> PyResult<Self> {
+        // Fast paths: 3D arrays of the supported dtypes — no shape gymnastics.
         if let Ok(arr) = data.extract::<Py<PyArray3<u8>>>() {
             return Ok(Self::wrap(py, arr, mode));
         }
+        if let Ok(arr) = data.extract::<Py<PyArray3<u16>>>() {
+            return Ok(Self::wrap_u16(py, arr, mode));
+        }
 
+        // 2D fallback: reshape to (H, W, 1) and retry per-dtype. We probe
+        // shape first so we don't reshape a non-array object.
         if let Ok(shape_attr) = data.getattr("shape") {
             if let Ok(shape) = shape_attr.extract::<Vec<usize>>() {
                 if shape.len() == 2 {
-                    if let Ok(arr) = data
+                    let reshaped = data
                         .call_method1("reshape", ((shape[0], shape[1], 1usize),))
-                        .and_then(|r| Ok(r.extract::<Py<PyArray3<u8>>>()?))
-                    {
+                        .map_err(|e| {
+                            PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
+                                "frombuffer reshape failed: {}",
+                                e
+                            ))
+                        })?;
+                    if let Ok(arr) = reshaped.extract::<Py<PyArray3<u8>>>() {
                         return Ok(Self::wrap(py, arr, mode));
                     }
+                    if let Ok(arr) = reshaped.extract::<Py<PyArray3<u16>>>() {
+                        return Ok(Self::wrap_u16(py, arr, mode));
+                    }
+                    return Err(value_err(
+                        "frombuffer: 2D array dtype must be uint8 or uint16",
+                    ));
                 } else if shape.len() != 3 {
                     return Err(value_err(format!(
                         "Expected 2D or 3D array, got {}D",
                         shape.len()
                     )));
                 }
+                // 3D but dtype mismatched — give a precise error.
+                return Err(value_err(
+                    "frombuffer: 3D array dtype must be uint8 or uint16",
+                ));
             }
         }
 
@@ -817,23 +1040,38 @@ impl PyImageApi {
         ))
     }
 
+    /// PIL-compatible alias for :meth:`frombuffer`.
+    ///
+    /// PIL's :func:`Image.fromarray` is the standard way to wrap a numpy
+    /// array — exposing the same name here means existing PIL-style code
+    /// works against ``kornia_rs.image.Image`` without renames.
+    #[staticmethod]
+    #[pyo3(signature = (data, mode=None))]
+    fn fromarray(py: Python<'_>, data: &Bound<'_, PyAny>, mode: Option<String>) -> PyResult<Self> {
+        Self::frombuffer(py, data, mode)
+    }
+
     /// Create an Image by copying raw pixel data into a new buffer.
     ///
     /// Accepts bytes, bytearray, memoryview, or any object with a
-    /// .tobytes() method. Width, height, and channels must be specified
+    /// `.tobytes()` method. Width, height, and channels must be specified
     /// so the flat data can be reshaped to (H, W, C).
     ///
     /// Args:
-    ///     data: raw pixel data (bytes, bytearray, memoryview, or .tobytes()-capable).
+    ///     data: raw pixel data (bytes, bytearray, memoryview, or
+    ///         `.tobytes()`-capable).
     ///     width: image width in pixels.
     ///     height: image height in pixels.
     ///     channels: number of channels (default 3).
-    ///     mode: color mode string (e.g. "RGB", "L"). Auto-inferred if omitted.
+    ///     mode: color mode string. Auto-inferred from channels + dtype.
+    ///     dtype: ``"uint8"`` (default) or ``"uint16"``. ``uint16`` requires
+    ///         exactly ``2 * height * width * channels`` bytes (little-endian
+    ///         on the host).
     ///
     /// Returns:
     ///     Image owning a copy of the data.
     #[staticmethod]
-    #[pyo3(signature = (data, width, height, channels=3, mode=None))]
+    #[pyo3(signature = (data, width, height, channels=3, mode=None, dtype=None))]
     fn frombytes(
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
@@ -841,9 +1079,21 @@ impl PyImageApi {
         height: usize,
         channels: Option<usize>,
         mode: Option<String>,
+        dtype: Option<&str>,
     ) -> PyResult<Self> {
         let c = channels.unwrap_or(3);
-        let expected = height * width * c;
+        let dtype = dtype.unwrap_or("uint8");
+        let itemsize = match dtype {
+            "uint8" | "u8" => 1usize,
+            "uint16" | "u16" => 2usize,
+            other => {
+                return Err(value_err(format!(
+                    "Unsupported dtype {:?}: must be \"uint8\" or \"uint16\"",
+                    other
+                )))
+            }
+        };
+        let expected = height * width * c * itemsize;
 
         let bytes: Vec<u8> = if let Ok(v) = data.extract::<Vec<u8>>() {
             v
@@ -857,29 +1107,61 @@ impl PyImageApi {
 
         if bytes.len() != expected {
             return Err(value_err(format!(
-                "Expected {} bytes ({}x{}x{}), got {}",
+                "Expected {} bytes ({}x{}x{}, dtype={}), got {}",
                 expected,
                 height,
                 width,
                 c,
+                dtype,
                 bytes.len()
             )));
         }
 
-        let arr = vec_to_pyarray(py, bytes, height, width, c);
-        Ok(Self::wrap(py, arr, mode))
+        if itemsize == 1 {
+            let arr = vec_to_pyarray(py, bytes, height, width, c);
+            Ok(Self::wrap(py, arr, mode))
+        } else {
+            // Re-interpret little-endian byte pairs as uint16. Allocates a
+            // typed buffer; numpy will hold the canonical view.
+            let mut u16_buf = Vec::with_capacity(bytes.len() / 2);
+            for pair in bytes.chunks_exact(2) {
+                u16_buf.push(u16::from_le_bytes([pair[0], pair[1]]));
+            }
+            let arr = vec_to_pyarray_u16(py, u16_buf, height, width, c);
+            Ok(Self::wrap_u16(py, arr, mode))
+        }
     }
 
-    /// Load an image from file (JPEG, PNG, TIFF). Returns RGB.
+    /// Load an image from a file (JPEG, PNG, TIFF). Auto-detects bit depth
+    /// from the file: PNG-16 / TIFF-16 produce a 16-bit Image; everything
+    /// else produces an 8-bit Image.
+    ///
+    /// PIL parity: equivalent to ``PIL.Image.open(path)``.
     #[staticmethod]
     fn load(py: Python<'_>, path: &str) -> PyResult<Self> {
         let path_str = pyo3::types::PyString::new(py, path);
         let arr_any = crate::io::functional::read_image(path_str.into_any())?;
-        let arr: Py<PyArray3<u8>> = arr_any.extract(py)?;
-        Ok(Self::wrap(py, arr, None))
+        // The functional dispatcher returns either Py<PyArray3<u8>> or
+        // Py<PyArray3<u16>> depending on the file's pixel format. Try the u8
+        // path first (the dominant case) and fall through to u16.
+        if let Ok(arr) = arr_any.extract::<Py<PyArray3<u8>>>(py) {
+            return Ok(Self::wrap(py, arr, None));
+        }
+        let arr: Py<PyArray3<u16>> = arr_any.extract(py).map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                "load: file decoded to unsupported dtype (expected uint8 or uint16)",
+            )
+        })?;
+        Ok(Self::wrap_u16(py, arr, None))
     }
 
     /// Decode encoded image bytes (JPEG, PNG) into an Image.
+    ///
+    /// Auto-detects the format from magic bytes and the bit depth from the
+    /// PNG IHDR chunk. PNG-16 (16-bit) bytes produce a 16-bit Image; PNG-8
+    /// and JPEG produce 8-bit Images. ``mode`` selects the channel layout
+    /// (``"RGB"`` / ``"RGBA"`` / ``"L"``); for PNG-16 it maps to the 16-bit
+    /// equivalent.
     #[staticmethod]
     #[pyo3(signature = (data, mode="RGB"))]
     fn decode(py: Python<'_>, data: &[u8], mode: &str) -> PyResult<Self> {
@@ -890,42 +1172,61 @@ impl PyImageApi {
             _ => "rgb",
         };
 
-        let arr = if data.len() >= 2 && data[0] == 0xff && data[1] == 0xd8 {
-            // JPEG
-            match crate::io::jpegturbo::decode_image_jpegturbo(data, native_mode) {
+        // JPEG: always 8-bit per channel.
+        if data.len() >= 2 && data[0] == 0xff && data[1] == 0xd8 {
+            let arr = match crate::io::jpegturbo::decode_image_jpegturbo(data, native_mode) {
                 Ok(a) => a,
                 Err(_) => crate::io::jpeg::decode_image_jpeg(data)?,
-            }
-        } else if data.len() >= 4 && &data[0..4] == b"\x89PNG" {
-            // PNG: parse dimensions from IHDR
-            if data.len() < 24 {
+            };
+            return Ok(Self::wrap(py, arr, Some(mode.to_string())));
+        }
+
+        // PNG: parse dimensions + bit depth from IHDR (length 13 starting at byte 16
+        // after the 8-byte signature + 4 length + 4 type bytes). IHDR layout:
+        //   width(4) height(4) bit_depth(1) color_type(1) compression(1) filter(1) interlace(1)
+        if data.len() >= 4 && &data[0..4] == b"\x89PNG" {
+            if data.len() < 26 {
                 return Err(value_err("Data too short to be a valid PNG"));
             }
             let width = u32::from_be_bytes([data[16], data[17], data[18], data[19]]) as usize;
             let height = u32::from_be_bytes([data[20], data[21], data[22], data[23]]) as usize;
-            crate::io::png::decode_image_png_u8(data, (height, width), native_mode)?
-        } else {
-            return Err(value_err("Unsupported image format: not JPEG or PNG"));
-        };
+            let bit_depth = data[24];
 
-        Ok(Self::wrap(py, arr, Some(mode.to_string())))
+            return if bit_depth == 16 {
+                let arr =
+                    crate::io::png::decode_image_png_u16(data, (height, width), native_mode)?;
+                let mode_u16 = match mode {
+                    "RGB" => "RGB;16".to_string(),
+                    "RGBA" => "RGBA;16".to_string(),
+                    "L" => "I;16".to_string(),
+                    other => other.to_string(),
+                };
+                Ok(Self::wrap_u16(py, arr, Some(mode_u16)))
+            } else {
+                let arr =
+                    crate::io::png::decode_image_png_u8(data, (height, width), native_mode)?;
+                Ok(Self::wrap(py, arr, Some(mode.to_string())))
+            };
+        }
+
+        Err(value_err("Unsupported image format: not JPEG or PNG"))
     }
 
     // --- Properties ---
 
     #[getter]
     pub fn width(&self, py: Python<'_>) -> usize {
-        self.data.bind(py).shape()[1]
+        self.data.shape3(py)[1]
     }
 
     #[getter]
     pub fn height(&self, py: Python<'_>) -> usize {
-        self.data.bind(py).shape()[0]
+        self.data.shape3(py)[0]
     }
 
     #[getter]
     fn channels(&self, py: Python<'_>) -> usize {
-        self.data.bind(py).shape()[2]
+        self.data.channels(py)
     }
 
     #[getter]
@@ -935,76 +1236,168 @@ impl PyImageApi {
 
     #[getter]
     fn size(&self, py: Python<'_>) -> (usize, usize) {
-        let s = self.data.bind(py).shape();
+        let s = self.data.shape3(py);
         (s[1], s[0])
     }
 
     #[getter]
     fn shape(&self, py: Python<'_>) -> (usize, usize, usize) {
-        let s = self.data.bind(py).shape();
+        let s = self.data.shape3(py);
         (s[0], s[1], s[2])
     }
 
     #[getter]
     fn dtype(&self, py: Python<'_>) -> Py<PyAny> {
-        self.data.bind(py).dtype().clone().unbind().into_any()
+        match &self.data {
+            ImageData::U8(a) => a.bind(py).dtype().clone().unbind().into_any(),
+            ImageData::U16(a) => a.bind(py).dtype().clone().unbind().into_any(),
+        }
     }
 
+    /// The underlying numpy array. Returns ``Py<PyAny>`` because the dtype
+    /// depends on the bit depth (uint8 or uint16); callers can pass to
+    /// numpy directly or test ``img.dtype`` to branch.
     #[getter]
-    pub fn data(&self, py: Python<'_>) -> Py<PyArray3<u8>> {
-        self.data.clone_ref(py)
+    pub fn data(&self, py: Python<'_>) -> Py<PyAny> {
+        match &self.data {
+            ImageData::U8(a) => a.clone_ref(py).into_any(),
+            ImageData::U16(a) => a.clone_ref(py).into_any(),
+        }
     }
 
     #[getter]
     fn nbytes(&self, py: Python<'_>) -> usize {
-        let s = self.data.bind(py).shape();
-        s[0] * s[1] * s[2]
+        let s = self.data.shape3(py);
+        s[0] * s[1] * s[2] * self.data.itemsize()
     }
 
     // --- IO ---
 
-    /// Save image to file. Format detected from extension.
-    #[pyo3(signature = (path, quality=95))]
-    fn save(&self, py: Python<'_>, path: &str, quality: u8) -> PyResult<()> {
-        let c = self.data.bind(py).shape()[2];
-        if c != 3 {
-            return Err(value_err(format!(
-                "save requires 3-channel RGB image, got {} channels",
-                c
-            )));
-        }
+    /// Save the image to a file path or file-like object.
+    ///
+    /// PIL-compatible: ``fp`` accepts either a ``str``/``Path`` (writes a
+    /// file directly) or a writable object with ``.write(bytes)`` (writes
+    /// encoded bytes — works with ``io.BytesIO()`` for in-memory capture).
+    /// Format is resolved in this order:
+    ///
+    ///   1. explicit ``format=`` argument (case-insensitive: ``"PNG"`` /
+    ///      ``"JPEG"`` / ``"JPG"``)
+    ///   2. extension on the path (``.png``, ``.jpg``, ``.jpeg``)
+    ///   3. error
+    ///
+    /// 16-bit Images can only save to PNG (JPEG would lose precision and
+    /// smear depth discontinuities); the call returns a ``ValueError``
+    /// otherwise.
+    #[pyo3(signature = (fp, format=None, quality=95))]
+    fn save(
+        &self,
+        py: Python<'_>,
+        fp: &Bound<'_, PyAny>,
+        format: Option<&str>,
+        quality: u8,
+    ) -> PyResult<()> {
+        // Resolve target type: path-like vs file-like.
+        let path_str: Option<String> = fp.extract().ok();
 
-        let ext = path.rsplit('.').next().unwrap_or("").to_lowercase();
-        match ext.as_str() {
-            "jpg" | "jpeg" => {
-                crate::io::jpeg::write_image_jpeg(path, self.data.clone_ref(py), "rgb", quality)
+        // Resolve format.
+        let resolved_format = match format {
+            Some(f) => f.to_lowercase(),
+            None => {
+                let path = path_str.as_deref().ok_or_else(|| {
+                    value_err(
+                        "save: format= is required when target is a file-like object",
+                    )
+                })?;
+                path.rsplit('.').next().unwrap_or("").to_lowercase()
             }
-            "png" => crate::io::png::write_image_png_u8(path, self.data.clone_ref(py), "rgb"),
-            _ => Err(value_err(format!(
-                "Unsupported format: .{}. Supported: .jpg, .jpeg, .png",
-                ext
-            ))),
+        };
+
+        // Encode to bytes (handles u8/u16 dispatch internally).
+        let bytes = self.encode_to_bytes(py, &resolved_format, quality)?;
+
+        if let Some(path) = path_str {
+            std::fs::write(&path, &bytes).map_err(|e| {
+                PyErr::new::<pyo3::exceptions::PyIOError, _>(format!(
+                    "save: failed to write {}: {}",
+                    path, e
+                ))
+            })
+        } else {
+            // File-like: requires .write(bytes). PIL accepts BytesIO, file
+            // handles, S3 file objects, etc. — anything quacking like a writer.
+            let pybytes = pyo3::types::PyBytes::new(py, &bytes);
+            fp.call_method1("write", (pybytes,)).map_err(|e| {
+                value_err(format!(
+                    "save: target object must have .write(bytes) — {}",
+                    e
+                ))
+            })?;
+            Ok(())
         }
     }
 
-    /// Return a copy of the underlying numpy array.
-    fn to_numpy(&self, py: Python<'_>) -> PyResult<Py<PyArray3<u8>>> {
-        let copy = self.data.bind(py).call_method0("copy")?;
-        Ok(copy.extract()?)
+    /// Encode the image to in-memory bytes — the in-memory complement of `save`.
+    ///
+    /// PIL parity: ``Image.save(BytesIO(), format=...)`` works because the
+    /// underlying encoder writes to any file-like; here we expose the same
+    /// thing with a direct ``bytes`` return so callers don't need to set up a
+    /// ``BytesIO`` round-trip. Use this when you need to ship an encoded image
+    /// over a wire (Zenoh, MQTT, gRPC) or embed it in a container (MCAP).
+    ///
+    /// Args:
+    ///     format: ``"jpeg"`` (alias ``"jpg"``) or ``"png"``. Case-insensitive.
+    ///     quality: JPEG quality 1-100 (ignored for PNG). Default 95.
+    ///
+    /// Returns:
+    ///     bytes: The encoded image data.
+    ///
+    /// Example::
+    ///
+    ///     img = Image.frombuffer(rgb_array)
+    ///     jpeg_bytes = img.encode("jpeg", quality=80)
+    ///     png_bytes = img.encode("png")
+    #[pyo3(signature = (format, quality=95))]
+    fn encode(&self, py: Python<'_>, format: &str, quality: u8) -> PyResult<Vec<u8>> {
+        self.encode_to_bytes(py, &format.to_lowercase(), quality)
+    }
+
+    /// Return a copy of the underlying numpy array. Dtype matches the
+    /// Image's bit depth (``uint8`` or ``uint16``); returns ``Py<PyAny>``
+    /// because the static type isn't known at compile time.
+    fn to_numpy(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        match &self.data {
+            ImageData::U8(a) => {
+                let copy = a.bind(py).call_method0("copy")?;
+                Ok(copy.extract::<Py<PyArray3<u8>>>()?.into_any())
+            }
+            ImageData::U16(a) => {
+                let copy = a.bind(py).call_method0("copy")?;
+                Ok(copy.extract::<Py<PyArray3<u16>>>()?.into_any())
+            }
+        }
     }
 
     /// Return a deep copy of this image.
     pub fn copy(&self, py: Python<'_>) -> PyResult<Self> {
-        let copy: Py<PyArray3<u8>> = self.data.bind(py).call_method0("copy")?.extract()?;
+        let new_data = match &self.data {
+            ImageData::U8(a) => {
+                let copy: Py<PyArray3<u8>> = a.bind(py).call_method0("copy")?.extract()?;
+                ImageData::U8(copy)
+            }
+            ImageData::U16(a) => {
+                let copy: Py<PyArray3<u16>> = a.bind(py).call_method0("copy")?.extract()?;
+                ImageData::U16(copy)
+            }
+        };
         Ok(Self {
-            data: copy,
+            data: new_data,
             mode: self.mode.clone(),
         })
     }
 
     // --- Chainable transforms ---
 
-    /// Resize image to (width, height).
+    /// Resize image to (width, height). 8-bit only.
     #[pyo3(signature = (width, height, interpolation="bilinear"))]
     fn resize(
         &self,
@@ -1013,12 +1406,13 @@ impl PyImageApi {
         height: usize,
         interpolation: &str,
     ) -> PyResult<Self> {
-        let arr = self.data.bind(py);
+        let data = self.require_u8("resize")?;
+        let arr = data.bind(py);
         let c = arr.shape()[2];
         if c == 3 {
             let result = crate::resize::resize(
                 py,
-                self.data.clone_ref(py),
+                data.clone_ref(py),
                 (height, width),
                 interpolation,
                 true,
@@ -1031,12 +1425,13 @@ impl PyImageApi {
         }
     }
 
-    /// Flip image horizontally.
+    /// Flip image horizontally. 8-bit only.
     pub fn flip_horizontal(&self, py: Python<'_>) -> PyResult<Self> {
-        let arr = self.data.bind(py);
+        let data = self.require_u8("flip_horizontal")?;
+        let arr = data.bind(py);
         let c = arr.shape()[2];
         if c == 3 {
-            let result = crate::flip::horizontal_flip(py, self.data.clone_ref(py))?;
+            let result = crate::flip::horizontal_flip(py, data.clone_ref(py))?;
             Ok(Self::wrap(py, result, Some(self.mode.clone())))
         } else {
             let (src, h, w, _) = pyarray_data(arr);
@@ -1045,12 +1440,13 @@ impl PyImageApi {
         }
     }
 
-    /// Flip image vertically.
+    /// Flip image vertically. 8-bit only.
     pub fn flip_vertical(&self, py: Python<'_>) -> PyResult<Self> {
-        let arr = self.data.bind(py);
+        let data = self.require_u8("flip_vertical")?;
+        let arr = data.bind(py);
         let c = arr.shape()[2];
         if c == 3 {
-            let result = crate::flip::vertical_flip(py, self.data.clone_ref(py))?;
+            let result = crate::flip::vertical_flip(py, data.clone_ref(py))?;
             Ok(Self::wrap(py, result, Some(self.mode.clone())))
         } else {
             let (src, h, w, _) = pyarray_data(arr);
@@ -1059,7 +1455,7 @@ impl PyImageApi {
         }
     }
 
-    /// Crop image at (x, y) with given width and height.
+    /// Crop image at (x, y) with given width and height. 8-bit only.
     pub fn crop(
         &self,
         py: Python<'_>,
@@ -1068,10 +1464,11 @@ impl PyImageApi {
         width: usize,
         height: usize,
     ) -> PyResult<Self> {
-        let arr = self.data.bind(py);
+        let data = self.require_u8("crop")?;
+        let arr = data.bind(py);
         let c = arr.shape()[2];
         if c == 3 {
-            let result = crate::crop::crop(py, self.data.clone_ref(py), x, y, width, height)?;
+            let result = crate::crop::crop(py, data.clone_ref(py), x, y, width, height)?;
             Ok(Self::wrap(py, result, Some(self.mode.clone())))
         } else {
             let (src, _, src_w, _) = pyarray_data(arr);
@@ -1080,14 +1477,15 @@ impl PyImageApi {
         }
     }
 
-    /// Apply Gaussian blur.
+    /// Apply Gaussian blur. 8-bit only.
     #[pyo3(signature = (kernel_size=3, sigma=1.0))]
     fn gaussian_blur(&self, py: Python<'_>, kernel_size: usize, sigma: f32) -> PyResult<Self> {
-        let c = self.data.bind(py).shape()[2];
+        let data = self.require_u8("gaussian_blur")?;
+        let c = data.bind(py).shape()[2];
         if c == 3 {
             let result = crate::blur::gaussian_blur(
                 py,
-                self.data.clone_ref(py),
+                data.clone_ref(py),
                 (kernel_size, kernel_size),
                 (sigma, sigma),
             )?;
@@ -1097,22 +1495,24 @@ impl PyImageApi {
         }
     }
 
-    /// Apply box blur.
+    /// Apply box blur. 8-bit only.
     #[pyo3(signature = (kernel_size=3))]
     fn box_blur(&self, py: Python<'_>, kernel_size: usize) -> PyResult<Self> {
-        let c = self.data.bind(py).shape()[2];
+        let data = self.require_u8("box_blur")?;
+        let c = data.bind(py).shape()[2];
         if c == 3 {
             let result =
-                crate::blur::box_blur(py, self.data.clone_ref(py), (kernel_size, kernel_size))?;
+                crate::blur::box_blur(py, data.clone_ref(py), (kernel_size, kernel_size))?;
             Ok(Self::wrap(py, result, Some(self.mode.clone())))
         } else {
             self.copy(py)
         }
     }
 
-    /// Adjust brightness. Factor is additive in [0,1] range.
+    /// Adjust brightness. Factor is additive in [0,1] range. 8-bit only.
     pub fn adjust_brightness(&self, py: Python<'_>, factor: f32) -> PyResult<Self> {
-        let arr = self.data.bind(py);
+        let data = self.require_u8("adjust_brightness")?;
+        let arr = data.bind(py);
         let (src, h, w, c) = pyarray_data(arr);
         Ok(Self::wrap(
             py,
@@ -1121,9 +1521,10 @@ impl PyImageApi {
         ))
     }
 
-    /// Adjust contrast. factor=1.0 is identity, >1 increases contrast.
+    /// Adjust contrast. factor=1.0 is identity, >1 increases contrast. 8-bit only.
     pub fn adjust_contrast(&self, py: Python<'_>, factor: f64) -> PyResult<Self> {
-        let arr = self.data.bind(py);
+        let data = self.require_u8("adjust_contrast")?;
+        let arr = data.bind(py);
         let (src, h, w, c) = pyarray_data(arr);
         Ok(Self::wrap(
             py,
@@ -1132,9 +1533,10 @@ impl PyImageApi {
         ))
     }
 
-    /// Adjust saturation. factor=1.0 is identity, 0.0 is grayscale.
+    /// Adjust saturation. factor=1.0 is identity, 0.0 is grayscale. 8-bit only.
     pub fn adjust_saturation(&self, py: Python<'_>, factor: f64) -> PyResult<Self> {
-        let arr = self.data.bind(py);
+        let data = self.require_u8("adjust_saturation")?;
+        let arr = data.bind(py);
         if arr.shape()[2] != 3 {
             return self.copy(py);
         }
@@ -1146,9 +1548,10 @@ impl PyImageApi {
         ))
     }
 
-    /// Adjust hue. factor is in [-0.5, 0.5], fraction of hue wheel.
+    /// Adjust hue. factor is in [-0.5, 0.5], fraction of hue wheel. 8-bit only.
     pub fn adjust_hue(&self, py: Python<'_>, factor: f64) -> PyResult<Self> {
-        let arr = self.data.bind(py);
+        let data = self.require_u8("adjust_hue")?;
+        let arr = data.bind(py);
         if arr.shape()[2] != 3 || factor == 0.0 {
             return self.copy(py);
         }
@@ -1160,14 +1563,15 @@ impl PyImageApi {
         ))
     }
 
-    /// Normalize image to float32 using mean and std per channel.
+    /// Normalize image to float32 using mean and std per channel. 8-bit only.
     fn normalize(
         &self,
         py: Python<'_>,
         mean: (f32, f32, f32),
         std: (f32, f32, f32),
     ) -> PyResult<Py<PyArray3<f32>>> {
-        let arr = self.data.bind(py);
+        let data = self.require_u8("normalize")?;
+        let arr = data.bind(py);
         let (src, h, w, c) = pyarray_data(arr);
         let npixels = h * w;
         let out = unsafe { PyArray::<f32, _>::new(py, [h, w, c], false) };
@@ -1200,9 +1604,10 @@ impl PyImageApi {
         Ok(out.unbind())
     }
 
-    /// Convert RGB image to grayscale (1 channel).
+    /// Convert RGB image to grayscale (1 channel). 8-bit only.
     fn to_grayscale(&self, py: Python<'_>) -> PyResult<Self> {
-        let arr = self.data.bind(py);
+        let data = self.require_u8("to_grayscale")?;
+        let arr = data.bind(py);
         let s = arr.shape();
         let (h, w, c) = (s[0], s[1], s[2]);
         if c == 1 {
@@ -1224,17 +1629,18 @@ impl PyImageApi {
         Ok(Self::wrap(py, out.unbind(), Some("L".to_string())))
     }
 
-    /// Convert grayscale to RGB (3 channels).
+    /// Convert grayscale to RGB (3 channels). 8-bit only.
     fn to_rgb(&self, py: Python<'_>) -> PyResult<Self> {
-        let c = self.data.bind(py).shape()[2];
+        let data = self.require_u8("to_rgb")?;
+        let c = data.bind(py).shape()[2];
         if c == 3 {
             return self.copy(py);
         }
         if c == 1 {
-            let result = crate::color::rgb_from_gray(py, self.data.clone_ref(py))?;
+            let result = crate::color::rgb_from_gray(py, data.clone_ref(py))?;
             Ok(Self::wrap(py, result, Some("RGB".to_string())))
         } else if c == 4 {
-            let result = crate::color::rgb_from_rgba(py, self.data.clone_ref(py), None)?;
+            let result = crate::color::rgb_from_rgba(py, data.clone_ref(py), None)?;
             Ok(Self::wrap(py, result, Some("RGB".to_string())))
         } else {
             Err(value_err(format!(
@@ -1244,7 +1650,7 @@ impl PyImageApi {
         }
     }
 
-    /// Rotate image by angle degrees (counter-clockwise).
+    /// Rotate image by angle degrees (counter-clockwise). 8-bit only.
     ///
     /// Fast paths (exact k·90° only, no epsilon):
     ///  - 0°: copy
@@ -1252,20 +1658,21 @@ impl PyImageApi {
     ///  - ±90°/±270° with H == W: transpose+flip (shape preserved)
     /// Non-exact or non-square 90°/270°: general bilinear warp.
     pub fn rotate(&self, py: Python<'_>, angle: f64) -> PyResult<Self> {
-        let s = self.data.bind(py).shape();
+        let data = self.require_u8("rotate")?;
+        let s = data.bind(py).shape();
         let (h, w, c) = (s[0], s[1], s[2]);
 
         if let Some(k) = exact_k90(angle) {
             match k {
                 0 => return self.copy(py),
                 2 => {
-                    let arr = self.data.bind(py);
+                    let arr = data.bind(py);
                     let (src, _, _, _) = pyarray_data(arr);
                     let (out, _, _) = rot90_generic(src, h, w, c, 2);
                     return Ok(self.wrap_vec(py, out, h, w, c));
                 }
                 1 | 3 if h == w => {
-                    let arr = self.data.bind(py);
+                    let arr = data.bind(py);
                     let (src, _, _, _) = pyarray_data(arr);
                     let (out, nh, nw) = rot90_generic(src, h, w, c, k as i32);
                     return Ok(self.wrap_vec(py, out, nh, nw, c));
@@ -1282,7 +1689,7 @@ impl PyImageApi {
         let ty = (cy - sin_a as f64 * cx - cos_a as f64 * cy) as f32;
         let m = [cos_a, -sin_a, tx, sin_a, cos_a, ty];
         let result =
-            crate::warp::warp_affine(py, self.data.clone_ref(py), m, (h, w), "bilinear", None)?;
+            crate::warp::warp_affine(py, data.clone_ref(py), m, (h, w), "bilinear", None)?;
         Ok(Self::wrap(py, result, Some(self.mode.clone())))
     }
 
@@ -1290,33 +1697,57 @@ impl PyImageApi {
 
     fn __reduce__(&self, py: Python<'_>) -> PyResult<(Py<PyAny>, Py<PyAny>)> {
         let cls = Self::type_object(py).unbind().into_any();
+        // Pickle as (numpy_array, mode) — `frombuffer` will auto-detect the
+        // dtype on reconstruction, so we don't need to thread an extra tag.
+        let arr_any: Py<PyAny> = match &self.data {
+            ImageData::U8(a) => a.clone_ref(py).into_any(),
+            ImageData::U16(a) => a.clone_ref(py).into_any(),
+        };
         let args = pyo3::types::PyTuple::new(
             py,
             [
-                self.data.bind(py).as_any(),
-                pyo3::types::PyString::new(py, &self.mode).as_any(),
+                arr_any.bind(py).clone(),
+                pyo3::types::PyString::new(py, &self.mode).into_any(),
             ],
         )?
         .unbind();
         Ok((cls, args.into_any()))
     }
 
-    fn __getstate__(&self, py: Python<'_>) -> (Py<PyArray3<u8>>, String) {
-        (self.data.clone_ref(py), self.mode.clone())
+    fn __getstate__(&self, py: Python<'_>) -> (Py<PyAny>, String) {
+        let arr_any: Py<PyAny> = match &self.data {
+            ImageData::U8(a) => a.clone_ref(py).into_any(),
+            ImageData::U16(a) => a.clone_ref(py).into_any(),
+        };
+        (arr_any, self.mode.clone())
     }
 
-    fn __setstate__(&mut self, _py: Python<'_>, state: (Py<PyArray3<u8>>, String)) {
-        self.data = state.0;
+    fn __setstate__(&mut self, py: Python<'_>, state: (Py<PyAny>, String)) -> PyResult<()> {
+        // Reconstruct the storage variant from the array's runtime dtype.
+        let bound = state.0.bind(py);
+        if let Ok(arr) = bound.extract::<Py<PyArray3<u8>>>() {
+            self.data = ImageData::U8(arr);
+        } else if let Ok(arr) = bound.extract::<Py<PyArray3<u16>>>() {
+            self.data = ImageData::U16(arr);
+        } else {
+            return Err(value_err(
+                "__setstate__: array dtype must be uint8 or uint16",
+            ));
+        }
         self.mode = state.1;
+        Ok(())
     }
 
     // --- Dunder methods ---
 
     fn __repr__(&self, py: Python<'_>) -> String {
-        let s = self.data.bind(py).shape();
+        let s = self.data.shape3(py);
         format!(
-            "Image(mode={}, size={}x{}, dtype=uint8)",
-            self.mode, s[1], s[0]
+            "Image(mode={}, size={}x{}, dtype={})",
+            self.mode,
+            s[1],
+            s[0],
+            self.data.dtype_name()
         )
     }
 
@@ -1324,15 +1755,33 @@ impl PyImageApi {
         if self.mode != other.mode {
             return false;
         }
-        let a = self.data.bind(py);
-        let b = other.data.bind(py);
-        if a.shape() != b.shape() {
-            return false;
+        // Different bit depths can't be equal — short-circuit before any
+        // raw-byte comparison that would crash on stride mismatches.
+        match (&self.data, &other.data) {
+            (ImageData::U8(a), ImageData::U8(b)) => {
+                let a = a.bind(py);
+                let b = b.bind(py);
+                if a.shape() != b.shape() {
+                    return false;
+                }
+                let len: usize = a.shape().iter().product();
+                let sa = unsafe { std::slice::from_raw_parts(a.data(), len) };
+                let sb = unsafe { std::slice::from_raw_parts(b.data(), len) };
+                sa == sb
+            }
+            (ImageData::U16(a), ImageData::U16(b)) => {
+                let a = a.bind(py);
+                let b = b.bind(py);
+                if a.shape() != b.shape() {
+                    return false;
+                }
+                let len: usize = a.shape().iter().product();
+                let sa = unsafe { std::slice::from_raw_parts(a.data(), len) };
+                let sb = unsafe { std::slice::from_raw_parts(b.data(), len) };
+                sa == sb
+            }
+            _ => false,
         }
-        let len: usize = a.shape().iter().product();
-        let sa = unsafe { std::slice::from_raw_parts(a.data(), len) };
-        let sb = unsafe { std::slice::from_raw_parts(b.data(), len) };
-        sa == sb
     }
 
     #[pyo3(signature = (dtype=None, copy=None))]
@@ -1342,33 +1791,42 @@ impl PyImageApi {
         dtype: Option<&str>,
         copy: Option<bool>,
     ) -> PyResult<Py<PyAny>> {
-        let arr = self.data.bind(py);
+        let arr_any: Py<PyAny> = match &self.data {
+            ImageData::U8(a) => a.clone_ref(py).into_any(),
+            ImageData::U16(a) => a.clone_ref(py).into_any(),
+        };
+        let bound = arr_any.bind(py);
         if let Some(dt) = dtype {
-            Ok(arr
+            Ok(bound
                 .call_method1("astype", (dt,))?
                 .call_method0("copy")?
                 .unbind())
         } else if copy.unwrap_or(false) {
-            Ok(arr.call_method0("copy")?.unbind())
+            Ok(bound.call_method0("copy")?.unbind())
         } else {
-            Ok(self.data.clone_ref(py).into_any())
+            Ok(arr_any)
         }
     }
 
     fn __len__(&self, py: Python<'_>) -> usize {
-        self.data.bind(py).shape()[0]
+        self.data.shape3(py)[0]
     }
 
     /// PEP 3118 buffer protocol — delegates to the backing numpy array so
     /// `memoryview(img)`, `torch.asarray(img)`, and `torch.frombuffer(img)`
-    /// get zero-copy access without going through `np.asarray`.
+    /// get zero-copy access without going through `np.asarray`. Works for
+    /// both u8 and u16 — numpy reports the correct itemsize via the buffer
+    /// protocol's `format` field.
     unsafe fn __getbuffer__(
         slf: pyo3::PyRefMut<'_, Self>,
         view: *mut pyo3::ffi::Py_buffer,
         flags: std::os::raw::c_int,
     ) -> PyResult<()> {
         let py = slf.py();
-        let arr_ptr = slf.data.bind(py).as_ptr();
+        let arr_ptr = match &slf.data {
+            ImageData::U8(a) => a.bind(py).as_ptr(),
+            ImageData::U16(a) => a.bind(py).as_ptr(),
+        };
         let ret = unsafe { pyo3::ffi::PyObject_GetBuffer(arr_ptr, view, flags) };
         if ret != 0 {
             Err(PyErr::fetch(py))

--- a/kornia-py/src/image.rs
+++ b/kornia-py/src/image.rs
@@ -160,7 +160,7 @@ impl_pyarray_to_image!(f32, FromPyImageF32, from_pyimage_f32, PyImageF32);
 ///
 /// * `width` - The width of the image.
 /// * `height` - The height of the image.
-#[pyclass(name = "ImageSize", frozen, from_py_object)]
+#[pyclass(name = "ImageSize", frozen, from_py_object, module = "kornia_rs.image")]
 #[derive(Clone)]
 pub struct PyImageSize {
     inner: ImageSize,
@@ -220,7 +220,7 @@ impl From<PyImageSize> for ImageSize {
 ///
 /// Supports standard unsigned 8-bit (U8), unsigned 16-bit (U16),
 /// and 32-bit floating point (F32) formats.
-#[pyclass(name = "PixelFormat", from_py_object)]
+#[pyclass(name = "PixelFormat", from_py_object, module = "kornia_rs.image")]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum PyPixelFormat {
     U8,
@@ -258,7 +258,7 @@ impl From<PyPixelFormat> for PixelFormat {
 /// * `image_size` - The dimensions of the image.
 /// * `channels` - The number of channels (e.g., 3 for RGB).
 /// * `pixel_format` - The data type of the pixels.
-#[pyclass(name = "ImageLayout", frozen, from_py_object)]
+#[pyclass(name = "ImageLayout", frozen, from_py_object, module = "kornia_rs.image")]
 #[derive(Clone)]
 pub struct PyImageLayout {
     inner: ImageLayout,

--- a/kornia-py/src/image.rs
+++ b/kornia-py/src/image.rs
@@ -810,7 +810,7 @@ impl ImageData {
 ///
 /// Thread-safe and serialization-friendly for use with Ray Data,
 /// multiprocessing, and other parallel execution frameworks.
-#[pyclass(name = "Image", weakref)]
+#[pyclass(name = "Image", weakref, module = "kornia_rs.image")]
 pub struct PyImageApi {
     data: ImageData,
     mode: String,

--- a/kornia-py/tests/test_image.py
+++ b/kornia-py/tests/test_image.py
@@ -1,5 +1,6 @@
 """Tests for the Image API and augmentations."""
 
+import io
 import multiprocessing
 import tempfile
 import os
@@ -854,6 +855,188 @@ class TestDecode:
         garbage = bytes([0xDE, 0xAD, 0xBE, 0xEF] * 16)
         with pytest.raises(Exception):
             Image.decode(garbage)
+
+
+class TestEncode:
+    """Test Image.encode() in-memory and Image.encode_png_u16() for depth maps.
+
+    `encode` is the in-memory complement of `save` — same backend, no path on
+    disk. `encode_png_u16` is the static-method bridge for 16-bit data until
+    Image natively supports uint16 storage; PNG-16 is the only safe lossless
+    format for depth (JPEG smears object-edge discontinuities).
+    """
+
+    def test_encode_jpeg_returns_bytes(self):
+        arr = np.random.randint(0, 255, (32, 64, 3), dtype=np.uint8)
+        img = Image.frombuffer(arr)
+        out = img.encode("jpeg")
+        assert isinstance(out, bytes)
+        # JPEG SOI marker.
+        assert out[:3] == b"\xff\xd8\xff"
+
+    def test_encode_jpeg_quality_is_honoured(self):
+        # High-frequency content so the quality knob actually moves the bytes.
+        arr = np.random.randint(0, 255, (64, 64, 3), dtype=np.uint8)
+        img = Image.frombuffer(arr)
+        small = img.encode("jpeg", quality=20)
+        big = img.encode("jpeg", quality=95)
+        assert len(big) > len(small)
+
+    def test_encode_jpg_alias(self):
+        # "jpg" must work as an alias of "jpeg" — matches `save` extension behavior.
+        arr = np.zeros((8, 8, 3), dtype=np.uint8)
+        img = Image.frombuffer(arr)
+        a = img.encode("jpg")
+        b = img.encode("jpeg")
+        # Same encoder, same input → identical bytes.
+        assert a == b
+
+    def test_encode_png_rgb(self):
+        arr = np.random.randint(0, 255, (32, 64, 3), dtype=np.uint8)
+        img = Image.frombuffer(arr)
+        out = img.encode("png")
+        assert isinstance(out, bytes)
+        # PNG signature (8 bytes).
+        assert out[:8] == b"\x89PNG\r\n\x1a\n"
+        # Round-trip via decode → exact match (PNG is lossless).
+        decoded = Image.decode(out)
+        assert decoded.width == 64
+        assert decoded.height == 32
+        assert decoded.channels == 3
+        assert np.array_equal(np.array(decoded), arr)
+
+    def test_encode_png_grayscale(self):
+        arr = np.full((16, 16, 1), 128, dtype=np.uint8)
+        img = Image.frombuffer(arr)
+        out = img.encode("png")
+        assert out[:8] == b"\x89PNG\r\n\x1a\n"
+
+    def test_encode_png_rgba(self):
+        arr = np.zeros((16, 16, 4), dtype=np.uint8)
+        arr[:, :, 3] = 255  # opaque alpha
+        img = Image.frombuffer(arr)
+        out = img.encode("png")
+        assert out[:8] == b"\x89PNG\r\n\x1a\n"
+
+    def test_encode_unsupported_format_raises(self):
+        arr = np.zeros((4, 4, 3), dtype=np.uint8)
+        img = Image.frombuffer(arr)
+        with pytest.raises(ValueError, match="Unsupported"):
+            img.encode("webp")
+
+    def test_encode_jpeg_rejects_grayscale(self):
+        # JPEG path requires 3-channel; mirror the `save` constraint.
+        arr = np.zeros((8, 8, 1), dtype=np.uint8)
+        img = Image.frombuffer(arr)
+        with pytest.raises(ValueError):
+            img.encode("jpeg")
+
+    # --- u16 (depth) — full Image lifecycle, not a static bridge ---
+
+    def test_u16_image_construction_2d(self):
+        # 2D uint16 → 1-channel u16 Image (depth-map shape).
+        depth = np.full((32, 64), 1500, dtype=np.uint16)
+        img = Image.fromarray(depth)
+        assert img.dtype == np.uint16
+        assert img.mode == "I;16"
+        assert img.width == 64 and img.height == 32 and img.channels == 1
+
+    def test_u16_image_construction_3d(self):
+        depth = np.full((16, 16, 1), 1500, dtype=np.uint16)
+        img = Image.fromarray(depth)
+        assert img.dtype == np.uint16
+        assert img.shape == (16, 16, 1)
+
+    def test_u16_image_encode_png(self):
+        # Realistic depth: smooth gradient + sharp object — what PNG-16 preserves.
+        h, w = 48, 64
+        depth = np.fromfunction(
+            lambda y, x: 1000 + (x.astype(np.uint16) * 8) + (y.astype(np.uint16) * 4),
+            (h, w),
+            dtype=np.uint16,
+        )
+        depth[10:20, 20:40] = 500
+        img = Image.fromarray(depth)
+        out = img.encode("png")
+        assert out[:8] == b"\x89PNG\r\n\x1a\n"
+
+        # Round-trip: decode produces an equal u16 Image (PNG-16 is lossless).
+        back = Image.decode(out, mode="L")
+        assert back.dtype == np.uint16
+        assert back.mode == "I;16"
+        assert np.array_equal(np.array(back).reshape(h, w), depth)
+
+    def test_u16_image_save_to_bytesio(self):
+        # PIL parity: save accepts a file-like (BytesIO) target.
+        depth = np.full((8, 8, 1), 9000, dtype=np.uint16)
+        img = Image.fromarray(depth)
+        buf = io.BytesIO()
+        img.save(buf, format="png")
+        out = buf.getvalue()
+        assert out[:8] == b"\x89PNG\r\n\x1a\n"
+
+    def test_u16_image_jpeg_rejected(self):
+        depth = np.full((8, 8, 1), 1500, dtype=np.uint16)
+        img = Image.fromarray(depth)
+        with pytest.raises(ValueError, match="16-bit"):
+            img.encode("jpeg")
+
+    def test_u16_image_imgproc_raises_clear_error(self):
+        # 8-bit-only methods raise NotImplementedError on u16 with a hint.
+        depth = np.full((8, 8, 1), 1500, dtype=np.uint16)
+        img = Image.fromarray(depth)
+        with pytest.raises(NotImplementedError, match="uint16"):
+            img.resize(4, 4)
+        with pytest.raises(NotImplementedError, match="uint16"):
+            img.flip_horizontal()
+        with pytest.raises(NotImplementedError, match="uint16"):
+            img.adjust_brightness(0.5)
+
+
+class TestSaveToBytesIO:
+    """PIL-parity: ``Image.save(BytesIO, format=...)`` works for u8 too."""
+
+    def test_save_to_bytesio_jpeg(self):
+        arr = np.zeros((8, 8, 3), dtype=np.uint8)
+        img = Image.frombuffer(arr)
+        buf = io.BytesIO()
+        img.save(buf, format="jpeg")
+        out = buf.getvalue()
+        assert out[:3] == b"\xff\xd8\xff"
+
+    def test_save_to_bytesio_png(self):
+        arr = np.full((8, 8, 3), 64, dtype=np.uint8)
+        img = Image.frombuffer(arr)
+        buf = io.BytesIO()
+        img.save(buf, format="png")
+        out = buf.getvalue()
+        assert out[:8] == b"\x89PNG\r\n\x1a\n"
+
+    def test_save_to_bytesio_requires_format(self):
+        # No path extension to fall back on → format= is mandatory.
+        arr = np.zeros((4, 4, 3), dtype=np.uint8)
+        img = Image.frombuffer(arr)
+        buf = io.BytesIO()
+        with pytest.raises(ValueError, match="format="):
+            img.save(buf)
+
+
+class TestFromarrayAlias:
+    """``Image.fromarray`` is the PIL idiom; verify it's a true alias of frombuffer."""
+
+    def test_fromarray_u8(self):
+        arr = np.zeros((4, 4, 3), dtype=np.uint8)
+        a = Image.fromarray(arr)
+        b = Image.frombuffer(arr)
+        assert a.mode == b.mode
+        assert a.dtype == b.dtype
+        assert a.shape == b.shape
+
+    def test_fromarray_u16(self):
+        arr = np.full((4, 4), 1234, dtype=np.uint16)
+        img = Image.fromarray(arr)
+        assert img.dtype == np.uint16
+        assert img.mode == "I;16"
 
 
 # --- Multiprocessing tests ---


### PR DESCRIPTION
## Summary

Closes the asymmetric PNG IO surface (in-memory decode + file-only write) and brings the Python `Image` class to PIL parity for the depth-recording use case.

**Before:** PNG had `decode_image_png_*(bytes)` for in-memory reads but only `write_image_png_*(file_path, ...)` for writes — callers needing PNG bytes for network/MCAP transit had to detour through Pillow or a tempfile. The Python `Image` class was uint8-only.

**After:** Symmetric in-memory PNG IO matching the JPEG pattern, plus a PIL-style `Image` class that natively holds uint16 (depth maps), accepts file-like targets in `save()`, and exposes `Image.fromarray` / `Image.encode(format)`.

## Changes

### kornia-io (Rust)
- Refactor `write_png_impl(file_path, ...)` → generic `write_png_into<W: Write>` used by both file-path writers and the new in-memory encoders.
- Add 6 buffer-based encoders mirroring the JPEG signature:
  `encode_image_png_{rgb8, rgba8, gray8, rgb16, rgba16, gray16}`.
- 6 new round-trip tests + 1 buffer-reuse test (10 total in png module).

### kornia-py — \`Image\` class refactor
- New `ImageData` enum holds either `Py<PyArray3<u8>>` or `Py<PyArray3<u16>>`; storage variant is part of the Image's identity.
- Properties (width/height/channels/size/shape/dtype/data/nbytes/`__len__`/`__array__`/`__getbuffer__`/`__repr__`/`__eq__`) dispatch on the variant.
- Constructors auto-detect dtype from the numpy array: \`Image(arr)\`, \`Image.frombuffer(arr)\`, \`Image.fromarray(arr)\` (PIL alias), \`Image.frombytes(data, w, h, c, dtype=\"uint8\"|\"uint16\")\`.
- `Image.load(path)`: bit depth comes from the file (PNG-16 → u16 Image).
- `Image.decode(bytes)`: peeks PNG IHDR `bit_depth` byte; PNG-16 → u16 Image.
- `Image.save(fp, format=None, quality=95)`: accepts a path string OR any file-like with `.write(bytes)` (BytesIO, S3 file objects, etc.). Format resolved from `format=` or extension.
- `Image.encode(format, quality=95)`: in-memory bytes; one canonical `encode_to_bytes` helper drives both `encode` and `save`. JPEG paths reject u16 (would corrupt depth discontinuities); PNG handles u8 + u16 across 1/3/4 channels.
- 8-bit-only imgproc methods (resize/flip/crop/blur/brightness/contrast/saturation/hue/normalize/to_grayscale/to_rgb/rotate) raise `NotImplementedError` on u16 with a clear remediation hint via shared `require_u8` helper.
- Pickling (`__reduce__` / `__getstate__` / `__setstate__`) reconstructs the variant from the stored numpy array's runtime dtype.

### kornia-py — tests
- 19 new \`Image\`/IO tests in `test_image.py` covering encode/save round-trips, uint16 lifecycle, BytesIO save, fromarray alias, JPEG rejection on u16, imgproc-on-u16 error path.
- **127 tests in `test_image.py` pass** (108 pre-existing + 19 new).
- **147 tests pass across the broader compatible suite** with no regressions.
- All 10 Rust PNG tests pass (4 existing + 6 new).

## Zero-copy + in-memory properties preserved

| Property | Before | After |
|---|---|---|
| In-memory PNG-8 + PNG-16 encode | ❌ file-only | ✅ |
| Buffer reuse at Rust API | JPEG only | uniform across JPEG + PNG |
| Generic \`Write\` writer | ❌ | ✅ via \`write_png_into<W: Write>\` |
| \`FromPyImage\` one-copy at numpy→Rust boundary | one copy (existing TODO) | unchanged |
| \`Vec<u8>→PyBytes\` one-copy at Rust→Python boundary | one copy (PyO3 standard) | unchanged |
| \`save()\` accepts BytesIO (PIL parity) | ❌ | ✅ |
| Image natively holds uint16 | ❌ | ✅ |

## Motivation

Depth recording for OAK cameras over Zenoh requires PNG-16 in memory (JPEG corrupts object-edge discontinuities into meters-deep holes). Previously this required a Pillow detour; now it's native to kornia-rs with the PIL-compatible API users already know.

## Known PIL-parity gaps (deliberately deferred)

For follow-up PRs:
- \`Image.open(fp)\` unified entry (accepts path **or** bytes/file-like in one method)
- WebP and TIFF in \`encode\`/\`save\`/\`decode\`/\`load\` (kornia-rs already has both at the Rust level)
- \`img.tobytes()\`, \`img.convert(mode)\`, \`img.format\`, \`Image.new(mode, size, color)\`
- \`img.crop((x1,y1,x2,y2))\` 4-tuple PIL signature
- u16 imgproc methods (currently raise \`NotImplementedError\`)
- Float32 (\`F\` mode) storage variant

These are tracked as future work — see commit message for details.

## Test plan

- [ ] CI passes (Rust + Python)
- [ ] Manual: \`maturin develop && python -m pytest kornia-py/tests/test_image.py\`
- [ ] Verify no regression in cross-arch ORB / feature tests
- [ ] Smoke-test downstream depth-recording use case (linked Bubbaloop PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)