### PR TITLE
chore(release): set up cargo publish workflow for the Rust workspace

### DIFF
--- a/.github/workflows/rust_release.yml
+++ b/.github/workflows/rust_release.yml
@@ -1,0 +1,53 @@
+name: Rust Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "publish" to confirm — this publishes to crates.io and is irreversible'
+        required: true
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: cargo publish (topological)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Guard — require explicit confirmation
+        env:
+          CONFIRM: ${{ inputs.confirm }}
+        run: |
+          if [ "$CONFIRM" != "publish" ]; then
+            echo "::error::Confirmation field must be exactly 'publish' (got: '$CONFIRM')"
+            echo "::error::This workflow publishes to crates.io and is irreversible."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v6
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Install build deps for cargo publish verification
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            cmake \
+            nasm \
+            libjpeg-turbo8-dev \
+            pkg-config \
+            libssl-dev
+
+      - name: Show planned publish order (dry-run leaves)
+        run: ./scripts/release_rust.sh
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: ./scripts/release_rust.sh --execute

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -398,20 +398,61 @@ pixi run rust-cross-test-aarch64
 
 ## Release (maintainers)
 
-The script `scripts/release_rust.sh` publishes all crates using `cross publish` and runs in dry-run mode by default.
+Three things publish independently:
 
-Steps:
-1. Update versions across crates and workspace; update dependency pins in `[workspace.dependencies]` accordingly.
-2. Verify locally:
-   ```bash
-   pixi run rust-lint
-   pixi run rust-test
-   ./scripts/release_rust.sh  # dry-run
-   ```
-3. Perform the real publish when ready:
-   ```bash
-   ./scripts/release_rust.sh --no-dry-run
-   ```
+1. **Rust crates → crates.io** — via `scripts/release_rust.sh` (or the `Rust Release` GitHub Actions workflow).
+2. **Python wheel `kornia-rs` → PyPI** — via the `Python Release` workflow (`.github/workflows/python_release.yml`).
+3. **GitHub release with binaries / changelog** — created manually after both of the above succeed.
+
+These are independent: a PyPI publish doesn't push to crates.io, and vice versa. Pick the steps relevant to what you're releasing.
+
+### Versioning
+
+The workspace uses a shared version in the root `Cargo.toml` and every workspace member inherits it via `version = { workspace = true }`. When bumping:
+
+- Update `[workspace.package].version` in root `Cargo.toml`
+- Update each version pin in `[workspace.dependencies]` (e.g. `kornia-image = { path = "...", version = "X.Y.Z" }`)
+- Run `cargo check` to refresh `Cargo.lock`
+- Run `pixi run toml-fmt`
+
+### Publishing to crates.io
+
+The script `scripts/release_rust.sh` publishes the workspace's Rust crates **in topological order** (deps first), sleeping between steps so the crates.io index has time to propagate.
+
+Default mode is `plan` — prints what would be published and dry-runs the tier-0 leaf crates. (Cargo can't dry-run a workspace crate whose deps aren't already on crates.io, so dependent crates are validated by the actual publish.)
+
+```bash
+# Local: preview what would publish
+./scripts/release_rust.sh
+
+# Local: actually publish (requires CARGO_REGISTRY_TOKEN or `cargo login`)
+CARGO_REGISTRY_TOKEN=cio_xxx ./scripts/release_rust.sh --execute
+
+# CI: trigger the `Rust Release` workflow from the Actions tab.
+# It requires typing "publish" in the confirmation field, and reads
+# CARGO_REGISTRY_TOKEN from the repo secrets.
+```
+
+#### Setup: crates.io token (one-time)
+
+1. Generate a token at <https://crates.io/settings/tokens> with `publish-update` scope.
+2. Add it as a repo secret named `CARGO_REGISTRY_TOKEN` (Settings → Secrets and variables → Actions).
+
+#### Crates currently published
+
+`kornia-algebra`, `kornia-bow`, `kornia-tensor`, `kornia-tensor-ops`, `kornia-image`, `kornia-io`, `kornia-imgproc`, `kornia-3d` — in that order.
+
+#### Crates intentionally skipped
+
+- `kornia` — the umbrella crate; needs decisions on optional/feature gating before re-enabling.
+- `kornia-vlm` — pulls in `candle`, `tokio`, `hf-hub`; heavy publish surface.
+- `kornia-apriltag` — has a large git submodule of test images that `cargo publish` verification trips on.
+
+To add them back, append the crate to `PUBLISH_ORDER` in `scripts/release_rust.sh`.
+
+### Publishing the Python wheel
+
+Trigger the `Python Release` workflow (`.github/workflows/python_release.yml`) from the Actions tab. It builds wheels for Linux / macOS / Windows × Python 3.8–3.14t and uploads to PyPI using the `PYPI_PASSWORD` secret.
 
 ## Python bindings (`kornia-py`)
 

