### PR TITLE
feat(kornia-py): move solve_pnp into k3d as solve_pnp_ransac

### DIFF
--- a/kornia-py/src/lib.rs
+++ b/kornia-py/src/lib.rs
@@ -16,6 +16,7 @@ mod io;
 mod normalize;
 mod orb;
 mod pipeline;
+mod pnp;
 mod pointcloud;
 mod pyutils;
 mod ransac;
@@ -446,6 +447,7 @@ pub fn kornia_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     )?)?;
     k3d_mod.add_function(wrap_pyfunction!(homography::find_homography_py, &k3d_mod)?)?;
     k3d_mod.add_function(wrap_pyfunction!(homography::find_fundamental_py, &k3d_mod)?)?;
+    k3d_mod.add_function(wrap_pyfunction!(pnp::solve_pnp_ransac_py, &k3d_mod)?)?;
     m.add_submodule(&k3d_mod)?;
 
     // Apriltag submodule

--- a/kornia-py/src/pnp.rs
+++ b/kornia-py/src/pnp.rs
@@ -35,7 +35,7 @@ use rand::{rngs::StdRng, SeedableRng};
 /// Raises ValueError on shape mismatches or when RANSAC produces no model.
 #[pyfunction(name = "solve_pnp_ransac")]
 #[pyo3(signature = (world, image, k, threshold=4.0, max_iterations=1000, confidence=0.999, seed=None))]
-#[allow(clippy::type_complexity)]
+#[allow(clippy::type_complexity, clippy::too_many_arguments)]
 pub fn solve_pnp_ransac_py<'py>(
     py: Python<'py>,
     world: Bound<'py, PyArray2<f64>>,
@@ -145,7 +145,7 @@ pub fn solve_pnp_ransac_py<'py>(
         r_arr[8] as f64,
     ];
     let r_py = numpy::PyArray::from_vec(py, r_rmaj).reshape([3usize, 3])?;
