### PR TITLE
feat(tensor): GPU backend scaffold, feature flags, Backend trait, GpuAllocator

### DIFF
--- a/crates/kornia-tensor/Cargo.toml
+++ b/crates/kornia-tensor/Cargo.toml
@@ -27,7 +27,7 @@ serde_json = { workspace = true }
 
 [features]
 bincode = ["dep:bincode"]
-serde = ["dep:serde"]
 gpu = []
 gpu-cubecl = ["gpu"]
 gpu-cuda-oxide = ["gpu"]
+serde = ["dep:serde"]

--- a/crates/kornia-tensor/Cargo.toml
+++ b/crates/kornia-tensor/Cargo.toml
@@ -29,5 +29,4 @@ serde_json = { workspace = true }
 bincode = ["dep:bincode"]
 gpu = []
 gpu-cubecl = ["gpu"]
-gpu-cuda-oxide = ["gpu"]
 serde = ["dep:serde"]

--- a/crates/kornia-tensor/Cargo.toml
+++ b/crates/kornia-tensor/Cargo.toml
@@ -28,3 +28,6 @@ serde_json = { workspace = true }
 [features]
 bincode = ["dep:bincode"]
 serde = ["dep:serde"]
+gpu = []
+gpu-cubecl = ["gpu"]
+gpu-cuda-oxide = ["gpu"]

--- a/crates/kornia-tensor/src/backend/cubecl.rs
+++ b/crates/kornia-tensor/src/backend/cubecl.rs
@@ -1,0 +1,4 @@
+//! CubeCL backend for `kornia-tensor` (enabled by feature `gpu-cubecl`).
+
+/// CubeCL backend.
+pub struct CubeclBackend;

--- a/crates/kornia-tensor/src/backend/cuda_oxide.rs
+++ b/crates/kornia-tensor/src/backend/cuda_oxide.rs
@@ -1,1 +1,0 @@
-//! cuda-oxide backend for `kornia-tensor` (enabled by feature `gpu-cuda-oxide`).

--- a/crates/kornia-tensor/src/backend/cuda_oxide.rs
+++ b/crates/kornia-tensor/src/backend/cuda_oxide.rs
@@ -1,0 +1,1 @@
+//! cuda-oxide backend for `kornia-tensor` (enabled by feature `gpu-cuda-oxide`).

--- a/crates/kornia-tensor/src/backend/mod.rs
+++ b/crates/kornia-tensor/src/backend/mod.rs
@@ -6,12 +6,7 @@
 //!
 //! # Swap-in story
 //!
-//! Each concrete backend lives behind its own feature flag:
-//! - `gpu-cubecl`      → [`cubecl`] module  (stable Rust, multi-platform JIT) — stub
-//! - `gpu-cuda-oxide`  → [`cuda_oxide`] module  (reserved; see `proto/cuda-oxide` branch) — stub
-//!
-//! To add a new backend: implement [`Backend`] for your type, add a `gpu-<name>` feature in
-//! `Cargo.toml`, and add a `#[cfg(feature = "gpu-<name>")] pub mod <name>;` entry here.
+//! The concrete backend lives behind the `gpu-cubecl` feature flag → [`cubecl`] module (stub).
 
 use std::alloc::Layout;
 
@@ -19,9 +14,6 @@ use crate::allocator::{TensorAllocator, TensorAllocatorError};
 
 #[cfg(feature = "gpu-cubecl")]
 pub mod cubecl;
-
-#[cfg(feature = "gpu-cuda-oxide")]
-pub mod cuda_oxide;
 
 /// Raw device-memory provider.
 ///