--- a/scripts/release_rust.sh
+++ b/scripts/release_rust.sh
@@ -1,26 +1,126 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+#
+# Publish the workspace's Rust crates to crates.io in topological order.
+#
+# Default: plan mode — prints what would be published and runs `cargo
+# publish --dry-run` against the leaf crates only (tier 0, no kornia-* deps).
+# `cargo publish --dry-run` for the dependent crates always fails for
+# workspaces because the not-yet-published deps aren't resolvable from the
+# crates.io index — that's a Cargo limitation, not a script bug.
+#
+# Pass --execute to actually publish. Requires CARGO_REGISTRY_TOKEN env var.
+#
+# Crates are published deps-first. crates.io's index has a few-seconds
+# propagation lag after each publish, so we sleep between dependent steps.
+#
+# Crates intentionally not published from this script:
+#   - kornia            (umbrella — re-enable once we decide how to gate
+#                        optional/feature-heavy deps)
+#   - kornia-vlm        (pulls in candle, tokio, hf-hub — heavy)
+#   - kornia-apriltag   (large git submodule of test images)
+# Add them back to PUBLISH_ORDER below once those constraints are sorted.
 
-set -x # echo on
-set -e # exit on error
+set -euo pipefail
 
-# Set dry-run as default
-DRY_RUN="--dry-run"
+MODE="plan"        # plan | execute
+SLEEP_SECS=20
 
-# Check if --no-dry-run argument is passed
-if [[ "$1" == "--no-dry-run" ]]; then
-  DRY_RUN=""
+for arg in "$@"; do
+  case "$arg" in
+    --execute|--no-dry-run)
+      MODE="execute"
+      ;;
+    --help|-h)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $arg" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Topological publish order. Every crate's kornia-* dependencies must
+# already be on crates.io (or appear earlier in this list).
+#
+# Tier 0 (no kornia-* deps):       kornia-algebra, kornia-bow, kornia-tensor
+# Tier 1 (-> tensor):              kornia-tensor-ops, kornia-image
+# Tier 2 (-> image, tensor):       kornia-io
+# Tier 3 (-> algebra/image/tensor/io): kornia-imgproc
+# Tier 4 (-> everything above):    kornia-3d
+PUBLISH_ORDER=(
+  kornia-algebra
+  kornia-bow
+  kornia-tensor
+  kornia-tensor-ops
+  kornia-image
+  kornia-io
+  kornia-imgproc
+  kornia-3d
+)
+
+# Tier-0 leaves (no kornia-* deps) — these can be `cargo publish --dry-run`'d
+# locally for verification because there's nothing to resolve from crates.io.
+TIER_0=(kornia-algebra kornia-bow kornia-tensor)
+
+# Pass --all-features to crates whose optional features are part of the
+# published surface so docs.rs builds them. Anything not listed defaults
+# to just the default features.
+declare -A CRATE_FEATURES=(
+  [kornia-tensor]="--all-features"
+  [kornia-io]="--all-features"
+)
+
+is_tier_0() {
+  local target="$1"
+  for c in "${TIER_0[@]}"; do
+    [[ "$c" == "$target" ]] && return 0
+  done
+  return 1
+}
+
+if [[ "$MODE" == "plan" ]]; then
+  echo "==> PLAN — would publish ${#PUBLISH_ORDER[@]} crates in this order:"
+  for crate in "${PUBLISH_ORDER[@]}"; do
+    features="${CRATE_FEATURES[$crate]:-}"
+    echo "      cargo publish -p $crate $features"
+  done
+  echo
+  echo "==> Dry-running tier-0 leaves (no kornia-* deps) to validate packaging..."
+  for crate in "${TIER_0[@]}"; do
+    features="${CRATE_FEATURES[$crate]:-}"
+    echo "==> cargo publish -p $crate $features --dry-run"
+    cargo publish -p "$crate" $features --dry-run
+  done
+  echo
+  echo "==> Plan validation complete. Re-run with --execute to publish for real."
+  echo "    (Dependent crates can only be 'dry-run' after their deps are on"
+  echo "     crates.io — that's a Cargo workspace publish limitation.)"
+  exit 0
 fi
 
-# NOTE: don't touch the order of the crates as it is used to determine the dependencies
-# Publish crates
-cross publish -p kornia-algebra $DRY_RUN
-cross publish -p kornia-3d $DRY_RUN
-cross publish -p kornia-tensor --all-features $DRY_RUN
-cross publish -p kornia-tensor-ops $DRY_RUN
-cross publish -p kornia-image $DRY_RUN
-cross publish -p kornia-io --all-features $DRY_RUN
-cross publish -p kornia-imgproc $DRY_RUN
-cross publish -p kornia-apriltag $DRY_RUN
+# --- execute mode ---
 