-    let t_py = vec![
+    let t_py = [
         model.translation.x as f64,
         model.translation.y as f64,
         model.translation.z as f64,

--- a/kornia-py/src/pnp.rs
+++ b/kornia-py/src/pnp.rs
@@ -1,0 +1,158 @@
+//! `kornia_rs.k3d.solve_pnp_ransac` — `cv2.solvePnPRansac`-shaped binding.
+//!
+//! Wraps `kornia_3d::ransac::run` over `EPnPEstimator` so the Python surface
+//! matches OpenCV's calling convention while the underlying solver is the
+//! generic kornia RANSAC driver (NEON/AVX2 scoring, adaptive iter cap).
+//!
+//! P3P kernel is queued as a follow-up; today's RANSAC kernel is EPnP.
+
+use kornia_3d::ransac::{
+    estimators::EPnPEstimator, run, Match2d3d, RansacConfig, ThresholdConsensus, UniformSampler,
+};
+use kornia_algebra::{Mat3AF32, Vec2F64, Vec3AF32, Vec3F64};
+use numpy::{PyArray1, PyArray2, PyArrayMethods, PyUntypedArrayMethods, ToPyArray};
+use pyo3::prelude::*;
+use rand::{rngs::StdRng, SeedableRng};
+
+/// `cv2.solvePnPRansac` analog. Recovers `(R, t)` from 3D-2D correspondences.
+///
+/// Args:
+///     world: `(N, 3)` float64 world points.
+///     image: `(N, 2)` float64 pixel observations (same length as world).
+///     k: `(3, 3)` float64 row-major pinhole intrinsics.
+///     threshold: reprojection-error threshold in pixels (default 4.0).
+///     max_iterations: RANSAC iteration cap (default 1000).
+///     confidence: target probability of an all-inlier sample (default 0.999).
+///     seed: optional RNG seed for deterministic runs.
+///
+/// Returns:
+///     `(R, t, inlier_mask, inlier_count)` where:
+///     * `R` — `(3, 3)` float64 row-major rotation (world → camera).
+///     * `t` — `(3,)` float64 translation in the camera frame.
+///     * `inlier_mask` — `(N,)` uint8 per-correspondence mask (1 = inlier).
+///     * `inlier_count` — total inliers (int).
+///
+/// Raises ValueError on shape mismatches or when RANSAC produces no model.
+#[pyfunction(name = "solve_pnp_ransac")]
+#[pyo3(signature = (world, image, k, threshold=4.0, max_iterations=1000, confidence=0.999, seed=None))]
+#[allow(clippy::type_complexity)]
+pub fn solve_pnp_ransac_py<'py>(
+    py: Python<'py>,
+    world: Bound<'py, PyArray2<f64>>,
+    image: Bound<'py, PyArray2<f64>>,
+    k: Bound<'py, PyArray2<f64>>,
+    threshold: f64,
+    max_iterations: u32,
+    confidence: f64,
+    seed: Option<u64>,
+) -> PyResult<(
+    Bound<'py, PyArray2<f64>>,
+    Bound<'py, PyArray1<f64>>,
+    Bound<'py, PyArray1<u8>>,
+    usize,
+)> {
+    let world_shape = world.shape();
+    let image_shape = image.shape();
+    let k_shape = k.shape();
+    if world_shape.len() != 2 || world_shape[1] != 3 {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "world must be (N, 3) float64",
+        ));
+    }
+    if image_shape.len() != 2 || image_shape[1] != 2 {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "image must be (N, 2) float64",
+        ));
+    }
+    if world_shape[0] != image_shape[0] {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "world and image must have matching N",
+        ));
+    }
+    if k_shape.len() != 2 || k_shape[0] != 3 || k_shape[1] != 3 {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "k must be (3, 3) float64",
+        ));
+    }
+    let n = world_shape[0];
+    if n < 4 {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "solve_pnp_ransac requires N >= 4 correspondences",
+        ));
+    }
+
+    // SAFETY: only used to read; no aliasing concerns since we copy into samples below.
+    let world_ro = unsafe { world.as_array() };
+    let image_ro = unsafe { image.as_array() };
+    let k_ro = unsafe { k.as_array() };
+
+    let samples: Vec<Match2d3d> = (0..n)
+        .map(|i| {
+            Match2d3d::new(
+                Vec3F64::new(world_ro[[i, 0]], world_ro[[i, 1]], world_ro[[i, 2]]),
+                Vec2F64::new(image_ro[[i, 0]], image_ro[[i, 1]]),
+            )
+        })
+        .collect();
+
+    // Row-major numpy → column-major Mat3AF32: col j is K's column j.
+    let k_mat = Mat3AF32::from_cols(
+        Vec3AF32::new(
+            k_ro[[0, 0]] as f32,
+            k_ro[[1, 0]] as f32,
+            k_ro[[2, 0]] as f32,
+        ),
+        Vec3AF32::new(
+            k_ro[[0, 1]] as f32,
+            k_ro[[1, 1]] as f32,
+            k_ro[[2, 1]] as f32,
+        ),
+        Vec3AF32::new(
+            k_ro[[0, 2]] as f32,
+            k_ro[[1, 2]] as f32,
+            k_ro[[2, 2]] as f32,
+        ),
+    );
+
+    let est = EPnPEstimator::new(k_mat);
+    let mut sampler = UniformSampler::new(StdRng::seed_from_u64(seed.unwrap_or(0)));
+    let consensus = ThresholdConsensus { threshold };
+    let cfg = RansacConfig {
+        max_iters: max_iterations,
+        confidence,
+        inlier_threshold: threshold,
+        ..Default::default()
+    };
+
+    let result = run(&est, &consensus, &mut sampler, &samples, &cfg);
+    let model = result.model.ok_or_else(|| {
+        pyo3::exceptions::PyValueError::new_err(
+            "solve_pnp_ransac: no model recovered (check threshold + iter budget)",
+        )
+    })?;
+
+    // Row-major repack of column-major Mat3AF32: row i = (col0[i], col1[i], col2[i]).
+    let r_arr = model.rotation.to_cols_array();
+    let r_rmaj: Vec<f64> = vec![
+        r_arr[0] as f64,
+        r_arr[3] as f64,
+        r_arr[6] as f64,
+        r_arr[1] as f64,
+        r_arr[4] as f64,
+        r_arr[7] as f64,
+        r_arr[2] as f64,
+        r_arr[5] as f64,
+        r_arr[8] as f64,
+    ];
+    let r_py = numpy::PyArray::from_vec(py, r_rmaj).reshape([3usize, 3])?;
+    let t_py = vec![
+        model.translation.x as f64,
+        model.translation.y as f64,
+        model.translation.z as f64,
+    ]
+    .to_pyarray(py);
+    let mask: Vec<u8> = result.inliers.iter().map(|&b| b as u8).collect();
+    let mask_py = mask.to_pyarray(py);
+    let inlier_count = result.inliers.iter().filter(|&&b| b).count();
+    Ok((r_py, t_py, mask_py, inlier_count))
+}

