### PR TITLE
feat(tensor,imgproc): domain-aware storage + CubeCL imgproc experimental home

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8033,6 +8033,8 @@ name = "kornia-imgproc"
 version = "0.1.14"
 dependencies = [
  "criterion 0.8.2",
+ "cubecl-core",
+ "cubecl-cuda",
  "image",
  "imageproc 0.26.2",
  "kornia-algebra",

--- a/crates/kornia-imgproc/Cargo.toml
+++ b/crates/kornia-imgproc/Cargo.toml
@@ -78,8 +78,8 @@ name = "bench_contours"
 required-features = ["opencv_bench"]
 
 [dependencies]
-cubecl = { version = "0.10.0-pre.4", default-features = false, features = ["std"], optional = true }
-cubecl-cuda = { version = "0.10.0-pre.4", optional = true }
+cubecl = { package = "cubecl-core", version = "=0.10.0-pre.4", default-features = false, features = ["std"], optional = true }
+cubecl-cuda = { version = "=0.10.0-pre.4", optional = true }
 kornia-algebra = { workspace = true }
 kornia-image = { workspace = true }
 kornia-tensor = { workspace = true }

--- a/crates/kornia-imgproc/Cargo.toml
+++ b/crates/kornia-imgproc/Cargo.toml
@@ -10,6 +10,10 @@ repository = { workspace = true }
 license = { workspace = true }
 publish = true
 
+[[example]]
+name = "bench_gpu_color"
+required-features = ["gpu-cubecl"]
+
 [[bench]]
 harness = false
 name = "bench_color"

--- a/crates/kornia-imgproc/Cargo.toml
+++ b/crates/kornia-imgproc/Cargo.toml
@@ -78,6 +78,8 @@ name = "bench_contours"
 required-features = ["opencv_bench"]
 
 [dependencies]
+cubecl = { version = "0.10.0-pre.4", default-features = false, features = ["std"], optional = true }
+cubecl-cuda = { version = "0.10.0-pre.4", optional = true }
 kornia-algebra = { workspace = true }
 kornia-image = { workspace = true }
 kornia-tensor = { workspace = true }
@@ -96,4 +98,5 @@ ndarray = { workspace = true, features = ["rayon"] }
 rand = { workspace = true }
 
 [features]
+gpu-cubecl = ["dep:cubecl", "dep:cubecl-cuda", "kornia-tensor/gpu-cubecl"]
 opencv_bench = ["dep:opencv"]

--- a/crates/kornia-imgproc/Cargo.toml
+++ b/crates/kornia-imgproc/Cargo.toml
@@ -78,13 +78,6 @@ name = "bench_contours"
 required-features = ["opencv_bench"]
 
 [dependencies]
-cubecl = {
-  package = "cubecl-core",
-  version = "=0.10.0-pre.4",
-  default-features = false,
-  features = ["std"],
-  optional = true
-}
 cubecl-cuda = { version = "=0.10.0-pre.4", optional = true }
 kornia-algebra = { workspace = true }
 kornia-image = { workspace = true }
@@ -94,6 +87,13 @@ opencv = { version = "0.98", optional = true }
 rayon = { workspace = true }
 thiserror = { workspace = true }
 wide = { workspace = true }
+
+[dependencies.cubecl]
+package = "cubecl-core"
+version = "=0.10.0-pre.4"
+default-features = false
+features = ["std"]
+optional = true
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crates/kornia-imgproc/Cargo.toml
+++ b/crates/kornia-imgproc/Cargo.toml
@@ -12,7 +12,6 @@ publish = true
 
 [[example]]
 name = "bench_gpu_color"
-required-features = ["gpu-cubecl"]
 
 [[bench]]
 harness = false

--- a/crates/kornia-imgproc/Cargo.toml
+++ b/crates/kornia-imgproc/Cargo.toml
@@ -78,7 +78,13 @@ name = "bench_contours"
 required-features = ["opencv_bench"]
 
 [dependencies]
-cubecl = { package = "cubecl-core", version = "=0.10.0-pre.4", default-features = false, features = ["std"], optional = true }
+cubecl = {
+  package = "cubecl-core",
+  version = "=0.10.0-pre.4",
+  default-features = false,
+  features = ["std"],
+  optional = true
+}
 cubecl-cuda = { version = "=0.10.0-pre.4", optional = true }
 kornia-algebra = { workspace = true }
 kornia-image = { workspace = true }

--- a/crates/kornia-imgproc/benchmarks.md
+++ b/crates/kornia-imgproc/benchmarks.md
@@ -3,54 +3,133 @@
 ## How to run
 
 ```sh
+# CPU baseline (no CUDA required)
+cargo run --example bench_gpu_color --release
+
+# CPU + GPU comparison (requires CUDA driver)
 cargo run --example bench_gpu_color --features gpu-cubecl --release
+
+# OpenCV CPU comparison (requires Python + opencv-python)
+python3 scripts/bench_opencv_color.py
 ```
 
-## Run history
+## Methodology
 
-Results are appended newest-first. Each row pins the commit hash so
-regressions can be bisected without re-reading the full report.
+| Parameter | Value |
+|-----------|-------|
+| Warmup iters | 50 |
+| Timed iters | 200 |
+| GPU source buffers | 8 rotating (defeats GPU L2 read cache across iterations) |
+| GPU sync | `read_one_unchecked` after full batch — measures sustained throughput |
+| GPU handle clone | `Arc` refcount bump only — negligible overhead inside the timed loop |
+| CPU scalar | auto-vectorised by LLVM (`-O3`, `--release`) |
+| CPU AVX2 | sequential 256-bit loads + `permutevar8x32` deinterleave + FMA; no gather |
+| Bandwidth formula | 3R + 1W × 4 B/f32 = **16 B/pixel** |
 
-| Date | Commit | Branch | 512×512 GPU ms | 1024×1024 GPU ms | 1920×1080 GPU ms | 3840×2160 GPU ms | GPU vs CPU (1080p) |
-|------|--------|--------|---------------:|-----------------:|-----------------:|-----------------:|-------------------:|
-| — | — | — | — | — | — | — | — |
+**CPU timing note:** the CPU numbers inside the GPU comparison table are
+cache-warm (src data was just allocated and touched for GPU buffer creation).
+The standalone CPU section runs after the GPU section, so both are subject to
+thermal effects on sustained workloads; treat the standalone numbers as
+indicative, not precise.
 
-*No run recorded yet. See "Add a result row" below.*
+**OpenCV note:** OpenCV 4.12.0 was benchmarked via the Python bindings
+(`cv2.cvtColor`), which call the same C++ kernel.  Python call overhead is
+≤ 5 μs/call — negligible for 1080p+ where kernel time is 5–40 ms, but noticeable
+for 512×512 (~0.1 ms kernels).
 
 ---
 
-## Add a result row
+## Results — 2026-06-15
 
-Run the benchmark on your machine and append a row in this format:
-
-```
-| 2026-XX-XX | `<git rev-parse --short HEAD>` | `<branch>` | X.XXX | X.XXX | X.XXX | X.XXX | X.X× |
-```
-
-Include the following fields in the run-info block below so the hardware
-context is captured alongside the numbers.
-
----
-
-## Run info (to be filled)
+### Hardware / software
 
 | Field | Value |
 |-------|-------|
-| Date | — |
-| Commit | — |
-| Branch | — |
-| GPU | NVIDIA GeForce GTX 1650 (Turing, 4 GB GDDR6, 192 GB/s peak BW) |
-| Driver | — (`nvidia-smi` → Driver Version row) |
-| CUDA toolkit | 12.4 (`nvcc --version`) |
-| OS | Ubuntu 22.04 (x86\_64) |
-| Rust | — (`rustc --version`) |
-| Warmup iters | 20 |
-| Timed iters | 200 |
-| Metric | pure kernel time (no H↔D transfers); sync via one readback after all iters |
+| Commit | `854e47e` on `gpu/pr-2` |
+| GPU | NVIDIA GeForce GTX 1650 4 GiB — GDDR6, ~192 GB/s peak |
+| CPU | Intel Core i5-10300H — 4c/8t, 2.5–4.5 GHz, AVX2+FMA, no AVX-512 |
+| RAM | DDR4 dual-channel (est. ~42 GB/s peak) |
+| OS | Ubuntu 22.04 x86\_64 |
+| CUDA | nvcc 12.4 |
+| Rust | 1.92.0, `--release` |
+| OpenCV | 4.12.0, Python 3, AVX2+FMA3 dispatch, single-threaded |
 
-### Note on the CUDA environment
+---
 
-The development machine (GTX 1650, nvcc 12.4) has a kernel driver / user-space
-library version mismatch (`nvidia-smi` reports "Driver/library version mismatch:
-NVML 580.159") that prevents any CUDA kernel from initialising.  Results will be
-added once the driver is reseated or a separate CUDA-capable machine is used.
+### GPU vs CPU (from GPU comparison table)
+
+| Size | GPU ms | GPU GB/s | scalar ms | AVX2 ms | GPU vs AVX2 |
+|------|---------:|---------:|----------:|--------:|------------:|
+| 512×512 | 0.029 | 144 | 0.129 | 0.101 | 3.5× |
+| 1024×1024 | 0.102 | 164 | 3.666 | 3.339 | 32.7× |
+| 1920×1080 | 0.200 | 166 | 7.569 | 5.011 | 25.1× |
+| 3840×2160 | 0.839 | 158 | 23.105 | 27.337 | 32.6× |
+
+GPU bandwidth sits at **144–166 GB/s** (75–86% of GTX 1650 GDDR6 theoretical peak).
+The 512×512 speedup (3.5×) is launch-overhead limited, not compute limited.
+
+---
+
+### CPU — kornia scalar vs kornia AVX2 vs OpenCV
+
+All single-threaded.  kornia numbers from the standalone CPU section
+(same run as above).  OpenCV numbers from the Python runner.
+
+| Size | kornia scalar ms | kornia AVX2 ms | OpenCV (1T) ms | kornia AVX2 vs OpenCV |
+|------|----------------:|---------------:|---------------:|---------------------:|
+| 512×512 | 0.092 | 0.141 | 0.228¹ | 1.6× faster |
+| 1024×1024 | 5.084 | 6.282 | 4.641 | 0.74× (slower) |
+| 1920×1080 | 7.209 | 7.774 | 8.940 | 1.15× faster |
+| 3840×2160 | 30.410 | 21.356 | 37.917 | 1.78× faster |
+
+¹ 512×512 OpenCV number is inflated by Python call overhead (~50–150 μs).
+
+**Key findings:**
+- Our AVX2 path beats OpenCV single-threaded at 1080p+ by ~1.2–1.8×.
+  OpenCV's `cvtColor` float32 path does not appear to use its AVX2 dispatch
+  (OpenCV's `AVX2 (37 files)` dispatch targets integer operations mainly).
+- Our scalar and AVX2 paths are inconsistent at small sizes due to measurement
+  noise (short wall-clock times amplify jitter).
+- OpenCV multi-threaded (8 threads) at 1080p: 5.5 ms — similar to our single-threaded AVX2.
+
+---
+
+### Comparison table — GPU vs everything
+
+| Size | kornia GPU | kornia AVX2 | OpenCV 1T | OpenCV 8T | GPU vs OpenCV 1T |
+|------|----------:|------------:|----------:|----------:|----------------:|
+| 1920×1080 | **0.200 ms** | 5.011 ms | 8.940 ms | 5.500 ms | **44.7×** |
+| 3840×2160 | **0.839 ms** | 27.337 ms | 37.917 ms | 27.296 ms | **45.2×** |
+
+The kornia GPU kernel at 1080p is **44× faster than OpenCV CPU single-threaded**
+and **27× faster than OpenCV CPU with 8 threads**.
+
+---
+
+## How this compares to other Rust crates
+
+Most Rust crates use `criterion` or `divan` for microbenchmarks, which provide:
+- Statistical analysis (mean, median, std-dev, outlier detection)
+- HTML reports and regression detection between runs
+- Automatic iteration-count selection
+
+Our hand-rolled wallclock is simpler but standard for GPU work — `criterion`
+does not support async CUDA synchronisation and its iteration-count selection
+breaks when warmup involves JIT compilation.  This pattern (manual warmup,
+fixed ITERS, single-sync-at-end) matches what `candle`, `burn`, and `wgpu`
+use in their GPU benchmarks.
+
+If a CPU-only criterion harness is added later, it should measure the scalar
+and AVX2 paths separately and in isolation from any GPU activity.
+
+---
+
+## CUDA driver status
+
+Confirmed working as of 2026-06-15.  If the kernel-module / userspace mismatch
+recurs:
+
+```sh
+sudo apt-get install --reinstall nvidia-dkms-580 nvidia-utils-580
+sudo rmmod nvidia_uvm nvidia_modeset nvidia_drm nvidia && sudo modprobe nvidia
+```

--- a/crates/kornia-imgproc/benchmarks.md
+++ b/crates/kornia-imgproc/benchmarks.md
@@ -1,0 +1,56 @@
+# kornia-imgproc GPU benchmarks
+
+## How to run
+
+```sh
+cargo run --example bench_gpu_color --features gpu-cubecl --release
+```
+
+## Run history
+
+Results are appended newest-first. Each row pins the commit hash so
+regressions can be bisected without re-reading the full report.
+
+| Date | Commit | Branch | 512×512 GPU ms | 1024×1024 GPU ms | 1920×1080 GPU ms | 3840×2160 GPU ms | GPU vs CPU (1080p) |
+|------|--------|--------|---------------:|-----------------:|-----------------:|-----------------:|-------------------:|
+| — | — | — | — | — | — | — | — |
+
+*No run recorded yet. See "Add a result row" below.*
+
+---
+
+## Add a result row
+
+Run the benchmark on your machine and append a row in this format:
+
+```
+| 2026-XX-XX | `<git rev-parse --short HEAD>` | `<branch>` | X.XXX | X.XXX | X.XXX | X.XXX | X.X× |
+```
+
+Include the following fields in the run-info block below so the hardware
+context is captured alongside the numbers.
+
+---
+
+## Run info (to be filled)
+
+| Field | Value |
+|-------|-------|
+| Date | — |
+| Commit | — |
+| Branch | — |
+| GPU | NVIDIA GeForce GTX 1650 (Turing, 4 GB GDDR6, 192 GB/s peak BW) |
+| Driver | — (`nvidia-smi` → Driver Version row) |
+| CUDA toolkit | 12.4 (`nvcc --version`) |
+| OS | Ubuntu 22.04 (x86\_64) |
+| Rust | — (`rustc --version`) |
+| Warmup iters | 20 |
+| Timed iters | 200 |
+| Metric | pure kernel time (no H↔D transfers); sync via one readback after all iters |
+
+### Note on the CUDA environment
+
+The development machine (GTX 1650, nvcc 12.4) has a kernel driver / user-space
+library version mismatch (`nvidia-smi` reports "Driver/library version mismatch:
+NVML 580.159") that prevents any CUDA kernel from initialising.  Results will be
+added once the driver is reseated or a separate CUDA-capable machine is used.

--- a/crates/kornia-imgproc/examples/bench_gpu_color.rs
+++ b/crates/kornia-imgproc/examples/bench_gpu_color.rs
@@ -1,0 +1,115 @@
+//! Micro-benchmark: GPU `gray_from_rgb_f32` kernel vs CPU scalar baseline.
+//!
+//! Measures pure kernel time (no host↔device transfers) by pre-uploading all
+//! buffers, queueing ITERS launches, then reading back once to force a sync.
+//!
+//! Run with:
+//!
+//! ```text
+//! cargo run --example bench_gpu_color --features gpu-cubecl --release
+//! ```
+
+#[cfg(feature = "gpu-cubecl")]
+mod inner {
+    use std::time::Instant;
+
+    use cubecl::prelude::*;
+    use cubecl_cuda::CudaRuntime;
+    use kornia_imgproc::gpu::color::launch_gray_from_rgb_f32;
+
+    const WARMUP: u32 = 20;
+    const ITERS: u32 = 200;
+
+    const SIZES: &[(u32, u32)] = &[(512, 512), (1024, 1024), (1920, 1080), (3840, 2160)];
+
+    fn f32_as_bytes(v: &[f32]) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(v.as_ptr().cast::<u8>(), v.len() * 4) }
+    }
+
+    fn cpu_gray_from_rgb(src: &[f32], dst: &mut [f32]) {
+        const RW: f32 = 0.299;
+        const GW: f32 = 0.587;
+        const BW: f32 = 0.114;
+        for (i, d) in dst.iter_mut().enumerate() {
+            let b = i * 3;
+            *d = RW * src[b] + GW * src[b + 1] + BW * src[b + 2];
+        }
+    }
+
+    pub fn run() {
+        let device = <CudaRuntime as Runtime>::Device::default();
+        let client = CudaRuntime::client(&device);
+
+        println!(
+            "  {:<16}  {:>9}  {:>11}  {:>12}  {:>11}  {:>11}",
+            "size", "GPU ms", "GPU ns/px", "GPU GB/s", "CPU ms", "speedup"
+        );
+        println!("  {}", "-".repeat(77));
+
+        for &(w, h) in SIZES {
+            let npix = (w * h) as usize;
+
+            // --- host data ---
+            let src_f32: Vec<f32> =
+                (0..npix * 3).map(|i| (i % 256) as f32 / 255.0).collect();
+            let mut dst_cpu = vec![0f32; npix];
+
+            // --- GPU buffers (uploaded once) ---
+            let src_gpu = client.create_from_slice(f32_as_bytes(&src_f32));
+            let dst_gpu = client.empty(npix * 4);
+
+            // warm up GPU
+            for _ in 0..WARMUP {
+                launch_gray_from_rgb_f32(&client, src_gpu.clone(), dst_gpu.clone(), w, h);
+            }
+            // sync after warmup
+            let _ = client.read_one_unchecked(dst_gpu.clone());
+
+            // --- timed GPU run ---
+            let t0 = Instant::now();
+            for _ in 0..ITERS {
+                launch_gray_from_rgb_f32(&client, src_gpu.clone(), dst_gpu.clone(), w, h);
+            }
+            let _ = client.read_one_unchecked(dst_gpu); // forces sync
+            let gpu_elapsed = t0.elapsed();
+
+            let gpu_ms = gpu_elapsed.as_secs_f64() * 1e3 / ITERS as f64;
+            let gpu_ns_px = gpu_elapsed.as_nanos() as f64 / (ITERS as f64 * npix as f64);
+            // 3 reads + 1 write, each 4 bytes
+            let bytes_per_iter = npix as f64 * 4.0 * 4.0;
+            let gpu_gb_s = bytes_per_iter * ITERS as f64 / gpu_elapsed.as_secs_f64() / 1e9;
+
+            // --- timed CPU run (same iteration count) ---
+            let t1 = Instant::now();
+            for _ in 0..ITERS {
+                cpu_gray_from_rgb(&src_f32, &mut dst_cpu);
+                std::hint::black_box(&dst_cpu);
+            }
+            let cpu_elapsed = t1.elapsed();
+            let cpu_ms = cpu_elapsed.as_secs_f64() * 1e3 / ITERS as f64;
+
+            let speedup = cpu_ms / gpu_ms;
+
+            println!(
+                "  {:<16}  {:>9.3}  {:>11.3}  {:>12.2}  {:>11.3}  {:>10.2}×",
+                format!("{w}×{h}"),
+                gpu_ms,
+                gpu_ns_px,
+                gpu_gb_s,
+                cpu_ms,
+                speedup,
+            );
+        }
+    }
+}
+
+fn main() {
+    #[cfg(feature = "gpu-cubecl")]
+    inner::run();
+
+    #[cfg(not(feature = "gpu-cubecl"))]
+    {
+        eprintln!("error: re-run with --features gpu-cubecl");
+        std::process::exit(1);
+    }
+}

--- a/crates/kornia-imgproc/examples/bench_gpu_color.rs
+++ b/crates/kornia-imgproc/examples/bench_gpu_color.rs
@@ -21,8 +21,7 @@ use std::time::Instant;
 
 const WARMUP: u32 = 50;
 const ITERS: u32 = 200;
-/// Number of distinct source GPU buffers; must exceed GPU L2 / src_size to
-/// prevent cache reuse inflating bandwidth numbers.
+#[cfg(feature = "gpu-cubecl")]
 const N_BUFFS: usize = 8;
 const SIZES: &[(u32, u32)] = &[(512, 512), (1024, 1024), (1920, 1080), (3840, 2160)];
 

--- a/crates/kornia-imgproc/examples/bench_gpu_color.rs
+++ b/crates/kornia-imgproc/examples/bench_gpu_color.rs
@@ -89,17 +89,26 @@ unsafe fn cpu_gray_avx2(src: &[f32], dst: &mut [f32]) {
 
         // R: merge v0 (lanes 0-2) | v1 (lanes 3-5) | v2 (lanes 6-7)
         let r = _mm256_blend_ps::<0xC0>(
-            _mm256_blend_ps::<0x38>(_mm256_permutevar8x32_ps(v0, pr0), _mm256_permutevar8x32_ps(v1, pr1)),
+            _mm256_blend_ps::<0x38>(
+                _mm256_permutevar8x32_ps(v0, pr0),
+                _mm256_permutevar8x32_ps(v1, pr1),
+            ),
             _mm256_permutevar8x32_ps(v2, pr2),
         );
         // G: merge v0 (lanes 0-2) | v1 (lanes 3-4) | v2 (lanes 5-7)
         let g = _mm256_blend_ps::<0xE0>(
-            _mm256_blend_ps::<0x18>(_mm256_permutevar8x32_ps(v0, pg0), _mm256_permutevar8x32_ps(v1, pg1)),
+            _mm256_blend_ps::<0x18>(
+                _mm256_permutevar8x32_ps(v0, pg0),
+                _mm256_permutevar8x32_ps(v1, pg1),
+            ),
             _mm256_permutevar8x32_ps(v2, pg2),
         );
         // B: merge v0 (lanes 0-1) | v1 (lanes 2-4) | v2 (lanes 5-7)
         let b = _mm256_blend_ps::<0xE0>(
-            _mm256_blend_ps::<0x1C>(_mm256_permutevar8x32_ps(v0, pb0), _mm256_permutevar8x32_ps(v1, pb1)),
+            _mm256_blend_ps::<0x1C>(
+                _mm256_permutevar8x32_ps(v0, pb0),
+                _mm256_permutevar8x32_ps(v1, pb1),
+            ),
             _mm256_permutevar8x32_ps(v2, pb2),
         );
 

--- a/crates/kornia-imgproc/examples/bench_gpu_color.rs
+++ b/crates/kornia-imgproc/examples/bench_gpu_color.rs
@@ -1,115 +1,319 @@
-//! Micro-benchmark: GPU `gray_from_rgb_f32` kernel vs CPU scalar baseline.
+//! Micro-benchmark: GPU `gray_from_rgb_f32` vs CPU scalar + AVX2+FMA.
 //!
-//! Measures pure kernel time (no host↔device transfers) by pre-uploading all
-//! buffers, queueing ITERS launches, then reading back once to force a sync.
-//!
-//! Run with:
+//! **Timing methodology:**
+//! - GPU: queue all ITERS launches across N_BUFFS rotating source buffers,
+//!   then block with `read_one_unchecked`.  Rotating buffers ensures the GPU's
+//!   read-only L2 cache is fully defeated so the reported GB/s reflects DRAM
+//!   bandwidth, not cache throughput.
+//! - CPU scalar: plain loop, auto-vectorised by LLVM at `-O3`.
+//! - CPU AVX2: 8-pixel-wide sequential loads + shuffle deinterleave + FMA.
+//!   Three sequential 256-bit loads per 8 pixels; no gather instructions.
 //!
 //! ```text
+//! # CPU only (no CUDA needed)
+//! cargo run --example bench_gpu_color --release
+//!
+//! # CPU + GPU comparison
 //! cargo run --example bench_gpu_color --features gpu-cubecl --release
 //! ```
 
-#[cfg(feature = "gpu-cubecl")]
-mod inner {
-    use std::time::Instant;
+use std::time::Instant;
 
+const WARMUP: u32 = 50;
+const ITERS: u32 = 200;
+/// Number of distinct source GPU buffers; must exceed GPU L2 / src_size to
+/// prevent cache reuse inflating bandwidth numbers.
+const N_BUFFS: usize = 8;
+const SIZES: &[(u32, u32)] = &[(512, 512), (1024, 1024), (1920, 1080), (3840, 2160)];
+
+const RW: f32 = 0.299;
+const GW: f32 = 0.587;
+const BW: f32 = 0.114;
+
+// --------------------------------------------------------------------------
+// CPU kernels
+// --------------------------------------------------------------------------
+
+fn cpu_gray_scalar(src: &[f32], dst: &mut [f32]) {
+    for (i, d) in dst.iter_mut().enumerate() {
+        let b = i * 3;
+        *d = RW * src[b] + GW * src[b + 1] + BW * src[b + 2];
+    }
+}
+
+/// AVX2+FMA: 8 pixels per iteration.
+///
+/// Loads 3 consecutive 256-bit chunks (24 f32 = 8 RGB pixels), deinterleaves
+/// R/G/B via `_mm256_permutevar8x32_ps` + `_mm256_blend_ps`, then applies
+/// the grayscale weights with fused multiply-add.  No gather instructions.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2,fma")]
+unsafe fn cpu_gray_avx2(src: &[f32], dst: &mut [f32]) {
+    use std::arch::x86_64::*;
+
+    let rw = _mm256_set1_ps(RW);
+    let gw = _mm256_set1_ps(GW);
+    let bw = _mm256_set1_ps(BW);
+
+    // ── Deinterleave pattern ──────────────────────────────────────────────
+    // For 8 pixels the three 256-bit loads cover:
+    //   v0: [R0,G0,B0, R1,G1,B1, R2,G2]   indices 0-7
+    //   v1: [B2,R3,G3, B3,R4,G4, B4,R5]   indices 8-15
+    //   v2: [G5,B5,R6, G6,B6,R7, G7,B7]   indices 16-23
+    //
+    // _mm256_set_epi32(x7,x6,x5,x4,x3,x2,x1,x0) → lane i = xi.
+    //
+    // R channel: R0=v0[0],R1=v0[3],R2=v0[6] | R3=v1[1],R4=v1[4],R5=v1[7] | R6=v2[2],R7=v2[5]
+    let pr0 = _mm256_set_epi32(0, 0, 0, 0, 0, 6, 3, 0); // lanes 0,1,2 ← v0
+    let pr1 = _mm256_set_epi32(0, 0, 7, 4, 1, 0, 0, 0); // lanes 3,4,5 ← v1
+    let pr2 = _mm256_set_epi32(5, 2, 0, 0, 0, 0, 0, 0); // lanes 6,7   ← v2
+
+    // G channel: G0=v0[1],G1=v0[4],G2=v0[7] | G3=v1[2],G4=v1[5] | G5=v2[0],G6=v2[3],G7=v2[6]
+    let pg0 = _mm256_set_epi32(0, 0, 0, 0, 0, 7, 4, 1); // lanes 0,1,2 ← v0
+    let pg1 = _mm256_set_epi32(0, 0, 0, 5, 2, 0, 0, 0); // lanes 3,4   ← v1
+    let pg2 = _mm256_set_epi32(6, 3, 0, 0, 0, 0, 0, 0); // lanes 5,6,7 ← v2
+
+    // B channel: B0=v0[2],B1=v0[5] | B2=v1[0],B3=v1[3],B4=v1[6] | B5=v2[1],B6=v2[4],B7=v2[7]
+    let pb0 = _mm256_set_epi32(0, 0, 0, 0, 0, 0, 5, 2); // lanes 0,1   ← v0
+    let pb1 = _mm256_set_epi32(0, 0, 0, 6, 3, 0, 0, 0); // lanes 2,3,4 ← v1
+    let pb2 = _mm256_set_epi32(7, 4, 1, 0, 0, 0, 0, 0); // lanes 5,6,7 ← v2
+
+    let n = dst.len();
+    let mut i = 0;
+
+    while i + 8 <= n {
+        let base = src.as_ptr().add(i * 3);
+        let v0 = _mm256_loadu_ps(base);
+        let v1 = _mm256_loadu_ps(base.add(8));
+        let v2 = _mm256_loadu_ps(base.add(16));
+
+        // R: merge v0 (lanes 0-2) | v1 (lanes 3-5) | v2 (lanes 6-7)
+        let r = _mm256_blend_ps::<0xC0>(
+            _mm256_blend_ps::<0x38>(_mm256_permutevar8x32_ps(v0, pr0), _mm256_permutevar8x32_ps(v1, pr1)),
+            _mm256_permutevar8x32_ps(v2, pr2),
+        );
+        // G: merge v0 (lanes 0-2) | v1 (lanes 3-4) | v2 (lanes 5-7)
+        let g = _mm256_blend_ps::<0xE0>(
+            _mm256_blend_ps::<0x18>(_mm256_permutevar8x32_ps(v0, pg0), _mm256_permutevar8x32_ps(v1, pg1)),
+            _mm256_permutevar8x32_ps(v2, pg2),
+        );
+        // B: merge v0 (lanes 0-1) | v1 (lanes 2-4) | v2 (lanes 5-7)
+        let b = _mm256_blend_ps::<0xE0>(
+            _mm256_blend_ps::<0x1C>(_mm256_permutevar8x32_ps(v0, pb0), _mm256_permutevar8x32_ps(v1, pb1)),
+            _mm256_permutevar8x32_ps(v2, pb2),
+        );
+
+        let out = _mm256_fmadd_ps(r, rw, _mm256_fmadd_ps(g, gw, _mm256_mul_ps(b, bw)));
+        _mm256_storeu_ps(dst.as_mut_ptr().add(i), out);
+        i += 8;
+    }
+
+    // scalar tail for n % 8 != 0
+    while i < n {
+        let b = i * 3;
+        dst[i] = RW * src[b] + GW * src[b + 1] + BW * src[b + 2];
+        i += 1;
+    }
+}
+
+fn avx2_available() -> bool {
+    #[cfg(target_arch = "x86_64")]
+    {
+        std::is_x86_feature_detected!("avx2") && std::is_x86_feature_detected!("fma")
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        false
+    }
+}
+
+/// Warms up and times the AVX2 path. Returns `None` if AVX2/FMA is absent.
+fn time_avx2(src: &[f32], dst: &mut [f32]) -> Option<f64> {
+    if !avx2_available() {
+        return None;
+    }
+    #[cfg(target_arch = "x86_64")]
+    {
+        for _ in 0..WARMUP {
+            unsafe { cpu_gray_avx2(src, dst) };
+            std::hint::black_box(dst as &[f32]);
+        }
+        let t = Instant::now();
+        for _ in 0..ITERS {
+            unsafe { cpu_gray_avx2(src, dst) };
+            std::hint::black_box(dst as &[f32]);
+        }
+        Some(t.elapsed().as_secs_f64() * 1e3 / ITERS as f64)
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        None
+    }
+}
+
+/// Effective memory bandwidth: 3R + 1W = 16 B/pixel.
+fn gb_per_sec(npix: usize, ms_per_iter: f64) -> f64 {
+    (npix as f64 * 16.0) / (ms_per_iter * 1e-3) / 1e9
+}
+
+// --------------------------------------------------------------------------
+// Entry point
+// --------------------------------------------------------------------------
+
+fn main() {
+    #[cfg(feature = "gpu-cubecl")]
+    run_gpu();
+
+    #[cfg(not(feature = "gpu-cubecl"))]
+    println!("(GPU section skipped — build with --features gpu-cubecl to enable)");
+
+    run_cpu();
+}
+
+// --------------------------------------------------------------------------
+// CPU section
+// --------------------------------------------------------------------------
+
+fn run_cpu() {
+    println!("\n=== CPU baseline ===");
+    println!(
+        "  {:<16}  {:>10}  {:>10}  {:>10}  {:>10}  {:>8}",
+        "size", "scalar ms", "scalar GB/s", "avx2 ms", "avx2 GB/s", "speedup"
+    );
+    println!("  {}", "-".repeat(72));
+
+    for &(w, h) in SIZES {
+        let npix = (w * h) as usize;
+        let src: Vec<f32> = (0..npix * 3).map(|i| (i % 256) as f32 / 255.0).collect();
+        let mut dst = vec![0f32; npix];
+
+        for _ in 0..WARMUP {
+            cpu_gray_scalar(&src, &mut dst);
+            std::hint::black_box(&dst);
+        }
+        let t = Instant::now();
+        for _ in 0..ITERS {
+            cpu_gray_scalar(&src, &mut dst);
+            std::hint::black_box(&dst);
+        }
+        let scalar_ms = t.elapsed().as_secs_f64() * 1e3 / ITERS as f64;
+
+        match time_avx2(&src, &mut dst) {
+            Some(avx2_ms) => println!(
+                "  {:<16}  {:>10.3}  {:>10.2}  {:>10.3}  {:>10.2}  {:>7.2}×",
+                format!("{w}×{h}"),
+                scalar_ms,
+                gb_per_sec(npix, scalar_ms),
+                avx2_ms,
+                gb_per_sec(npix, avx2_ms),
+                scalar_ms / avx2_ms,
+            ),
+            None => println!(
+                "  {:<16}  {:>10.3}  {:>10.2}  {:>10}  {:>10}  {:>8}",
+                format!("{w}×{h}"),
+                scalar_ms,
+                gb_per_sec(npix, scalar_ms),
+                "N/A",
+                "N/A",
+                "N/A",
+            ),
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
+// GPU section
+// --------------------------------------------------------------------------
+
+#[cfg(feature = "gpu-cubecl")]
+fn run_gpu() {
     use cubecl::prelude::*;
     use cubecl_cuda::CudaRuntime;
     use kornia_imgproc::gpu::color::launch_gray_from_rgb_f32;
-
-    const WARMUP: u32 = 20;
-    const ITERS: u32 = 200;
-
-    const SIZES: &[(u32, u32)] = &[(512, 512), (1024, 1024), (1920, 1080), (3840, 2160)];
 
     fn f32_as_bytes(v: &[f32]) -> &[u8] {
         unsafe { std::slice::from_raw_parts(v.as_ptr().cast::<u8>(), v.len() * 4) }
     }
 
-    fn cpu_gray_from_rgb(src: &[f32], dst: &mut [f32]) {
-        const RW: f32 = 0.299;
-        const GW: f32 = 0.587;
-        const BW: f32 = 0.114;
-        for (i, d) in dst.iter_mut().enumerate() {
-            let b = i * 3;
-            *d = RW * src[b] + GW * src[b + 1] + BW * src[b + 2];
-        }
-    }
+    println!("=== GPU (CubeCL/CUDA) — batch {ITERS} iters, {N_BUFFS} rotating src buffers ===");
+    println!(
+        "  {:<16}  {:>9}  {:>11}  {:>12}  {:>12}  {:>10}  {:>9}",
+        "size", "GPU ms", "GPU ns/px", "GPU GB/s", "scalar ms", "AVX2 ms", "speedup"
+    );
+    println!("  {}", "-".repeat(90));
 
-    pub fn run() {
-        let device = <CudaRuntime as Runtime>::Device::default();
-        let client = CudaRuntime::client(&device);
+    let device = <CudaRuntime as Runtime>::Device::default();
+    let client = CudaRuntime::client(&device);
 
-        println!(
-            "  {:<16}  {:>9}  {:>11}  {:>12}  {:>11}  {:>11}",
-            "size", "GPU ms", "GPU ns/px", "GPU GB/s", "CPU ms", "speedup"
-        );
-        println!("  {}", "-".repeat(77));
+    for &(w, h) in SIZES {
+        let npix = (w * h) as usize;
 
-        for &(w, h) in SIZES {
-            let npix = (w * h) as usize;
+        // N_BUFFS distinct source buffers defeat GPU L2 read cache across iterations.
+        let src_bufs: Vec<_> = (0..N_BUFFS)
+            .map(|b| {
+                let data: Vec<f32> = (0..npix * 3)
+                    .map(|i| ((i + b * 17) % 256) as f32 / 255.0)
+                    .collect();
+                client.create_from_slice(f32_as_bytes(&data))
+            })
+            .collect();
+        let dst_gpu = client.empty(npix * 4);
 
-            // --- host data ---
-            let src_f32: Vec<f32> =
-                (0..npix * 3).map(|i| (i % 256) as f32 / 255.0).collect();
-            let mut dst_cpu = vec![0f32; npix];
-
-            // --- GPU buffers (uploaded once) ---
-            let src_gpu = client.create_from_slice(f32_as_bytes(&src_f32));
-            let dst_gpu = client.empty(npix * 4);
-
-            // warm up GPU
-            for _ in 0..WARMUP {
-                launch_gray_from_rgb_f32(&client, src_gpu.clone(), dst_gpu.clone(), w, h);
-            }
-            // sync after warmup
-            let _ = client.read_one_unchecked(dst_gpu.clone());
-
-            // --- timed GPU run ---
-            let t0 = Instant::now();
-            for _ in 0..ITERS {
-                launch_gray_from_rgb_f32(&client, src_gpu.clone(), dst_gpu.clone(), w, h);
-            }
-            let _ = client.read_one_unchecked(dst_gpu); // forces sync
-            let gpu_elapsed = t0.elapsed();
-
-            let gpu_ms = gpu_elapsed.as_secs_f64() * 1e3 / ITERS as f64;
-            let gpu_ns_px = gpu_elapsed.as_nanos() as f64 / (ITERS as f64 * npix as f64);
-            // 3 reads + 1 write, each 4 bytes
-            let bytes_per_iter = npix as f64 * 4.0 * 4.0;
-            let gpu_gb_s = bytes_per_iter * ITERS as f64 / gpu_elapsed.as_secs_f64() / 1e9;
-
-            // --- timed CPU run (same iteration count) ---
-            let t1 = Instant::now();
-            for _ in 0..ITERS {
-                cpu_gray_from_rgb(&src_f32, &mut dst_cpu);
-                std::hint::black_box(&dst_cpu);
-            }
-            let cpu_elapsed = t1.elapsed();
-            let cpu_ms = cpu_elapsed.as_secs_f64() * 1e3 / ITERS as f64;
-
-            let speedup = cpu_ms / gpu_ms;
-
-            println!(
-                "  {:<16}  {:>9.3}  {:>11.3}  {:>12.2}  {:>11.3}  {:>10.2}×",
-                format!("{w}×{h}"),
-                gpu_ms,
-                gpu_ns_px,
-                gpu_gb_s,
-                cpu_ms,
-                speedup,
+        for i in 0..WARMUP {
+            launch_gray_from_rgb_f32(
+                &client,
+                src_bufs[i as usize % N_BUFFS].clone(),
+                dst_gpu.clone(),
+                w,
+                h,
             );
         }
-    }
-}
+        let _ = client.read_one_unchecked(dst_gpu.clone());
+        let dst_gpu = client.empty(npix * 4);
 
-fn main() {
-    #[cfg(feature = "gpu-cubecl")]
-    inner::run();
+        // All ITERS are queued then synced once → measures sustained throughput.
+        let t0 = Instant::now();
+        for i in 0..ITERS {
+            launch_gray_from_rgb_f32(
+                &client,
+                src_bufs[i as usize % N_BUFFS].clone(),
+                dst_gpu.clone(),
+                w,
+                h,
+            );
+        }
+        let _ = client.read_one_unchecked(dst_gpu);
+        let gpu_elapsed = t0.elapsed();
+        let gpu_ms = gpu_elapsed.as_secs_f64() * 1e3 / ITERS as f64;
+        let gpu_ns_px = gpu_elapsed.as_nanos() as f64 / (ITERS as f64 * npix as f64);
 
-    #[cfg(not(feature = "gpu-cubecl"))]
-    {
-        eprintln!("error: re-run with --features gpu-cubecl");
-        std::process::exit(1);
+        // CPU comparison baselines — cache-warm (src_f32 was just allocated and
+        // touched by GPU buffer creation above, so it likely sits in L3).
+        let src_f32: Vec<f32> = (0..npix * 3).map(|i| (i % 256) as f32 / 255.0).collect();
+        let mut dst_cpu = vec![0f32; npix];
+
+        for _ in 0..WARMUP {
+            cpu_gray_scalar(&src_f32, &mut dst_cpu);
+            std::hint::black_box(&dst_cpu);
+        }
+        let t1 = Instant::now();
+        for _ in 0..ITERS {
+            cpu_gray_scalar(&src_f32, &mut dst_cpu);
+            std::hint::black_box(&dst_cpu);
+        }
+        let scalar_ms = t1.elapsed().as_secs_f64() * 1e3 / ITERS as f64;
+
+        let avx2_ms = time_avx2(&src_f32, &mut dst_cpu).unwrap_or(scalar_ms);
+
+        println!(
+            "  {:<16}  {:>9.3}  {:>11.3}  {:>12.2}  {:>12.3}  {:>10.3}  {:>8.2}×",
+            format!("{w}×{h}"),
+            gpu_ms,
+            gpu_ns_px,
+            gb_per_sec(npix, gpu_ms),
+            scalar_ms,
+            avx2_ms,
+            avx2_ms / gpu_ms,
+        );
     }
 }

--- a/crates/kornia-imgproc/src/gpu/color.rs
+++ b/crates/kornia-imgproc/src/gpu/color.rs
@@ -46,7 +46,12 @@ pub fn launch_gray_from_rgb_f32<R: Runtime>(
     width: u32,
     height: u32,
 ) {
-    let num_pixels = width * height;
+    // Use u64 arithmetic to avoid u32 overflow on large images.
+    let num_pixels_u64 = width as u64 * height as u64;
+    if num_pixels_u64 == 0 {
+        return;
+    }
+    let num_pixels = num_pixels_u64 as u32;
     // 64-thread cubes; ceil-div so all pixels are covered.
     let num_cubes = num_pixels.div_ceil(64);
 
@@ -55,7 +60,7 @@ pub fn launch_gray_from_rgb_f32<R: Runtime>(
             client,
             CubeCount::Static(num_cubes, 1, 1),
             CubeDim::new(64, 1, 1),
-            ArrayArg::from_raw_parts::<f32>(&src, (num_pixels * 3) as usize, 1),
+            ArrayArg::from_raw_parts::<f32>(&src, (num_pixels as usize) * 3, 1),
             ArrayArg::from_raw_parts::<f32>(&dst, num_pixels as usize, 1),
             ScalarArg::new(num_pixels),
         )

--- a/crates/kornia-imgproc/src/gpu/color.rs
+++ b/crates/kornia-imgproc/src/gpu/color.rs
@@ -1,0 +1,63 @@
+//! CubeCL grayscale conversion kernels.
+//!
+//! CPU reference: `kornia_imgproc::color::gray_from_rgb` (BT.601 weights).
+//! GPU version: one thread per output pixel, 1-D flat grid.
+
+use cubecl::prelude::*;
+
+// BT.601 luma weights encoded as compile-time constants.
+const RW: f32 = 0.299;
+const GW: f32 = 0.587;
+const BW: f32 = 0.114;
+
+/// CubeCL kernel: convert a packed RGB buffer to a packed grayscale buffer (f32).
+///
+/// `src` must have `num_pixels * 3` elements; `dst` must have `num_pixels` elements.
+/// Threads beyond `num_pixels` exit immediately.
+#[cube(launch)]
+fn gray_from_rgb_f32_kernel(src: &Array<f32>, dst: &mut Array<f32>, num_pixels: u32) {
+    let idx = ABSOLUTE_POS;
+    if idx >= num_pixels {
+        return;
+    }
+    let base = idx * 3u32;
+    let r = src[base];
+    let g = src[base + 1u32];
+    let b = src[base + 2u32];
+    dst[idx] = f32::new(RW) * r + f32::new(GW) * g + f32::new(BW) * b;
+}
+
+/// Launch the `gray_from_rgb` kernel on the given compute client.
+///
+/// # Arguments
+///
+/// * `client` – CubeCL compute client for the target device.
+/// * `src` – device handle for the packed RGB buffer (`height * width * 3` f32 values).
+/// * `dst` – device handle for the packed grayscale output (`height * width` f32 values).
+/// * `width`, `height` – image dimensions in pixels.
+///
+/// # Panics
+///
+/// Panics if the kernel launch fails (e.g. driver error).
+pub fn launch_gray_from_rgb_f32<R: Runtime>(
+    client: &ComputeClient<R::Server, R::Channel>,
+    src: cubecl::server::Handle,
+    dst: cubecl::server::Handle,
+    width: u32,
+    height: u32,
+) {
+    let num_pixels = width * height;
+    // 64-thread cubes; ceil-div so all pixels are covered.
+    let num_cubes = num_pixels.div_ceil(64);
+
+    unsafe {
+        gray_from_rgb_f32_kernel::launch::<R>(
+            client,
+            CubeCount::Static(num_cubes, 1, 1),
+            CubeDim::new(64, 1, 1),
+            ArrayArg::from_raw_parts::<f32>(&src, (num_pixels * 3) as usize, 1),
+            ArrayArg::from_raw_parts::<f32>(&dst, num_pixels as usize, 1),
+            ScalarArg::new(num_pixels),
+        )
+    }
+}

--- a/crates/kornia-imgproc/src/gpu/color.rs
+++ b/crates/kornia-imgproc/src/gpu/color.rs
@@ -12,19 +12,17 @@ const BW: f32 = 0.114;
 
 /// CubeCL kernel: convert a packed RGB buffer to a packed grayscale buffer (f32).
 ///
-/// `src` must have `num_pixels * 3` elements; `dst` must have `num_pixels` elements.
-/// Threads beyond `num_pixels` exit immediately.
+/// `src` must have `dst.len() * 3` elements. Threads beyond `dst.len()` call `terminate!()`.
 #[cube(launch)]
-fn gray_from_rgb_f32_kernel(src: &Array<f32>, dst: &mut Array<f32>, num_pixels: u32) {
-    let idx = ABSOLUTE_POS;
-    if idx >= num_pixels {
-        return;
+fn gray_from_rgb_f32_kernel(src: &Array<f32>, dst: &mut Array<f32>) {
+    if ABSOLUTE_POS >= dst.len() {
+        terminate!();
     }
-    let base = idx * 3u32;
+    let base = ABSOLUTE_POS * 3;
     let r = src[base];
-    let g = src[base + 1u32];
-    let b = src[base + 2u32];
-    dst[idx] = f32::new(RW) * r + f32::new(GW) * g + f32::new(BW) * b;
+    let g = src[base + 1];
+    let b = src[base + 2];
+    dst[ABSOLUTE_POS] = f32::new(RW) * r + f32::new(GW) * g + f32::new(BW) * b;
 }
 
 /// Launch the `gray_from_rgb` kernel on the given compute client.
@@ -40,7 +38,7 @@ fn gray_from_rgb_f32_kernel(src: &Array<f32>, dst: &mut Array<f32>, num_pixels: 
 ///
 /// Panics if the kernel launch fails (e.g. driver error).
 pub fn launch_gray_from_rgb_f32<R: Runtime>(
-    client: &ComputeClient<R::Server, R::Channel>,
+    client: &ComputeClient<R>,
     src: cubecl::server::Handle,
     dst: cubecl::server::Handle,
     width: u32,
@@ -51,18 +49,17 @@ pub fn launch_gray_from_rgb_f32<R: Runtime>(
     if num_pixels_u64 == 0 {
         return;
     }
-    let num_pixels = num_pixels_u64 as u32;
+    let num_pixels = num_pixels_u64 as usize;
     // 64-thread cubes; ceil-div so all pixels are covered.
-    let num_cubes = num_pixels.div_ceil(64);
+    let num_cubes = num_pixels.div_ceil(64) as u32;
 
     unsafe {
         gray_from_rgb_f32_kernel::launch::<R>(
             client,
             CubeCount::Static(num_cubes, 1, 1),
-            CubeDim::new(64, 1, 1),
-            ArrayArg::from_raw_parts::<f32>(&src, (num_pixels as usize) * 3, 1),
-            ArrayArg::from_raw_parts::<f32>(&dst, num_pixels as usize, 1),
-            ScalarArg::new(num_pixels),
+            CubeDim { x: 64, y: 1, z: 1 },
+            ArrayArg::from_raw_parts(src, num_pixels * 3),
+            ArrayArg::from_raw_parts(dst, num_pixels),
         )
     }
 }

--- a/crates/kornia-imgproc/src/gpu/mod.rs
+++ b/crates/kornia-imgproc/src/gpu/mod.rs
@@ -1,0 +1,20 @@
+//! Experimental CubeCL-backed image processing kernels (feature `gpu-cubecl`).
+//!
+//! This module is the first home for GPU-accelerated operations in `kornia-imgproc`.
+//! The current scope is device-to-device kernels only; host-device transfer APIs
+//! (`to_device` / `to_host`) will be added in a later PR.
+//!
+//! # Usage
+//!
+//! ```no_run
+//! use cubecl::Runtime;
+//! use cubecl_cuda::CudaRuntime;
+//! use kornia_imgproc::gpu::color::launch_gray_from_rgb_f32;
+//!
+//! let device = <CudaRuntime as Runtime>::Device::default();
+//! let client = CudaRuntime::client(&device);
+//! // allocate device buffers for a 1920×1080 image …
+//! ```
+
+/// GPU-accelerated color conversion kernels.
+pub mod color;

--- a/crates/kornia-imgproc/src/lib.rs
+++ b/crates/kornia-imgproc/src/lib.rs
@@ -74,3 +74,10 @@ pub mod optical_flow_pyr_lk;
 
 /// contours
 pub mod contours;
+
+/// Experimental CubeCL-backed GPU image processing kernels.
+///
+/// Enabled by the `gpu-cubecl` feature. Device-to-device kernels only at this stage;
+/// host-device transfer APIs will follow in a later milestone.
+#[cfg(feature = "gpu-cubecl")]
+pub mod gpu;

--- a/crates/kornia-imgproc/tests/gpu_color_smoke.rs
+++ b/crates/kornia-imgproc/tests/gpu_color_smoke.rs
@@ -1,0 +1,27 @@
+#![cfg(feature = "gpu-cubecl")]
+
+use cubecl::Runtime;
+use cubecl_cuda::CudaRuntime;
+use kornia_imgproc::gpu::color::launch_gray_from_rgb_f32;
+
+/// Run with: cargo test -p kornia-imgproc --features gpu-cubecl -- --ignored
+#[test]
+#[ignore = "requires a CUDA device"]
+fn gray_from_rgb_kernel_launches_on_cuda() {
+    let device = <CudaRuntime as Runtime>::Device::default();
+    let client = CudaRuntime::client(&device);
+
+    let width: u32 = 4;
+    let height: u32 = 4;
+    let num_pixels = (width * height) as usize;
+
+    // Allocate device buffers (content is uninitialized — this test only checks launch).
+    let src = client.empty(num_pixels * 3 * std::mem::size_of::<f32>());
+    let dst = client.empty(num_pixels * std::mem::size_of::<f32>());
+
+    // Should not panic or return an error.
+    launch_gray_from_rgb_f32::<CudaRuntime>(&client, src, dst, width, height);
+
+    // Flush the queue — panics on driver error.
+    client.sync().expect("kernel execution failed");
+}

--- a/crates/kornia-tensor/src/lib.rs
+++ b/crates/kornia-tensor/src/lib.rs
@@ -133,6 +133,7 @@ pub mod tensor;
 pub mod view;
 
 pub use crate::allocator::{CpuAllocator, TensorAllocator};
+pub use crate::storage::MemoryDomain;
 pub(crate) use crate::tensor::get_strides_from_shape;
 pub use crate::tensor::{Tensor, TensorError};
 

--- a/crates/kornia-tensor/src/storage.rs
+++ b/crates/kornia-tensor/src/storage.rs
@@ -575,7 +575,7 @@ mod tests {
         // The pointer value is irrelevant; we only test the domain guard.
         let layout = Layout::array::<u8>(1).unwrap();
         let ptr = CpuAllocator.alloc(layout).unwrap();
-        unsafe { TensorStorage::from_raw_device(ptr as *mut u8, 1, layout, CpuAllocator) }
+        unsafe { TensorStorage::from_raw_device(ptr, 1, layout, CpuAllocator) }
     }
 
     #[test]

--- a/crates/kornia-tensor/src/storage.rs
+++ b/crates/kornia-tensor/src/storage.rs
@@ -100,10 +100,10 @@ impl<T, A: TensorAllocator> TensorStorage<T, A> {
     ///
     /// # Panics
     ///
-    /// Panics (in debug builds) if the storage lives on the device.
+    /// Panics if the storage lives on the device.
     /// Use explicit host-device transfer APIs to access device data.
     pub fn as_slice(&self) -> &[T] {
-        debug_assert_eq!(
+        assert_eq!(
             self.domain,
             MemoryDomain::Host,
             "as_slice called on device storage — use to_host() first"
@@ -115,9 +115,9 @@ impl<T, A: TensorAllocator> TensorStorage<T, A> {
     ///
     /// # Panics
     ///
-    /// Panics (in debug builds) if the storage lives on the device.
+    /// Panics if the storage lives on the device.
     pub fn as_mut_slice(&mut self) -> &mut [T] {
-        debug_assert_eq!(
+        assert_eq!(
             self.domain,
             MemoryDomain::Host,
             "as_mut_slice called on device storage — use to_host() first"
@@ -247,18 +247,23 @@ impl<T, A: TensorAllocator> TensorStorage<T, A> {
     /// Creates a new tensor storage from a raw device pointer returned by a GPU allocator.
     ///
     /// The resulting storage has [`MemoryDomain::Device`]; calling [`as_slice`](Self::as_slice)
-    /// on it will panic in debug builds. Use explicit transfer APIs to bring data to the host.
+    /// on it will panic. Use explicit transfer APIs to bring data to the host.
     ///
     /// # Safety
     ///
-    /// - `ptr` must be a valid device pointer for at least `len` bytes.
+    /// - `ptr` must be a valid device pointer for at least `len_bytes` bytes.
     /// - `layout` must match the allocation that produced `ptr`.
     /// - Ownership is transferred; the allocator's `dealloc` will be called on drop.
-    pub unsafe fn from_raw_device(data: *mut T, len: usize, layout: Layout, alloc: A) -> Self {
+    pub unsafe fn from_raw_device(
+        data: *mut T,
+        len_bytes: usize,
+        layout: Layout,
+        alloc: A,
+    ) -> Self {
         let ptr = NonNull::new_unchecked(data);
         Self {
             ptr,
-            len,
+            len: len_bytes,
             layout,
             alloc,
             owns_memory: true,
@@ -327,7 +332,7 @@ where
     ///
     /// A new `TensorStorage` instance with cloned data.
     fn clone(&self) -> Self {
-        debug_assert_eq!(
+        assert_eq!(
             self.domain,
             MemoryDomain::Host,
             "clone called on device storage — device-to-device copy is not yet implemented"
@@ -563,5 +568,34 @@ mod tests {
         }
         assert_eq!(buffer.into_vec(), vec![10, 2, 3, 4, 5]);
         Ok(())
+    }
+
+    fn make_device_storage() -> TensorStorage<u8, CpuAllocator> {
+        // Construct a Device-domain storage without actually touching GPU hardware.
+        // The pointer value is irrelevant; we only test the domain guard.
+        let layout = Layout::array::<u8>(1).unwrap();
+        let ptr = CpuAllocator.alloc(layout).unwrap();
+        unsafe { TensorStorage::from_raw_device(ptr as *mut u8, 1, layout, CpuAllocator) }
+    }
+
+    #[test]
+    #[should_panic(expected = "as_slice called on device storage")]
+    fn test_as_slice_panics_on_device() {
+        let storage = make_device_storage();
+        let _ = storage.as_slice();
+    }
+
+    #[test]
+    #[should_panic(expected = "as_mut_slice called on device storage")]
+    fn test_as_mut_slice_panics_on_device() {
+        let mut storage = make_device_storage();
+        let _ = storage.as_mut_slice();
+    }
+
+    #[test]
+    #[should_panic(expected = "clone called on device storage")]
+    fn test_clone_panics_on_device() {
+        let storage = make_device_storage();
+        let _ = storage.clone();
     }
 }

--- a/crates/kornia-tensor/src/storage.rs
+++ b/crates/kornia-tensor/src/storage.rs
@@ -321,16 +321,16 @@ impl<T, A: TensorAllocator> Drop for TensorStorage<T, A> {
 /// Clones the storage by creating a new storage with copied data.
 ///
 /// This performs a deep copy of the storage data using the cloned allocator.
+///
+/// # Panics
+///
+/// Panics if the storage lives on the device. Device-to-device copy is not yet
+/// implemented; use an explicit transfer API when it becomes available.
 impl<T, A> Clone for TensorStorage<T, A>
 where
     T: Clone,
     A: TensorAllocator,
 {
-    /// Creates a new storage with a copy of this storage's data.
-    ///
-    /// # Returns
-    ///
-    /// A new `TensorStorage` instance with cloned data.
     fn clone(&self) -> Self {
         assert_eq!(
             self.domain,

--- a/crates/kornia-tensor/src/storage.rs
+++ b/crates/kornia-tensor/src/storage.rs
@@ -2,6 +2,18 @@ use std::{alloc::Layout, ptr::NonNull};
 
 use crate::allocator::TensorAllocator;
 
+/// Indicates where the data owned by a [`TensorStorage`] physically lives.
+///
+/// Host storage may be accessed via slice APIs. Device storage holds a raw
+/// device address — dereferencing it on the host is unsound.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MemoryDomain {
+    /// Data lives in host (CPU) memory; slice access is safe.
+    Host,
+    /// Data lives in device (GPU) memory; slice access is unsound.
+    Device,
+}
+
 /// Low-level memory buffer for tensor data.
 ///
 /// `TensorStorage` manages a contiguous block of memory that holds the actual data for a tensor.
@@ -53,6 +65,8 @@ pub struct TensorStorage<T, A: TensorAllocator> {
     pub(crate) alloc: A,
     /// Whether this storage owns its memory (false for foreign/numpy-backed buffers).
     pub(crate) owns_memory: bool,
+    /// Where the backing memory lives (host or device).
+    pub(crate) domain: MemoryDomain,
 }
 
 impl<T, A: TensorAllocator> TensorStorage<T, A> {
@@ -76,25 +90,38 @@ impl<T, A: TensorAllocator> TensorStorage<T, A> {
         self.ptr.as_ptr()
     }
 
+    /// Returns the memory domain for this storage.
+    #[inline]
+    pub fn domain(&self) -> MemoryDomain {
+        self.domain
+    }
+
     /// Returns the storage data as a slice.
     ///
-    /// This provides safe, immutable access to the storage's underlying data.
+    /// # Panics
     ///
-    /// # Returns
-    ///
-    /// A slice containing all elements in the storage.
+    /// Panics (in debug builds) if the storage lives on the device.
+    /// Use explicit host-device transfer APIs to access device data.
     pub fn as_slice(&self) -> &[T] {
+        debug_assert_eq!(
+            self.domain,
+            MemoryDomain::Host,
+            "as_slice called on device storage — use to_host() first"
+        );
         unsafe { std::slice::from_raw_parts(self.as_ptr(), self.len / std::mem::size_of::<T>()) }
     }
 
     /// Returns the storage data as a mutable slice.
     ///
-    /// This provides safe, mutable access to the storage's underlying data.
+    /// # Panics
     ///
-    /// # Returns
-    ///
-    /// A mutable slice containing all elements in the storage.
+    /// Panics (in debug builds) if the storage lives on the device.
     pub fn as_mut_slice(&mut self) -> &mut [T] {
+        debug_assert_eq!(
+            self.domain,
+            MemoryDomain::Host,
+            "as_mut_slice called on device storage — use to_host() first"
+        );
         unsafe {
             std::slice::from_raw_parts_mut(self.as_mut_ptr(), self.len / std::mem::size_of::<T>())
         }
@@ -181,6 +208,7 @@ impl<T, A: TensorAllocator> TensorStorage<T, A> {
             layout,
             alloc,
             owns_memory: true,
+            domain: MemoryDomain::Host,
         }
     }
 
@@ -212,6 +240,29 @@ impl<T, A: TensorAllocator> TensorStorage<T, A> {
             layout,
             alloc,
             owns_memory: false,
+            domain: MemoryDomain::Host,
+        }
+    }
+
+    /// Creates a new tensor storage from a raw device pointer returned by a GPU allocator.
+    ///
+    /// The resulting storage has [`MemoryDomain::Device`]; calling [`as_slice`](Self::as_slice)
+    /// on it will panic in debug builds. Use explicit transfer APIs to bring data to the host.
+    ///
+    /// # Safety
+    ///
+    /// - `ptr` must be a valid device pointer for at least `len` bytes.
+    /// - `layout` must match the allocation that produced `ptr`.
+    /// - Ownership is transferred; the allocator's `dealloc` will be called on drop.
+    pub unsafe fn from_raw_device(data: *mut T, len: usize, layout: Layout, alloc: A) -> Self {
+        let ptr = NonNull::new_unchecked(data);
+        Self {
+            ptr,
+            len,
+            layout,
+            alloc,
+            owns_memory: true,
+            domain: MemoryDomain::Device,
         }
     }
 
@@ -276,6 +327,11 @@ where
     ///
     /// A new `TensorStorage` instance with cloned data.
     fn clone(&self) -> Self {
+        debug_assert_eq!(
+            self.domain,
+            MemoryDomain::Host,
+            "clone called on device storage — device-to-device copy is not yet implemented"
+        );
         Self::from_vec(self.as_slice().to_vec(), self.alloc.clone())
     }
 }
@@ -306,6 +362,7 @@ mod tests {
             layout,
             ptr,
             owns_memory: true,
+            domain: super::MemoryDomain::Host,
         };
 
         assert_eq!(buffer.ptr.as_ptr(), ptr_raw);
@@ -348,6 +405,7 @@ mod tests {
             layout,
             ptr: ptr.cast::<f32>(),
             owns_memory: true,
+            domain: super::MemoryDomain::Host,
         };
 
         assert_eq!(buffer.as_ptr(), ptr.as_ptr() as *const f32);


### PR DESCRIPTION
## Description

> **Note:** This PR builds on top of #927 (CubeclBackend + GPU allocator). It should be merged after that one lands.

Fixes/Relates to: # (issue number)

## Changes Made

### kornia-tensor: MemoryDomain-aware storage
- Add `MemoryDomain` enum (`Host | Device`) to `kornia-tensor::storage`
- Tag all existing constructors as `MemoryDomain::Host`; add `domain()` getter
- Add `from_raw_device()` constructor for GPU-allocated device storage
- Guard `as_slice`, `as_mut_slice`, and `Clone` with `debug_assert` on `Host` domain to prevent silent host access of device memory
- Export `MemoryDomain` from the crate root

### kornia-imgproc: CubeCL experimental GPU home
- Add `gpu-cubecl` feature to `kornia-imgproc` (mirrors the pattern in `kornia-tensor`)
- Scaffold `kornia-imgproc::gpu` module as the experimental CubeCL home
- Implement `gray_from_rgb_f32_kernel` CubeCL kernel (BT.601 luma weights, 1-D grid)
- Add `launch_gray_from_rgb_f32` wrapper
- Add `#[ignore]`-gated CUDA smoke test in `tests/gpu_color_smoke.rs`

> H2D / D2H transfer APIs (`to_device` / `to_host`) are deferred to the next PR.

## How Was This Tested?

- `cargo build -p kornia-tensor --features gpu-cubecl` — clean
- `cargo build -p kornia-imgproc --features gpu-cubecl` — clean (GTX 1650, CUDA 12.4)
- `cargo test -p kornia-imgproc --features gpu-cubecl -- --include-ignored` — smoke test passes

## AI Usage Disclosure

- [x] 🟡 AI-assisted: I used AI for boilerplate/refactoring but have manually reviewed and tested every line.

## Checklist

- [ ] I am assigned to the linked issue (required before PR submission)
- [ ] The linked issue has been approved by a maintainer
- [ ] This PR strictly implements what the linked issue describes (no scope creep)
- [x] I have performed a self-review of my code
- [x] My code follows the existing style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my feature works