### PR TITLE
ci: pin macOS Rust check runner to macos-15 (avoid Tahoe SDK link failure)

### DIFF
--- a/.github/workflows/rust_lint.yml
+++ b/.github/workflows/rust_lint.yml
@@ -61,7 +61,11 @@ jobs:
 
   cross-platform-check-macos:
     name: Check - macOS
-    runs-on: macos-latest
+    # Pinned to macOS 15 (Sequoia) to avoid the macOS 26 (Tahoe) beta runner, where
+    # the conda/pixi cxx-compiler clang fails to resolve libSystem symbols (___stderrp)
+    # when building turbojpeg-sys's bundled libjpeg-turbo CLI tools.  When GitHub
+    # promotes Tahoe to a stable runner and conda-forge catches up, revisit this pin.
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary

- Pins the `Check - macOS` job in `rust_lint.yml` from `macos-latest` to `macos-15` (Sequoia)
- `macos-latest` recently rolled to macOS 26 (Tahoe), where the pixi/conda `cxx-compiler` clang fails to resolve `___stderrp` (libSystem) when building `turbojpeg-sys`'s bundled libjpeg-turbo CLI tools, producing a link error with `-mmacosx-version-min=26.5`
- The existing `SDKROOT`/`CONDA_BUILD_SYSROOT` workaround (lines 79-80) is insufficient against the Tahoe SDK — this is an upstream conda-forge / runner-image regression, not caused by any code change
- Keeps the `SDKROOT` workaround intact (still needed on any macOS image)
- Consistent with existing repo practice: `python_release.yml` already pins to `macos-14`
- Scope is minimal: does **not** touch `cpp_test.yml` (its macOS job doesn't rebuild turbojpeg-sys from source and is currently green)

## Test plan

- [ ] CI `Check - macOS` job goes green on `macos-15` runner
- [ ] Other lint jobs (Rustfmt, Clippy, Check, Check - Windows) remain unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)