### PR TITLE
Added mps fallback to device.rs

### DIFF
--- a/crates/kornia-vlm/Cargo.toml
+++ b/crates/kornia-vlm/Cargo.toml
@@ -36,6 +36,7 @@ rand = "0.9.0"
 
 [features]
 default = []
+metal = ["candle-core/metal"]
 cuda = [
   "candle-core/cuda",
   "candle-nn/cuda",

--- a/crates/kornia-vlm/Cargo.toml
+++ b/crates/kornia-vlm/Cargo.toml
@@ -36,7 +36,6 @@ rand = "0.9.0"
 
 [features]
 default = []
-metal = ["candle-core/metal"]
 cuda = [
   "candle-core/cuda",
   "candle-nn/cuda",
@@ -44,3 +43,4 @@ cuda = [
   "cudarc"
 ]
 flash-attn = ["candle-transformers/flash-attn"]
+metal = ["candle-core/metal"]

--- a/crates/kornia-vlm/src/device.rs
+++ b/crates/kornia-vlm/src/device.rs
@@ -23,7 +23,7 @@ pub fn get_device_and_dtype() -> (Device, DType) {
         }
     }
     // MPS path (Apple Silicon)
-    #[cfg(feature = "metal")]
+    #[cfg(all(feature = "metal", target_os = "macos"))]
     {
         match Device::new_metal(0) {
             Ok(device) => {

--- a/crates/kornia-vlm/src/device.rs
+++ b/crates/kornia-vlm/src/device.rs
@@ -17,8 +17,21 @@ pub fn get_device_and_dtype() -> (Device, DType) {
                 return (device, dtype); // ← explicit return so the CPU fallback below applies on Err
             }
             Err(e) => {
-                log::warn!("CUDA not available, defaulting to CPU: {:?}", e);
+                log::warn!("CUDA not available: {:?}", e);
                 // falls through to CPU fallback below
+            }
+        }
+    }
+    // MPS path (Apple Silicon)
+    #[cfg(feature = "metal")]
+    {
+        match Device::new_metal(0) {
+            Ok(device) => {
+                log::info!("Using Apple Metal (MPS) backend with F16");
+                return (device, DType::F16);
+            }
+            Err(e) => {
+                log::warn!("Metal unavailable: {:?}", e);
             }
         }
     }


### PR DESCRIPTION
## 📝 Description

**Fixes/Relates to:** #909 
Adds Apple Metal/MPS backend support to the device selection path. When CUDA is unavailable or not enabled, the code now attempts to initialize Candle's Metal backend before falling back to CPU. This enables Apple Silicon machines to run on MPS with `F16` instead of always falling back to CPU `F32`.


## 🛠️ Changes Made
- [x] Added a `metal` feature-gated Apple Metal/MPS device selection path using `Device::new_metal(0)`.
- [x] Updated fallback order to prefer CUDA first, then Metal/MPS, then CPU.
- [x] Kept CUDA dtype selection unchanged, using `BF16` when supported and `F16` otherwise.
- [x] Kept CPU fallback unchanged with `Device::Cpu` and `DType::F32`.

---

## 🧪 How Was This Tested?
- [ ] **Unit Tests:** (List new/updated tests)

- [x] **Manual Verification:** (Describe the steps you took)
- Verified the updated fallback path compiles and correctly attempts Metal initialization behind the `metal` feature flag.

- [ ] **Performance/Edge Cases:** (How does this handle nulls, large data, etc.?)

---

## 🕵️ AI Usage Disclosure
*Check one of the following:*
- [x] 🟢 **No AI used.**
- [ ] 🟡 **AI-assisted:** I used AI for boilerplate/refactoring but have manually reviewed and tested every line.
- [ ] 🔴 **AI-generated:** (Note: These PRs may be subject to stricter scrutiny or immediate closure if the logic is not explained).

---

## 🚦 Checklist
- [x] I am assigned to the linked issue (required before PR submission)
- [x] The linked issue has been approved by a maintainer
- [x] This PR strictly implements what the linked issue describes (no scope creep)
- [x] I have performed a **self-review** of my code (no "ghost" variables or hallucinations).
- [x] My code follows the existing style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] (Optional) I have attached screenshots/recordings for UI changes.

---

## 💭 Additional Context
Add any other context or screenshots about the pull request here.

Fixes: #909 