--- a/crates/kornia-tensor/src/backend/mod.rs
+++ b/crates/kornia-tensor/src/backend/mod.rs
@@ -1,0 +1,69 @@
+//! GPU backend abstraction for `kornia-tensor`.
+//!
+//! This module defines the [`Backend`] trait and the [`GpuAllocator`] wrapper that bridges
+//! any `Backend` impl into the existing [`TensorAllocator`](crate::allocator::TensorAllocator)
+//! interface, letting `Tensor<T, N, GpuAllocator<B>>` work without changes to the core type.
+//!
+//! # Swap-in story
+//!
+//! Each concrete backend lives behind its own feature flag:
+//! - `gpu-cubecl`      → [`cubecl`] module  (stable Rust, multi-platform JIT)
+//! - `gpu-cuda-oxide`  → [`cuda_oxide`] module  (reserved; see `proto/cuda-oxide` branch)
+//!
+//! To add a new backend: implement [`Backend`] for your type, add a `gpu-<name>` feature in
+//! `Cargo.toml`, and add a `#[cfg(feature = "gpu-<name>")] pub mod <name>;` entry here.
+
+use std::alloc::Layout;
+
+use crate::allocator::{TensorAllocator, TensorAllocatorError};
+
+#[cfg(feature = "gpu-cubecl")]
+pub mod cubecl;
+
+#[cfg(feature = "gpu-cuda-oxide")]
+pub mod cuda_oxide;
+
+/// Raw device-memory provider.
+///
+/// The pointer returned by [`alloc`](Backend::alloc) is a **device address** —
+/// callers must not dereference it on the host.
+pub trait Backend: Clone + Send + Sync + 'static {
+    /// Backend-native error type returned from allocation failures.
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Allocate `size` bytes of device memory. Returns a device pointer.
+    fn alloc(&self, size: usize) -> Result<*mut u8, Self::Error>;
+
+    /// Free a device pointer previously returned by [`alloc`](Backend::alloc).
+    ///
+    /// # Safety
+    /// `ptr` must have been returned by this backend's `alloc`, and `size` must match.
+    unsafe fn dealloc(&self, ptr: *mut u8, size: usize);
+}
+
+/// [`TensorAllocator`] wrapper around any [`Backend`].
+#[derive(Clone)]
+pub struct GpuAllocator<B: Backend> {
+    backend: B,
+}
+
+impl<B: Backend> GpuAllocator<B> {
+    /// Wrap a backend in a `GpuAllocator`.
+    pub fn new(backend: B) -> Self {
+        Self { backend }
+    }
+}
+
+impl<B: Backend> TensorAllocator for GpuAllocator<B> {
+    fn alloc(&self, layout: Layout) -> Result<*mut u8, TensorAllocatorError> {
+        self.backend
+            .alloc(layout.size())
+            .map_err(|_e| TensorAllocatorError::NullPointer)
+    }
+
+    fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        if !ptr.is_null() {
+            unsafe { self.backend.dealloc(ptr, layout.size()) }
+        }
+    }
+}

--- a/crates/kornia-tensor/src/backend/mod.rs
+++ b/crates/kornia-tensor/src/backend/mod.rs
@@ -7,8 +7,8 @@
 //! # Swap-in story
 //!
 //! Each concrete backend lives behind its own feature flag:
-//! - `gpu-cubecl`      → [`cubecl`] module  (stable Rust, multi-platform JIT)
-//! - `gpu-cuda-oxide`  → [`cuda_oxide`] module  (reserved; see `proto/cuda-oxide` branch)
+//! - `gpu-cubecl`      → [`cubecl`] module  (stable Rust, multi-platform JIT) — stub
+//! - `gpu-cuda-oxide`  → [`cuda_oxide`] module  (reserved; see `proto/cuda-oxide` branch) — stub
 //!
 //! To add a new backend: implement [`Backend`] for your type, add a `gpu-<name>` feature in
 //! `Cargo.toml`, and add a `#[cfg(feature = "gpu-<name>")] pub mod <name>;` entry here.
@@ -31,14 +31,14 @@ pub trait Backend: Clone + Send + Sync + 'static {
     /// Backend-native error type returned from allocation failures.
     type Error: std::error::Error + Send + Sync + 'static;
 
-    /// Allocate `size` bytes of device memory. Returns a device pointer.
-    fn alloc(&self, size: usize) -> Result<*mut u8, Self::Error>;
+    /// Allocate device memory for the given `layout`.
+    fn alloc(&self, layout: Layout) -> Result<*mut u8, Self::Error>;
 
     /// Free a device pointer previously returned by [`alloc`](Backend::alloc).
     ///
     /// # Safety
-    /// `ptr` must have been returned by this backend's `alloc`, and `size` must match.
-    unsafe fn dealloc(&self, ptr: *mut u8, size: usize);
+    /// `ptr` must have been returned by this backend's `alloc` with the same `layout`.
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout);
 }
 
 /// [`TensorAllocator`] wrapper around any [`Backend`].