--- a/kornia-py/src/ransac.rs
+++ b/kornia-py/src/ransac.rs
@@ -15,10 +15,10 @@
 //! lifetimes leak across the FFI boundary.
 
 use kornia_3d::ransac::{
-    estimators::{EPnPEstimator, EssentialEstimator, FundamentalEstimator, HomographyEstimator},
-    run, Match2d2d, Match2d3d, RansacConfig, ThresholdConsensus, UniformSampler,
+    estimators::{EssentialEstimator, FundamentalEstimator, HomographyEstimator},
+    run, Match2d2d, RansacConfig, ThresholdConsensus, UniformSampler,
 };
-use kornia_algebra::{Mat3AF32, Vec2F64, Vec3AF32, Vec3F64};
+use kornia_algebra::Vec2F64;
 use numpy::{PyReadonlyArray2, PyUntypedArrayMethods};
 use pyo3::prelude::*;
 use rand::{rngs::StdRng, SeedableRng};
@@ -36,27 +36,6 @@ pub struct PyRansacTwoViewResult {
     #[pyo3(get)]
     pub num_iters: u32,
     /// Best consensus score (higher is better).
-    #[pyo3(get)]
-    pub score: f64,
-}
-
-/// EPnP RANSAC result. Rotation is a row-major 3×3 in `model[..9]` and
-/// translation is in `translation`.
-#[pyclass(frozen, name = "RansacPnPResult", module = "kornia_rs.ransac")]
-pub struct PyRansacPnPResult {
-    /// Best-scoring rotation (row-major 3×3, 9 floats), or `None`.
-    #[pyo3(get)]
-    pub rotation: Option<Vec<f64>>,
-    /// Translation vector (3 floats), or `None`.
-    #[pyo3(get)]
-    pub translation: Option<Vec<f64>>,
-    /// Inlier mask.
-    #[pyo3(get)]
-    pub inliers: Vec<bool>,
-    /// Number of hypotheses evaluated.
-    #[pyo3(get)]
-    pub num_iters: u32,
-    /// Best consensus score.
     #[pyo3(get)]
     pub score: f64,
 }
@@ -183,100 +162,22 @@ pub fn homography(
     })
 }
 
-/// `cv2.solvePnPRansac` analog (EPnP kernel).
-///
-/// `matches` is `(N, 5)` with rows `[Xw, Yw, Zw, u, v]`. `k` is `(3, 3)` row-major
-/// pinhole intrinsics (no distortion supported in v1).
-#[pyfunction]
-#[pyo3(signature = (matches, k, threshold=4.0, max_iters=1000, confidence=0.999, seed=None))]
-pub fn solve_pnp(
-    py: Python<'_>,
-    matches: PyReadonlyArray2<'_, f64>,
-    k: PyReadonlyArray2<'_, f64>,
-    threshold: f64,
-    max_iters: u32,
-    confidence: f64,
-    seed: Option<u64>,
-) -> PyResult<PyRansacPnPResult> {
-    let _ = py;
-    let shape = matches.shape();
-    if shape.len() != 2 || shape[1] != 5 {
-        return Err(pyo3::exceptions::PyValueError::new_err(
-            "expected (N, 5) float64 array [Xw, Yw, Zw, u, v]",
-        ));
-    }
-    let m = matches.as_array();
-    let samples: Vec<Match2d3d> = (0..shape[0])
-        .map(|i| {
-            Match2d3d::new(
-                Vec3F64::new(m[[i, 0]], m[[i, 1]], m[[i, 2]]),
-                Vec2F64::new(m[[i, 3]], m[[i, 4]]),
-            )
-        })
-        .collect();
-
-    let kshape = k.shape();
-    if kshape.len() != 2 || kshape[0] != 3 || kshape[1] != 3 {
-        return Err(pyo3::exceptions::PyValueError::new_err(
-            "expected (3, 3) float64 K matrix",
-        ));
-    }
-    let kv = k.as_array();
-    // Row-major numpy → column-major Mat3AF32: col 0 is the first column of K.
-    let k_mat = Mat3AF32::from_cols(
-        Vec3AF32::new(kv[[0, 0]] as f32, kv[[1, 0]] as f32, kv[[2, 0]] as f32),
-        Vec3AF32::new(kv[[0, 1]] as f32, kv[[1, 1]] as f32, kv[[2, 1]] as f32),
-        Vec3AF32::new(kv[[0, 2]] as f32, kv[[1, 2]] as f32, kv[[2, 2]] as f32),
-    );
-    let est = EPnPEstimator::new(k_mat);
-    let mut sampler = UniformSampler::new(StdRng::seed_from_u64(seed.unwrap_or(0)));
-    let consensus = ThresholdConsensus { threshold };
-    let cfg = make_cfg(threshold, max_iters, confidence);
-    let result = run(&est, &consensus, &mut sampler, &samples, &cfg);
-    let (rot, tr) = match &result.model {
-        Some(m) => {
-            let r_arr = m.rotation.to_cols_array(); // column-major [c0.x..c2.z]
-                                                    // Row-major repack: row i = (col0[i], col1[i], col2[i])
-            let rmaj = vec![
-                r_arr[0] as f64,
-                r_arr[3] as f64,
-                r_arr[6] as f64,
-                r_arr[1] as f64,
-                r_arr[4] as f64,
-                r_arr[7] as f64,
-                r_arr[2] as f64,
-                r_arr[5] as f64,
-                r_arr[8] as f64,
-            ];
-            (
-                Some(rmaj),
-                Some(vec![
-                    m.translation.x as f64,
-                    m.translation.y as f64,
-                    m.translation.z as f64,
-                ]),
-            )
-        }
-        None => (None, None),
-    };
-    Ok(PyRansacPnPResult {
-        rotation: rot,
-        translation: tr,
-        inliers: result.inliers,
-        num_iters: result.num_iters,
-        score: result.score,
-    })
-}
+// PnP RANSAC moved to `kornia_rs.k3d.solve_pnp_ransac` (see `crate::pnp`)
+// to align with the OpenCV-shaped `find_fundamental` / `find_homography`
+// neighbours. The lower-level generic-trait path stays accessible via
+// the Rust API (`kornia_3d::ransac::run` + `EPnPEstimator`).
 
 /// Build the `kornia_rs.ransac` submodule.