-# TODO: decide if we want to publish kornia crate and if so, how to handle the dependencies
-# cross publish -p kornia --all-features $DRY_RUN
+if [[ -z "${CARGO_REGISTRY_TOKEN:-}" ]]; then
+  echo "ERROR: CARGO_REGISTRY_TOKEN is not set." >&2
+  echo "       Either export it, or run 'cargo login' first." >&2
+  exit 1
+fi
+
+echo "==> EXECUTE — publishing ${#PUBLISH_ORDER[@]} crates"
+echo
+
+for crate in "${PUBLISH_ORDER[@]}"; do
+  features="${CRATE_FEATURES[$crate]:-}"
+  echo "==> cargo publish -p $crate $features"
+  cargo publish -p "$crate" $features
+
+  if [[ "$crate" != "${PUBLISH_ORDER[-1]}" ]]; then
+    echo "    sleeping ${SLEEP_SECS}s for crates.io index propagation..."
+    sleep "$SLEEP_SECS"
+  fi
+done
+
+echo
+echo "==> Done — published ${#PUBLISH_ORDER[@]} crates"


### PR DESCRIPTION
## Why

The Rust crates in this workspace haven't been re-published to crates.io since **2025-11-08 (v0.1.10)**. As a result:
- `kornia-algebra` isn't on crates.io at all (it was added 2025-11-30, after the last publish)
- `kornia-3d` (which depends on `kornia-algebra`) is on crates.io but its 0.1.10 manifest predates the algebra dep
- Downstream users like `bubbaloop-nodes-official/rtsp-camera` are stuck on `kornia-image = "0.1.10"` and miss every workspace fix shipped since then

The existing `scripts/release_rust.sh` was non-functional: it called `cross publish` (`cross` doesn't have a `publish` subcommand — only `build`, `test`, `run`) and listed crates in incorrect topological order.

## What this PR ships

**`scripts/release_rust.sh` — rewritten:**
- Uses real `cargo publish`
- Correct topological order (deps first):
  `algebra, bow, tensor → tensor-ops, image → io → imgproc → 3d`
- Inter-step sleep so crates.io's index has time to propagate before the next dependent crate uploads (otherwise the next `cargo publish` errors with `no matching package found`)
- Default `plan` mode prints the publish order and dry-runs only the tier-0 leaves (Cargo cannot dry-run a workspace crate whose deps aren't already on crates.io — that's a Cargo limitation, not a script bug)
- `--execute` mode does the real publish; requires `CARGO_REGISTRY_TOKEN`

**`.github/workflows/rust_release.yml` — new workflow:**
- `workflow_dispatch` only (no auto-trigger)
- Requires typing `publish` in the confirmation field (guards against accidental clicks)
- Installs `cmake`, `nasm`, `libjpeg-turbo8-dev`, `pkg-config`, `libssl-dev` so `cargo publish` verification can build crates with C deps (turbojpeg in particular)
- Runs `release_rust.sh` in plan mode first, then `--execute` with the `CARGO_REGISTRY_TOKEN` repo secret

**`CONTRIBUTING.md` — updated:**
- Documents the three independent publish surfaces (crates.io / PyPI / GitHub release)
- Lists which crates are published and which are skipped (`kornia` umbrella, `kornia-vlm`, `kornia-apriltag`) with rationale
- Notes the one-time `CARGO_REGISTRY_TOKEN` repo-secret setup

## Setup before first use

A maintainer with publish access to <https://crates.io/crates/kornia-image> etc. needs to:

1. Generate a token at <https://crates.io/settings/tokens> with `publish-update` scope
2. Add it as a repo secret named `CARGO_REGISTRY_TOKEN`

## Verification

- [x] `./scripts/release_rust.sh` (plan mode) runs locally and dry-runs the 3 tier-0 leaves successfully
- [x] `./scripts/release_rust.sh --help` prints the documented usage
- [x] Each crate's required metadata (description, license, repository, homepage) is in place — verified for the 3 not-yet-on-crates.io crates (`kornia-algebra`, `kornia-bow`)
- [ ] Workflow dry-run: trigger from Actions tab with confirm=`publish` after `CARGO_REGISTRY_TOKEN` is added — surfaces any C-dep verification issues before the real publish

## Out of scope

- Publishing `kornia-vlm` (heavy candle/tokio/hf-hub deps), `kornia-apriltag` (large git submodule), or the `kornia` umbrella (decisions on optional-feature gating) — documented in the script header so it's clear how to add them back
- Auto-trigger on tag push — kept manual + confirmation-gated for now since crates.io publishes are irreversible

🤖 Generated with [Claude Code](https://claude.com/claude-code)