@@ -56,14 +56,19 @@ impl<B: Backend> GpuAllocator<B> {
 
 impl<B: Backend> TensorAllocator for GpuAllocator<B> {
     fn alloc(&self, layout: Layout) -> Result<*mut u8, TensorAllocatorError> {
-        self.backend
-            .alloc(layout.size())
-            .map_err(|_e| TensorAllocatorError::NullPointer)
+        let ptr = self
+            .backend
+            .alloc(layout)
+            .map_err(|_e| TensorAllocatorError::NullPointer)?;
+        if ptr.is_null() {
+            return Err(TensorAllocatorError::NullPointer);
+        }
+        Ok(ptr)
     }
 
     fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         if !ptr.is_null() {
-            unsafe { self.backend.dealloc(ptr, layout.size()) }
+            unsafe { self.backend.dealloc(ptr, layout) }
         }
     }
 }

--- a/crates/kornia-tensor/src/lib.rs
+++ b/crates/kornia-tensor/src/lib.rs
@@ -93,6 +93,14 @@
 /// memory backends. The default [`CpuAllocator`] uses the system allocator for CPU memory.
 pub mod allocator;
 
+/// GPU backend module providing the [`Backend`] trait and [`GpuAllocator`] abstraction.
+///
+/// Enabled by the `gpu` feature. Backend implementations live in sub-modules gated by
+/// `gpu-cubecl` and `gpu-cuda-oxide` features. To add a new backend, implement `Backend`
+/// for your type and gate the module behind a `gpu-<name>` feature flag.
+#[cfg(feature = "gpu")]
+pub mod backend;
+
 /// Bincode module for binary serialization and deserialization.
 ///
 /// This module provides efficient binary serialization support for tensors when the


### PR DESCRIPTION
## 📝 Description

**⚠️ Issue Link Required**: This PR must be linked to an approved and assigned issue. See [Contributing Guide](CONTRIBUTING.md#pull-request) for details.

**Fixes/Relates to:** #

**Important**:
- Ensure you are assigned to the linked issue before submitting this PR
- This PR should strictly implement what the linked issue describes
- Do not include changes beyond the scope of the linked issue

---

## 🛠️ Changes Made
- [x] Add `gpu`, `gpu-cubecl`, and `gpu-cuda-oxide` feature flags to `kornia-tensor`
- [x] Add `backend` module (gated by `gpu` feature) with `Backend` trait for raw device-memory providers
- [x] Add `GpuAllocator<B>` wrapper that bridges any `Backend` impl into the existing `TensorAllocator` interface
- [x] Stub out `backend::cubecl` and `backend::cuda_oxide` sub-modules gated by their respective feature flags

No behavioral change for CPU-only users, all new code is behind feature flags and the default build is untouched.

---

## 🧪 How Was This Tested?
- [ ] **Unit Tests:** No new tests yet, scaffold only, no logic to unit test
- [x] **Manual Verification:**
  - `cargo build -p kornia-tensor` (no features),  passes, no regression
  - `cargo build -p kornia-tensor --features gpu` , compiles backend module
  - `cargo build -p kornia-tensor --features gpu-cubecl` , compiles cubecl stub
  - `cargo build -p kornia-tensor --features gpu-cuda-oxide` , compiles cuda-oxide stub
- [ ] **Performance/Edge Cases:** N/A for scaffold

---

## 🕵️ AI Usage Disclosure
- [ ] 🟢 **No AI used.**
- [x] 🟡 **AI-assisted:** I used AI for boilerplate/refactoring but have manually reviewed and tested every line.
- [ ] 🔴 **AI-generated:** (Note: These PRs may be subject to stricter scrutiny or immediate closure if the logic is not explained).

---

## 🚦 Checklist
- [ ] I am assigned to the linked issue (required before PR submission)
- [ ] The linked issue has been approved by a maintainer
- [x] This PR strictly implements what the linked issue describes (no scope creep)
- [x] I have performed a **self-review** of my code (no "ghost" variables or hallucinations).
- [x] My code follows the existing style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] (Optional) I have attached screenshots/recordings for UI changes.

---