+///
+/// Two-view-only here; PnP/EPnP RANSAC has moved to
+/// [`kornia_rs.k3d.solve_pnp_ransac`] to align with the OpenCV-shape
+/// namespace convention used by `find_fundamental` / `find_homography`.
 pub fn register(py: Python<'_>, parent: &Bound<'_, PyModule>) -> PyResult<()> {
     let m = PyModule::new(py, "ransac")?;
     m.add_class::<PyRansacTwoViewResult>()?;
-    m.add_class::<PyRansacPnPResult>()?;
     m.add_function(wrap_pyfunction!(fundamental, &m)?)?;
     m.add_function(wrap_pyfunction!(essential, &m)?)?;
     m.add_function(wrap_pyfunction!(homography, &m)?)?;
-    m.add_function(wrap_pyfunction!(solve_pnp, &m)?)?;
     parent.add_submodule(&m)?;
     Ok(())
 }


### PR DESCRIPTION
## Summary

Move `solve_pnp` from `kornia_rs.ransac` to `kornia_rs.k3d.solve_pnp_ransac`. Aligns the Python surface with the OpenCV-shape convention already used by `k3d.find_fundamental` / `k3d.find_homography`, and renames to match `cv2.solvePnPRansac` exactly.

```python
R, t, inlier_mask, inlier_count = kornia_rs.k3d.solve_pnp_ransac(
    world,    # (N, 3) float64
    image,    # (N, 2) float64
    k,        # (3, 3) float64 row-major
    threshold=4.0,
    max_iterations=1000,
    confidence=0.999,
    seed=42,
)
```

The `kornia_rs.ransac` submodule keeps the F/E/H lower-level functions for the generic-trait path. `solve_pnp` + `RansacPnPResult` landed only in #899 days ago, so removal is safe.

Underlying kernel is still **EPnP**; **P3P** (the OpenCV default and the kernel real SLAM/SfM pipelines use — ORB-SLAM3, VINS-Fusion, COLMAP) is queued as a follow-up.

## Test plan

- [x] `cargo check -p kornia-py` clean
- [x] `cargo fmt --all --check` clean
- [ ] `cargo clippy --workspace --no-deps --all-targets --features ci` (CI will run)
- [ ] CI test matrix
- [ ] Manual: `kornia_rs.k3d.solve_pnp_ransac(...)` round-trip after wheel rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)