### PR TITLE
feat(cuda): cudarc device-memory integration (CudaResource/CudaAllocator, Tensor::to_cuda, CudaKernel)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
   "kornia-cpp",  # kornia-rs C++ bindings
   "kornia-py",  # kornia-rs python bindings
 ]
-exclude = ["examples/dora"]
+exclude = ["examples/cuda_imgproc", "examples/dora"]
 default-members = ["crates/*"]
 
 [workspace.package]

--- a/crates/kornia-image/Cargo.toml
+++ b/crates/kornia-image/Cargo.toml
@@ -37,8 +37,8 @@ half = { workspace = true }
 [features]
 default = []
 arrow = ["dep:arrow"]
-dlpack = ["dep:dlpack-rs", "kornia-tensor/dlpack"]
 # cudarc device-memory integration — default OFF.
 # Enables Image::to_cuda for H2D uploads.
 # Verify absence: `cargo tree -p kornia-image -e features | grep -i cudarc`
 cudarc = ["dep:cudarc", "kornia-tensor/cudarc"]
+dlpack = ["dep:dlpack-rs", "kornia-tensor/dlpack"]

--- a/crates/kornia-image/Cargo.toml
+++ b/crates/kornia-image/Cargo.toml
@@ -16,6 +16,14 @@ name = "bench_image"
 
 [dependencies]
 arrow = { workspace = true, optional = true }
+cudarc = { version = "0.19.0", default-features = false, features = [
+  "cuda-version-from-build-system",
+  "driver",
+  "fallback-dynamic-loading",
+  "fallback-latest",
+  "nvrtc",
+  "std",
+], optional = true }
 dlpack-rs = { git = "https://github.com/kornia/dlpack-rs", tag = "v0.3.2", default-features = false, optional = true }
 kornia-tensor = { workspace = true }
 num-traits = { workspace = true }
@@ -30,3 +38,7 @@ half = { workspace = true }
 default = []
 arrow = ["dep:arrow"]
 dlpack = ["dep:dlpack-rs", "kornia-tensor/dlpack"]
+# cudarc device-memory integration — default OFF.
+# Enables Image::to_cuda for H2D uploads.
+# Verify absence: `cargo tree -p kornia-image -e features | grep -i cudarc`
+cudarc = ["dep:cudarc", "kornia-tensor/cudarc"]

--- a/crates/kornia-image/src/cuda.rs
+++ b/crates/kornia-image/src/cuda.rs
@@ -1,0 +1,58 @@
+//! CUDA device-memory integration for [`Image`].
+//!
+//! This module is enabled by the `cudarc` feature flag. It provides
+//! [`Image::to_cuda`], which uploads a host-backed image to a new
+//! device-backed [`kornia_tensor::Tensor`] via a host-to-device copy.
+//!
+//! # Example
+//!
+//! ```no_run
+//! # #[cfg(feature = "cudarc")]
+//! # {
+//! use kornia_image::color_spaces::Rgb8;
+//! use kornia_tensor::CpuAllocator;
+//! use cudarc::driver::CudaContext;
+//! use std::sync::Arc;
+//!
+//! let rgb = Rgb8::from_size_val(
+//!     kornia_image::ImageSize { width: 2, height: 2 },
+//!     [0u8; 3],
+//!     CpuAllocator,
+//! ).unwrap();
+//!
+//! let ctx = CudaContext::new(0).unwrap();
+//! let stream = ctx.default_stream();
+//! // Works via Deref: Rgb8 → Image<u8,3,_> → to_cuda
+//! let _dev = rgb.to_cuda(&stream).unwrap();
+//! # }
+//! ```
+
+use std::sync::Arc;
+
+use cudarc::driver::{CudaStream, DeviceRepr, ValidAsZeroBits};
+
+use crate::allocator::ImageAllocator;
+use crate::image::Image;
+use kornia_tensor::{CudaAllocator, CudaError, Tensor};
+
+impl<T, const C: usize, A: ImageAllocator> Image<T, C, A>
+where
+    T: DeviceRepr + ValidAsZeroBits + Clone + Default + 'static,
+    A: 'static,
+{
+    /// Upload this image's buffer to a new device tensor (H2D) on `stream`.
+    ///
+    /// The entire contiguous `H × W × C` byte buffer is copied from host to
+    /// device in a single `clone_htod` call. The returned tensor has shape
+    /// `[H, W, C]` and is backed by a [`CudaAllocator`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CudaError::Driver`] on CUDA failure.
+    pub fn to_cuda(
+        &self,
+        stream: &Arc<CudaStream>,
+    ) -> Result<Tensor<T, 3, CudaAllocator>, CudaError> {
+        self.0.to_cuda(stream)
+    }
+}

--- a/crates/kornia-image/src/lib.rs
+++ b/crates/kornia-image/src/lib.rs
@@ -27,3 +27,7 @@ pub mod arrow;
 /// DLPack interoperability for typed [`Image`].
 #[cfg(feature = "dlpack")]
 pub mod dlpack;
+
+/// CUDA device-memory integration: [`Image::to_cuda`].
+#[cfg(feature = "cudarc")]
+pub mod cuda;

--- a/crates/kornia-tensor/Cargo.toml
+++ b/crates/kornia-tensor/Cargo.toml
@@ -48,11 +48,11 @@ serde_json = { workspace = true }
 
 [features]
 bincode = ["dep:bincode"]
-dlpack = ["dep:dlpack-rs"]
 # cudarc device-memory integration — default OFF.
 # Enables CudaResource / CudaAllocator and Tensor::to_cuda / to_host etc.
 # Verify absence: `cargo tree -p kornia-tensor -e features | grep -i cudarc`
 cudarc = ["dep:cudarc"]
+dlpack = ["dep:dlpack-rs"]
 gpu = []
 gpu-cubecl = ["dep:cubecl-core", "dep:cubecl-cuda", "dep:cudarc", "gpu"]
 serde = ["dep:serde"]

--- a/crates/kornia-tensor/Cargo.toml
+++ b/crates/kornia-tensor/Cargo.toml
@@ -29,10 +29,6 @@ default-features = false
 features = ["std"]
 optional = true
 
-# cudarc is used directly by the CubeclBackend (malloc_sync / free_sync) when
-# the `gpu-cubecl` feature is enabled.  It is NOT the standalone `cudarc`
-# device-tensor feature (which has been removed); it is here only as a low-level
-# CUDA driver accessor for CubeCL memory management.
 [dependencies.cudarc]
 version = "0.19.0"
 default-features = false
@@ -53,6 +49,10 @@ serde_json = { workspace = true }
 [features]
 bincode = ["dep:bincode"]
 dlpack = ["dep:dlpack-rs"]
