### PR TITLE
Optim: Add local optimization option to solve_pnp_ransac

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5290,17 +5290,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
 
 [[package]]
-name = "fisheye_rerun_viewer"
-version = "0.1.14"
-dependencies = [
- "argh",
- "kornia",
- "rerun",
- "serde",
- "serde_yaml",
-]
-
-[[package]]
 name = "fixed"
 version = "1.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7996,25 +7985,6 @@ dependencies = [
  "pyo3",
  "rand 0.9.2",
  "rayon",
-]
-
-[[package]]
-name = "kornia-slam"
-version = "0.1.14"
-dependencies = [
- "argh",
- "criterion",
- "kornia-3d",
- "kornia-algebra",
- "kornia-image",
- "kornia-imgproc",
- "kornia-io",
- "kornia-tensor",
- "rerun",
- "serde",
- "serde_json",
- "tempfile",
- "thiserror 2.0.17",
 ]
 
 [[package]]

--- a/kornia-py/src/pnp.rs
+++ b/kornia-py/src/pnp.rs
@@ -34,7 +34,7 @@ use rand::{rngs::StdRng, SeedableRng};
 ///
 /// Raises ValueError on shape mismatches or when RANSAC produces no model.
 #[pyfunction(name = "solve_pnp_ransac")]
-#[pyo3(signature = (world, image, k, threshold=4.0, max_iterations=1000, confidence=0.999, seed=None))]
+#[pyo3(signature = (world, image, k, threshold=4.0, max_iterations=1000, confidence=0.999, lo_every = 2, seed=None))]
 #[allow(clippy::type_complexity, clippy::too_many_arguments)]
 pub fn solve_pnp_ransac_py<'py>(
     py: Python<'py>,
@@ -44,6 +44,7 @@ pub fn solve_pnp_ransac_py<'py>(
     threshold: f64,
     max_iterations: u32,
     confidence: f64,
+    lo_every: u32,
     seed: Option<u64>,
 ) -> PyResult<(
     Bound<'py, PyArray2<f64>>,
@@ -121,6 +122,7 @@ pub fn solve_pnp_ransac_py<'py>(
         max_iters: max_iterations,
         confidence,
         inlier_threshold: threshold,
+        lo_every,
         ..Default::default()
     };
 


### PR DESCRIPTION
## 📝 Description
Enables local optimization (LO-RANSAC) in `kornia_rs.k3d.solve_pnp_ransac` 
by setting `lo_every: 2` in `RansacConfig` and exposing it as a Python 
parameter. This is a partial fix.

**Benchmark results show LO alone does not close the gap against OpenCV AP3P.**
At 10% inlier ratio kornia-rs recovers ~6 inliers vs OpenCV's 58, across all 
`lo_every` values. The root cause is the underlying EPnP solver — it is a 
batch solver not suited to 3-point minimal sampling, so the seed models fed 
into the LO step are already too poor to refine.

The LO infrastructure in `kornia_3d::ransac::run()` is working correctly. 
The remaining gap requires:
1. Implementing an AP3P estimator (`SAMPLE_SIZE = 3`) in `kornia_3d`
2. Swapping `EPnPEstimator` for `AP3PEstimator` in `pnp.rs`

**For further optimization and making the pnp algorithm more in line with OpenCV, I propose:**
1. Implement AP3P solver and Estimator
2. Utilize SymPy to produce the complex expressions described in `An Efficient Algebraic Solution to the Perspective-Three-Point Problem" by L. Ke and S. I. Roumeliotis (2017)`
4. Integration of the AP3P solver with the RANSAC pipeline as an Estimator 

**Fixes/Relates to:** #929 

---

## 🛠️ Changes Made
- Added a default local optim for every iteration using lo_every
- Default lo_every = 2

---

## 🧪 How Was This Tested?
- [x] **Unit Tests:**
- [x] **Bench Marking:** 
- [ ] **Manual Verification:** (Describe the steps you took)
- [ ] **Performance/Edge Cases:** (How does this handle nulls, large data, etc.?)

---

## 🕵️ AI Usage Disclosure
*Check one of the following:*
- [ ] 🟢 **No AI used.**
- [x] 🟡 **AI-assisted:** I used AI for boilerplate/refactoring but have manually reviewed and tested every line.
- [ ] 🔴 **AI-generated:**

---

## 🚦 Checklist
- [ ] I am assigned to the linked issue (required before PR submission)
- [ ] The linked issue has been approved by a maintainer
- [x] This PR strictly implements what the linked issue describes (no scope creep)
- [x] I have performed a **self-review** of my code (no "ghost" variables or hallucinations).
- [x] My code follows the existing style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] (Optional) I have attached screenshots/recordings for UI changes.

---

## 💭 Additional Context
Benchmark before:
```
set (602 pairs, pooled across 20 candidate keyframes, ~10% true inlier ratio):
Solver | Threshold | Iterations | Inliers
cv2.solvePnPRansac(SOLVEPNP_AP3P) | 6 px | 50000 | 57 / 602
kornia_rs.k3d.solve_pnp_ransac | 4 px | 50000 | 12 / 602
kornia_rs.k3d.solve_pnp_ransac | 6 px | 50000 | 14 / 602
kornia_rs.k3d.solve_pnp_ransac | 10 px | 50000 | 18 / 602
```


Benchmark after Adding Local Otimization
602 points, Ratio: 10%, Noise: 1.5px, Iters: 50000
```
═════════════════════════════════════════════════════════════════════
Solver              Ratio  Inliers  Recall   R_err°    t_err       ms
─────────────────────────────────────────────────────────────────────
kornia_lo0            10%      5.6    0.09   64.246   3.0664    156.1
kornia_lo1            10%      6.2    0.10   64.007   3.0775    155.2
kornia_lo2            10%      6.2    0.10   64.007   3.0775    156.8
kornia_lo3            10%      5.6    0.09   64.246   3.0664    154.8
opencv_ap3p           10%     58.0    0.97    0.217   0.0182    206.1
─────────────────────────────────────────────────────────────────────
kornia_lo0            20%     65.6    0.55    0.809   0.0561    154.3
kornia_lo1            20%     68.8    0.57    0.678   0.0567    153.9
kornia_lo2            20%     67.0    0.56    0.762   0.0580    153.6
kornia_lo3            20%     68.8    0.57    0.678   0.0567    154.0
opencv_ap3p           20%    120.2    1.00    0.124   0.0123     88.4
─────────────────────────────────────────────────────────────────────
kornia_lo0            30%    112.8    0.63    0.517   0.0336     89.9
kornia_lo1            30%    112.8    0.63    0.517   0.0336     89.7
kornia_lo2            30%    112.8    0.63    0.517   0.0336     89.6
kornia_lo3            30%    112.8    0.63    0.517   0.0336     89.4
opencv_ap3p           30%    177.2    0.98    0.095   0.0101     19.3
─────────────────────────────────────────────────────────────────────
kornia_lo0            50%    194.0    0.65    0.479   0.0494     11.1
kornia_lo1            50%    194.0    0.65    0.479   0.0494     11.1
kornia_lo2            50%    194.0    0.65    0.479   0.0494     11.0
kornia_lo3            50%    194.0    0.65    0.479   0.0494     11.0
opencv_ap3p           50%    295.4    0.98    0.060   0.0066      2.6
═════════════════════════════════════════════════════════════════════
```