### PR TITLE
feat(3d): expose the left rectifying rotation on StereoRectifier

### DIFF
--- a/crates/kornia-3d/src/stereo/rectify.rs
+++ b/crates/kornia-3d/src/stereo/rectify.rs
@@ -63,6 +63,8 @@ pub struct StereoRectifier {
     cy: f64,
     /// Metric stereo baseline (‖translation between cameras‖).
     baseline: f64,
+    /// Rotation mapping raw left-camera coordinates into the rectified frame.
+    rect_left: Mat3F64,
     /// Per-output-pixel source coordinate in the raw left image (`[u, v]`).
     left_map: Vec<[f32; 2]>,
     /// Per-output-pixel source coordinate in the raw right image.
@@ -162,9 +164,17 @@ impl StereoRectifier {
             cx,
             cy,
             baseline: nt,
+            rect_left: rect_l,
             left_map,
             right_map,
         })
+    }
+
+    /// Rotation mapping raw left-camera coordinates into the rectified frame
+    /// (`p_rect = R · p_left_raw`). Lets callers re-express raw-frame
+    /// extrinsics (e.g. a camera-IMU `T_BS`) for the rectified virtual camera.
+    pub fn left_rectifying_rotation(&self) -> Mat3F64 {
+        self.rect_left
     }
 
     /// Rectified pinhole camera (shared by both views; zero distortion).


### PR DESCRIPTION
## What

Stores the left rectifying rotation (`rect_l`, already computed in `StereoRectifier::from_calib` to build the remap tables) on the struct and adds a `left_rectifying_rotation()` getter.

## Why

The rectified virtual camera is the raw left camera rotated by the Bouguet rectifying rotation (`p_rect = R_rect · p_left_raw`). Any extrinsic calibrated against the raw camera frame therefore has to be re-expressed before it can be used with rectified images — most importantly a camera-IMU `T_BS`:

```
T_B,rect = T_BS · R_rectᵀ    (translation unchanged)
```

Without access to `R_rect`, visual-inertial pipelines running on rectified stereo (e.g. kornia-slam's stereo-inertial mode on EuRoC) cannot relate IMU preintegration deltas (body frame) to the rectified camera poses, which silently corrupts the estimated gravity direction.

Verified downstream in kornia-slam: stereo-inertial init on EuRoC MH_01 recovers the same physical gravity vector as the mono (unrectified) path, re-expressed in the rectified frame, and a gyro bias matching the known sensor bias.

## Changes

- `StereoRectifier`: new private `rect_left: Mat3F64` field, populated in `from_calib`
- new getter `left_rectifying_rotation() -> Mat3F64`

No behavior changes; existing stereo tests pass.