+# cudarc device-memory integration — default OFF.
+# Enables CudaResource / CudaAllocator and Tensor::to_cuda / to_host etc.
+# Verify absence: `cargo tree -p kornia-tensor -e features | grep -i cudarc`
+cudarc = ["dep:cudarc"]
 gpu = []
 gpu-cubecl = ["dep:cubecl-core", "dep:cubecl-cuda", "dep:cudarc", "gpu"]
 serde = ["dep:serde"]

--- a/crates/kornia-tensor/src/allocator.rs
+++ b/crates/kornia-tensor/src/allocator.rs
@@ -38,6 +38,12 @@ pub enum TensorAllocatorError {
     /// driver error message from CubeCL.
     #[error("Allocation failed: {0}")]
     AllocationFailed(String),
+    /// A CUDA allocation or driver call failed.
+    ///
+    /// Only produced when the `cudarc` feature is enabled.
+    #[cfg(feature = "cudarc")]
+    #[error("CUDA allocator error: {0}")]
+    CudaError(String),
 }
 
 /// Trait for custom tensor memory allocators.

--- a/crates/kornia-tensor/src/cuda.rs
+++ b/crates/kornia-tensor/src/cuda.rs
@@ -1,0 +1,872 @@
+//! CUDA device memory integration for `kornia-tensor` via `cudarc 0.19`.
+//!
+//! This module is enabled by the `cudarc` feature flag.  It provides:
+//!
+//! - [`CudaResource`]: an owning [`MemoryResource`] that wraps a [`CudaSlice<u8>`].
+//!   The `CudaSlice`'s own `Drop` frees the device allocation — there is no manual
+//!   `cudaFree` call here, which is the guarantee against double-free.
+//!
+//! - [`CudaAllocator`]: a [`TensorAllocator`] that allocates zero-initialised device
+//!   memory via `stream.alloc_zeros::<u8>(n)` and wraps the result in a `CudaResource`.
+//!
+//! - Five methods on [`Tensor`]:
+//!   - [`Tensor::from_cudaslice`] — wrap an existing `CudaSlice<T>` as a device tensor.
+//!   - [`Tensor::as_cudaslice`] — borrow the underlying `CudaSlice<u8>` (if any).
+//!   - [`Tensor::into_cudaslice`] — consume the tensor and return the `CudaSlice<u8>`.
+//!   - [`Tensor::to_cuda`] — copy a host tensor to a new device tensor (h→d).
+//!   - [`Tensor::to_host`] — copy a device tensor back to a new host tensor (d→h).
+//!
+//! # Memory-safety invariants
+//!
+//! - Each `CudaSlice<u8>` is stored **exactly once**: inside `CudaResource`.
+//!   `CudaResource` is owned by a `Box<dyn MemoryResource>` in `TensorStorage`.
+//!   When the `Tensor` drops, the chain drops, `CudaSlice::drop` runs exactly once,
+//!   and cudarc frees the device memory.
+//!
+//! - `CudaAllocator::allocate` calls `stream.alloc_zeros::<u8>(n)` — all memory is
+//!   zero-initialised and the `CudaSlice<u8>` carries the free obligation.
+//!
+//! - `into_cudaslice` extracts the `CudaSlice<u8>` by consuming the `Box<CudaResource>`
+//!   via `ManuallyDrop`, so the `CudaSlice` is moved out before any destructor runs.
+//!   The heap allocation for the `CudaResource` struct itself is freed by `Box::from_raw`;
+//!   the `CudaSlice` it contained is *not* dropped (we return it to the caller instead).
+//!
+//! - `from_cudaslice` ZERO-COPY WRAPS the input `CudaSlice<T>`: it caches the device
+//!   pointer (via `DevicePtr::device_ptr`) and moves the slice, unchanged, into a
+//!   generic `CudaResource<T>`. The resulting tensor aliases the same device allocation
+//!   — no host round-trip, no device copy. `CudaResource` is generic over `T` precisely
+//!   so this requires no transmute or byte coercion. (`to_cuda`/`to_host` DO copy —
+//!   they are host↔device transfers, which is correct.)
+//!
+//! - `miri` cannot execute CUDA driver calls; device tests are guarded by
+//!   `#[cfg(all(test, feature = "cudarc"))]` and run on the real Jetson Orin.
+
+use std::{
+    any::Any,
+    collections::HashMap,
+    marker::PhantomData,
+    ptr::NonNull,
+    sync::{Arc, Mutex, OnceLock},
+};
+
+use cudarc::driver::{
+    CudaContext, CudaFunction, CudaSlice, CudaStream, DevicePtr, DeviceRepr, LaunchArgs,
+    LaunchConfig, PushKernelArg, ValidAsZeroBits,
+};
+use cudarc::nvrtc::{compile_ptx_with_opts, CompileOptions};
+
+use crate::{
+    allocator::{CpuAllocator, TensorAllocator, TensorAllocatorError},
+    resource::{MemoryDomain, MemoryResource},
+    storage::TensorStorage,
+    tensor::{get_strides_from_shape, Tensor, TensorError},
+};
+
+// ── CudaResource ─────────────────────────────────────────────────────────────
+
+/// An owning [`MemoryResource`] that wraps a [`CudaSlice<T>`].
+///
+/// The wrapped `CudaSlice<T>` is the **sole owner** of the device allocation and its
+/// own `Drop` impl frees the device memory exactly once.  No manual free is performed
+/// here — the `CudaResource` is purely a keepalive + type-erasable handle.
+///
+/// `CudaResource` is generic over the element type `T` so that
+/// [`Tensor::from_cudaslice`] can **zero-copy wrap** (alias) an existing
+/// `CudaSlice<T>` without any host round-trip or byte coercion.  The
+/// [`CudaAllocator`] produces `CudaResource<u8>`.
+pub struct CudaResource<T> {
+    /// Owns the device allocation; freed when this struct is dropped.
+    pub(crate) slice: CudaSlice<T>,
+    /// Cached raw device pointer (device-addressable; NOT safe to dereference on host).
+    ptr: *mut u8,
+    /// CUDA device ordinal (returned by `CudaContext::ordinal()`).
+    id: i32,
+}
+
+// SAFETY: CudaSlice<T> is Send + Sync.  `ptr` is a device pointer that is never
+// dereferenced on the host — it is only passed back to CUDA APIs.
+unsafe impl<T> Send for CudaResource<T> {}
+unsafe impl<T> Sync for CudaResource<T> {}
+
+// SAFETY: CudaResource<T> is unconditionally Send + Sync (see the unsafe impls above);
+// `T: 'static` is required only so the value is `Any`-downcastable via `as_any`.
+impl<T: 'static> MemoryResource for CudaResource<T> {
+    /// Returns the cached device pointer (NOT host-dereferenceable).
+    fn as_ptr(&self) -> *mut u8 {
+        self.ptr
+    }
+
+    fn len_bytes(&self) -> usize {
+        self.slice.num_bytes()
+    }
+
+    fn domain(&self) -> MemoryDomain {
+        MemoryDomain::Device { id: self.id }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+// Implicit Drop: `CudaSlice::drop` calls cudarc's device-free path exactly once.
+
+// ── CudaAllocator ─────────────────────────────────────────────────────────────
+
+/// A [`TensorAllocator`] that allocates zero-initialised CUDA device memory.
+///
+/// Uses [`CudaStream::alloc_zeros::<u8>`] so all bytes are guaranteed zero.
+#[derive(Clone)]
+pub struct CudaAllocator {
+    /// Shared CUDA context (keeps the driver alive).
+    pub ctx: Arc<CudaContext>,
+    /// Stream on which allocations (and later free-async) are issued.
+    pub stream: Arc<CudaStream>,
+}
+
+// SAFETY: Arc<CudaContext> and Arc<CudaStream> are Send + Sync.
+unsafe impl Send for CudaAllocator {}
+unsafe impl Sync for CudaAllocator {}
+
+impl TensorAllocator for CudaAllocator {
+    fn allocate(
+        &self,
+        layout: std::alloc::Layout,
+    ) -> Result<Box<dyn MemoryResource>, TensorAllocatorError> {
+        let n_bytes = layout.size();
+        let slice: CudaSlice<u8> = self
+            .stream
+            .alloc_zeros::<u8>(n_bytes)
+            .map_err(|e| TensorAllocatorError::CudaError(e.to_string()))?;
+
+        // Extract the raw device pointer before moving the slice.
+        // _sync must be dropped before we move `slice` into CudaResource.
+        let ptr = {
+            let (cu_ptr, _sync) = slice.device_ptr(&self.stream);
+            cu_ptr as *mut u8
+            // `_sync` drops here, releasing the borrow on `slice`
+        };
+        let id = self.ctx.ordinal() as i32;
+
+        Ok(Box::new(CudaResource::<u8> { slice, ptr, id }))
+    }
+}
+
+// ── Error type ────────────────────────────────────────────────────────────────
+
+/// Error type for CUDA tensor operations.
+#[derive(Debug, thiserror::Error)]
+pub enum CudaError {
+    /// cudarc driver error.
+    #[error("CUDA driver error: {0}")]
+    Driver(String),
+
+    /// Shape / element-count mismatch.
+    #[error("Tensor error: {0}")]
+    Tensor(#[from] TensorError),
+
+    /// Storage is not backed by a `CudaResource`.
+    #[error("Tensor storage is not device-backed by CudaResource")]
+    NotCudaBacked,
+}
+
+// ── CudaKernel ────────────────────────────────────────────────────────────────
+
+/// A compiled CUDA kernel that wraps a [`CudaFunction`] (which internally keeps
+/// its owning `CudaModule` alive).
+///
+/// Construct via [`CudaKernel::compile`], then launch via
+/// [`CudaKernel::launch_builder`].
+pub struct CudaKernel {
+    /// The loaded kernel. `CudaFunction` internally holds an `Arc<CudaModule>`,
+    /// so the module stays alive as long as this kernel exists — no separate
+    /// keep-alive field is needed.
+    func: CudaFunction,
+}
+
+impl CudaKernel {
+    /// Compile a CUDA C source string and return a ready-to-launch kernel.
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx`     — CUDA context; used to detect compute capability and load the module.
+    /// * `src`     — CUDA C (`.cu`) source string.
+    /// * `fn_name` — name of the `extern "C" __global__` function to load.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CudaError::Driver`] on nvrtc compile failure or module/function
+    /// load failure.
+    pub fn compile(ctx: &Arc<CudaContext>, src: &str, fn_name: &str) -> Result<Self, CudaError> {
+        // Detect arch from the context's device.
+        let (major, minor) = ctx
+            .compute_capability()
+            .map_err(|e| CudaError::Driver(e.to_string()))?;
+
+        // `CompileOptions.arch` is `Option<&'static str>`.
+        // We cache the leaked `&'static str` per (major, minor) compute capability so
+        // that at most one string is ever leaked per distinct arch value (typically a
+        // handful in the lifetime of a process), rather than one per `compile` call.
+        static ARCH_CACHE: OnceLock<Mutex<HashMap<(i32, i32), &'static str>>> = OnceLock::new();
+        let arch_str: &'static str = {
+            let mut map = ARCH_CACHE
+                .get_or_init(|| Mutex::new(HashMap::new()))
+                .lock()
+                .expect("ARCH_CACHE mutex poisoned");
+            if let Some(&s) = map.get(&(major, minor)) {
+                s
+            } else {
+                let s: &'static str =
+                    Box::leak(format!("compute_{}{}", major, minor).into_boxed_str());
+                map.insert((major, minor), s);
+                s
+            }
+        };
+
+        let ptx = compile_ptx_with_opts(
+            src,
+            CompileOptions {
+                arch: Some(arch_str),
+                ..Default::default()
+            },
+        )
+        .map_err(|e| CudaError::Driver(format!("{e:?}")))?;
+
+        let module = ctx
+            .load_module(ptx)
+            .map_err(|e| CudaError::Driver(e.to_string()))?;
+        // `load_function` returns a `CudaFunction` that holds its own
+        // `Arc<CudaModule>`, so `module` may drop at the end of this scope.
+        let func = module
+            .load_function(fn_name)
+            .map_err(|e| CudaError::Driver(e.to_string()))?;
+
+        Ok(CudaKernel { func })
+    }
+
+    /// Create a [`CudaLaunchBuilder`] pre-bound to this kernel and the given stream.
+    pub fn launch_builder<'a>(&'a self, stream: &'a Arc<CudaStream>) -> CudaLaunchBuilder<'a> {
+        CudaLaunchBuilder {
+            inner: stream.launch_builder(&self.func),
+        }
+    }
+}
+
+// ── CudaLaunchBuilder ─────────────────────────────────────────────────────────
+
+/// Ergonomic wrapper around cudarc's [`LaunchArgs`] that accumulates kernel
+/// arguments and provides a one-liner `launch_1d` helper.
+///
+/// Obtain via [`CudaKernel::launch_builder`].
+///
+/// # Example
+///
+/// ```ignore
+/// kernel.launch_builder(&stream)
+///     .arg(&input_slice)
+///     .arg(&mut output_slice)
+///     .arg(&n_i32)
+///     .launch_1d(n as u32)?;
+/// ```
+pub struct CudaLaunchBuilder<'a> {
+    inner: LaunchArgs<'a>,
+}
+
+impl<'a> CudaLaunchBuilder<'a> {
+    /// Push a kernel argument.  `T` must implement [`PushKernelArg`] for
+    /// [`LaunchArgs<'a>`], which is satisfied by `&T` (for `T: DeviceRepr`),
+    /// `&CudaSlice<T>`, `&mut CudaSlice<T>`, and similar cudarc types.
+    pub fn arg<T>(mut self, v: T) -> Self
+    where
+        LaunchArgs<'a>: PushKernelArg<T>,
+    {
+        self.inner.arg(v);
+        self
+    }
+
+    /// Launch the kernel with a 1-D grid sized to cover `n` elements.
+    ///
+    /// Uses a fixed block size of 256 threads.
+    ///
+    /// # Safety (internal)
+    ///
+    /// The `unsafe { self.inner.launch(cfg) }` call is inherently unsafe because
+    /// CUDA cannot verify that the accumulated arguments are valid.  This wrapper
+    /// provides the ergonomic surface; callers must ensure argument types and
+    /// counts match the kernel signature.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CudaError::Driver`] on CUDA launch failure.
+    pub fn launch_1d(mut self, n: u32) -> Result<(), CudaError> {
+        const BLOCK: u32 = 256;
+        let cfg = LaunchConfig {
+            block_dim: (BLOCK, 1, 1),
+            grid_dim: (n.div_ceil(BLOCK), 1, 1),
+            shared_mem_bytes: 0,
+        };
+        // SAFETY: The caller is responsible for ensuring the kernel arguments match
+        // the kernel's parameter list in type, count, and alignment.
+        unsafe { self.inner.launch(cfg) }
+            .map(|_| ()) // discard optional (CudaEvent, CudaEvent) timing pair
+            .map_err(|e| CudaError::Driver(e.to_string()))
+    }
+}
+
+// ── zeros_cuda ────────────────────────────────────────────────────────────────
+
+/// Allocate a zero-initialised device tensor with shape `shape` on `stream`.
+///
+/// Uses [`CudaAllocator`] (which calls `stream.alloc_zeros::<u8>`) so all bytes
+/// are guaranteed to be zero on the device.
+///
+/// # Type parameters
+///
+/// * `T` — element type; must satisfy [`DeviceRepr`] + [`ValidAsZeroBits`].
+/// * `N` — number of dimensions.
+///
+/// # Errors
+///
+/// Returns [`CudaError::Driver`] on CUDA allocation failure. A zero-element
+/// shape is allowed and yields an empty (0-byte) device tensor.
+pub fn zeros_cuda<T, const N: usize>(
+    shape: [usize; N],
+    stream: &Arc<CudaStream>,
+) -> Result<Tensor<T, N, CudaAllocator>, CudaError>
+where
+    T: DeviceRepr + ValidAsZeroBits + 'static,
+{
+    let ctx = stream.context().clone();
+    let alloc = CudaAllocator {
+        ctx: ctx.clone(),
+        stream: stream.clone(),
+    };
+
+    let numel: usize = shape.iter().product();
+    let n_bytes = numel * std::mem::size_of::<T>();
+
+    // Allocate zero-initialised device memory via the stream.
+    let slice: CudaSlice<u8> = stream
+        .alloc_zeros::<u8>(n_bytes)
+        .map_err(|e| CudaError::Driver(e.to_string()))?;
+
+    // Cache device pointer before moving `slice` into CudaResource.
+    let id = ctx.ordinal() as i32;
+    let ptr = {
+        let (cu_ptr, _sync) = slice.device_ptr(stream);
+        cu_ptr as *mut u8
+        // _sync drops here
+    };
+
+    let resource = CudaResource::<u8> { slice, ptr, id };
+
+    // SAFETY: `ptr` is the device pointer inside `resource`; `n_bytes` is the
+    // allocation size; `resource` is the sole owner of that device memory.
+    let storage = unsafe { storage_from_cuda_resource(resource, ptr as *mut T, n_bytes, alloc) };
+    let strides = get_strides_from_shape(shape);
+    Ok(Tensor {
+        storage,
+        shape,
+        strides,
+    })
+}
+
+// ── Helper: build a TensorStorage from a CudaResource ─────────────────────────
+
+/// Build a `TensorStorage<T, A>` that owns the given [`CudaResource<R>`].
+///
+/// `R` is the element type of the wrapped `CudaSlice` (e.g. `u8` from the allocator,
+/// or `T` from `from_cudaslice`); `T` is the tensor's element type.
+///
+/// # Safety
+///
+/// `ptr` must be the device pointer inside `resource` (cached from
+/// `resource.slice.device_ptr(stream)`).  It must be valid for `len_bytes` bytes on
+/// the device.  The caller guarantees `resource` is the sole owner of that allocation.
+unsafe fn storage_from_cuda_resource<T, R, A>(
+    resource: CudaResource<R>,
+    ptr: *mut T,
+    len_bytes: usize,
+    alloc: A,
+) -> TensorStorage<T, A>
+where
+    R: 'static,
+    A: TensorAllocator,
+{
+    let owner: Box<dyn MemoryResource> = Box::new(resource);
+    let nn_ptr = NonNull::new_unchecked(ptr);
+    TensorStorage {
+        ptr: nn_ptr,
+        len: len_bytes,
+        owner,
+        alloc,
+        _marker: PhantomData,
+    }
+}
+
+// ── Tensor: from_cudaslice / as_cudaslice / into_cudaslice ────────────────────
+
+impl<T, const N: usize> Tensor<T, N, CudaAllocator>
+where
+    T: DeviceRepr + ValidAsZeroBits + 'static,
+{
+    /// Zero-copy wrap an existing `CudaSlice<T>` as a device-backed tensor.
+    ///
+    /// The resulting tensor **aliases the same device allocation** as `slice` — no
+    /// host round-trip and no device-to-device copy occur.  The `CudaSlice<T>` is
+    /// moved (unchanged) into a [`CudaResource<T>`]; its own `Drop` remains the sole
+    /// owner of the device memory and frees it exactly once when the tensor drops.
+    ///
+    /// The tensor's cached device pointer equals the input slice's device pointer.
+    ///
+    /// # Arguments
+    ///
+    /// * `slice` — source device slice; `slice.len()` must equal `shape.iter().product()`.
+    /// * `shape` — N-dimensional tensor shape.
+    /// * `stream` — stream owning `slice`'s context; retained in the `CudaAllocator`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `slice.len() != shape.iter().product()`.
+    pub fn from_cudaslice(slice: CudaSlice<T>, shape: [usize; N], stream: Arc<CudaStream>) -> Self {
+        let numel = shape.iter().product::<usize>();
+        assert_eq!(
+            slice.len(),
+            numel,
+            "from_cudaslice: slice.len() ({}) != shape product ({})",
+            slice.len(),
+            numel,
+        );
+
+        let n_bytes = slice.num_bytes(); // numel * size_of::<T>()
+        let ctx = stream.context().clone();
+        let id = ctx.ordinal() as i32;
+
+        // Cache the raw device pointer of the EXISTING allocation (no copy).
+        // _sync must be dropped before we move `slice` into CudaResource.
+        let ptr = {
+            let (cu_ptr, _sync) = slice.device_ptr(&stream);
+            cu_ptr as *mut u8
+            // _sync drops here, releasing the borrow on `slice`
+        };
+
+        let alloc = CudaAllocator { ctx, stream };
+        // Move the original CudaSlice<T> in, unchanged — this is the aliasing wrap.
+        let resource = CudaResource::<T> { slice, ptr, id };
+
+        let storage =
+            unsafe { storage_from_cuda_resource(resource, ptr as *mut T, n_bytes, alloc) };
+        let strides = get_strides_from_shape(shape);
+        Tensor {
+            storage,
+            shape,
+            strides,
+        }
+    }
+
+    /// Borrow the underlying `CudaSlice<T>` if the storage is backed by a
+    /// [`CudaResource<T>`] (i.e. was built via [`from_cudaslice`](Self::from_cudaslice)).
+    ///
+    /// Returns `None` if the storage is not a `CudaResource<T>` (e.g. it was allocated
+    /// by [`CudaAllocator`] which produces `CudaResource<u8>`, or T differs).
+    pub fn as_cudaslice(&self) -> Option<&CudaSlice<T>> {
+        self.storage
+            .owner
+            .as_any()
+            .downcast_ref::<CudaResource<T>>()
+            .map(|r| &r.slice)
+    }
+
+    /// Mutably borrow the underlying `CudaSlice<T>` if the storage is backed by a
+    /// [`CudaResource<T>`].
+    ///
+    /// This is the mutable sibling of [`as_cudaslice`](Self::as_cudaslice); it lets a
+    /// device-owning output tensor be passed as a mutable kernel argument
+    /// (e.g. `kernel.launch_builder(&stream).arg(out.as_cudaslice_mut().unwrap())`).
+    ///
+    /// Returns `None` if the storage is not a `CudaResource<T>` (e.g. host-backed, or T differs).
+    pub fn as_cudaslice_mut(&mut self) -> Option<&mut CudaSlice<T>> {
+        self.storage
+            .owner
+            .as_any_mut()
+            .downcast_mut::<CudaResource<T>>()
+            .map(|r| &mut r.slice)
+    }
+
+    /// Consume the tensor and return the underlying `CudaSlice<T>`.
+    ///
+    /// Returns `Err(self)` if the storage is not backed by a [`CudaResource<T>`].
+    ///
+    /// # Memory safety — no double-free
+    ///
+    /// The `Box<dyn MemoryResource>` is downcast to `Box<CudaResource<T>>` via
+    /// `Box::into_raw` → `Box::from_raw`.  The `CudaSlice<T>` is then moved out via
+    /// `ManuallyDrop` so the `CudaResource`'s own `Drop` does NOT run.  The
+    /// `Box<CudaResource<T>>` heap allocation is freed (struct metadata only); the
+    /// device memory is now owned by the returned `CudaSlice<T>`.
+    pub fn into_cudaslice(self) -> Result<CudaSlice<T>, Self> {
+        if self
+            .storage
+            .owner
+            .as_any()
+            .downcast_ref::<CudaResource<T>>()
+            .is_none()
+        {
+            return Err(self);
+        }
+
+        // Consume `self` without running TensorStorage's Drop or CudaResource's Drop.
+        let storage = self.storage;
+        let md_storage = std::mem::ManuallyDrop::new(storage);
+
+        // Read `owner` out of the ManuallyDrop without running TensorStorage's Drop.
+        // SAFETY: We are the sole owner; ManuallyDrop prevents double-drop of the storage.
+        let owner: Box<dyn MemoryResource> = unsafe { std::ptr::read(&md_storage.owner) };
+        // Drop the allocator field explicitly (Arc fields drop normally).
+        let _alloc = unsafe { std::ptr::read(&md_storage.alloc) };
+        // ptr/len/marker are Copy/ZST — nothing else to drop.
+
+        // Downcast Box<dyn MemoryResource> → Box<CudaResource<T>>.
+        // SAFETY: We verified above (downcast_ref) that the concrete type is CudaResource<T>.
+        let raw: *mut dyn MemoryResource = Box::into_raw(owner);
+        let cuda_box: Box<CudaResource<T>> = unsafe { Box::from_raw(raw as *mut CudaResource<T>) };
+
+        // Move CudaSlice<T> out without running CudaResource's Drop.
+        let mut md_res = std::mem::ManuallyDrop::new(*cuda_box);
+        // SAFETY: md_res prevents CudaResource from dropping its fields; we take the slice.
+        let slice = unsafe { std::ptr::read(&md_res.slice) };
+        // Poison the ptr to make residual state obviously invalid (defensive).
+        md_res.ptr = std::ptr::null_mut();
+
+        Ok(slice)
+    }
+}
+
+// ── Tensor::to_cuda (host → device) ──────────────────────────────────────────
+
+impl<T, const N: usize, A: TensorAllocator> Tensor<T, N, A>
+where
+    T: DeviceRepr + ValidAsZeroBits + Clone + Default + 'static,
+    A: 'static,
+{
+    /// Copy this host tensor to a new device-backed tensor on `stream`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CudaError::Driver`] on CUDA failure.
+    pub fn to_cuda(
+        &self,
+        stream: &Arc<CudaStream>,
+    ) -> Result<Tensor<T, N, CudaAllocator>, CudaError> {
+        let src_slice = self.as_slice(); // panics (correctly) if non-host-accessible
+
+        let ctx = stream.context().clone();
+        let id = ctx.ordinal() as i32;
+        let n_bytes = std::mem::size_of_val(src_slice);
+
+        // Copy host slice → a new device CudaSlice<T> (this is a transfer, copy is correct).
+        let dev_slice: CudaSlice<T> = stream
+            .clone_htod(src_slice)
+            .map_err(|e| CudaError::Driver(e.to_string()))?;
+
+        // Extract device pointer; _sync must drop before dev_slice is moved.
+        let ptr = {
+            let (cu_ptr, _sync) = dev_slice.device_ptr(stream);
+            cu_ptr as *mut u8
+            // _sync drops here
+        };
+        let alloc = CudaAllocator {
+            ctx,
+            stream: stream.clone(),
+        };
+        // Store as CudaResource<T> so as_cudaslice::<T>() also works on to_cuda results.
+        let resource = CudaResource::<T> {
+            slice: dev_slice,
+            ptr,
+            id,
+        };
+        let storage =
+            unsafe { storage_from_cuda_resource(resource, ptr as *mut T, n_bytes, alloc) };
+        let strides = get_strides_from_shape(self.shape);
+        Ok(Tensor {
+            storage,
+            shape: self.shape,
+            strides,
+        })
+    }
+}
+
+// ── Tensor::to_host (device → host) ──────────────────────────────────────────
+
+impl<T, const N: usize> Tensor<T, N, CudaAllocator>
+where
+    T: DeviceRepr + ValidAsZeroBits + Clone + Default + 'static,
+{
+    /// Copy this device tensor to a new host-backed tensor.
+    ///
+    /// Synchronizes the stream before returning so the host data is valid.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CudaError::Driver`] on CUDA failure or [`CudaError::NotCudaBacked`]
+    /// if the storage owner is not a [`CudaResource<T>`].
+    pub fn to_host(
+        &self,
+        stream: &Arc<CudaStream>,
+    ) -> Result<Tensor<T, N, CpuAllocator>, CudaError> {
+        let cuda_res = self
+            .storage
+            .owner
+            .as_any()
+            .downcast_ref::<CudaResource<T>>()
+            .ok_or(CudaError::NotCudaBacked)?;
+
+        // D→H typed copy into a Vec<T> (this is a transfer, copy is correct).
+        let host_data: Vec<T> = stream
+            .clone_dtoh(&cuda_res.slice)
+            .map_err(|e| CudaError::Driver(e.to_string()))?;
+        stream
+            .synchronize()
+            .map_err(|e| CudaError::Driver(e.to_string()))?;
+
+        let storage = TensorStorage::from_vec(host_data, CpuAllocator);
+        let strides = get_strides_from_shape(self.shape);
+        Ok(Tensor {
+            storage,
+            shape: self.shape,
+            strides,
+        })
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(all(test, feature = "cudarc"))]
+mod tests {
+    use super::*;
+    use crate::{CpuAllocator, Tensor};
+
+    /// Device round-trip: host → GPU → host, bytes must match exactly.
+    /// Also verifies domain is Device and as_cudaslice is Some.
+    #[test]
+    fn cuda_roundtrip_and_as_slice_panics() {
+        let ctx = CudaContext::new(0).unwrap();
+        let stream = ctx.default_stream();
+
+        let host =
+            Tensor::<u8, 1, CpuAllocator>::from_shape_vec([4], vec![1, 2, 3, 4], CpuAllocator)
+                .unwrap();
+
+        let dev = host.to_cuda(&stream).unwrap();
+        assert!(
+            matches!(dev.storage.domain(), MemoryDomain::Device { .. }),
+            "expected Device domain, got {:?}",
+            dev.storage.domain()
+        );
+        assert!(
+            dev.as_cudaslice().is_some(),
+            "as_cudaslice should return Some for a CudaResource-backed tensor"
+        );
+
+        let back = dev.to_host(&stream).unwrap();
+        assert_eq!(
+            back.as_slice(),
+            &[1u8, 2, 3, 4],
+            "round-trip bytes must match"
+        );
+    }
+
+    /// `as_cudaslice_mut` returns `Some` for a device tensor (CudaResource<T>-backed) and
+    /// `None` when the concrete element type does not match the stored `CudaResource`.
+    /// Mutating through the returned `&mut CudaSlice` must be observable after `to_host`.
+    #[test]
+    fn as_cudaslice_mut_some_for_device_none_for_mismatch() {
+        let ctx = CudaContext::new(0).unwrap();
+        let stream = ctx.default_stream();
+
+        // Device tensor backed by CudaResource<u8> (via to_cuda).
+        let host =
+            Tensor::<u8, 1, CpuAllocator>::from_shape_vec([4], vec![1, 2, 3, 4], CpuAllocator)
+                .unwrap();
+        let mut dev = host.to_cuda(&stream).unwrap();
+
+        // Some: same element type u8.
+        assert!(
+            dev.as_cudaslice_mut().is_some(),
+            "as_cudaslice_mut should return Some for a CudaResource<u8>-backed device tensor"
+        );
+
+        // Mutate the whole slice on-device through the &mut CudaSlice, then verify D2H.
+        {
+            let slice = dev.as_cudaslice_mut().expect("must be device-backed");
+            stream.memset_zeros(slice).unwrap();
+        }
+        let back = dev.to_host(&stream).unwrap();
+        assert_eq!(
+            back.as_slice(),
+            &[0u8, 0, 0, 0],
+            "mutation through as_cudaslice_mut must be observable after to_host"
+        );
+
+        // None branch: `zeros_cuda` always stores a `CudaResource<u8>`, so an i16 device
+        // tensor's owner does NOT downcast to `CudaResource<i16>` — the mutable query is None.
+        let mut dev_i16: Tensor<i16, 1, CudaAllocator> = zeros_cuda([4], &stream).unwrap();
+        assert!(
+            dev_i16.as_cudaslice_mut().is_none(),
+            "zeros_cuda stores CudaResource<u8>; querying as CudaSlice<i16> must be None"
+        );
+    }
+
+    /// `as_slice()` on a device tensor must panic with "non-host-accessible".
+    #[test]
+    #[should_panic(expected = "non-host-accessible")]
+    fn as_slice_on_device_panics() {
+        let ctx = CudaContext::new(0).unwrap();
+        let stream = ctx.default_stream();
+        let host =
+            Tensor::<u8, 1, CpuAllocator>::from_shape_vec([4], vec![1, 2, 3, 4], CpuAllocator)
+                .unwrap();
+        let dev = host.to_cuda(&stream).unwrap();
+        let _ = dev.as_slice(); // must panic: Device is not host-accessible
+    }
+
+    /// `into_cudaslice` returns the slice; no double-free.
+    /// A subsequent alloc must succeed (proves no CUDA error state after the free).
+    #[test]
+    fn into_cudaslice_no_double_free() {
+        let ctx = CudaContext::new(0).unwrap();
+        let stream = ctx.default_stream();
+
+        let host = Tensor::<u8, 1, CpuAllocator>::from_shape_vec([8], vec![10u8; 8], CpuAllocator)
+            .unwrap();
+        let dev = host.to_cuda(&stream).unwrap();
+        let slice = dev.into_cudaslice().ok().expect("must be cuda-backed");
+        // The slice now owns the device memory.  Drop it — cudarc frees exactly once.
+        drop(slice);
+        // A subsequent allocation must succeed (no CUDA error state after the free).
+        let _s2 = stream
+            .alloc_zeros::<u8>(8)
+            .expect("second alloc must succeed after into_cudaslice+drop");
+    }
+
+    /// `from_cudaslice` → drop: device memory freed once, no double-free.
+    #[test]
+    fn from_cudaslice_drop_once() {
+        let ctx = CudaContext::new(0).unwrap();
+        let stream = ctx.default_stream();
+
+        // Allocate on device directly via cudarc.
+        let dev_slice: CudaSlice<u8> = stream.alloc_zeros::<u8>(16).unwrap();
+        let tensor =
+            Tensor::<u8, 1, CudaAllocator>::from_cudaslice(dev_slice, [16], stream.clone());
+        // Drop tensor → TensorStorage drops → Box<CudaResource> drops → CudaSlice::drop
+        // → cudarc frees the device memory exactly once.
+        drop(tensor);
+        // A fresh allocation must succeed (no CUDA error after the free).
+        let _verify = stream
+            .alloc_zeros::<u8>(16)
+            .expect("allocation after from_cudaslice+drop must succeed");
+    }
+
+    /// Compile a trivial `copy_bytes` kernel, launch it via `CudaKernel` + `CudaLaunchBuilder`,
+    /// and verify that the output slice matches the input.
+    #[test]
+    fn cuda_kernel_compile_and_launch() {
+        const COPY_BYTES_SRC: &str = r#"
+            extern "C" __global__ void copy_bytes(
+                const unsigned char* __restrict__ src,
+                unsigned char* __restrict__ dst,
+                int n)
+            {
+                int i = blockIdx.x * blockDim.x + threadIdx.x;
+                if (i < n) { dst[i] = src[i]; }
+            }
+        "#;
+
+        let ctx = CudaContext::new(0).unwrap();
+        let stream = ctx.default_stream();
+
+        let kernel = CudaKernel::compile(&ctx, COPY_BYTES_SRC, "copy_bytes")
+            .expect("kernel compile must succeed");
+
+        const N: usize = 16;
+        let input_data: Vec<u8> = (0u8..N as u8).collect();
+        let input: CudaSlice<u8> = stream.clone_htod(&input_data).unwrap();
+        let mut output: CudaSlice<u8> = stream.alloc_zeros::<u8>(N).unwrap();
+
+        let n_i32: i32 = N as i32;
+        kernel
+            .launch_builder(&stream)
+            .arg(&input)
+            .arg(&mut output)
+            .arg(&n_i32)
+            .launch_1d(N as u32)
+            .expect("kernel launch must succeed");
+
+        let result: Vec<u8> = stream.clone_dtoh(&output).unwrap();
+        stream.synchronize().unwrap();
+        assert_eq!(
+            result, input_data,
+            "copy_bytes kernel output must match input"
+        );
+    }
+
+    /// `zeros_cuda` allocates a device tensor; `to_host` must return all-zero bytes.
+    #[test]
+    fn zeros_cuda_test() {
+        let ctx = CudaContext::new(0).unwrap();
+        let stream = ctx.default_stream();
+
+        let dev = zeros_cuda::<u8, 1>([8], &stream).expect("zeros_cuda must succeed");
+        let host = dev.to_host(&stream).expect("to_host must succeed");
+        assert_eq!(
+            host.as_slice(),
+            &[0u8; 8],
+            "zeros_cuda result must be all zeros"
+        );
+    }
+
+    /// `from_cudaslice` must ZERO-COPY WRAP (alias) the existing device allocation:
+    /// the resulting tensor's device pointer must equal the source slice's device pointer.
+    #[test]
+    fn from_cudaslice_zero_copy_alias() {
+        let ctx = CudaContext::new(0).unwrap();
+        let stream = ctx.default_stream();
+
+        // Allocate on device; record its device pointer.
+        let dev_slice: CudaSlice<u8> = stream.alloc_zeros::<u8>(32).unwrap();
+        let orig_ptr = {
+            let (cu_ptr, _sync) = dev_slice.device_ptr(&stream);
+            cu_ptr as usize
+        };
+
+        let tensor =
+            Tensor::<u8, 1, CudaAllocator>::from_cudaslice(dev_slice, [32], stream.clone());
+
+        // The tensor's cached device pointer must equal the original allocation's pointer
+        // → same device memory → aliased, not copied.
+        let tensor_ptr = tensor.as_ptr() as usize;
+        assert_eq!(
+            tensor_ptr, orig_ptr,
+            "from_cudaslice must alias the original device allocation \
+             (tensor ptr {tensor_ptr:#x} != orig ptr {orig_ptr:#x})"
+        );
+
+        // as_cudaslice must also report the same device pointer.
+        let wrapped = tensor
+            .as_cudaslice()
+            .expect("must be CudaResource<u8>-backed");
+        let wrapped_ptr = {
+            let (cu_ptr, _sync) = wrapped.device_ptr(&stream);
+            cu_ptr as usize
+        };
+        assert_eq!(
+            wrapped_ptr, orig_ptr,
+            "as_cudaslice must report the aliased pointer"
+        );
+    }
+}

--- a/crates/kornia-tensor/src/lib.rs
+++ b/crates/kornia-tensor/src/lib.rs
@@ -129,6 +129,18 @@ pub mod serde;
 /// and [`resource::ForeignResource`] (externally owned memory: numpy, gstreamer, dlpack, …).
 pub mod resource;
 
+/// CUDA device-memory integration via `cudarc 0.19`.
+///
+/// Enabled by the `cudarc` feature (default OFF). Provides [`cuda::CudaResource`],
+/// [`cuda::CudaAllocator`], [`cuda::CudaKernel`], [`cuda::CudaLaunchBuilder`],
+/// [`cuda::zeros_cuda`], and `Tensor` methods `to_cuda`/`to_host`/`from_cudaslice`/
+/// `as_cudaslice`/`into_cudaslice` for first-class device tensor support.
+#[cfg(feature = "cudarc")]
+pub mod cuda;
+
+#[cfg(feature = "cudarc")]
+pub use crate::cuda::{zeros_cuda, CudaAllocator, CudaError, CudaKernel, CudaLaunchBuilder};
+
 /// Storage module containing low-level memory buffer implementations.
 ///
 /// This module provides [`storage::TensorStorage`] which manages the actual memory buffer

--- a/examples/cuda_imgproc/Cargo.toml
+++ b/examples/cuda_imgproc/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "cuda-imgproc"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+cudarc = { version = "0.19", default-features = false, features = [
+  "cuda-version-from-build-system",
+  "driver",
+  "fallback-dynamic-loading",
+  "fallback-latest",
+  "nvrtc",
+  "std",
+] }
+kornia-image = { path = "../../crates/kornia-image", features = ["cudarc"] }
+kornia-io = { path = "../../crates/kornia-io" }
+kornia-tensor = { path = "../../crates/kornia-tensor", features = ["cudarc"] }

--- a/examples/cuda_imgproc/src/main.rs
+++ b/examples/cuda_imgproc/src/main.rs
@@ -1,0 +1,103 @@
+//! CUDA imgproc — load a real image from disk, convert RGB→Gray on device.
+//!
+//! Usage:
+//!   cargo run --release                      # uses default test image
+//!   cargo run --release -- /path/to/img.jpg  # custom image path
+//!
+//! Pipeline (all device buffers stay kornia `Tensor`s):
+//!   load RGB8 (kornia-io) → to_cuda (H2D) → kernel → to_host (D2H) → write PNG
+//!
+//! Eased CUDA API used here (from `kornia_tensor`, behind the `cudarc` feature):
+//!   - `Tensor::to_cuda`        — upload a host tensor to device (no manual flatten/copy)
+//!   - `zeros_cuda`             — allocate a zero-filled device output tensor
+//!   - `CudaKernel::compile`    — NVRTC compile with the device arch auto-detected
+//!   - `launch_builder().arg()` — chained kernel-arg builder + `launch_1d`
+//!   - `as_cudaslice` / `as_cudaslice_mut` — borrow device buffers as kernel args
+
+use cudarc::driver::CudaContext;
+use kornia_image::color_spaces::Gray8;
+use kornia_image::image::ImageSize;
+use kornia_io::functional::read_image_any_rgb8;
+use kornia_io::png::write_image_png_gray8;
+use kornia_tensor::{zeros_cuda, CpuAllocator, CudaKernel, Tensor};
+
+// BT.601 RGB→gray CUDA kernel (u8 interleaved RGB → u8 planar gray).
+// `src` is the flat h*w*3 byte buffer; `dst` is the flat h*w gray buffer.
+const RGB_TO_GRAY_SRC: &str = r#"
+extern "C" __global__ void rgb_to_gray(
+    const unsigned char* __restrict__ src,
+    unsigned char*       __restrict__ dst,
+    int npix)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= npix) return;
+    int base = idx * 3;
+    float r = (float)src[base];
+    float g = (float)src[base + 1];
+    float b = (float)src[base + 2];
+    dst[idx] = (unsigned char)(0.299f * r + 0.587f * g + 0.114f * b + 0.5f);
+}
+"#;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Resolve the input path (CLI arg, else a bundled test image).
+    let path = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "/home/nvidia/kornia-rs/tests/data/dog.jpeg".to_owned());
+    println!("Loading image: {path}");
+
+    // Load an RGB8 image from disk via kornia-io. `Rgb8` derefs/owns an
+    // `Image<u8, 3, CpuAllocator>`, which is a newtype over `Tensor3<u8, _>`.
+    let rgb = read_image_any_rgb8(&path)?;
+    let (h, w) = (rgb.rows(), rgb.cols());
+    let npix = h * w;
+    println!("Image size: {w}x{h} ({npix} pixels)");
+
+    let ctx = CudaContext::new(0)?;
+    let stream = ctx.default_stream();
+
+    // ── Eased device path: everything stays a kornia Tensor ──────────────────
+    // Upload the RGB image directly — `to_cuda` copies the contiguous
+    // h*w*3 bytes to a device tensor (no manual host flatten / Vec copy).
+    let dev_rgb: Tensor<u8, 3, _> = rgb.to_cuda(&stream)?;
+    // Allocate the device output as a zero-filled device tensor (no raw CudaSlice).
+    let mut dev_gray = zeros_cuda::<u8, 1>([npix], &stream)?;
+
+    // Compile (device arch auto-detected) and launch via the chained builder.
+    let kernel = CudaKernel::compile(&ctx, RGB_TO_GRAY_SRC, "rgb_to_gray")?;
+    kernel
+        .launch_builder(&stream)
+        .arg(dev_rgb.as_cudaslice().unwrap())
+        .arg(dev_gray.as_cudaslice_mut().unwrap())
+        .arg(&(npix as i32))
+        .launch_1d(npix as u32)?;
+    println!("Kernel launched: rgb_to_gray ({npix} pixels)");
+
+    // Download the result back to a host tensor (D2H + stream sync).
+    let gray = dev_gray.to_host(&stream)?;
+
+    // Verify: print the first pixels and a u64 checksum.
+    let gray_slice = gray.as_slice();
+    let checksum: u64 = gray_slice.iter().map(|&b| b as u64).sum();
+    println!(
+        "First 8 gray pixels: {:?}",
+        &gray_slice[..8.min(gray_slice.len())]
+    );
+    println!("Gray checksum: {checksum}");
+
+    // Wrap the gray bytes as a Gray8 image and write a PNG.
+    let gray_img = Gray8::from_size_vec(
+        ImageSize {
+            width: w,
+            height: h,
+        },
+        gray_slice.to_vec(),
+        CpuAllocator,
+    )?;
+    let out_path = "/tmp/cuda_imgproc_output.png";
+    write_image_png_gray8(out_path, &gray_img)?;
+    println!("Saved grayscale output to: {out_path}");
+
+    println!("\nDone.");
+    Ok(())
+}


### PR DESCRIPTION
**Stacked on #944** (the MemoryResource foundation). Base branch is `feat/gray-neon-kernels`; merge **after** #944 lands. The diff shown here is cuda-only (10 files, +1091) once the base is in.

Adds the default-off `cudarc` feature:
- `CudaResource<T>` / `CudaAllocator` on top of the `MemoryResource` core (zero-copy `from_cudaslice`, `as_cudaslice`, `into_cudaslice`).
- `Tensor::to_cuda`/`to_host` and `Image::to_cuda` (H2D/D2H over a `CudaStream`).
- Ergonomic `CudaKernel` (NVRTC compile + auto-arch + `launch_1d`/builder) and `zeros_cuda`.
- Root `examples/cuda_imgproc` (load via kornia-io → `to_cuda` → kernel → `to_host` → PNG).

Backend-agnostic core unchanged: device-ness flows through `MemoryDomain::Device` + the opaque owner; no cudarc coupling in default builds. Verified `cargo check --features cudarc` (Jetson Orin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)