### PR TITLE
feat(tensor/image): remove compile-time allocator type param; runtime AllocHandle + host-default constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ use kornia::io::functional as F;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // read the image
-    let image: Image<u8, 3, _> = F::read_image_any_rgb8("tests/data/dog.jpeg")?;
+    let image: Image<u8, 3> = F::read_image_any_rgb8("tests/data/dog.jpeg")?;
 
     println!("Hello, world! 🦀");
     println!("Loaded Image size: {:?}", image.size());
@@ -154,13 +154,13 @@ use kornia::io::functional as F;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // read the image
-    let image: Image<u8, 3, _> = F::read_image_any_rgb8("tests/data/dog.jpeg")?;
+    let image: Image<u8, 3> = F::read_image_any_rgb8("tests/data/dog.jpeg")?;
     let image_viz = image.clone();
 
-    let image_f32: Image<f32, 3, _> = image.cast_and_scale::<f32>(1.0 / 255.0)?;
+    let image_f32: Image<f32, 3> = image.cast_and_scale::<f32>(1.0 / 255.0)?;
 
     // convert the image to grayscale
-    let mut gray = Image::<f32, 1, _>::from_size_val(image_f32.size(), 0.0)?;
+    let mut gray = Image::<f32, 1>::from_size_val(image_f32.size(), 0.0)?;
     imgproc::color::gray_from_rgb(&image_f32, &mut gray)?;
 
     // resize the image
@@ -169,7 +169,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         height: 128,
     };
 
-    let mut gray_resized = Image::<f32, 1, _>::from_size_val(new_size, 0.0)?;
+    let mut gray_resized = Image::<f32, 1>::from_size_val(new_size, 0.0)?;
     imgproc::resize::resize_native(
         &gray, &mut gray_resized,
         imgproc::interpolation::InterpolationMode::Bilinear,

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,7 +22,7 @@ use kornia::io::functional as F;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // 读取图片
-    let image: Image<u8, 3, _> = F::read_image_any_rgb8("tests/data/dog.jpeg")?;
+    let image: Image<u8, 3> = F::read_image_any_rgb8("tests/data/dog.jpeg")?;
 
     println!("Hello, world! 🦀");
     println!("Loaded Image size: {:?}", image.size());
@@ -133,13 +133,13 @@ use kornia::io::functional as F;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // 读取图片
-    let image: Image<u8, 3, _> = F::read_image_any_rgb8("tests/data/dog.jpeg")?;
+    let image: Image<u8, 3> = F::read_image_any_rgb8("tests/data/dog.jpeg")?;
     let image_viz = image.clone();
 
-    let image_f32: Image<f32, 3, _> = image.cast_and_scale::<f32>(1.0 / 255.0)?;
+    let image_f32: Image<f32, 3> = image.cast_and_scale::<f32>(1.0 / 255.0)?;
 
     // 转为灰度图
-    let mut gray = Image::<f32, 1, _>::from_size_val(image_f32.size(), 0.0)?;
+    let mut gray = Image::<f32, 1>::from_size_val(image_f32.size(), 0.0)?;
     imgproc::color::gray_from_rgb(&image_f32, &mut gray)?;
 
     // 缩放图片
@@ -148,7 +148,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         height: 128,
     };
 
-    let mut gray_resized = Image::<f32, 1, _>::from_size_val(new_size, 0.0)?;
+    let mut gray_resized = Image::<f32, 1>::from_size_val(new_size, 0.0)?;
     imgproc::resize::resize_native(
         &gray, &mut gray_resized,
         imgproc::interpolation::InterpolationMode::Bilinear,

--- a/best_practices.md
+++ b/best_practices.md
@@ -242,7 +242,7 @@ color/gray/
 mod sealed { pub trait Sealed {} }
 pub trait GrayFromRgb: sealed::Sealed + Sized {
     #[doc(hidden)]
-    fn gray_from_rgb_impl<A1, A2>(...) -> Result<(), ImageError>;
+    fn gray_from_rgb_impl(...) -> Result<(), ImageError>;
 }
 impl sealed::Sealed for u8 {}
 impl GrayFromRgb for u8 { /* → kernels::rgb_to_gray_u8 */ }
@@ -251,8 +251,8 @@ impl GrayFromRgb for f32 { /* → kernels::rgb_to_gray_f32 */ }
 impl sealed::Sealed for f64 {}
 impl GrayFromRgb for f64 { /* → scalar */ }
 
-pub fn gray_from_rgb<T: GrayFromRgb, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<T, 3, A1>, dst: &mut Image<T, 1, A2>,
+pub fn gray_from_rgb<T: GrayFromRgb>(
+    src: &Image<T, 3>, dst: &mut Image<T, 1>,
 ) -> Result<(), ImageError> {
     T::gray_from_rgb_impl(src, dst)
 }

--- a/crates/kornia-3d/src/pose/twoview.rs
+++ b/crates/kornia-3d/src/pose/twoview.rs
@@ -3337,12 +3337,7 @@ mod tests {
     }
 
     fn u8_to_f32_image(src: &kornia_image::Image<u8, 1>) -> kornia_image::Image<f32, 1> {
-        let mut dst = kornia_image::Image::from_size_val(
-            src.size(),
-            0.0,
-            kornia_image::allocator::host_alloc(),
-        )
-        .unwrap();
+        let mut dst = kornia_image::Image::from_size_val(src.size(), 0.0).unwrap();
         src.as_slice()
             .iter()
             .zip(dst.as_slice_mut())

--- a/crates/kornia-3d/src/pose/twoview.rs
+++ b/crates/kornia-3d/src/pose/twoview.rs
@@ -1743,47 +1743,49 @@ unsafe fn score_inliers_h_neon(
     count: &mut usize,
     score: &mut f64,
 ) -> usize {
-    use std::arch::aarch64::*;
-    let (a, b, c, d, e, f, g, hh, ii) = coeffs;
-    let a_v = vdupq_n_f64(a);
-    let b_v = vdupq_n_f64(b);
-    let c_v = vdupq_n_f64(c);
-    let d_v = vdupq_n_f64(d);
-    let e_v = vdupq_n_f64(e);
-    let f_v = vdupq_n_f64(f);
-    let g_v = vdupq_n_f64(g);
-    let h_v = vdupq_n_f64(hh);
-    let i_v = vdupq_n_f64(ii);
-    let n = x1_x.len();
-    let mut idx = 0usize;
-    while idx + 2 <= n {
-        let x1 = vld1q_f64(x1_x.as_ptr().add(idx));
-        let y1 = vld1q_f64(x1_y.as_ptr().add(idx));
-        let x2 = vld1q_f64(x2_x.as_ptr().add(idx));
-        let y2 = vld1q_f64(x2_y.as_ptr().add(idx));
-        // hx = a*x + b*y + c ; hy = d*x + e*y + f ; hw = g*x + h*y + i
-        let hx = vfmaq_f64(vfmaq_f64(c_v, x1, a_v), y1, b_v);
-        let hy = vfmaq_f64(vfmaq_f64(f_v, x1, d_v), y1, e_v);
-        let hw = vfmaq_f64(vfmaq_f64(i_v, x1, g_v), y1, h_v);
-        let u = vdivq_f64(hx, hw);
-        let v = vdivq_f64(hy, hw);
-        let dx = vsubq_f64(u, x2);
-        let dy = vsubq_f64(v, y2);
-        let sq = vfmaq_f64(vmulq_f64(dx, dx), dy, dy);
-        let mut buf = [0.0f64; 2];
-        vst1q_f64(buf.as_mut_ptr(), sq);
-        // Commit per-lane (scalar reduction — count++/score+= are data-dependent).
-        for k in 0..2 {
-            let dd = buf[k];
-            if dd.is_finite() && dd <= thresh_sq {
-                *inliers.get_unchecked_mut(idx + k) = true;
-                *count += 1;
-                *score += dd;
+    unsafe {
+        use std::arch::aarch64::*;
+        let (a, b, c, d, e, f, g, hh, ii) = coeffs;
+        let a_v = vdupq_n_f64(a);
+        let b_v = vdupq_n_f64(b);
+        let c_v = vdupq_n_f64(c);
+        let d_v = vdupq_n_f64(d);
+        let e_v = vdupq_n_f64(e);
+        let f_v = vdupq_n_f64(f);
+        let g_v = vdupq_n_f64(g);
+        let h_v = vdupq_n_f64(hh);
+        let i_v = vdupq_n_f64(ii);
+        let n = x1_x.len();
+        let mut idx = 0usize;
+        while idx + 2 <= n {
+            let x1 = vld1q_f64(x1_x.as_ptr().add(idx));
+            let y1 = vld1q_f64(x1_y.as_ptr().add(idx));
+            let x2 = vld1q_f64(x2_x.as_ptr().add(idx));
+            let y2 = vld1q_f64(x2_y.as_ptr().add(idx));
+            // hx = a*x + b*y + c ; hy = d*x + e*y + f ; hw = g*x + h*y + i
+            let hx = vfmaq_f64(vfmaq_f64(c_v, x1, a_v), y1, b_v);
+            let hy = vfmaq_f64(vfmaq_f64(f_v, x1, d_v), y1, e_v);
+            let hw = vfmaq_f64(vfmaq_f64(i_v, x1, g_v), y1, h_v);
+            let u = vdivq_f64(hx, hw);
+            let v = vdivq_f64(hy, hw);
+            let dx = vsubq_f64(u, x2);
+            let dy = vsubq_f64(v, y2);
+            let sq = vfmaq_f64(vmulq_f64(dx, dx), dy, dy);
+            let mut buf = [0.0f64; 2];
+            vst1q_f64(buf.as_mut_ptr(), sq);
+            // Commit per-lane (scalar reduction — count++/score+= are data-dependent).
+            for k in 0..2 {
+                let dd = buf[k];
+                if dd.is_finite() && dd <= thresh_sq {
+                    *inliers.get_unchecked_mut(idx + k) = true;
+                    *count += 1;
+                    *score += dd;
+                }
             }
+            idx += 2;
         }
-        idx += 2;
+        idx
     }
-    idx
 }
 
 /// AVX2 mirror of [`score_inliers_h_neon`]. Same H-reprojection math, but
@@ -1953,62 +1955,64 @@ unsafe fn score_inliers_f_neon(
     count: &mut usize,
     score: &mut f64,
 ) -> usize {
-    use std::arch::aarch64::*;
-    let (f00, f01, f02, f10, f11, f12, f20, f21, f22) = f;
-    let f00v = vdupq_n_f64(f00);
-    let f01v = vdupq_n_f64(f01);
-    let f02v = vdupq_n_f64(f02);
-    let f10v = vdupq_n_f64(f10);
-    let f11v = vdupq_n_f64(f11);
-    let f12v = vdupq_n_f64(f12);
-    let f20v = vdupq_n_f64(f20);
-    let f21v = vdupq_n_f64(f21);
-    let f22v = vdupq_n_f64(f22);
-    let n = x1_x.len();
-    let mut idx = 0usize;
-    while idx + 2 <= n {
-        let x1 = vld1q_f64(x1_x.as_ptr().add(idx));
-        let y1 = vld1q_f64(x1_y.as_ptr().add(idx));
-        let x2 = vld1q_f64(x2_x.as_ptr().add(idx));
-        let y2 = vld1q_f64(x2_y.as_ptr().add(idx));
+    unsafe {
+        use std::arch::aarch64::*;
+        let (f00, f01, f02, f10, f11, f12, f20, f21, f22) = f;
+        let f00v = vdupq_n_f64(f00);
+        let f01v = vdupq_n_f64(f01);
+        let f02v = vdupq_n_f64(f02);
+        let f10v = vdupq_n_f64(f10);
+        let f11v = vdupq_n_f64(f11);
+        let f12v = vdupq_n_f64(f12);
+        let f20v = vdupq_n_f64(f20);
+        let f21v = vdupq_n_f64(f21);
+        let f22v = vdupq_n_f64(f22);
+        let n = x1_x.len();
+        let mut idx = 0usize;
+        while idx + 2 <= n {
+            let x1 = vld1q_f64(x1_x.as_ptr().add(idx));
+            let y1 = vld1q_f64(x1_y.as_ptr().add(idx));
+            let x2 = vld1q_f64(x2_x.as_ptr().add(idx));
+            let y2 = vld1q_f64(x2_y.as_ptr().add(idx));
 
-        // fx1 = F * [x1; y1; 1]
-        let fx1x = vfmaq_f64(vfmaq_f64(f02v, x1, f00v), y1, f01v);
-        let fx1y = vfmaq_f64(vfmaq_f64(f12v, x1, f10v), y1, f11v);
-        let fx1z = vfmaq_f64(vfmaq_f64(f22v, x1, f20v), y1, f21v);
-        // ftx2 = F^T * [x2; y2; 1]  (only x,y components needed for denom)
-        let ftx2x = vfmaq_f64(vfmaq_f64(f20v, x2, f00v), y2, f10v);
-        let ftx2y = vfmaq_f64(vfmaq_f64(f21v, x2, f01v), y2, f11v);
+            // fx1 = F * [x1; y1; 1]
+            let fx1x = vfmaq_f64(vfmaq_f64(f02v, x1, f00v), y1, f01v);
+            let fx1y = vfmaq_f64(vfmaq_f64(f12v, x1, f10v), y1, f11v);
+            let fx1z = vfmaq_f64(vfmaq_f64(f22v, x1, f20v), y1, f21v);
+            // ftx2 = F^T * [x2; y2; 1]  (only x,y components needed for denom)
+            let ftx2x = vfmaq_f64(vfmaq_f64(f20v, x2, f00v), y2, f10v);
+            let ftx2y = vfmaq_f64(vfmaq_f64(f21v, x2, f01v), y2, f11v);
 
-        // err = [x2; y2; 1] · fx1
-        let err = vfmaq_f64(vfmaq_f64(fx1z, x2, fx1x), y2, fx1y);
-        // denom = fx1x² + fx1y² + ftx2x² + ftx2y²
-        let denom = vfmaq_f64(
-            vfmaq_f64(vfmaq_f64(vmulq_f64(fx1x, fx1x), fx1y, fx1y), ftx2x, ftx2x),
-            ftx2y,
-            ftx2y,
-        );
-        let err_sq = vmulq_f64(err, err);
-        // If denom > 0, use err²/denom; else err². Branchless select via bitwise
-        // (denom > 1e-12) mask — otherwise fall back to scalar handling per lane.
-        let denom_ok = vcgtq_f64(denom, vdupq_n_f64(1e-12));
-        let safe_denom = vbslq_f64(denom_ok, denom, vdupq_n_f64(1.0));
-        let div_val = vdivq_f64(err_sq, safe_denom);
-        let dd = vbslq_f64(denom_ok, div_val, err_sq);
+            // err = [x2; y2; 1] · fx1
+            let err = vfmaq_f64(vfmaq_f64(fx1z, x2, fx1x), y2, fx1y);
+            // denom = fx1x² + fx1y² + ftx2x² + ftx2y²
+            let denom = vfmaq_f64(
+                vfmaq_f64(vfmaq_f64(vmulq_f64(fx1x, fx1x), fx1y, fx1y), ftx2x, ftx2x),
+                ftx2y,
+                ftx2y,
+            );
+            let err_sq = vmulq_f64(err, err);
+            // If denom > 0, use err²/denom; else err². Branchless select via bitwise
+            // (denom > 1e-12) mask — otherwise fall back to scalar handling per lane.
+            let denom_ok = vcgtq_f64(denom, vdupq_n_f64(1e-12));
+            let safe_denom = vbslq_f64(denom_ok, denom, vdupq_n_f64(1.0));
+            let div_val = vdivq_f64(err_sq, safe_denom);
+            let dd = vbslq_f64(denom_ok, div_val, err_sq);
 
-        let mut buf = [0.0f64; 2];
-        vst1q_f64(buf.as_mut_ptr(), dd);
-        for k in 0..2 {
-            let dd_k = buf[k];
-            if dd_k.is_finite() && dd_k <= thresh_sq {
-                *inliers.get_unchecked_mut(idx + k) = true;
-                *count += 1;
-                *score += dd_k;
+            let mut buf = [0.0f64; 2];
+            vst1q_f64(buf.as_mut_ptr(), dd);
+            for k in 0..2 {
+                let dd_k = buf[k];
+                if dd_k.is_finite() && dd_k <= thresh_sq {
+                    *inliers.get_unchecked_mut(idx + k) = true;
+                    *count += 1;
+                    *score += dd_k;
+                }
             }
+            idx += 2;
         }
-        idx += 2;
+        idx
     }
-    idx
 }
 
 /// AVX2 mirror of [`score_inliers_f_neon`]. Same F Sampson math at 4-lane
@@ -2227,7 +2231,7 @@ mod tests {
             x1.iter()
                 .zip(x2.iter())
                 .zip(res.inliers.iter())
-                .filter(|(_, &inl)| inl)
+                .filter(|&(_, &inl)| inl)
                 .map(|((p1, p2), _)| sampson_distance(&res.model, p1, p2))
                 .sum::<f64>()
         };
@@ -3332,12 +3336,13 @@ mod tests {
         );
     }
 
-    fn u8_to_f32_image(
-        src: &kornia_image::Image<u8, 1, kornia_tensor::CpuAllocator>,
-    ) -> kornia_image::Image<f32, 1, kornia_tensor::CpuAllocator> {
-        let mut dst =
-            kornia_image::Image::from_size_val(src.size(), 0.0, kornia_tensor::CpuAllocator)
-                .unwrap();
+    fn u8_to_f32_image(src: &kornia_image::Image<u8, 1>) -> kornia_image::Image<f32, 1> {
+        let mut dst = kornia_image::Image::from_size_val(
+            src.size(),
+            0.0,
+            kornia_image::allocator::host_alloc(),
+        )
+        .unwrap();
         src.as_slice()
             .iter()
             .zip(dst.as_slice_mut())

--- a/crates/kornia-3d/src/ransac/estimators/fundamental.rs
+++ b/crates/kornia-3d/src/ransac/estimators/fundamental.rs
@@ -193,52 +193,54 @@ fn sampson_residual_batch_scalar_tail(
 #[target_feature(enable = "neon")]
 #[inline]
 unsafe fn sampson_residual_batch_neon(f: FPacked, samples: &[Match2d2d], out: &mut [f64]) -> usize {
-    use std::arch::aarch64::*;
-    let (f00, f01, f02, f10, f11, f12, f20, f21, f22) = f;
-    let f00v = vdupq_n_f64(f00);
-    let f01v = vdupq_n_f64(f01);
-    let f02v = vdupq_n_f64(f02);
-    let f10v = vdupq_n_f64(f10);
-    let f11v = vdupq_n_f64(f11);
-    let f12v = vdupq_n_f64(f12);
-    let f20v = vdupq_n_f64(f20);
-    let f21v = vdupq_n_f64(f21);
-    let f22v = vdupq_n_f64(f22);
-    let eps = vdupq_n_f64(1e-12);
-    let one = vdupq_n_f64(1.0);
+    unsafe {
+        use std::arch::aarch64::*;
+        let (f00, f01, f02, f10, f11, f12, f20, f21, f22) = f;
+        let f00v = vdupq_n_f64(f00);
+        let f01v = vdupq_n_f64(f01);
+        let f02v = vdupq_n_f64(f02);
+        let f10v = vdupq_n_f64(f10);
+        let f11v = vdupq_n_f64(f11);
+        let f12v = vdupq_n_f64(f12);
+        let f20v = vdupq_n_f64(f20);
+        let f21v = vdupq_n_f64(f21);
+        let f22v = vdupq_n_f64(f22);
+        let eps = vdupq_n_f64(1e-12);
+        let one = vdupq_n_f64(1.0);
 
-    let n = samples.len();
-    let mut idx = 0usize;
-    while idx + 2 <= n {
-        let base = samples.as_ptr().add(idx) as *const f64;
-        let lanes = vld4q_f64(base);
-        let x1 = lanes.0;
-        let y1 = lanes.1;
-        let x2 = lanes.2;
-        let y2 = lanes.3;
+        let n = samples.len();
+        let mut idx = 0usize;
+        while idx + 2 <= n {
+            let base = samples.as_ptr().add(idx) as *const f64;
+            let lanes = vld4q_f64(base);
+            let x1 = lanes.0;
+            let y1 = lanes.1;
+            let x2 = lanes.2;
+            let y2 = lanes.3;
 
-        let fx1x = vfmaq_f64(vfmaq_f64(f02v, x1, f00v), y1, f01v);
-        let fx1y = vfmaq_f64(vfmaq_f64(f12v, x1, f10v), y1, f11v);
-        let fx1z = vfmaq_f64(vfmaq_f64(f22v, x1, f20v), y1, f21v);
-        let ftx2x = vfmaq_f64(vfmaq_f64(f20v, x2, f00v), y2, f10v);
-        let ftx2y = vfmaq_f64(vfmaq_f64(f21v, x2, f01v), y2, f11v);
+            let fx1x = vfmaq_f64(vfmaq_f64(f02v, x1, f00v), y1, f01v);
+            let fx1y = vfmaq_f64(vfmaq_f64(f12v, x1, f10v), y1, f11v);
+            let fx1z = vfmaq_f64(vfmaq_f64(f22v, x1, f20v), y1, f21v);
+            let ftx2x = vfmaq_f64(vfmaq_f64(f20v, x2, f00v), y2, f10v);
+            let ftx2y = vfmaq_f64(vfmaq_f64(f21v, x2, f01v), y2, f11v);
 
-        let err = vfmaq_f64(vfmaq_f64(fx1z, x2, fx1x), y2, fx1y);
-        let denom = vfmaq_f64(
-            vfmaq_f64(vfmaq_f64(vmulq_f64(fx1x, fx1x), fx1y, fx1y), ftx2x, ftx2x),
-            ftx2y,
-            ftx2y,
-        );
-        let err_sq = vmulq_f64(err, err);
-        let denom_ok = vcgtq_f64(denom, eps);
-        let safe_denom = vbslq_f64(denom_ok, denom, one);
-        let div_val = vdivq_f64(err_sq, safe_denom);
-        let dd = vbslq_f64(denom_ok, div_val, err_sq);
+            let err = vfmaq_f64(vfmaq_f64(fx1z, x2, fx1x), y2, fx1y);
+            let denom = vfmaq_f64(
+                vfmaq_f64(vfmaq_f64(vmulq_f64(fx1x, fx1x), fx1y, fx1y), ftx2x, ftx2x),
+                ftx2y,
+                ftx2y,
+            );
+            let err_sq = vmulq_f64(err, err);
+            let denom_ok = vcgtq_f64(denom, eps);
+            let safe_denom = vbslq_f64(denom_ok, denom, one);
+            let div_val = vdivq_f64(err_sq, safe_denom);
+            let dd = vbslq_f64(denom_ok, div_val, err_sq);
 
-        vst1q_f64(out.as_mut_ptr().add(idx), dd);
-        idx += 2;
+            vst1q_f64(out.as_mut_ptr().add(idx), dd);
+            idx += 2;
+        }
+        idx
     }
-    idx
 }
 
 /// 4-lane f64 AVX2+FMA kernel.

--- a/crates/kornia-3d/src/ransac/estimators/homography.rs
+++ b/crates/kornia-3d/src/ransac/estimators/homography.rs
@@ -188,50 +188,52 @@ fn transfer_error_batch_scalar_tail(
 #[target_feature(enable = "neon")]
 #[inline]
 unsafe fn transfer_error_batch_neon(h: HPacked, samples: &[Match2d2d], out: &mut [f64]) -> usize {
-    use std::arch::aarch64::*;
-    let (h00, h01, h02, h10, h11, h12, h20, h21, h22) = h;
-    let h00v = vdupq_n_f64(h00);
-    let h01v = vdupq_n_f64(h01);
-    let h02v = vdupq_n_f64(h02);
-    let h10v = vdupq_n_f64(h10);
-    let h11v = vdupq_n_f64(h11);
-    let h12v = vdupq_n_f64(h12);
-    let h20v = vdupq_n_f64(h20);
-    let h21v = vdupq_n_f64(h21);
-    let h22v = vdupq_n_f64(h22);
-    let eps = vdupq_n_f64(1e-12);
-    let inf = vdupq_n_f64(f64::INFINITY);
+    unsafe {
+        use std::arch::aarch64::*;
+        let (h00, h01, h02, h10, h11, h12, h20, h21, h22) = h;
+        let h00v = vdupq_n_f64(h00);
+        let h01v = vdupq_n_f64(h01);
+        let h02v = vdupq_n_f64(h02);
+        let h10v = vdupq_n_f64(h10);
+        let h11v = vdupq_n_f64(h11);
+        let h12v = vdupq_n_f64(h12);
+        let h20v = vdupq_n_f64(h20);
+        let h21v = vdupq_n_f64(h21);
+        let h22v = vdupq_n_f64(h22);
+        let eps = vdupq_n_f64(1e-12);
+        let inf = vdupq_n_f64(f64::INFINITY);
 
-    let n = samples.len();
-    let mut idx = 0usize;
-    while idx + 2 <= n {
-        let base = samples.as_ptr().add(idx) as *const f64;
-        let lanes = vld4q_f64(base);
-        let x1 = lanes.0;
-        let y1 = lanes.1;
-        let x2 = lanes.2;
-        let y2 = lanes.3;
+        let n = samples.len();
+        let mut idx = 0usize;
+        while idx + 2 <= n {
+            let base = samples.as_ptr().add(idx) as *const f64;
+            let lanes = vld4q_f64(base);
+            let x1 = lanes.0;
+            let y1 = lanes.1;
+            let x2 = lanes.2;
+            let y2 = lanes.3;
 
-        let mx = vfmaq_f64(vfmaq_f64(h02v, x1, h00v), y1, h01v);
-        let my = vfmaq_f64(vfmaq_f64(h12v, x1, h10v), y1, h11v);
-        let mz = vfmaq_f64(vfmaq_f64(h22v, x1, h20v), y1, h21v);
+            let mx = vfmaq_f64(vfmaq_f64(h02v, x1, h00v), y1, h01v);
+            let my = vfmaq_f64(vfmaq_f64(h12v, x1, h10v), y1, h11v);
+            let mz = vfmaq_f64(vfmaq_f64(h22v, x1, h20v), y1, h21v);
 
-        // Behind-plane mask: |mz| > eps (use bitcast-abs via subtraction trick).
-        let abs_mz = vabsq_f64(mz);
-        let mz_ok = vcgtq_f64(abs_mz, eps);
-        // Avoid divide-by-zero: replace mz with 1.0 in unsafe lanes.
-        let safe_mz = vbslq_f64(mz_ok, mz, vdupq_n_f64(1.0));
-        let inv_z = vdivq_f64(vdupq_n_f64(1.0), safe_mz);
-        let dx = vsubq_f64(vmulq_f64(mx, inv_z), x2);
-        let dy = vsubq_f64(vmulq_f64(my, inv_z), y2);
-        let dd = vfmaq_f64(vmulq_f64(dx, dx), dy, dy);
-        // Replace bad-mz lanes with +∞ (matches scalar branch).
-        let result = vbslq_f64(mz_ok, dd, inf);
+            // Behind-plane mask: |mz| > eps (use bitcast-abs via subtraction trick).
+            let abs_mz = vabsq_f64(mz);
+            let mz_ok = vcgtq_f64(abs_mz, eps);
+            // Avoid divide-by-zero: replace mz with 1.0 in unsafe lanes.
+            let safe_mz = vbslq_f64(mz_ok, mz, vdupq_n_f64(1.0));
+            let inv_z = vdivq_f64(vdupq_n_f64(1.0), safe_mz);
+            let dx = vsubq_f64(vmulq_f64(mx, inv_z), x2);
+            let dy = vsubq_f64(vmulq_f64(my, inv_z), y2);
+            let dd = vfmaq_f64(vmulq_f64(dx, dx), dy, dy);
+            // Replace bad-mz lanes with +∞ (matches scalar branch).
+            let result = vbslq_f64(mz_ok, dd, inf);
 
-        vst1q_f64(out.as_mut_ptr().add(idx), result);
-        idx += 2;
+            vst1q_f64(out.as_mut_ptr().add(idx), result);
+            idx += 2;
+        }
+        idx
     }
-    idx
 }
 
 /// 4-lane f64 AVX2+FMA kernel — same 4×4 transpose trick as F.

--- a/crates/kornia-3d/src/stereo/rectify.rs
+++ b/crates/kornia-3d/src/stereo/rectify.rs
@@ -242,7 +242,6 @@ impl StereoRectifier {
                 height: self.height,
             },
             &out,
-            kornia_image::allocator::host_alloc(),
         )?)
     }
 }
@@ -393,11 +392,7 @@ mod tests {
     ) -> Result<Image<u8, 1>, ImageError> {
         let mut buf = vec![0u8; width * height];
         buf[v * width + u] = 255;
-        Image::from_size_slice(
-            ImageSize { width, height },
-            &buf,
-            kornia_image::allocator::host_alloc(),
-        )
+        Image::from_size_slice(ImageSize { width, height }, &buf)
     }
 
     /// Intensity-weighted centroid `(u, v)` of all non-zero pixels.

--- a/crates/kornia-3d/src/stereo/rectify.rs
+++ b/crates/kornia-3d/src/stereo/rectify.rs
@@ -14,7 +14,7 @@
 
 use crate::camera::PinholeCamera;
 use kornia_algebra::{Mat3F64, Vec3F64, SO3F64};
-use kornia_image::{allocator::CpuAllocator, Image, ImageError, ImageSize};
+use kornia_image::{Image, ImageError, ImageSize};
 use kornia_imgproc::calibration::distortion::{distort_point_polynomial, PolynomialDistortion};
 use kornia_imgproc::calibration::CameraIntrinsic;
 
@@ -206,10 +206,7 @@ impl StereoRectifier {
     /// # Errors
     /// [`StereoError::ImageSizeMismatch`] if `img`'s resolution differs from
     /// the rectifier's.
-    pub fn rectify_left(
-        &self,
-        img: &Image<u8, 1, CpuAllocator>,
-    ) -> Result<Image<u8, 1, CpuAllocator>, StereoError> {
+    pub fn rectify_left(&self, img: &Image<u8, 1>) -> Result<Image<u8, 1>, StereoError> {
         self.remap(img, &self.left_map)
     }
 
@@ -218,18 +215,11 @@ impl StereoRectifier {
     /// # Errors
     /// [`StereoError::ImageSizeMismatch`] if `img`'s resolution differs from
     /// the rectifier's.
-    pub fn rectify_right(
-        &self,
-        img: &Image<u8, 1, CpuAllocator>,
-    ) -> Result<Image<u8, 1, CpuAllocator>, StereoError> {
+    pub fn rectify_right(&self, img: &Image<u8, 1>) -> Result<Image<u8, 1>, StereoError> {
         self.remap(img, &self.right_map)
     }
 
-    fn remap(
-        &self,
-        img: &Image<u8, 1, CpuAllocator>,
-        map: &[[f32; 2]],
-    ) -> Result<Image<u8, 1, CpuAllocator>, StereoError> {
+    fn remap(&self, img: &Image<u8, 1>, map: &[[f32; 2]]) -> Result<Image<u8, 1>, StereoError> {
         if (img.width(), img.height()) != (self.width, self.height) {
             return Err(StereoError::ImageSizeMismatch {
                 got: (img.width(), img.height()),
@@ -252,7 +242,7 @@ impl StereoRectifier {
                 height: self.height,
             },
             &out,
-            CpuAllocator,
+            kornia_image::allocator::host_alloc(),
         )?)
     }
 }
@@ -400,14 +390,18 @@ mod tests {
         height: usize,
         u: usize,
         v: usize,
-    ) -> Result<Image<u8, 1, CpuAllocator>, ImageError> {
+    ) -> Result<Image<u8, 1>, ImageError> {
         let mut buf = vec![0u8; width * height];
         buf[v * width + u] = 255;
-        Image::from_size_slice(ImageSize { width, height }, &buf, CpuAllocator)
+        Image::from_size_slice(
+            ImageSize { width, height },
+            &buf,
+            kornia_image::allocator::host_alloc(),
+        )
     }
 
     /// Intensity-weighted centroid `(u, v)` of all non-zero pixels.
-    fn centroid(img: &Image<u8, 1, CpuAllocator>) -> Option<(f64, f64)> {
+    fn centroid(img: &Image<u8, 1>) -> Option<(f64, f64)> {
         let w = img.width();
         let (mut su, mut sv, mut sw) = (0.0, 0.0, 0.0);
         for (i, &p) in img.as_slice().iter().enumerate() {

--- a/crates/kornia-apriltag/README.md
+++ b/crates/kornia-apriltag/README.md
@@ -33,7 +33,7 @@ kornia-apriltag = "0.1.0"
 
 ```rust
 use kornia_apriltag::{AprilTagDecoder, DecodeTagsConfig, family::TagFamilyKind};
-use kornia_image::{Image, ImageSize, allocator::CpuAllocator};
+use kornia_image::{Image, ImageSize};
 // use kornia_io::functional as F; // Assuming you have an image reader
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -45,10 +45,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // let gray_image = kornia_imgproc::color::rgb_to_gray(&image)?;
 
     // Create dummy image for example
-    let gray_image = Image::<u8, 1, _>::new(
+    let gray_image = Image::<u8, 1>::new(
         ImageSize { width: 100, height: 100 },
         vec![0u8; 10000],
-        CpuAllocator
     )?;
 
     // 3. Initialize decoder

--- a/crates/kornia-apriltag/benches/bench_decoding.rs
+++ b/crates/kornia-apriltag/benches/bench_decoding.rs
@@ -1,7 +1,7 @@
 use apriltag::DetectorBuilder;
 use criterion::{criterion_group, criterion_main, Criterion};
 use kornia_apriltag::{family::TagFamilyKind, AprilTagDecoder, DecodeTagsConfig};
-use kornia_image::{allocator::CpuAllocator, Image};
+use kornia_image::{allocator::host_alloc, Image};
 use kornia_imgproc::color::gray_from_rgb_u8;
 use kornia_io::jpeg::read_image_jpeg_rgb8;
 use std::path::PathBuf;
@@ -12,7 +12,7 @@ fn bench_decoding(c: &mut Criterion) {
 
     // Kornia
     let img = read_image_jpeg_rgb8(img_path).unwrap();
-    let mut gray_img = Image::from_size_val(img.size(), 0, CpuAllocator).unwrap();
+    let mut gray_img = Image::from_size_val(img.size(), 0, host_alloc()).unwrap();
     gray_from_rgb_u8(&img, &mut gray_img).unwrap();
 
     let kornia_detector_config = DecodeTagsConfig::new(vec![TagFamilyKind::Tag36H11]).unwrap();

--- a/crates/kornia-apriltag/benches/bench_decoding.rs
+++ b/crates/kornia-apriltag/benches/bench_decoding.rs
@@ -1,7 +1,7 @@
 use apriltag::DetectorBuilder;
 use criterion::{criterion_group, criterion_main, Criterion};
 use kornia_apriltag::{family::TagFamilyKind, AprilTagDecoder, DecodeTagsConfig};
-use kornia_image::{allocator::host_alloc, Image};
+use kornia_image::Image;
 use kornia_imgproc::color::gray_from_rgb_u8;
 use kornia_io::jpeg::read_image_jpeg_rgb8;
 use std::path::PathBuf;
@@ -12,7 +12,7 @@ fn bench_decoding(c: &mut Criterion) {
 
     // Kornia
     let img = read_image_jpeg_rgb8(img_path).unwrap();
-    let mut gray_img = Image::from_size_val(img.size(), 0, host_alloc()).unwrap();
+    let mut gray_img = Image::from_size_val(img.size(), 0).unwrap();
     gray_from_rgb_u8(&img, &mut gray_img).unwrap();
 
     let kornia_detector_config = DecodeTagsConfig::new(vec![TagFamilyKind::Tag36H11]).unwrap();

--- a/crates/kornia-apriltag/src/decoder.rs
+++ b/crates/kornia-apriltag/src/decoder.rs
@@ -7,7 +7,7 @@ use crate::{
     utils::value_for_pixel,
 };
 use kornia_algebra::Mat3F32;
-use kornia_image::{allocator::ImageAllocator, Image};
+use kornia_image::Image;
 
 /// Represents a model for grayscale interpolation using a quadratic surface.
 /// The model fits a function of the form f(x, y) = c.x*x + c.y*y + c.z.
@@ -345,8 +345,8 @@ impl SharpeningBuffer {
 /// # Returns
 ///
 /// Returns a vector of `Detection` containing information about each successfully decoded tag.
-pub fn decode_tags<A: ImageAllocator>(
-    src: &Image<u8, 1, A>,
+pub fn decode_tags(
+    src: &Image<u8, 1>,
     quads: &mut [Quad],
     tag_families: &mut [(TagFamilyKind, TagFamily)],
     refine_edges_enabled: bool,
@@ -421,7 +421,7 @@ pub fn decode_tags<A: ImageAllocator>(
 /// * `src` - Reference to the grayscale source image.
 /// * `quad` - Mutable reference to the quadrilateral to refine.
 // TODO: Consider moving this somewhere in kornia-imgproc.
-fn refine_edges<A: ImageAllocator>(src: &Image<u8, 1, A>, quad: &mut Quad) {
+fn refine_edges(src: &Image<u8, 1>, quad: &mut Quad) {
     let src_slice = src.as_slice();
     let mut lines: [[f32; 4]; 4] = Default::default();
 
@@ -596,8 +596,8 @@ fn refine_edges<A: ImageAllocator>(src: &Image<u8, 1, A>, quad: &mut Quad) {
 /// # Returns
 ///
 /// Returns `Some(f32)` containing the decision margin if decoding is successful, or `None` otherwise.
-fn quad_decode<A: ImageAllocator>(
-    src: &Image<u8, 1, A>,
+fn quad_decode(
+    src: &Image<u8, 1>,
     tag_family: &mut TagFamily,
     quad: &Quad,
     decode_sharpening: f32,
@@ -930,7 +930,7 @@ mod tests {
         utils::Pixel,
     };
     use kornia_algebra::Vec2F32;
-    use kornia_image::allocator::CpuAllocator;
+    use kornia_image::allocator::host_alloc;
     use kornia_io::png::read_image_png_mono8;
 
     const EPSILON: f32 = 0.0001;
@@ -941,7 +941,11 @@ mod tests {
         config.downscale_factor = 1;
         let src = read_image_png_mono8("../../tests/data/apriltag.png")?;
 
-        let mut bin = Image::from_size_val(src.size(), Pixel::Skip, CpuAllocator)?;
+        let mut bin = Image::from_size_val(
+            src.size(),
+            Pixel::Skip,
+            kornia_image::allocator::host_alloc(),
+        )?;
         let mut tile_min_max = TileMinMax::new(bin.size(), 4);
         let mut uf = UnionFind::new(bin.as_slice().len());
         let mut clusters = HashMap::new();

--- a/crates/kornia-apriltag/src/decoder.rs
+++ b/crates/kornia-apriltag/src/decoder.rs
@@ -940,11 +940,7 @@ mod tests {
         config.downscale_factor = 1;
         let src = read_image_png_mono8("../../tests/data/apriltag.png")?;
 
-        let mut bin = Image::from_size_val(
-            src.size(),
-            Pixel::Skip,
-            kornia_image::allocator::host_alloc(),
-        )?;
+        let mut bin = Image::from_size_val(src.size(), Pixel::Skip)?;
         let mut tile_min_max = TileMinMax::new(bin.size(), 4);
         let mut uf = UnionFind::new(bin.as_slice().len());
         let mut clusters = HashMap::new();

--- a/crates/kornia-apriltag/src/decoder.rs
+++ b/crates/kornia-apriltag/src/decoder.rs
@@ -930,7 +930,6 @@ mod tests {
         utils::Pixel,
     };
     use kornia_algebra::Vec2F32;
-    use kornia_image::allocator::host_alloc;
     use kornia_io::png::read_image_png_mono8;
 
     const EPSILON: f32 = 0.0001;

--- a/crates/kornia-apriltag/src/iter.rs
+++ b/crates/kornia-apriltag/src/iter.rs
@@ -2,7 +2,7 @@ use crate::{
     errors::AprilTagError,
     utils::{find_total_tiles, Point2d},
 };
-use kornia_image::{allocator::ImageAllocator, Image, ImageSize};
+use kornia_image::{Image, ImageSize};
 
 /// A lightweight, zero-allocation view into a rectangular sub-region of image data.
 ///
@@ -188,8 +188,8 @@ impl<'a, T> TileIterator<'a, T> {
     ///
     /// Returns a `TileIterator` that yields non-overlapping tiles of the specified size from the image.
     /// Tiles at the image edges may be smaller if the image dimensions are not multiples of the tile size.
-    pub fn from_image<const C: usize, A: ImageAllocator>(
-        img: &'a Image<T, C, A>,
+    pub fn from_image<const C: usize>(
+        img: &'a Image<T, C>,
         tile_size: usize,
     ) -> Result<Self, AprilTagError> {
         let img_size = img.size();
@@ -292,18 +292,18 @@ impl<'a, T> Iterator for TileIterator<'a, T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kornia_image::{allocator::CpuAllocator, Image, ImageSize};
+    use kornia_image::{Image, ImageSize};
 
     #[test]
     fn test_tile_iterator_basic() -> Result<(), Box<dyn std::error::Error>> {
         let data = vec![127u8; 100];
-        let image: Image<_, 1, _> = Image::new(
+        let image: Image<_, 1> = Image::new(
             ImageSize {
                 width: 25,
                 height: 4,
             },
             data,
-            CpuAllocator,
+            kornia_image::allocator::host_alloc(),
         )?;
 
         let tile_iter = TileIterator::from_image(&image, 4)?;
@@ -340,19 +340,19 @@ mod tests {
             26, 27, 28, 29, 30,
             31, 32, 33, 34, 35,
         ];
-        let img: Image<_, 1, _> = Image::new(
+        let img: Image<_, 1> = Image::new(
             ImageSize {
                 width: 5,
                 height: 7,
             },
             data,
-            CpuAllocator,
+            kornia_image::allocator::host_alloc(),
         )?;
 
         let mut iter = TileIterator::from_image(&img, 2)?;
 
         macro_rules! test_iter_next {
-            ($variant:ident, $x:expr, $y:expr, $index:expr, $full_index:expr, $rows:expr) => {
+            ($variant:ident, $x:expr_2021, $y:expr_2021, $index:expr_2021, $full_index:expr_2021, $rows:expr_2021) => {
                 let next = iter
                     .next()
                     .ok_or("Failed to get the next value from iterator")?;
@@ -396,13 +396,13 @@ mod tests {
 
     #[test]
     fn test_invalid_image() -> Result<(), Box<dyn std::error::Error>> {
-        let img: Image<_, 1, _> = Image::from_size_val(
+        let img: Image<_, 1> = Image::from_size_val(
             ImageSize {
                 width: 3,
                 height: 4,
             },
             0,
-            CpuAllocator,
+            kornia_image::allocator::host_alloc(),
         )?;
 
         let tile_iterator = TileIterator::from_image(&img, 4);

--- a/crates/kornia-apriltag/src/iter.rs
+++ b/crates/kornia-apriltag/src/iter.rs
@@ -303,7 +303,6 @@ mod tests {
                 height: 4,
             },
             data,
-            kornia_image::allocator::host_alloc(),
         )?;
 
         let tile_iter = TileIterator::from_image(&image, 4)?;
@@ -346,7 +345,6 @@ mod tests {
                 height: 7,
             },
             data,
-            kornia_image::allocator::host_alloc(),
         )?;
 
         let mut iter = TileIterator::from_image(&img, 2)?;
@@ -402,7 +400,6 @@ mod tests {
                 height: 4,
             },
             0,
-            kornia_image::allocator::host_alloc(),
         )?;
 
         let tile_iterator = TileIterator::from_image(&img, 4);

--- a/crates/kornia-apriltag/src/lib.rs
+++ b/crates/kornia-apriltag/src/lib.rs
@@ -3,10 +3,7 @@
 
 use std::collections::HashMap;
 
-use kornia_image::{
-    allocator::{CpuAllocator, ImageAllocator},
-    Image, ImageSize,
-};
+use kornia_image::{Image, ImageSize};
 use kornia_imgproc::resize::resize_fast_mono;
 
 use crate::{
@@ -144,8 +141,8 @@ impl DecodeTagsConfig {
 pub struct AprilTagDecoder {
     config: DecodeTagsConfig,
     cached_families: Vec<(TagFamilyKind, TagFamily)>,
-    downscale_img: Option<Image<u8, 1, CpuAllocator>>,
-    bin_img: Image<Pixel, 1, CpuAllocator>,
+    downscale_img: Option<Image<u8, 1>>,
+    bin_img: Image<Pixel, 1>,
     tile_min_max: TileMinMax,
     uf: UnionFind,
     clusters: HashMap<(usize, usize), Vec<GradientInfo>>,
@@ -189,7 +186,11 @@ impl AprilTagDecoder {
 
             (
                 new_size,
-                Some(Image::from_size_val(new_size, 0, CpuAllocator)?),
+                Some(Image::from_size_val(
+                    new_size,
+                    0,
+                    kornia_image::allocator::host_alloc(),
+                )?),
             )
         };
 
@@ -204,7 +205,8 @@ impl AprilTagDecoder {
             })
             .collect();
 
-        let bin_img = Image::from_size_val(img_size, Pixel::Skip, CpuAllocator)?;
+        let bin_img =
+            Image::from_size_val(img_size, Pixel::Skip, kornia_image::allocator::host_alloc())?;
         let tile_min_max = TileMinMax::new(img_size, 4);
         let uf = UnionFind::new(img_size.width * img_size.height);
 
@@ -234,10 +236,7 @@ impl AprilTagDecoder {
     ///
     /// If you are running this method multiple times on the same decoder instance,
     /// you should call [`AprilTagDecoder::clear`] between runs to reset internal state.
-    pub fn decode<A: ImageAllocator>(
-        &mut self,
-        src: &Image<u8, 1, A>,
-    ) -> Result<Vec<Detection>, AprilTagError> {
+    pub fn decode(&mut self, src: &Image<u8, 1>) -> Result<Vec<Detection>, AprilTagError> {
         if let Some(downscale_img) = self.downscale_img.as_mut() {
             resize_fast_mono(
                 src,

--- a/crates/kornia-apriltag/src/lib.rs
+++ b/crates/kornia-apriltag/src/lib.rs
@@ -184,14 +184,7 @@ impl AprilTagDecoder {
                 height: img_size.height / config.downscale_factor,
             };
 
-            (
-                new_size,
-                Some(Image::from_size_val(
-                    new_size,
-                    0,
-                    kornia_image::allocator::host_alloc(),
-                )?),
-            )
+            (new_size, Some(Image::from_size_val(new_size, 0)?))
         };
 
         // Build the tag family cache once
@@ -205,8 +198,7 @@ impl AprilTagDecoder {
             })
             .collect();
 
-        let bin_img =
-            Image::from_size_val(img_size, Pixel::Skip, kornia_image::allocator::host_alloc())?;
+        let bin_img = Image::from_size_val(img_size, Pixel::Skip)?;
         let tile_min_max = TileMinMax::new(img_size, 4);
         let uf = UnionFind::new(img_size.width * img_size.height);
 

--- a/crates/kornia-apriltag/src/quad.rs
+++ b/crates/kornia-apriltag/src/quad.rs
@@ -805,11 +805,7 @@ mod tests {
     fn test_fit_quads() -> Result<(), Box<dyn std::error::Error>> {
         let src = read_image_png_mono8("../../tests/data/apriltag.png")?;
 
-        let mut bin = Image::from_size_val(
-            src.size(),
-            Pixel::Skip,
-            kornia_image::allocator::host_alloc(),
-        )?;
+        let mut bin = Image::from_size_val(src.size(), Pixel::Skip)?;
         let mut tile_min_max = TileMinMax::new(src.size(), 4);
         let mut uf = UnionFind::new(src.as_slice().len());
         let mut clusters = HashMap::new();
@@ -901,11 +897,7 @@ mod tests {
     #[test]
     fn test_quad_segment_maxima() -> Result<(), Box<dyn std::error::Error>> {
         let src = read_image_png_mono8("../../tests/data/apriltag.png")?;
-        let mut bin = Image::from_size_val(
-            src.size(),
-            Pixel::Skip,
-            kornia_image::allocator::host_alloc(),
-        )?;
+        let mut bin = Image::from_size_val(src.size(), Pixel::Skip)?;
         let mut tile_min_max = TileMinMax::new(src.size(), 4);
         let mut uf = UnionFind::new(src.as_slice().len());
         let mut clusters = HashMap::new();
@@ -1056,12 +1048,7 @@ mod tests {
             width: 4,
             height: 4,
         };
-        let img = Image::<Pixel, 1>::from_size_val(
-            size,
-            Pixel::White,
-            kornia_image::allocator::host_alloc(),
-        )
-        .unwrap();
+        let img = Image::<Pixel, 1>::from_size_val(size, Pixel::White).unwrap();
 
         // Test 1: Single point
         let gradient_infos = vec![GradientInfo {

--- a/crates/kornia-apriltag/src/quad.rs
+++ b/crates/kornia-apriltag/src/quad.rs
@@ -4,7 +4,7 @@ use crate::{
     DecodeTagsConfig,
 };
 use kornia_algebra::{Mat3F32, Vec3F32};
-use kornia_image::{allocator::ImageAllocator, Image};
+use kornia_image::Image;
 use kornia_imgproc::filter::kernels::gaussian_kernel_1d;
 use std::{
     collections::HashMap,
@@ -118,8 +118,8 @@ impl Quad {
 ///
 /// A vector of detected `Quad` structures.
 // TODO: Support multiple tag families
-pub fn fit_quads<A: ImageAllocator>(
-    src: &Image<Pixel, 1, A>,
+pub fn fit_quads(
+    src: &Image<Pixel, 1>,
     clusters: &mut HashMap<(usize, usize), Vec<GradientInfo>>,
     config: &DecodeTagsConfig,
 ) -> Vec<Quad> {
@@ -175,8 +175,8 @@ pub fn fit_quads<A: ImageAllocator>(
 /// # Returns
 ///
 /// An `Option<Quad>` containing the detected quadrilateral if successful, or `None` otherwise.
-fn fit_single_quad<A: ImageAllocator>(
-    src: &Image<Pixel, 1, A>,
+fn fit_single_quad(
+    src: &Image<Pixel, 1>,
     cluster: &mut [GradientInfo],
     min_tag_width: usize,
     normal_border: bool,
@@ -406,8 +406,8 @@ struct LineFit {
 /// # Returns
 ///
 /// A vector of `LineFit` structures containing prefix sums for each point.
-fn compute_line_fit_prefix_sums<A: ImageAllocator>(
-    src: &Image<Pixel, 1, A>,
+fn compute_line_fit_prefix_sums(
+    src: &Image<Pixel, 1>,
     gradient_infos: &[GradientInfo],
 ) -> Vec<LineFit> {
     let src_slice = src.as_slice();
@@ -787,7 +787,7 @@ fn fit_line(
 
 #[cfg(test)]
 mod tests {
-    use kornia_image::allocator::CpuAllocator;
+    use kornia_image::allocator::host_alloc;
     use kornia_io::png::read_image_png_mono8;
 
     use crate::{
@@ -806,7 +806,11 @@ mod tests {
     fn test_fit_quads() -> Result<(), Box<dyn std::error::Error>> {
         let src = read_image_png_mono8("../../tests/data/apriltag.png")?;
 
-        let mut bin = Image::from_size_val(src.size(), Pixel::Skip, CpuAllocator)?;
+        let mut bin = Image::from_size_val(
+            src.size(),
+            Pixel::Skip,
+            kornia_image::allocator::host_alloc(),
+        )?;
         let mut tile_min_max = TileMinMax::new(src.size(), 4);
         let mut uf = UnionFind::new(src.as_slice().len());
         let mut clusters = HashMap::new();
@@ -898,7 +902,11 @@ mod tests {
     #[test]
     fn test_quad_segment_maxima() -> Result<(), Box<dyn std::error::Error>> {
         let src = read_image_png_mono8("../../tests/data/apriltag.png")?;
-        let mut bin = Image::from_size_val(src.size(), Pixel::Skip, CpuAllocator)?;
+        let mut bin = Image::from_size_val(
+            src.size(),
+            Pixel::Skip,
+            kornia_image::allocator::host_alloc(),
+        )?;
         let mut tile_min_max = TileMinMax::new(src.size(), 4);
         let mut uf = UnionFind::new(src.as_slice().len());
         let mut clusters = HashMap::new();
@@ -1049,7 +1057,12 @@ mod tests {
             width: 4,
             height: 4,
         };
-        let img = Image::<Pixel, 1, _>::from_size_val(size, Pixel::White, CpuAllocator).unwrap();
+        let img = Image::<Pixel, 1>::from_size_val(
+            size,
+            Pixel::White,
+            kornia_image::allocator::host_alloc(),
+        )
+        .unwrap();
 
         // Test 1: Single point
         let gradient_infos = vec![GradientInfo {

--- a/crates/kornia-apriltag/src/quad.rs
+++ b/crates/kornia-apriltag/src/quad.rs
@@ -787,7 +787,6 @@ fn fit_line(
 
 #[cfg(test)]
 mod tests {
-    use kornia_image::allocator::host_alloc;
     use kornia_io::png::read_image_png_mono8;
 
     use crate::{

--- a/crates/kornia-apriltag/src/segmentation.rs
+++ b/crates/kornia-apriltag/src/segmentation.rs
@@ -5,7 +5,7 @@ use crate::{
     union_find::UnionFind,
     utils::{Pixel, Point2d},
 };
-use kornia_image::{allocator::ImageAllocator, Image};
+use kornia_image::Image;
 
 /// Finds connected components in a binary image using union-find.
 ///
@@ -18,8 +18,8 @@ use kornia_image::{allocator::ImageAllocator, Image};
 /// # Returns
 ///
 /// * `Result<(), AprilTagError>` - Returns `Ok(())` if successful, or an error if the union-find size is invalid.
-pub fn find_connected_components<A: ImageAllocator>(
-    src: &Image<Pixel, 1, A>,
+pub fn find_connected_components(
+    src: &Image<Pixel, 1>,
     uf: &mut UnionFind,
 ) -> Result<(), AprilTagError> {
     let src_size = src.size();
@@ -150,8 +150,8 @@ impl Pixel {
 /// * `uf` - Mutable reference to a [`UnionFind`] structure for tracking connected components.
 /// * `clusters` - Mutable reference to a map where the gradient information between component pairs will be stored.
 ///   Make sure to call [`HashMap::clear`] if you are using this function multiple times with the same `clusters`
-pub fn find_gradient_clusters<A: ImageAllocator>(
-    src: &Image<Pixel, 1, A>,
+pub fn find_gradient_clusters(
+    src: &Image<Pixel, 1>,
     uf: &mut UnionFind,
     clusters: &mut HashMap<(usize, usize), Vec<GradientInfo>>,
 ) {
@@ -237,7 +237,7 @@ pub fn find_gradient_clusters<A: ImageAllocator>(
 mod tests {
     use super::*;
     use crate::threshold::{adaptive_threshold, TileMinMax};
-    use kornia_image::{allocator::CpuAllocator, ImageSize};
+    use kornia_image::ImageSize;
     use kornia_io::png::read_image_png_mono8;
 
     #[test]
@@ -257,7 +257,7 @@ mod tests {
                 height: 4,
             },
             bin_data,
-            CpuAllocator,
+            kornia_image::allocator::host_alloc(),
         )?;
 
         let mut uf = UnionFind::new(20);
@@ -290,7 +290,11 @@ mod tests {
     #[test]
     fn test_segmentation() -> Result<(), Box<dyn std::error::Error>> {
         let src = read_image_png_mono8("../../tests/data/apriltag.png")?;
-        let mut bin = Image::from_size_val(src.size(), Pixel::Skip, CpuAllocator)?;
+        let mut bin = Image::from_size_val(
+            src.size(),
+            Pixel::Skip,
+            kornia_image::allocator::host_alloc(),
+        )?;
 
         let mut tile_min_max = TileMinMax::new(src.size(), 4);
         adaptive_threshold(&src, &mut bin, &mut tile_min_max, 20)?;
@@ -323,7 +327,11 @@ mod tests {
     #[test]
     fn test_gradient_clusters() -> Result<(), Box<dyn std::error::Error>> {
         let src = read_image_png_mono8("../../tests/data/apriltag.png")?;
-        let mut bin = Image::from_size_val(src.size(), Pixel::Skip, CpuAllocator)?;
+        let mut bin = Image::from_size_val(
+            src.size(),
+            Pixel::Skip,
+            kornia_image::allocator::host_alloc(),
+        )?;
 
         let mut tile_min_max = TileMinMax::new(src.size(), 4);
         adaptive_threshold(&src, &mut bin, &mut tile_min_max, 20)?;

--- a/crates/kornia-apriltag/src/segmentation.rs
+++ b/crates/kornia-apriltag/src/segmentation.rs
@@ -257,7 +257,6 @@ mod tests {
                 height: 4,
             },
             bin_data,
-            kornia_image::allocator::host_alloc(),
         )?;
 
         let mut uf = UnionFind::new(20);
@@ -290,11 +289,7 @@ mod tests {
     #[test]
     fn test_segmentation() -> Result<(), Box<dyn std::error::Error>> {
         let src = read_image_png_mono8("../../tests/data/apriltag.png")?;
-        let mut bin = Image::from_size_val(
-            src.size(),
-            Pixel::Skip,
-            kornia_image::allocator::host_alloc(),
-        )?;
+        let mut bin = Image::from_size_val(src.size(), Pixel::Skip)?;
 
         let mut tile_min_max = TileMinMax::new(src.size(), 4);
         adaptive_threshold(&src, &mut bin, &mut tile_min_max, 20)?;
@@ -327,11 +322,7 @@ mod tests {
     #[test]
     fn test_gradient_clusters() -> Result<(), Box<dyn std::error::Error>> {
         let src = read_image_png_mono8("../../tests/data/apriltag.png")?;
-        let mut bin = Image::from_size_val(
-            src.size(),
-            Pixel::Skip,
-            kornia_image::allocator::host_alloc(),
-        )?;
+        let mut bin = Image::from_size_val(src.size(), Pixel::Skip)?;
 
         let mut tile_min_max = TileMinMax::new(src.size(), 4);
         adaptive_threshold(&src, &mut bin, &mut tile_min_max, 20)?;

--- a/crates/kornia-apriltag/src/threshold.rs
+++ b/crates/kornia-apriltag/src/threshold.rs
@@ -1,7 +1,7 @@
 use crate::iter::ImageTile;
 use crate::utils::{find_full_tiles, Pixel, Point2d};
 use crate::{errors::AprilTagError, iter::TileIterator};
-use kornia_image::{allocator::ImageAllocator, Image, ImageError, ImageSize};
+use kornia_image::{Image, ImageError, ImageSize};
 
 /// Stores the minimum and maximum pixel values for each tile for [adaptive_threshold]
 ///
@@ -163,7 +163,7 @@ impl TileMinMax {
 /// # Examples
 ///
 /// ```
-/// use kornia_image::{allocator::CpuAllocator, Image, ImageSize};
+/// use kornia_image::{Image, ImageSize};
 /// use kornia_apriltag::threshold::{adaptive_threshold, TileMinMax};
 /// use kornia_apriltag::utils::Pixel;
 ///
@@ -173,19 +173,19 @@ impl TileMinMax {
 ///         height: 3,
 ///     },
 ///     vec![0, 50, 100, 150, 200, 250],
-///     CpuAllocator,
+///     kornia_image::allocator::host_alloc(),
 /// )
 /// .unwrap();
-/// let mut dst = Image::from_size_val(src.size(), Pixel::Skip, CpuAllocator).unwrap();
+/// let mut dst = Image::from_size_val(src.size(), Pixel::Skip, kornia_image::allocator::host_alloc()).unwrap();
 ///
 /// let mut tile_buffers = TileMinMax::new(src.size(), 2);
 /// adaptive_threshold(&src, &mut dst, &mut tile_buffers, 20).unwrap();
 /// assert_eq!(dst.as_slice(), &[0, 0, 255, 255, 255, 255]);
 /// ```
 // TODO: Add support for parallelism
-pub fn adaptive_threshold<A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<u8, 1, A1>,
-    dst: &mut Image<Pixel, 1, A2>,
+pub fn adaptive_threshold(
+    src: &Image<u8, 1>,
+    dst: &mut Image<Pixel, 1>,
     tile_min_max: &mut TileMinMax,
     min_white_black_diff: u8,
 ) -> Result<(), AprilTagError> {
@@ -316,7 +316,7 @@ pub fn adaptive_threshold<A1: ImageAllocator, A2: ImageAllocator>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kornia_image::{allocator::CpuAllocator, ImageSize};
+    use kornia_image::ImageSize;
     use kornia_io::png::read_image_png_mono8;
 
     #[test]
@@ -355,9 +355,13 @@ mod tests {
                 100, 150, 200, 250, 0,
                 80,  127, 221, 20,  100,
             ],
-            CpuAllocator,
+            kornia_image::allocator::host_alloc(),
         )?;
-        let mut dst = Image::from_size_val(src.size(), Pixel::Skip, CpuAllocator)?;
+        let mut dst = Image::from_size_val(
+            src.size(),
+            Pixel::Skip,
+            kornia_image::allocator::host_alloc(),
+        )?;
 
         let mut tile_buffers = TileMinMax::new(src.size(), 2);
         adaptive_threshold(&src, &mut dst, &mut tile_buffers, 20)?;
@@ -384,9 +388,13 @@ mod tests {
                 height: 4,
             },
             vec![100; 16],
-            CpuAllocator,
+            kornia_image::allocator::host_alloc(),
         )?;
-        let mut dst = Image::from_size_val(src.size(), Pixel::Skip, CpuAllocator)?;
+        let mut dst = Image::from_size_val(
+            src.size(),
+            Pixel::Skip,
+            kornia_image::allocator::host_alloc(),
+        )?;
 
         let mut tile_buffers = TileMinMax::new(src.size(), 2);
         adaptive_threshold(&src, &mut dst, &mut tile_buffers, 20)?;
@@ -397,7 +405,11 @@ mod tests {
     #[test]
     fn test_adaptive_threshold_synthetic_image() -> Result<(), Box<dyn std::error::Error>> {
         let src = read_image_png_mono8("../../tests/data/apriltag.png")?;
-        let mut bin = Image::from_size_val(src.size(), Pixel::Skip, CpuAllocator)?;
+        let mut bin = Image::from_size_val(
+            src.size(),
+            Pixel::Skip,
+            kornia_image::allocator::host_alloc(),
+        )?;
 
         let mut tile_buffers = TileMinMax::new(src.size(), 4);
         adaptive_threshold(&src, &mut bin, &mut tile_buffers, 20)?;
@@ -413,9 +425,17 @@ mod tests {
             height: 4,
         };
 
-        let src = Image::new(img_size, vec![100u8; 16], CpuAllocator)?;
+        let src = Image::new(
+            img_size,
+            vec![100u8; 16],
+            kornia_image::allocator::host_alloc(),
+        )?;
 
-        let mut dst = Image::from_size_val(img_size, Pixel::default(), CpuAllocator)?;
+        let mut dst = Image::from_size_val(
+            img_size,
+            Pixel::default(),
+            kornia_image::allocator::host_alloc(),
+        )?;
 
         let mut tile_buffers = TileMinMax::new(
             ImageSize {

--- a/crates/kornia-apriltag/src/threshold.rs
+++ b/crates/kornia-apriltag/src/threshold.rs
@@ -173,10 +173,9 @@ impl TileMinMax {
 ///         height: 3,
 ///     },
 ///     vec![0, 50, 100, 150, 200, 250],
-///     kornia_image::allocator::host_alloc(),
 /// )
 /// .unwrap();
-/// let mut dst = Image::from_size_val(src.size(), Pixel::Skip, kornia_image::allocator::host_alloc()).unwrap();
+/// let mut dst = Image::from_size_val(src.size(), Pixel::Skip).unwrap();
 ///
 /// let mut tile_buffers = TileMinMax::new(src.size(), 2);
 /// adaptive_threshold(&src, &mut dst, &mut tile_buffers, 20).unwrap();
@@ -355,13 +354,8 @@ mod tests {
                 100, 150, 200, 250, 0,
                 80,  127, 221, 20,  100,
             ],
-            kornia_image::allocator::host_alloc(),
         )?;
-        let mut dst = Image::from_size_val(
-            src.size(),
-            Pixel::Skip,
-            kornia_image::allocator::host_alloc(),
-        )?;
+        let mut dst = Image::from_size_val(src.size(), Pixel::Skip)?;
 
         let mut tile_buffers = TileMinMax::new(src.size(), 2);
         adaptive_threshold(&src, &mut dst, &mut tile_buffers, 20)?;
@@ -388,13 +382,8 @@ mod tests {
                 height: 4,
             },
             vec![100; 16],
-            kornia_image::allocator::host_alloc(),
         )?;
-        let mut dst = Image::from_size_val(
-            src.size(),
-            Pixel::Skip,
-            kornia_image::allocator::host_alloc(),
-        )?;
+        let mut dst = Image::from_size_val(src.size(), Pixel::Skip)?;
 
         let mut tile_buffers = TileMinMax::new(src.size(), 2);
         adaptive_threshold(&src, &mut dst, &mut tile_buffers, 20)?;
@@ -405,11 +394,7 @@ mod tests {
     #[test]
     fn test_adaptive_threshold_synthetic_image() -> Result<(), Box<dyn std::error::Error>> {
         let src = read_image_png_mono8("../../tests/data/apriltag.png")?;
-        let mut bin = Image::from_size_val(
-            src.size(),
-            Pixel::Skip,
-            kornia_image::allocator::host_alloc(),
-        )?;
+        let mut bin = Image::from_size_val(src.size(), Pixel::Skip)?;
 
         let mut tile_buffers = TileMinMax::new(src.size(), 4);
         adaptive_threshold(&src, &mut bin, &mut tile_buffers, 20)?;
@@ -425,17 +410,9 @@ mod tests {
             height: 4,
         };
 
-        let src = Image::new(
-            img_size,
-            vec![100u8; 16],
-            kornia_image::allocator::host_alloc(),
-        )?;
+        let src = Image::new(img_size, vec![100u8; 16])?;
 
-        let mut dst = Image::from_size_val(
-            img_size,
-            Pixel::default(),
-            kornia_image::allocator::host_alloc(),
-        )?;
+        let mut dst = Image::from_size_val(img_size, Pixel::default())?;
 
         let mut tile_buffers = TileMinMax::new(
             ImageSize {

--- a/crates/kornia-apriltag/src/utils.rs
+++ b/crates/kornia-apriltag/src/utils.rs
@@ -2,7 +2,7 @@
 // such as kornia-linalg, or another location we decide on later.
 
 use kornia_algebra::Mat3F32;
-use kornia_image::{allocator::ImageAllocator, Image, ImageSize};
+use kornia_image::{Image, ImageSize};
 
 /// Calculates the total number of tiles needed to cover an image of the given size,
 /// including partial tiles at the edges.
@@ -175,10 +175,7 @@ pub(crate) fn homography_compute(c: [[f32; 4]; 4]) -> Option<Mat3F32> {
 ///
 /// An `Option<f32>` containing the interpolated pixel value, or `None` if the coordinate is out of bounds.
 // TODO: Make interpolate function in kornia-imgproc generic and use that instead
-pub(crate) fn value_for_pixel<A: ImageAllocator>(
-    src: &Image<u8, 1, A>,
-    p: kornia_algebra::Vec2F32,
-) -> Option<f32> {
+pub(crate) fn value_for_pixel(src: &Image<u8, 1>, p: kornia_algebra::Vec2F32) -> Option<f32> {
     let src_slice = src.as_slice();
 
     let x1 = (p.x - 0.5).floor() as isize;

--- a/crates/kornia-image/README.md
+++ b/crates/kornia-image/README.md
@@ -32,13 +32,14 @@ kornia-image = "0.1.0"
 Here is a simple example showing how to create and manipulate an image:
 
 ```rust
-use kornia_image::{Image, ImageSize, allocator::CpuAllocator};
+use kornia_image::{Image, ImageSize};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // 1. Create a dummy RGB image (3 channels) with u8 data
+    //    Host is the default — no allocator argument. (Custom allocator: `Image::new_in`.)
     let image_size = ImageSize { width: 10, height: 20 };
     let data = vec![0u8; 10 * 20 * 3];
-    let image = Image::<u8, 3, _>::new(image_size, data, CpuAllocator)?;
+    let image = Image::<u8, 3>::new(image_size, data)?;
 
     println!("Image size: {:?}", image.size());
     println!("Channels: {}", image.num_channels());

--- a/crates/kornia-image/benches/bench_image.rs
+++ b/crates/kornia-image/benches/bench_image.rs
@@ -1,7 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use half::f16;
 use kornia_image::{Image, ImageSize};
-use kornia_tensor::host_alloc;
 use std::hint::black_box;
 
 fn sample_image() -> Image<u8, 3> {
@@ -11,7 +10,6 @@ fn sample_image() -> Image<u8, 3> {
             height: 1080,
         },
         127,
-        host_alloc(),
     )
     .unwrap()
 }

--- a/crates/kornia-image/benches/bench_image.rs
+++ b/crates/kornia-image/benches/bench_image.rs
@@ -1,17 +1,17 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use half::f16;
 use kornia_image::{Image, ImageSize};
-use kornia_tensor::CpuAllocator;
+use kornia_tensor::host_alloc;
 use std::hint::black_box;
 
-fn sample_image() -> Image<u8, 3, CpuAllocator> {
+fn sample_image() -> Image<u8, 3> {
     Image::from_size_val(
         ImageSize {
             width: 1920,
             height: 1080,
         },
         127,
-        CpuAllocator,
+        host_alloc(),
     )
     .unwrap()
 }

--- a/crates/kornia-image/src/allocator.rs
+++ b/crates/kornia-image/src/allocator.rs
@@ -1,11 +1,2 @@
-// Re-export the CpuAllocator and ForeignAllocator from kornia-tensor
-pub use kornia_tensor::allocator::ForeignAllocator;
-pub use kornia_tensor::CpuAllocator;
-use kornia_tensor::TensorAllocator;
-
-/// A marker trait for allocating and deallocating memory for images.
-pub trait ImageAllocator: TensorAllocator {}
-
-impl ImageAllocator for CpuAllocator {}
-
-impl ImageAllocator for ForeignAllocator {}
+// Backward-compatibility re-exports. Prefer importing from `kornia_tensor` directly in new code.
+pub use kornia_tensor::{host_alloc, AllocHandle, CpuAllocator, ForeignAllocator, TensorAllocator};

--- a/crates/kornia-image/src/allocator.rs
+++ b/crates/kornia-image/src/allocator.rs
@@ -1,2 +1,2 @@
 // Backward-compatibility re-exports. Prefer importing from `kornia_tensor` directly in new code.
-pub use kornia_tensor::{host_alloc, AllocHandle, CpuAllocator, ForeignAllocator, TensorAllocator};
+pub use kornia_tensor::{host_alloc, AllocHandle, CpuAllocator};

--- a/crates/kornia-image/src/arrow.rs
+++ b/crates/kornia-image/src/arrow.rs
@@ -1,4 +1,4 @@
-use crate::{allocator::ImageAllocator, Image, ImageError, ImageSize};
+use crate::{Image, ImageError, ImageSize};
 use arrow::{
     array::{ArrayRef, BinaryArray, StructArray, UInt32Array},
     datatypes::{DataType, Field},
@@ -23,8 +23,6 @@ impl TensorAllocator for ArrowAllocator {
     }
 }
 
-impl ImageAllocator for ArrowAllocator {}
-
 /// Trait for converting to Arrow arrays
 pub trait IntoArrow {
     /// Convert the image to an Arrow array including the metadata
@@ -38,7 +36,7 @@ pub trait TryFromArrow: Sized {
 }
 
 /// Implementation of IntoArrow for Image
-impl<const C: usize, A: ImageAllocator> IntoArrow for Image<u8, C, A> {
+impl<const C: usize> IntoArrow for Image<u8, C> {
     fn into_arrow(self) -> arrow::array::ArrayRef {
         let width = self.width() as u32;
         let height = self.height() as u32;
@@ -66,7 +64,7 @@ impl<const C: usize, A: ImageAllocator> IntoArrow for Image<u8, C, A> {
     }
 }
 
-impl<const C: usize> TryFromArrow for Image<u8, C, ArrowAllocator> {
+impl<const C: usize> TryFromArrow for Image<u8, C> {
     fn try_from_arrow(array: arrow::array::ArrayRef) -> Result<Self, ImageError> {
         let struct_array = array
             .as_any()
@@ -111,7 +109,9 @@ impl<const C: usize> TryFromArrow for Image<u8, C, ArrowAllocator> {
         let data_ptr = buffer_owned.as_ptr();
         let data_len = buffer_owned.len();
 
-        let alloc = ArrowAllocator(buffer_owned);
+        use kornia_tensor::AllocHandle;
+        use std::sync::Arc;
+        let alloc: AllocHandle = Arc::new(ArrowAllocator(buffer_owned));
 
         let image = unsafe {
             Image::from_raw_parts(
@@ -132,26 +132,26 @@ impl<const C: usize> TryFromArrow for Image<u8, C, ArrowAllocator> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        allocator::CpuAllocator,
         arrow::{IntoArrow, TryFromArrow},
         image::Image,
         ImageError, ImageSize,
     };
+    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_image_into_arrow() -> Result<(), ImageError> {
-        let image = Image::<u8, 1, CpuAllocator>::new(
+        let image = Image::<u8, 1>::new(
             ImageSize {
                 width: 2,
                 height: 3,
             },
             vec![0, 1, 2, 3, 4, 5],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let arrow_array = image.into_arrow();
 
-        let image_arr = Image::<u8, 1, _>::try_from_arrow(arrow_array.clone())?;
+        let image_arr = Image::<u8, 1>::try_from_arrow(arrow_array.clone())?;
 
         assert_eq!(image_arr.width(), 2);
         assert_eq!(image_arr.height(), 3);

--- a/crates/kornia-image/src/arrow.rs
+++ b/crates/kornia-image/src/arrow.rs
@@ -136,7 +136,6 @@ mod tests {
         image::Image,
         ImageError, ImageSize,
     };
-    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_image_into_arrow() -> Result<(), ImageError> {
@@ -146,7 +145,6 @@ mod tests {
                 height: 3,
             },
             vec![0, 1, 2, 3, 4, 5],
-            host_alloc(),
         )?;
 
         let arrow_array = image.into_arrow();

--- a/crates/kornia-image/src/color_spaces.rs
+++ b/crates/kornia-image/src/color_spaces.rs
@@ -276,21 +276,31 @@ macro_rules! define_color_space {
 
         impl $name {
             #[doc = concat!("Create ", stringify!($name), " image from size and data")]
-            pub fn from_size_vec(
+            pub fn from_size_vec(size: ImageSize, data: Vec<$type>) -> Result<Self, ImageError> {
+                Self::from_size_vec_in(size, data, kornia_tensor::host_alloc())
+            }
+
+            #[doc = concat!("Like `from_size_vec` but with an explicit allocator handle")]
+            pub fn from_size_vec_in(
                 size: ImageSize,
                 data: Vec<$type>,
                 alloc: AllocHandle,
             ) -> Result<Self, ImageError> {
-                Ok(Self(Image::new(size, data, alloc)?))
+                Ok(Self(Image::new_in(size, data, alloc)?))
             }
 
             #[doc = concat!("Create ", stringify!($name), " image from size with default value")]
-            pub fn from_size_val(
+            pub fn from_size_val(size: ImageSize, val: $type) -> Result<Self, ImageError> {
+                Self::from_size_val_in(size, val, kornia_tensor::host_alloc())
+            }
+
+            #[doc = concat!("Like `from_size_val` but with an explicit allocator handle")]
+            pub fn from_size_val_in(
                 size: ImageSize,
                 val: $type,
                 alloc: AllocHandle,
             ) -> Result<Self, ImageError> {
-                Ok(Self(Image::from_size_val(size, val, alloc)?))
+                Ok(Self(Image::from_size_val_in(size, val, alloc)?))
             }
 
             /// Unwrap into the underlying Image
@@ -825,7 +835,7 @@ impl Bayer8 {
         alloc: AllocHandle,
     ) -> Result<Self, ImageError> {
         Ok(Self {
-            image: Image::new(size, data, alloc)?,
+            image: Image::new_in(size, data, alloc)?,
             pattern,
         })
     }
@@ -874,7 +884,6 @@ mod tests {
 
     use crate::color_spaces::{Grayf32, Rgbf32};
     use crate::{ColorSpace as CS, DynImage, ImageSize};
-    use kornia_tensor::host_alloc;
     use std::convert::TryFrom;
 
     #[test]
@@ -883,7 +892,7 @@ mod tests {
             width: 2,
             height: 2,
         };
-        let rgb = Rgbf32::from_size_val(size, 0.25, host_alloc()).unwrap();
+        let rgb = Rgbf32::from_size_val(size, 0.25).unwrap();
         let dynimg = DynImage::C3(CS::Rgb, rgb.into_inner());
         assert_eq!(dynimg.color_space(), CS::Rgb);
         assert_eq!(dynimg.channels(), 3);
@@ -899,7 +908,7 @@ mod tests {
             width: 2,
             height: 2,
         };
-        let gray = Grayf32::from_size_val(size, 0.0, host_alloc()).unwrap();
+        let gray = Grayf32::from_size_val(size, 0.0).unwrap();
         let dynimg = DynImage::C1(CS::Gray, gray.into_inner());
         // recovering as Rgbf32 must fail (channel mismatch C1 vs C3)
         assert!(Rgbf32::try_from(dynimg).is_err());

--- a/crates/kornia-image/src/color_spaces.rs
+++ b/crates/kornia-image/src/color_spaces.rs
@@ -5,10 +5,10 @@
 //! by [`define_color_space!`].
 
 use crate::{
-    allocator::ImageAllocator,
     error::ImageError,
     image::{Image, ImageSize},
 };
+use kornia_tensor::AllocHandle;
 use std::ops::{Deref, DerefMut};
 
 // ===== Runtime color-space vocabulary ===========================================
@@ -138,16 +138,16 @@ impl ColorSpace {
 
 /// Owned image whose channel count is known only at runtime. Mirrors Python's
 /// dynamic numpy-backed Image; produced by the runtime `cvt_color` path.
-pub enum DynImage<T, A: ImageAllocator> {
+pub enum DynImage<T> {
     /// 1-channel (e.g. Gray).
-    C1(ColorSpace, Image<T, 1, A>),
+    C1(ColorSpace, Image<T, 1>),
     /// 3-channel (Rgb/Bgr/Hsv/...).
-    C3(ColorSpace, Image<T, 3, A>),
+    C3(ColorSpace, Image<T, 3>),
     /// 4-channel (Rgba/Bgra).
-    C4(ColorSpace, Image<T, 4, A>),
+    C4(ColorSpace, Image<T, 4>),
 }
 
-impl<T, A: ImageAllocator> DynImage<T, A> {
+impl<T> DynImage<T> {
     /// The color space tag carried by this image.
     ///
     /// # Returns
@@ -200,12 +200,10 @@ impl<T, A: ImageAllocator> DynImage<T, A> {
 }
 
 macro_rules! impl_try_from_dyn {
-    ($newtype:ident, $t:ty, C1, $space:expr) => {
-        impl<A: ImageAllocator> std::convert::TryFrom<DynImage<$t, A>>
-            for crate::color_spaces::$newtype<A>
-        {
+    ($newtype:ident, $t:ty, C1, $space:expr_2021) => {
+        impl std::convert::TryFrom<DynImage<$t>> for crate::color_spaces::$newtype {
             type Error = ImageError;
-            fn try_from(d: DynImage<$t, A>) -> Result<Self, ImageError> {
+            fn try_from(d: DynImage<$t>) -> Result<Self, ImageError> {
                 match d {
                     DynImage::C1(s, img) if s == $space => Ok(Self(img)),
                     other => Err(ImageError::ColorSpaceMismatch {
@@ -216,12 +214,10 @@ macro_rules! impl_try_from_dyn {
             }
         }
     };
-    ($newtype:ident, $t:ty, C3, $space:expr) => {
-        impl<A: ImageAllocator> std::convert::TryFrom<DynImage<$t, A>>
-            for crate::color_spaces::$newtype<A>
-        {
+    ($newtype:ident, $t:ty, C3, $space:expr_2021) => {
+        impl std::convert::TryFrom<DynImage<$t>> for crate::color_spaces::$newtype {
             type Error = ImageError;
-            fn try_from(d: DynImage<$t, A>) -> Result<Self, ImageError> {
+            fn try_from(d: DynImage<$t>) -> Result<Self, ImageError> {
                 match d {
                     DynImage::C3(s, img) if s == $space => Ok(Self(img)),
                     other => Err(ImageError::ColorSpaceMismatch {
@@ -232,12 +228,10 @@ macro_rules! impl_try_from_dyn {
             }
         }
     };
-    ($newtype:ident, $t:ty, C4, $space:expr) => {
-        impl<A: ImageAllocator> std::convert::TryFrom<DynImage<$t, A>>
-            for crate::color_spaces::$newtype<A>
-        {
+    ($newtype:ident, $t:ty, C4, $space:expr_2021) => {
+        impl std::convert::TryFrom<DynImage<$t>> for crate::color_spaces::$newtype {
             type Error = ImageError;
-            fn try_from(d: DynImage<$t, A>) -> Result<Self, ImageError> {
+            fn try_from(d: DynImage<$t>) -> Result<Self, ImageError> {
                 match d {
                     DynImage::C4(s, img) if s == $space => Ok(Self(img)),
                     other => Err(ImageError::ColorSpaceMismatch {
@@ -273,19 +267,19 @@ impl_try_from_dyn!(Yuv8, u8, C3, ColorSpace::Yuv);
 
 /// Macro to define a color space wrapper type with explicit bit depth
 macro_rules! define_color_space {
-    ($name:ident, $type:ty, $channels:expr, $doc:expr) => {
+    ($name:ident, $type:ty, $channels:expr_2021, $doc:expr_2021) => {
         #[doc = $doc]
         ///
         /// This is a zero-cost wrapper that provides compile-time type safety.
         #[repr(transparent)]
-        pub struct $name<A: ImageAllocator>(pub Image<$type, $channels, A>);
+        pub struct $name(pub Image<$type, $channels>);
 
-        impl<A: ImageAllocator> $name<A> {
+        impl $name {
             #[doc = concat!("Create ", stringify!($name), " image from size and data")]
             pub fn from_size_vec(
                 size: ImageSize,
                 data: Vec<$type>,
-                alloc: A,
+                alloc: AllocHandle,
             ) -> Result<Self, ImageError> {
                 Ok(Self(Image::new(size, data, alloc)?))
             }
@@ -294,42 +288,42 @@ macro_rules! define_color_space {
             pub fn from_size_val(
                 size: ImageSize,
                 val: $type,
-                alloc: A,
+                alloc: AllocHandle,
             ) -> Result<Self, ImageError> {
                 Ok(Self(Image::from_size_val(size, val, alloc)?))
             }
 
             /// Unwrap into the underlying Image
-            pub fn into_inner(self) -> Image<$type, $channels, A> {
+            pub fn into_inner(self) -> Image<$type, $channels> {
                 self.0
             }
 
             /// Get a reference to the underlying Image
-            pub fn as_image(&self) -> &Image<$type, $channels, A> {
+            pub fn as_image(&self) -> &Image<$type, $channels> {
                 &self.0
             }
 
             /// Get a mutable reference to the underlying Image
-            pub fn as_image_mut(&mut self) -> &mut Image<$type, $channels, A> {
+            pub fn as_image_mut(&mut self) -> &mut Image<$type, $channels> {
                 &mut self.0
             }
         }
 
-        impl<A: ImageAllocator> Deref for $name<A> {
-            type Target = Image<$type, $channels, A>;
+        impl Deref for $name {
+            type Target = Image<$type, $channels>;
             fn deref(&self) -> &Self::Target {
                 &self.0
             }
         }
 
-        impl<A: ImageAllocator> DerefMut for $name<A> {
+        impl DerefMut for $name {
             fn deref_mut(&mut self) -> &mut Self::Target {
                 &mut self.0
             }
         }
 
-        impl<A: ImageAllocator> AsRef<Image<$type, $channels, A>> for $name<A> {
-            fn as_ref(&self) -> &Image<$type, $channels, A> {
+        impl AsRef<Image<$type, $channels>> for $name {
+            fn as_ref(&self) -> &Image<$type, $channels> {
                 &self.0
             }
         }
@@ -596,7 +590,7 @@ pub struct Yvyu8 {
 }
 
 macro_rules! define_packed_422 {
-    ($name:ident, $doc:expr) => {
+    ($name:ident, $doc:expr_2021) => {
         impl $name {
             #[doc = concat!("Create a ", stringify!($name), " buffer from a size and a packed 4:2:2 byte vector (len = width*height*2).")]
             pub fn from_size_vec(size: ImageSize, data: Vec<u8>) -> Result<Self, ImageError> {
@@ -677,7 +671,7 @@ pub struct Yv12 {
 }
 
 macro_rules! define_planar_420 {
-    ($name:ident, $doc:expr) => {
+    ($name:ident, $doc:expr_2021) => {
         impl $name {
             #[doc = concat!("Create a ", stringify!($name), " buffer from a size and a planar 4:2:0 byte vector (len = width*height*3/2).")]
             pub fn from_size_vec(size: ImageSize, data: Vec<u8>) -> Result<Self, ImageError> {
@@ -812,19 +806,19 @@ pub enum BayerPattern {
 ///
 /// Hand-written rather than via `define_color_space!` because it carries the
 /// `pattern` field alongside the underlying single-channel image.
-pub struct Bayer8<A: ImageAllocator> {
-    image: Image<u8, 1, A>,
+pub struct Bayer8 {
+    image: Image<u8, 1>,
     /// The mosaic pattern of `image`.
     pub pattern: BayerPattern,
 }
 
-impl<A: ImageAllocator> Bayer8<A> {
+impl Bayer8 {
     /// Create a Bayer8 image from a size, raw mosaic data, and a pattern.
     pub fn from_size_vec(
         size: ImageSize,
         data: Vec<u8>,
         pattern: BayerPattern,
-        alloc: A,
+        alloc: AllocHandle,
     ) -> Result<Self, ImageError> {
         Ok(Self {
             image: Image::new(size, data, alloc)?,
@@ -833,18 +827,18 @@ impl<A: ImageAllocator> Bayer8<A> {
     }
 
     /// Get a reference to the underlying single-channel mosaic image.
-    pub fn as_image(&self) -> &Image<u8, 1, A> {
+    pub fn as_image(&self) -> &Image<u8, 1> {
         &self.image
     }
 
     /// Unwrap into the underlying single-channel mosaic image.
-    pub fn into_inner(self) -> Image<u8, 1, A> {
+    pub fn into_inner(self) -> Image<u8, 1> {
         self.image
     }
 }
 
-impl<A: ImageAllocator> Deref for Bayer8<A> {
-    type Target = Image<u8, 1, A>;
+impl Deref for Bayer8 {
+    type Target = Image<u8, 1>;
     fn deref(&self) -> &Self::Target {
         &self.image
     }
@@ -874,9 +868,9 @@ mod tests {
         assert!(!ColorSpace::supports(ColorSpace::Gray, ColorSpace::Hsv));
     }
 
-    use crate::allocator::CpuAllocator;
     use crate::color_spaces::{Grayf32, Rgbf32};
     use crate::{ColorSpace as CS, DynImage, ImageSize};
+    use kornia_tensor::host_alloc;
     use std::convert::TryFrom;
 
     #[test]
@@ -885,13 +879,13 @@ mod tests {
             width: 2,
             height: 2,
         };
-        let rgb = Rgbf32::from_size_val(size, 0.25, CpuAllocator).unwrap();
+        let rgb = Rgbf32::from_size_val(size, 0.25, host_alloc()).unwrap();
         let dynimg = DynImage::C3(CS::Rgb, rgb.into_inner());
         assert_eq!(dynimg.color_space(), CS::Rgb);
         assert_eq!(dynimg.channels(), 3);
         assert_eq!(dynimg.size(), size);
         // typed recovery succeeds for matching space+channels
-        let back: Rgbf32<_> = Rgbf32::try_from(dynimg).unwrap();
+        let back: Rgbf32 = Rgbf32::try_from(dynimg).unwrap();
         assert_eq!(back.as_slice()[0], 0.25);
     }
 
@@ -901,7 +895,7 @@ mod tests {
             width: 2,
             height: 2,
         };
-        let gray = Grayf32::from_size_val(size, 0.0, CpuAllocator).unwrap();
+        let gray = Grayf32::from_size_val(size, 0.0, host_alloc()).unwrap();
         let dynimg = DynImage::C1(CS::Gray, gray.into_inner());
         // recovering as Rgbf32 must fail (channel mismatch C1 vs C3)
         assert!(Rgbf32::try_from(dynimg).is_err());

--- a/crates/kornia-image/src/color_spaces.rs
+++ b/crates/kornia-image/src/color_spaces.rs
@@ -564,6 +564,10 @@ define_color_space!(
 // These store luma and (subsampled) chroma in a single byte buffer with non-trivial
 // layouts, so they can't be a thin `Image<T, C>` wrapper. Each carries an `ImageSize`
 // and a `Vec<u8>`, and validates its length on construction.
+//
+// HOST/CPU-ONLY: unlike `Image<T, C>` these own a plain `Vec<u8>` and carry no
+// `AllocHandle`, so they cannot live in device or custom-allocator memory. They are
+// interchange formats decoded to `Image`/`DynImage` before any allocator-aware op.
 
 /// Packed 4:2:2 YUYV (a.k.a. YUY2): byte order `Y0 U Y1 V` per 2-pixel group.
 ///

--- a/crates/kornia-image/src/cuda.rs
+++ b/crates/kornia-image/src/cuda.rs
@@ -10,14 +10,12 @@
 //! # #[cfg(feature = "cudarc")]
 //! # {
 //! use kornia_image::color_spaces::Rgb8;
-//! use kornia_tensor::host_alloc;
 //! use cudarc::driver::CudaContext;
 //! use std::sync::Arc;
 //!
 //! let rgb = Rgb8::from_size_val(
 //!     kornia_image::ImageSize { width: 2, height: 2 },
 //!     [0u8; 3],
-//!     host_alloc(),
 //! ).unwrap();
 //!
 //! let ctx = CudaContext::new(0).unwrap();

--- a/crates/kornia-image/src/cuda.rs
+++ b/crates/kornia-image/src/cuda.rs
@@ -10,19 +10,19 @@
 //! # #[cfg(feature = "cudarc")]
 //! # {
 //! use kornia_image::color_spaces::Rgb8;
-//! use kornia_tensor::CpuAllocator;
+//! use kornia_tensor::host_alloc;
 //! use cudarc::driver::CudaContext;
 //! use std::sync::Arc;
 //!
 //! let rgb = Rgb8::from_size_val(
 //!     kornia_image::ImageSize { width: 2, height: 2 },
 //!     [0u8; 3],
-//!     CpuAllocator,
+//!     host_alloc(),
 //! ).unwrap();
 //!
 //! let ctx = CudaContext::new(0).unwrap();
 //! let stream = ctx.default_stream();
-//! // Works via Deref: Rgb8 → Image<u8,3,_> → to_cuda
+//! // Works via Deref: Rgb8 → Image<u8,3> → to_cuda
 //! let _dev = rgb.to_cuda(&stream).unwrap();
 //! # }
 //! ```
@@ -31,14 +31,12 @@ use std::sync::Arc;
 
 use cudarc::driver::{CudaStream, DeviceRepr, ValidAsZeroBits};
 
-use crate::allocator::ImageAllocator;
 use crate::image::Image;
-use kornia_tensor::{CudaAllocator, CudaError, Tensor};
+use kornia_tensor::{CudaError, Tensor};
 
-impl<T, const C: usize, A: ImageAllocator> Image<T, C, A>
+impl<T, const C: usize> Image<T, C>
 where
     T: DeviceRepr + ValidAsZeroBits + Clone + Default + 'static,
-    A: 'static,
 {
     /// Upload this image's buffer to a new device tensor (H2D) on `stream`.
     ///
@@ -49,10 +47,7 @@ where
     /// # Errors
     ///
     /// Returns [`CudaError::Driver`] on CUDA failure.
-    pub fn to_cuda(
-        &self,
-        stream: &Arc<CudaStream>,
-    ) -> Result<Tensor<T, 3, CudaAllocator>, CudaError> {
+    pub fn to_cuda(&self, stream: &Arc<CudaStream>) -> Result<Tensor<T, 3>, CudaError> {
         self.0.to_cuda(stream)
     }
 }

--- a/crates/kornia-image/src/dlpack.rs
+++ b/crates/kornia-image/src/dlpack.rs
@@ -319,7 +319,6 @@ mod tests {
                 width: 3,
             },
             data,
-            host_alloc(),
         )
         .unwrap();
 

--- a/crates/kornia-image/src/dlpack.rs
+++ b/crates/kornia-image/src/dlpack.rs
@@ -1,4 +1,4 @@
-//! DLPack interoperability for typed [`Image<T, C, A>`].
+//! DLPack interoperability for typed [`Image<T, C>`].
 //!
 //! Provides [`image_to_dlpack`] (export) and [`image_from_dlpack`] (import).
 //! Both CPU and CUDA device images are accepted at the container level.
@@ -8,18 +8,14 @@ use std::{any::Any, sync::Arc};
 use dlpack_rs::ffi::DLManagedTensor;
 use kornia_tensor::{dlpack::tensor_to_dlpack, storage::TensorStorage, MemoryDomain};
 
-use crate::{
-    allocator::{ForeignAllocator, ImageAllocator},
-    error::ImageError,
-    image::Image,
-};
+use crate::{error::ImageError, image::Image};
 
 /// Re-export [`DlpackElem`] so callers get it from one place.
 pub use kornia_tensor::dlpack::DlpackElem;
 
 // ── image_to_dlpack ──────────────────────────────────────────────────────────
 
-/// Exports a typed [`Image<T, C, A>`] to a heap-allocated `DLManagedTensor`.
+/// Exports a typed [`Image<T, C>`] to a heap-allocated `DLManagedTensor`.
 ///
 /// The image is moved into the DLManagedTensor's keepalive; the consumer MUST call
 /// `managed.deleter(managed)` when done to free the buffer.  Export is zero-copy.
@@ -36,10 +32,9 @@ pub use kornia_tensor::dlpack::DlpackElem;
 /// # Errors
 ///
 /// This function does not return an error. The allocation is infallible for heap-backed images.
-pub fn image_to_dlpack<T, const C: usize, A>(img: Image<T, C, A>) -> *mut DLManagedTensor
+pub fn image_to_dlpack<T, const C: usize>(img: Image<T, C>) -> *mut DLManagedTensor
 where
     T: DlpackElem + 'static + Send,
-    A: ImageAllocator + Send + 'static,
 {
     // Image<T,C,A> is a newtype over Tensor<T,3,A>; delegate directly.
     tensor_to_dlpack(img.0)
@@ -47,7 +42,7 @@ where
 
 // ── image_from_dlpack ────────────────────────────────────────────────────────
 
-/// Imports a typed [`Image<T, C, ForeignAllocator>`] from a raw `DLManagedTensor` pointer.
+/// Imports a typed [`Image<T, C>`] from a raw `DLManagedTensor` pointer.
 ///
 /// Zero-copy: the `keepalive` keeps the source alive. The caller must NOT call the
 /// tensor's own deleter after passing it here.
@@ -86,7 +81,7 @@ where
 pub unsafe fn image_from_dlpack<T, const C: usize>(
     mt: *mut DLManagedTensor,
     keepalive: Arc<dyn Any + Send + Sync>,
-) -> Result<Image<T, C, ForeignAllocator>, ImageError>
+) -> Result<Image<T, C>, ImageError>
 where
     T: DlpackElem + Clone,
 {
@@ -188,15 +183,21 @@ where
     let byte_offset = usize::try_from(dl.byte_offset)
         .map_err(|_| ImageError::DlpackShapeError("byte_offset overflows usize".to_string()))?;
 
-    // 11. Build storage with kornia-image's ForeignAllocator (no-op dealloc).
+    // 11. Build storage with host_alloc (no-op dealloc for foreign memory).
     // SAFETY: data pointer is valid for len_bytes (caller contract); keepalive keeps
     // the source alive; domain correctly reflects the DLDevice.
     let data_ptr = unsafe { (dl.data as *const u8).add(byte_offset) as *const T };
     let storage = unsafe {
-        TensorStorage::from_borrowed(data_ptr, len_bytes, ForeignAllocator, domain, keepalive)
+        TensorStorage::from_borrowed(
+            data_ptr,
+            len_bytes,
+            kornia_tensor::host_alloc(),
+            domain,
+            keepalive,
+        )
     };
 
-    // 12. Build Tensor<T, 3, ForeignAllocator>.
+    // 12. Build Tensor<T, 3>.
     // Compute C-contiguous strides for HWC layout: [W*C, C, 1].
     let strides: [usize; 3] = [shape[1] * shape[2], shape[2], 1];
     let tensor = kornia_tensor::Tensor {
@@ -205,8 +206,8 @@ where
         strides,
     };
 
-    // 13. Wrap into Image<T, C, ForeignAllocator>.
-    // Safe because: ndim==3, shape[2]==C (validated above), ForeignAllocator is correct.
+    // 13. Wrap into Image<T, C>.
+    // Safe because: ndim==3, shape[2]==C (validated above).
     Ok(Image(tensor))
 }
 
@@ -222,13 +223,13 @@ mod tests {
 
     use dlpack_rs::ffi::{DLManagedTensor, DLTensor};
     use dlpack_rs::safe;
-    use kornia_tensor::CpuAllocator;
+    use kornia_tensor::host_alloc;
 
-    use crate::{allocator::CpuAllocator as ImageCpuAllocator, image::ImageSize};
+    use crate::image::ImageSize;
 
-    // ── Test 1a: image_to_dlpack with ForeignAllocator drop-counter ─────────────
+    // ── Test 1a: image_to_dlpack with foreign-buffer drop-counter ───────────────
     //
-    // Build an Image<u8,3,ForeignAllocator> with a drop-counter keepalive and verify
+    // Build an Image<u8,3> with a drop-counter keepalive and verify
     // the deleter fires the counter exactly once.
 
     #[test]
@@ -269,7 +270,7 @@ mod tests {
             deleter: None,
         };
 
-        // Import as Image<u8,3,ForeignAllocator> (keepalive holds the DropGuard).
+        // Import as Image<u8,3> (keepalive holds the DropGuard).
         let img = unsafe { image_from_dlpack::<u8, 3>(&mut managed as *mut _, keepalive) }.unwrap();
 
         assert_eq!(counter.load(Ordering::SeqCst), 0, "not dropped yet");
@@ -304,21 +305,21 @@ mod tests {
         );
     }
 
-    // ── Test 1b: image_to_dlpack with CpuAllocator ──────────────────────────────
+    // ── Test 1b: image_to_dlpack with host allocator ─────────────────────────────
     //
-    // Build a real Image<u8,3,CpuAllocator> from known data, export via image_to_dlpack,
+    // Build a real Image<u8,3> from known data, export via image_to_dlpack,
     // verify shape/ndim/dtype, fire the deleter (no panic expected).
 
     #[test]
     fn test_image_to_dlpack_cpu_allocator() {
         let data: Vec<u8> = (0u8..18).collect();
-        let img = Image::<u8, 3, ImageCpuAllocator>::new(
+        let img = Image::<u8, 3>::new(
             ImageSize {
                 height: 2,
                 width: 3,
             },
             data,
-            ImageCpuAllocator,
+            host_alloc(),
         )
         .unwrap();
 

--- a/crates/kornia-image/src/image.rs
+++ b/crates/kornia-image/src/image.rs
@@ -300,9 +300,7 @@ impl<T, const C: usize> Image<T, C> {
     where
         T: Clone,
     {
-        let tensor: Tensor3<T> =
-            Tensor::from_shape_slice([size.height, size.width, C], data, alloc)?;
-        Image::try_from(tensor)
+        Image::new(size, data.to_vec(), alloc)
     }
 
     /// Map the pixel data of the image to a different type.
@@ -652,24 +650,17 @@ impl<T, const C: usize> Image<T, C> {
     }
 }
 
-/// helper to convert an single channel tensor to a kornia image with try into
-impl<T> TryFrom<Tensor2<T>> for Image<T, 1>
-where
-    T: Clone,
-{
+/// helper to convert a single-channel tensor to a kornia image with try into
+impl<T> TryFrom<Tensor2<T>> for Image<T, 1> {
     type Error = ImageError;
 
     fn try_from(value: Tensor2<T>) -> Result<Self, Self::Error> {
-        let alloc = value.storage.alloc();
-
-        Self::from_size_slice(
-            ImageSize {
-                width: value.shape[1],
-                height: value.shape[0],
-            },
-            value.as_slice(),
-            alloc.clone(),
-        )
+        let alloc = value.storage.alloc().clone();
+        let size = ImageSize {
+            width: value.shape[1],
+            height: value.shape[0],
+        };
+        Self::new(size, value.storage.into_vec(), alloc)
     }
 }
 

--- a/crates/kornia-image/src/image.rs
+++ b/crates/kornia-image/src/image.rs
@@ -1,8 +1,5 @@
-use crate::{
-    allocator::{CpuAllocator, ImageAllocator},
-    error::ImageError,
-};
-use kornia_tensor::{Tensor, Tensor2, Tensor3};
+use crate::error::ImageError;
+use kornia_tensor::{AllocHandle, Tensor, Tensor2, Tensor3};
 use rayon::prelude::*;
 
 /// Image size in pixels
@@ -136,11 +133,11 @@ impl ImageSize {
 /// Represents an image with pixel data.
 ///
 /// The image is represented as a 3D Tensor with shape (H, W, C), where H is the height of the image,
-pub struct Image<T, const C: usize, A: ImageAllocator = CpuAllocator>(pub Tensor3<T, A>);
+pub struct Image<T, const C: usize>(pub Tensor3<T>);
 
 /// helper to deference the inner tensor
-impl<T, const C: usize, A: ImageAllocator> std::ops::Deref for Image<T, C, A> {
-    type Target = Tensor3<T, A>;
+impl<T, const C: usize> std::ops::Deref for Image<T, C> {
+    type Target = Tensor3<T>;
 
     // Define the deref method to return a reference to the inner Tensor3<T>.
     fn deref(&self) -> &Self::Target {
@@ -149,14 +146,14 @@ impl<T, const C: usize, A: ImageAllocator> std::ops::Deref for Image<T, C, A> {
 }
 
 /// helper to deference the inner tensor
-impl<T, const C: usize, A: ImageAllocator> std::ops::DerefMut for Image<T, C, A> {
+impl<T, const C: usize> std::ops::DerefMut for Image<T, C> {
     // Define the deref_mut method to return a mutable reference to the inner Tensor3<T>.
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
-impl<T, const C: usize, A: ImageAllocator> Image<T, C, A> {
+impl<T, const C: usize> Image<T, C> {
     /// Create a new image from pixel data.
     ///
     /// # Arguments
@@ -177,22 +174,22 @@ impl<T, const C: usize, A: ImageAllocator> Image<T, C, A> {
     ///
     /// ```
     /// use kornia_image::{Image, ImageSize};
-    /// use kornia_image::allocator::CpuAllocator;
+    /// use kornia_tensor::host_alloc;
     ///
-    /// let image = Image::<u8, 3, _>::new(
+    /// let image = Image::<u8, 3>::new(
     ///    ImageSize {
     ///       width: 10,
     ///      height: 20,
     ///  },
     /// vec![0u8; 10 * 20 * 3],
-    /// CpuAllocator
+    /// host_alloc()
     /// ).unwrap();
     ///
     /// assert_eq!(image.size().width, 10);
     /// assert_eq!(image.size().height, 20);
     /// assert_eq!(image.num_channels(), 3);
     /// ```
-    pub fn new(size: ImageSize, data: Vec<T>, alloc: A) -> Result<Self, ImageError> {
+    pub fn new(size: ImageSize, data: Vec<T>, alloc: AllocHandle) -> Result<Self, ImageError> {
         // check if the data length matches the image size
         if data.len() != size.width * size.height * C {
             return Err(ImageError::InvalidChannelShape(
@@ -229,19 +226,19 @@ impl<T, const C: usize, A: ImageAllocator> Image<T, C, A> {
     ///
     /// ```
     /// use kornia_image::{Image, ImageSize};
-    /// use kornia_image::allocator::CpuAllocator;
+    /// use kornia_tensor::host_alloc;
     ///
-    /// let image = Image::<u8, 3, _>::from_size_val(
+    /// let image = Image::<u8, 3>::from_size_val(
     ///   ImageSize {
     ///     width: 10,
     ///    height: 20,
-    /// }, 0u8, CpuAllocator).unwrap();
+    /// }, 0u8, host_alloc()).unwrap();
     ///
     /// assert_eq!(image.size().width, 10);
     /// assert_eq!(image.size().height, 20);
     /// assert_eq!(image.num_channels(), 3);
     /// ```
-    pub fn from_size_val(size: ImageSize, val: T, alloc: A) -> Result<Self, ImageError>
+    pub fn from_size_val(size: ImageSize, val: T, alloc: AllocHandle) -> Result<Self, ImageError>
     where
         T: Clone,
     {
@@ -270,12 +267,14 @@ impl<T, const C: usize, A: ImageAllocator> Image<T, C, A> {
         size: ImageSize,
         data: *const T,
         len: usize,
-        alloc: A,
+        alloc: AllocHandle,
     ) -> Result<Self, ImageError>
     where
         T: Clone,
     {
-        Tensor::from_raw_parts([size.height, size.width, C], data, len, alloc)?.try_into()
+        unsafe {
+            Tensor::from_raw_parts([size.height, size.width, C], data, len, alloc)?.try_into()
+        }
     }
 
     /// Create a new image from a slice of pixel data.
@@ -293,11 +292,15 @@ impl<T, const C: usize, A: ImageAllocator> Image<T, C, A> {
     ///
     /// Returns an error if the length of the data slice doesn't match the image dimensions,
     /// or if there's an issue creating the tensor or image.
-    pub fn from_size_slice(size: ImageSize, data: &[T], alloc: A) -> Result<Self, ImageError>
+    pub fn from_size_slice(
+        size: ImageSize,
+        data: &[T],
+        alloc: AllocHandle,
+    ) -> Result<Self, ImageError>
     where
         T: Clone,
     {
-        let tensor: Tensor3<T, A> =
+        let tensor: Tensor3<T> =
             Tensor::from_shape_slice([size.height, size.width, C], data, alloc)?;
         Image::try_from(tensor)
     }
@@ -311,10 +314,10 @@ impl<T, const C: usize, A: ImageAllocator> Image<T, C, A> {
     /// # Returns
     ///
     /// A new image with the pixel data mapped to the new type.
-    pub fn map<U>(&self, f: impl Fn(&T) -> U) -> Result<Image<U, C, A>, ImageError> {
+    pub fn map<U>(&self, f: impl Fn(&T) -> U) -> Result<Image<U, C>, ImageError> {
         let data = self.as_slice().iter().map(f).collect::<Vec<U>>();
         let alloc = self.storage.alloc();
-        Image::<U, C, A>::new(self.size(), data, alloc.clone())
+        Image::<U, C>::new(self.size(), data, alloc.clone())
     }
 
     /// Cast the pixel data of the image to a different type.
@@ -340,18 +343,18 @@ impl<T, const C: usize, A: ImageAllocator> Image<T, C, A> {
     ///
     /// ```
     /// use kornia_image::{Image, ImageSize};
-    /// use kornia_image::allocator::CpuAllocator;
+    /// use kornia_tensor::host_alloc;
     ///
-    /// let image_u8 = Image::<u8, 3, CpuAllocator>::new(
+    /// let image_u8 = Image::<u8, 3>::new(
     ///     ImageSize { width: 2, height: 1 },
     ///     vec![0u8, 128, 255, 10, 20, 30],
-    ///     CpuAllocator,
+    ///     host_alloc(),
     /// ).unwrap();
     ///
     /// let image_f32 = image_u8.cast::<f32>().unwrap();
     /// assert_eq!(image_f32.as_slice()[2], 255.0f32);
     /// ```
-    pub fn cast<U>(&self) -> Result<Image<U, C, A>, ImageError>
+    pub fn cast<U>(&self) -> Result<Image<U, C>, ImageError>
     where
         U: num_traits::NumCast + Copy,
         T: num_traits::NumCast + Copy,
@@ -379,7 +382,7 @@ impl<T, const C: usize, A: ImageAllocator> Image<T, C, A> {
     /// # Errors
     ///
     /// If the channel index is out of bounds, an error is returned.
-    pub fn channel(&self, channel: usize) -> Result<Image<T, 1, A>, ImageError>
+    pub fn channel(&self, channel: usize) -> Result<Image<T, 1>, ImageError>
     where
         T: Clone,
     {
@@ -410,20 +413,20 @@ impl<T, const C: usize, A: ImageAllocator> Image<T, C, A> {
     ///
     /// ```
     /// use kornia_image::{Image, ImageSize};
-    /// use kornia_image::allocator::CpuAllocator;
+    /// use kornia_tensor::host_alloc;
     ///
-    /// let image = Image::<f32, 2, _>::from_size_val(
+    /// let image = Image::<f32, 2>::from_size_val(
     ///   ImageSize {
     ///    width: 10,
     ///   height: 20,
     /// },
     /// 0.0f32,
-    /// CpuAllocator).unwrap();
+    /// host_alloc()).unwrap();
     ///
     /// let channels = image.split_channels().unwrap();
     /// assert_eq!(channels.len(), 2);
     /// ```
-    pub fn split_channels(&self) -> Result<Vec<Image<T, 1, A>>, ImageError>
+    pub fn split_channels(&self) -> Result<Vec<Image<T, 1>>, ImageError>
     where
         T: Copy,
     {
@@ -487,17 +490,17 @@ impl<T, const C: usize, A: ImageAllocator> Image<T, C, A> {
     ///
     /// ```
     /// use kornia_image::{Image, ImageSize};
-    /// use kornia_image::allocator::CpuAllocator;
+    /// use kornia_tensor::host_alloc;
     ///
     /// let data = vec![0u8, 0, 255, 0, 0, 255];
     ///
-    /// let image_u8 = Image::<u8, 3, _>::new(
+    /// let image_u8 = Image::<u8, 3>::new(
     /// ImageSize {
     ///   height: 2,
     ///   width: 1,
     /// },
     /// data,
-    /// CpuAllocator
+    /// host_alloc()
     /// ).unwrap();
     ///
     /// let image_f32 = image_u8.cast_and_scale::<f32>(1. / 255.0).unwrap();
@@ -505,7 +508,7 @@ impl<T, const C: usize, A: ImageAllocator> Image<T, C, A> {
     /// assert_eq!(image_f32.get([1, 0, 2]), Some(&1.0f32));
     /// ```
     #[allow(clippy::uninit_vec)]
-    pub fn cast_and_scale<U>(self, scale: U) -> Result<Image<U, C, A>, ImageError>
+    pub fn cast_and_scale<U>(self, scale: U) -> Result<Image<U, C>, ImageError>
     where
         U: num_traits::NumCast + std::ops::Mul<Output = U> + Clone + Copy + Send + Sync,
         T: num_traits::NumCast + Clone + Copy + Send + Sync,
@@ -540,7 +543,7 @@ impl<T, const C: usize, A: ImageAllocator> Image<T, C, A> {
     ///
     /// A new image with the pixel data cast to the new type and scaled.
     #[allow(clippy::uninit_vec)]
-    pub fn scale_and_cast<U>(&self, scale: T) -> Result<Image<U, C, A>, ImageError>
+    pub fn scale_and_cast<U>(&self, scale: T) -> Result<Image<U, C>, ImageError>
     where
         U: num_traits::NumCast + Clone + Copy + Send + Sync,
         T: num_traits::NumCast + std::ops::Mul<Output = T> + Clone + Copy + Send + Sync,
@@ -650,13 +653,13 @@ impl<T, const C: usize, A: ImageAllocator> Image<T, C, A> {
 }
 
 /// helper to convert an single channel tensor to a kornia image with try into
-impl<T, A: ImageAllocator> TryFrom<Tensor2<T, A>> for Image<T, 1, A>
+impl<T> TryFrom<Tensor2<T>> for Image<T, 1>
 where
     T: Clone,
 {
     type Error = ImageError;
 
-    fn try_from(value: Tensor2<T, A>) -> Result<Self, Self::Error> {
+    fn try_from(value: Tensor2<T>) -> Result<Self, Self::Error> {
         let alloc = value.storage.alloc();
 
         Self::from_size_slice(
@@ -671,10 +674,10 @@ where
 }
 
 /// helper to convert an multi channel tensor to a kornia image with try into
-impl<T, const C: usize, A: ImageAllocator> TryFrom<Tensor3<T, A>> for Image<T, C, A> {
+impl<T, const C: usize> TryFrom<Tensor3<T>> for Image<T, C> {
     type Error = ImageError;
 
-    fn try_from(value: Tensor3<T, A>) -> Result<Self, Self::Error> {
+    fn try_from(value: Tensor3<T>) -> Result<Self, Self::Error> {
         if value.shape[2] != C {
             return Err(ImageError::InvalidChannelShape(value.shape[2], C));
         }
@@ -682,10 +685,10 @@ impl<T, const C: usize, A: ImageAllocator> TryFrom<Tensor3<T, A>> for Image<T, C
     }
 }
 
-impl<T, const C: usize, A: ImageAllocator> TryInto<Tensor3<T, A>> for Image<T, C, A> {
+impl<T, const C: usize> TryInto<Tensor3<T>> for Image<T, C> {
     type Error = ImageError;
 
-    fn try_into(self) -> Result<Tensor3<T, A>, Self::Error> {
+    fn try_into(self) -> Result<Tensor3<T>, Self::Error> {
         Ok(self.0)
     }
 }
@@ -693,7 +696,7 @@ impl<T, const C: usize, A: ImageAllocator> TryInto<Tensor3<T, A>> for Image<T, C
 #[cfg(test)]
 mod tests {
     use crate::image::{Image, ImageError, ImageSize};
-    use kornia_tensor::{CpuAllocator, Tensor};
+    use kornia_tensor::{host_alloc, Tensor};
 
     #[test]
     fn test_image_size() {
@@ -726,13 +729,13 @@ mod tests {
 
     #[test]
     fn test_image_smoke() -> Result<(), ImageError> {
-        let image = Image::<u8, 3, CpuAllocator>::new(
+        let image = Image::<u8, 3>::new(
             ImageSize {
                 width: 10,
                 height: 20,
             },
             vec![0u8; 10 * 20 * 3],
-            CpuAllocator,
+            host_alloc(),
         )?;
         assert_eq!(image.size().width, 10);
         assert_eq!(image.size().height, 20);
@@ -743,13 +746,13 @@ mod tests {
 
     #[test]
     fn test_image_from_vec() -> Result<(), ImageError> {
-        let image: Image<f32, 3, CpuAllocator> = Image::new(
+        let image: Image<f32, 3> = Image::new(
             ImageSize {
                 height: 3,
                 width: 2,
             },
             vec![0.0; 3 * 2 * 3],
-            CpuAllocator,
+            host_alloc(),
         )?;
         assert_eq!(image.size().width, 2);
         assert_eq!(image.size().height, 3);
@@ -760,13 +763,13 @@ mod tests {
 
     #[test]
     fn test_image_from_empty_vec() -> Result<(), ImageError> {
-        let image: Result<Image<f32, 1, CpuAllocator>, ImageError> = Image::new(
+        let image: Result<Image<f32, 1>, ImageError> = Image::new(
             ImageSize {
                 height: 0,
                 width: 0,
             },
             vec![0.0; 0],
-            CpuAllocator,
+            host_alloc(),
         );
         assert!(
             image.is_ok(),
@@ -779,17 +782,17 @@ mod tests {
     #[test]
     fn test_image_cast() -> Result<(), ImageError> {
         let data = vec![0, 1, 2, 3, 4, 5];
-        let image_u8 = Image::<_, 3, CpuAllocator>::new(
+        let image_u8 = Image::<_, 3>::new(
             ImageSize {
                 height: 2,
                 width: 1,
             },
             data,
-            CpuAllocator,
+            host_alloc(),
         )?;
         assert_eq!(image_u8.get([1, 0, 2]), Some(&5u8));
 
-        let image_i32: Image<i32, 3, CpuAllocator> = image_u8.cast()?;
+        let image_i32: Image<i32, 3> = image_u8.cast()?;
         assert_eq!(image_i32.get([1, 0, 2]), Some(&5i32));
 
         Ok(())
@@ -797,13 +800,13 @@ mod tests {
 
     #[test]
     fn test_image_rgbd() -> Result<(), ImageError> {
-        let image = Image::<f32, 4, CpuAllocator>::new(
+        let image = Image::<f32, 4>::new(
             ImageSize {
                 height: 2,
                 width: 3,
             },
             vec![0f32; 2 * 3 * 4],
-            CpuAllocator,
+            host_alloc(),
         )?;
         assert_eq!(image.size().width, 3);
         assert_eq!(image.size().height, 2);
@@ -814,13 +817,13 @@ mod tests {
 
     #[test]
     fn test_image_channel() -> Result<(), ImageError> {
-        let image = Image::<f32, 3, CpuAllocator>::new(
+        let image = Image::<f32, 3>::new(
             ImageSize {
                 height: 2,
                 width: 1,
             },
             vec![0., 1., 2., 3., 4., 5.],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let channel = image.channel(2)?;
@@ -831,13 +834,13 @@ mod tests {
 
     #[test]
     fn test_image_split_channels() -> Result<(), ImageError> {
-        let image = Image::<f32, 3, CpuAllocator>::new(
+        let image = Image::<f32, 3>::new(
             ImageSize {
                 height: 2,
                 width: 1,
             },
             vec![0., 1., 2., 3., 4., 5.],
-            CpuAllocator,
+            host_alloc(),
         )
         .unwrap();
         let channels = image.split_channels()?;
@@ -852,13 +855,13 @@ mod tests {
     #[test]
     fn test_scale_and_cast() -> Result<(), ImageError> {
         let data = vec![0u8, 0, 255, 0, 0, 255];
-        let image_u8 = Image::<u8, 3, CpuAllocator>::new(
+        let image_u8 = Image::<u8, 3>::new(
             ImageSize {
                 height: 2,
                 width: 1,
             },
             data,
-            CpuAllocator,
+            host_alloc(),
         )?;
         let image_f32 = image_u8.cast_and_scale::<f32>(1. / 255.0)?;
         assert_eq!(image_f32.get([1, 0, 2]), Some(&1.0f32));
@@ -869,13 +872,13 @@ mod tests {
     #[test]
     fn test_cast_and_scale() -> Result<(), ImageError> {
         let data = vec![0u8, 0, 255, 0, 0, 255];
-        let image_u8 = Image::<u8, 3, CpuAllocator>::new(
+        let image_u8 = Image::<u8, 3>::new(
             ImageSize {
                 height: 2,
                 width: 1,
             },
             data,
-            CpuAllocator,
+            host_alloc(),
         )?;
         let image_f32 = image_u8.cast_and_scale::<f32>(1. / 255.0)?;
         assert_eq!(image_f32.get([1, 0, 2]), Some(&1.0f32));
@@ -886,14 +889,14 @@ mod tests {
     #[test]
     fn test_image_from_tensor() -> Result<(), ImageError> {
         let data = vec![0u8, 1, 2, 3, 4, 5];
-        let tensor = Tensor::<u8, 2, _>::from_shape_vec([2, 3], data, CpuAllocator)?;
+        let tensor = Tensor::<u8, 2>::from_shape_vec([2, 3], data, host_alloc())?;
 
-        let image = Image::<u8, 1, CpuAllocator>::try_from(tensor.clone())?;
+        let image = Image::<u8, 1>::try_from(tensor.clone())?;
         assert_eq!(image.size().width, 3);
         assert_eq!(image.size().height, 2);
         assert_eq!(image.num_channels(), 1);
 
-        let image_2: Image<u8, 1, CpuAllocator> = tensor.try_into()?;
+        let image_2: Image<u8, 1> = tensor.try_into()?;
         assert_eq!(image_2.size().width, 3);
         assert_eq!(image_2.size().height, 2);
         assert_eq!(image_2.num_channels(), 1);
@@ -903,18 +906,15 @@ mod tests {
 
     #[test]
     fn test_image_from_tensor_3d() -> Result<(), ImageError> {
-        let tensor = Tensor::<u8, 3, CpuAllocator>::from_shape_vec(
-            [2, 3, 4],
-            vec![0u8; 2 * 3 * 4],
-            CpuAllocator,
-        )?;
+        let tensor =
+            Tensor::<u8, 3>::from_shape_vec([2, 3, 4], vec![0u8; 2 * 3 * 4], host_alloc())?;
 
-        let image = Image::<u8, 4, CpuAllocator>::try_from(tensor.clone())?;
+        let image = Image::<u8, 4>::try_from(tensor.clone())?;
         assert_eq!(image.size().width, 3);
         assert_eq!(image.size().height, 2);
         assert_eq!(image.num_channels(), 4);
 
-        let image_2: Image<u8, 4, CpuAllocator> = tensor.try_into()?;
+        let image_2: Image<u8, 4> = tensor.try_into()?;
         assert_eq!(image_2.size().width, 3);
         assert_eq!(image_2.size().height, 2);
         assert_eq!(image_2.num_channels(), 4);
@@ -926,12 +926,7 @@ mod tests {
     fn test_image_from_raw_parts() -> Result<(), ImageError> {
         let data = vec![0u8, 1, 2, 3, 4, 5];
         let image = unsafe {
-            Image::<_, 1, CpuAllocator>::from_raw_parts(
-                [2, 3].into(),
-                data.as_ptr(),
-                data.len(),
-                CpuAllocator,
-            )?
+            Image::<_, 1>::from_raw_parts([2, 3].into(), data.as_ptr(), data.len(), host_alloc())?
         };
         std::mem::forget(data);
         assert_eq!(image.size().width, 2);
@@ -942,13 +937,13 @@ mod tests {
 
     #[test]
     fn test_get_pixel() -> Result<(), ImageError> {
-        let image = Image::<u8, 3, CpuAllocator>::new(
+        let image = Image::<u8, 3>::new(
             ImageSize {
                 height: 2,
                 width: 1,
             },
             vec![1, 2, 5, 19, 255, 128],
-            CpuAllocator,
+            host_alloc(),
         )?;
         assert_eq!(image.get_pixel(0, 0, 0)?, &1);
         assert_eq!(image.get_pixel(0, 0, 1)?, &2);
@@ -961,13 +956,13 @@ mod tests {
 
     #[test]
     fn test_set_pixel() -> Result<(), ImageError> {
-        let mut image = Image::<u8, 3, CpuAllocator>::new(
+        let mut image = Image::<u8, 3>::new(
             ImageSize {
                 height: 2,
                 width: 1,
             },
             vec![1, 2, 5, 19, 255, 128],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         image.set_pixel(0, 0, 0, 128)?;
@@ -981,13 +976,13 @@ mod tests {
 
     #[test]
     fn test_image_map() -> Result<(), ImageError> {
-        let image_u8 = Image::<u8, 1, CpuAllocator>::new(
+        let image_u8 = Image::<u8, 1>::new(
             ImageSize {
                 height: 2,
                 width: 1,
             },
             vec![0, 128],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let image_f32 = image_u8.map(|x| (x + 2) as f32)?;
@@ -1005,13 +1000,13 @@ mod tests {
     fn test_cast_round_trip() -> Result<(), ImageError> {
         // f32 → u8 → f32: values representable as u8 should survive the round trip.
         let data_f32 = vec![0.0f32, 128.0, 255.0, 10.0, 20.0, 30.0];
-        let image_f32 = Image::<f32, 3, CpuAllocator>::new(
+        let image_f32 = Image::<f32, 3>::new(
             ImageSize {
                 height: 2,
                 width: 1,
             },
             data_f32.clone(),
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let image_u8 = image_f32.cast::<u8>()?;
@@ -1029,13 +1024,13 @@ mod tests {
     #[test]
     fn test_cast_out_of_range() -> Result<(), ImageError> {
         // f32::MAX cannot be represented as u8, so cast must fail.
-        let image_f32 = Image::<f32, 1, CpuAllocator>::new(
+        let image_f32 = Image::<f32, 1>::new(
             ImageSize {
                 height: 1,
                 width: 1,
             },
             vec![f32::MAX],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let result = image_f32.cast::<u8>();
@@ -1051,13 +1046,13 @@ mod tests {
     fn test_cast_shape_preservation() -> Result<(), ImageError> {
         // Cast a 2×1 image with C=3; result must have identical size and correct values.
         let data = vec![0u8, 64, 128, 192, 200, 255];
-        let image_u8 = Image::<u8, 3, CpuAllocator>::new(
+        let image_u8 = Image::<u8, 3>::new(
             ImageSize {
                 height: 2,
                 width: 1,
             },
             data.clone(),
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let image_f32 = image_u8.cast::<f32>()?;

--- a/crates/kornia-image/src/image.rs
+++ b/crates/kornia-image/src/image.rs
@@ -1,5 +1,5 @@
 use crate::error::ImageError;
-use kornia_tensor::{AllocHandle, Tensor, Tensor2, Tensor3};
+use kornia_tensor::{host_alloc, AllocHandle, Tensor, Tensor2, Tensor3};
 use rayon::prelude::*;
 
 /// Image size in pixels
@@ -160,7 +160,6 @@ impl<T, const C: usize> Image<T, C> {
     ///
     /// * `size` - The size of the image in pixels.
     /// * `data` - The pixel data of the image.
-    /// * `alloc` - The allocator of the image
     ///
     /// # Returns
     ///
@@ -174,7 +173,6 @@ impl<T, const C: usize> Image<T, C> {
     ///
     /// ```
     /// use kornia_image::{Image, ImageSize};
-    /// use kornia_tensor::host_alloc;
     ///
     /// let image = Image::<u8, 3>::new(
     ///    ImageSize {
@@ -182,14 +180,18 @@ impl<T, const C: usize> Image<T, C> {
     ///      height: 20,
     ///  },
     /// vec![0u8; 10 * 20 * 3],
-    /// host_alloc()
     /// ).unwrap();
     ///
     /// assert_eq!(image.size().width, 10);
     /// assert_eq!(image.size().height, 20);
     /// assert_eq!(image.num_channels(), 3);
     /// ```
-    pub fn new(size: ImageSize, data: Vec<T>, alloc: AllocHandle) -> Result<Self, ImageError> {
+    pub fn new(size: ImageSize, data: Vec<T>) -> Result<Self, ImageError> {
+        Self::new_in(size, data, host_alloc())
+    }
+
+    /// Like [`new`](Self::new) but with an explicit allocator handle.
+    pub fn new_in(size: ImageSize, data: Vec<T>, alloc: AllocHandle) -> Result<Self, ImageError> {
         // check if the data length matches the image size
         if data.len() != size.width * size.height * C {
             return Err(ImageError::InvalidChannelShape(
@@ -199,7 +201,7 @@ impl<T, const C: usize> Image<T, C> {
         }
 
         // allocate the image data
-        Ok(Self(Tensor3::from_shape_vec(
+        Ok(Self(Tensor3::from_shape_vec_in(
             [size.height, size.width, C],
             data,
             alloc,
@@ -212,7 +214,6 @@ impl<T, const C: usize> Image<T, C> {
     ///
     /// * `size` - The size of the image in pixels.
     /// * `val` - The default value of the pixel data.
-    /// * `alloc` - The allocator of the image
     ///
     /// # Returns
     ///
@@ -226,24 +227,31 @@ impl<T, const C: usize> Image<T, C> {
     ///
     /// ```
     /// use kornia_image::{Image, ImageSize};
-    /// use kornia_tensor::host_alloc;
     ///
     /// let image = Image::<u8, 3>::from_size_val(
     ///   ImageSize {
     ///     width: 10,
     ///    height: 20,
-    /// }, 0u8, host_alloc()).unwrap();
+    /// }, 0u8).unwrap();
     ///
     /// assert_eq!(image.size().width, 10);
     /// assert_eq!(image.size().height, 20);
     /// assert_eq!(image.num_channels(), 3);
     /// ```
-    pub fn from_size_val(size: ImageSize, val: T, alloc: AllocHandle) -> Result<Self, ImageError>
+    pub fn from_size_val(size: ImageSize, val: T) -> Result<Self, ImageError>
+    where
+        T: Clone,
+    {
+        Self::from_size_val_in(size, val, host_alloc())
+    }
+
+    /// Like [`from_size_val`](Self::from_size_val) but with an explicit allocator handle.
+    pub fn from_size_val_in(size: ImageSize, val: T, alloc: AllocHandle) -> Result<Self, ImageError>
     where
         T: Clone,
     {
         let data = vec![val; size.width * size.height * C];
-        let image = Image::new(size, data, alloc)?;
+        let image = Image::new_in(size, data, alloc)?;
 
         Ok(image)
     }
@@ -292,7 +300,15 @@ impl<T, const C: usize> Image<T, C> {
     ///
     /// Returns an error if the length of the data slice doesn't match the image dimensions,
     /// or if there's an issue creating the tensor or image.
-    pub fn from_size_slice(
+    pub fn from_size_slice(size: ImageSize, data: &[T]) -> Result<Self, ImageError>
+    where
+        T: Clone,
+    {
+        Self::from_size_slice_in(size, data, host_alloc())
+    }
+
+    /// Like [`from_size_slice`](Self::from_size_slice) but with an explicit allocator handle.
+    pub fn from_size_slice_in(
         size: ImageSize,
         data: &[T],
         alloc: AllocHandle,
@@ -300,7 +316,7 @@ impl<T, const C: usize> Image<T, C> {
     where
         T: Clone,
     {
-        Image::new(size, data.to_vec(), alloc)
+        Image::new_in(size, data.to_vec(), alloc)
     }
 
     /// Map the pixel data of the image to a different type.
@@ -315,7 +331,7 @@ impl<T, const C: usize> Image<T, C> {
     pub fn map<U>(&self, f: impl Fn(&T) -> U) -> Result<Image<U, C>, ImageError> {
         let data = self.as_slice().iter().map(f).collect::<Vec<U>>();
         let alloc = self.storage.alloc();
-        Image::<U, C>::new(self.size(), data, alloc.clone())
+        Image::<U, C>::new_in(self.size(), data, alloc.clone())
     }
 
     /// Cast the pixel data of the image to a different type.
@@ -341,12 +357,10 @@ impl<T, const C: usize> Image<T, C> {
     ///
     /// ```
     /// use kornia_image::{Image, ImageSize};
-    /// use kornia_tensor::host_alloc;
     ///
     /// let image_u8 = Image::<u8, 3>::new(
     ///     ImageSize { width: 2, height: 1 },
     ///     vec![0u8, 128, 255, 10, 20, 30],
-    ///     host_alloc(),
     /// ).unwrap();
     ///
     /// let image_f32 = image_u8.cast::<f32>().unwrap();
@@ -364,7 +378,7 @@ impl<T, const C: usize> Image<T, C> {
             .collect::<Result<Vec<U>, ImageError>>()?;
 
         let alloc = self.storage.alloc().clone();
-        let tensor = Tensor3::from_shape_vec(self.0.shape, data, alloc)?;
+        let tensor = Tensor3::from_shape_vec_in(self.0.shape, data, alloc)?;
         Ok(Image(tensor))
     }
 
@@ -398,7 +412,7 @@ impl<T, const C: usize> Image<T, C> {
 
         let alloc = self.storage.alloc();
 
-        Image::new(self.size(), channel_data, alloc.clone())
+        Image::new_in(self.size(), channel_data, alloc.clone())
     }
 
     /// Split the image into its channels.
@@ -411,15 +425,13 @@ impl<T, const C: usize> Image<T, C> {
     ///
     /// ```
     /// use kornia_image::{Image, ImageSize};
-    /// use kornia_tensor::host_alloc;
     ///
     /// let image = Image::<f32, 2>::from_size_val(
     ///   ImageSize {
     ///    width: 10,
     ///   height: 20,
     /// },
-    /// 0.0f32,
-    /// host_alloc()).unwrap();
+    /// 0.0f32).unwrap();
     ///
     /// let channels = image.split_channels().unwrap();
     /// assert_eq!(channels.len(), 2);
@@ -488,7 +500,6 @@ impl<T, const C: usize> Image<T, C> {
     ///
     /// ```
     /// use kornia_image::{Image, ImageSize};
-    /// use kornia_tensor::host_alloc;
     ///
     /// let data = vec![0u8, 0, 255, 0, 0, 255];
     ///
@@ -498,7 +509,6 @@ impl<T, const C: usize> Image<T, C> {
     ///   width: 1,
     /// },
     /// data,
-    /// host_alloc()
     /// ).unwrap();
     ///
     /// let image_f32 = image_u8.cast_and_scale::<f32>(1. / 255.0).unwrap();
@@ -528,7 +538,7 @@ impl<T, const C: usize> Image<T, C> {
             })?;
 
         let alloc = self.storage.alloc();
-        Image::new(self.size(), casted_data, alloc.clone())
+        Image::new_in(self.size(), casted_data, alloc.clone())
     }
 
     /// Cast the pixel data to a different type and scale it.
@@ -562,7 +572,7 @@ impl<T, const C: usize> Image<T, C> {
             })?;
 
         let alloc = self.storage.alloc();
-        Image::new(self.size(), casted_data, alloc.clone())
+        Image::new_in(self.size(), casted_data, alloc.clone())
     }
 
     /// Get the pixel data of the image.
@@ -660,7 +670,7 @@ impl<T> TryFrom<Tensor2<T>> for Image<T, 1> {
             width: value.shape[1],
             height: value.shape[0],
         };
-        Self::new(size, value.storage.into_vec(), alloc)
+        Self::new_in(size, value.storage.into_vec(), alloc)
     }
 }
 
@@ -726,7 +736,6 @@ mod tests {
                 height: 20,
             },
             vec![0u8; 10 * 20 * 3],
-            host_alloc(),
         )?;
         assert_eq!(image.size().width, 10);
         assert_eq!(image.size().height, 20);
@@ -743,7 +752,6 @@ mod tests {
                 width: 2,
             },
             vec![0.0; 3 * 2 * 3],
-            host_alloc(),
         )?;
         assert_eq!(image.size().width, 2);
         assert_eq!(image.size().height, 3);
@@ -760,7 +768,6 @@ mod tests {
                 width: 0,
             },
             vec![0.0; 0],
-            host_alloc(),
         );
         assert!(
             image.is_ok(),
@@ -779,7 +786,6 @@ mod tests {
                 width: 1,
             },
             data,
-            host_alloc(),
         )?;
         assert_eq!(image_u8.get([1, 0, 2]), Some(&5u8));
 
@@ -797,7 +803,6 @@ mod tests {
                 width: 3,
             },
             vec![0f32; 2 * 3 * 4],
-            host_alloc(),
         )?;
         assert_eq!(image.size().width, 3);
         assert_eq!(image.size().height, 2);
@@ -814,7 +819,6 @@ mod tests {
                 width: 1,
             },
             vec![0., 1., 2., 3., 4., 5.],
-            host_alloc(),
         )?;
 
         let channel = image.channel(2)?;
@@ -831,7 +835,6 @@ mod tests {
                 width: 1,
             },
             vec![0., 1., 2., 3., 4., 5.],
-            host_alloc(),
         )
         .unwrap();
         let channels = image.split_channels()?;
@@ -852,7 +855,6 @@ mod tests {
                 width: 1,
             },
             data,
-            host_alloc(),
         )?;
         let image_f32 = image_u8.cast_and_scale::<f32>(1. / 255.0)?;
         assert_eq!(image_f32.get([1, 0, 2]), Some(&1.0f32));
@@ -869,7 +871,6 @@ mod tests {
                 width: 1,
             },
             data,
-            host_alloc(),
         )?;
         let image_f32 = image_u8.cast_and_scale::<f32>(1. / 255.0)?;
         assert_eq!(image_f32.get([1, 0, 2]), Some(&1.0f32));
@@ -880,7 +881,7 @@ mod tests {
     #[test]
     fn test_image_from_tensor() -> Result<(), ImageError> {
         let data = vec![0u8, 1, 2, 3, 4, 5];
-        let tensor = Tensor::<u8, 2>::from_shape_vec([2, 3], data, host_alloc())?;
+        let tensor = Tensor::<u8, 2>::from_shape_vec([2, 3], data)?;
 
         let image = Image::<u8, 1>::try_from(tensor.clone())?;
         assert_eq!(image.size().width, 3);
@@ -897,8 +898,7 @@ mod tests {
 
     #[test]
     fn test_image_from_tensor_3d() -> Result<(), ImageError> {
-        let tensor =
-            Tensor::<u8, 3>::from_shape_vec([2, 3, 4], vec![0u8; 2 * 3 * 4], host_alloc())?;
+        let tensor = Tensor::<u8, 3>::from_shape_vec([2, 3, 4], vec![0u8; 2 * 3 * 4])?;
 
         let image = Image::<u8, 4>::try_from(tensor.clone())?;
         assert_eq!(image.size().width, 3);
@@ -934,7 +934,6 @@ mod tests {
                 width: 1,
             },
             vec![1, 2, 5, 19, 255, 128],
-            host_alloc(),
         )?;
         assert_eq!(image.get_pixel(0, 0, 0)?, &1);
         assert_eq!(image.get_pixel(0, 0, 1)?, &2);
@@ -953,7 +952,6 @@ mod tests {
                 width: 1,
             },
             vec![1, 2, 5, 19, 255, 128],
-            host_alloc(),
         )?;
 
         image.set_pixel(0, 0, 0, 128)?;
@@ -973,7 +971,6 @@ mod tests {
                 width: 1,
             },
             vec![0, 128],
-            host_alloc(),
         )?;
 
         let image_f32 = image_u8.map(|x| (x + 2) as f32)?;
@@ -997,7 +994,6 @@ mod tests {
                 width: 1,
             },
             data_f32.clone(),
-            host_alloc(),
         )?;
 
         let image_u8 = image_f32.cast::<u8>()?;
@@ -1021,7 +1017,6 @@ mod tests {
                 width: 1,
             },
             vec![f32::MAX],
-            host_alloc(),
         )?;
 
         let result = image_f32.cast::<u8>();
@@ -1043,7 +1038,6 @@ mod tests {
                 width: 1,
             },
             data.clone(),
-            host_alloc(),
         )?;
 
         let image_f32 = image_u8.cast::<f32>()?;

--- a/crates/kornia-image/src/lib.rs
+++ b/crates/kornia-image/src/lib.rs
@@ -1,5 +1,30 @@
 #![deny(missing_docs)]
 #![doc = env!("CARGO_PKG_DESCRIPTION")]
+//!
+//! # Memory model
+//!
+//! `Image<T, C>` is a thin wrapper over a `kornia_tensor::Tensor3<T>` and inherits its
+//! **runtime** memory model: there is no allocator/device type parameter. The backing
+//! [`TensorStorage`](kornia_tensor::storage::TensorStorage) records a memory domain
+//! (`Host` / `Device` / `Unified`) plus a runtime allocator handle; `as_slice` panics on a
+//! non-host-accessible (device) image. See the `kornia_tensor` crate docs for the full model.
+//!
+//! # Unified constructor API
+//!
+//! The common host case needs no allocator argument; `_in` variants take an explicit
+//! [`AllocHandle`](kornia_tensor::AllocHandle):
+//!
+//! ```rust
+//! use kornia_image::{Image, ImageSize};
+//!
+//! let size = ImageSize { width: 4, height: 3 };
+//! let img = Image::<u8, 3>::from_size_val(size, 0)?;            // host default
+//! let img2 = Image::<u8, 3>::new(size, vec![0u8; 4 * 3 * 3])?;  // host default
+//! # Ok::<(), kornia_image::ImageError>(())
+//! ```
+//!
+//! `new`/`new_in`, `from_size_val`/`_in`, and `from_size_slice`/`_in` follow the same
+//! host-default + `_in` pattern as `kornia_tensor`.
 
 /// image representation for computer vision purposes.
 pub mod image;

--- a/crates/kornia-image/src/lib.rs
+++ b/crates/kornia-image/src/lib.rs
@@ -1,9 +1,6 @@
 #![deny(missing_docs)]
 #![doc = env!("CARGO_PKG_DESCRIPTION")]
 
-/// allocator module containing the memory management utilities.
-pub mod allocator;
-
 /// image representation for computer vision purposes.
 pub mod image;
 
@@ -16,9 +13,17 @@ pub mod ops;
 /// Typed color-space wrappers and runtime color-space vocabulary.
 pub mod color_spaces;
 
+/// Allocator re-exports for backward compatibility.
+///
+/// `kornia_image::allocator::host_alloc()` and `kornia_image::allocator::CpuAllocator`
+/// resolve to the same items from `kornia_tensor`; prefer importing from `kornia_tensor`
+/// directly in new code.
+pub mod allocator;
+
 pub use crate::color_spaces::{ColorSpace, DynImage};
 pub use crate::error::ImageError;
 pub use crate::image::{Image, ImageLayout, ImageSize, InterpolationMode, PixelFormat};
+pub use kornia_tensor::{host_alloc, AllocHandle};
 
 /// Arrow integration for converting images to Arrow format
 #[cfg(feature = "arrow")]

--- a/crates/kornia-image/src/ops.rs
+++ b/crates/kornia-image/src/ops.rs
@@ -12,7 +12,6 @@ use crate::{Image, ImageError};
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 /// use kornia_image::ops::cast_and_scale;
 ///
 /// let image = Image::<u8, 1>::new(
@@ -21,10 +20,9 @@ use crate::{Image, ImageError};
 ///  height: 1,
 /// },
 /// vec![0u8, 255],
-/// host_alloc()
 /// ).unwrap();
 ///
-/// let mut image_f32 = Image::from_size_val(image.size(), 0.0f32, host_alloc()).unwrap();
+/// let mut image_f32 = Image::from_size_val(image.size(), 0.0f32).unwrap();
 ///
 /// cast_and_scale(&image, &mut image_f32, 1. / 255.0).unwrap();
 ///
@@ -65,7 +63,6 @@ where
 mod tests {
     use super::*;
     use crate::image::ImageSize;
-    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_cast_and_scale() -> Result<(), ImageError> {
@@ -75,10 +72,9 @@ mod tests {
                 width: 1,
             },
             vec![0u8, 0, 255, 0, 0, 255],
-            host_alloc(),
         )?;
 
-        let mut image_f64: Image<f64, 3> = Image::from_size_val(image.size(), 0.0, host_alloc())?;
+        let mut image_f64: Image<f64, 3> = Image::from_size_val(image.size(), 0.0)?;
 
         super::cast_and_scale(&image, &mut image_f64, 1. / 255.0)?;
 

--- a/crates/kornia-image/src/ops.rs
+++ b/crates/kornia-image/src/ops.rs
@@ -1,4 +1,4 @@
-use crate::{allocator::ImageAllocator, Image, ImageError};
+use crate::{Image, ImageError};
 
 /// Cast the pixel data of an image to a different type.
 ///
@@ -12,28 +12,28 @@ use crate::{allocator::ImageAllocator, Image, ImageError};
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_image::ops::cast_and_scale;
 ///
-/// let image = Image::<u8, 1, _>::new(
+/// let image = Image::<u8, 1>::new(
 ///  ImageSize {
 ///   width: 2,
 ///  height: 1,
 /// },
 /// vec![0u8, 255],
-/// CpuAllocator
+/// host_alloc()
 /// ).unwrap();
 ///
-/// let mut image_f32 = Image::from_size_val(image.size(), 0.0f32, CpuAllocator).unwrap();
+/// let mut image_f32 = Image::from_size_val(image.size(), 0.0f32, host_alloc()).unwrap();
 ///
 /// cast_and_scale(&image, &mut image_f32, 1. / 255.0).unwrap();
 ///
 /// assert_eq!(image_f32.get_pixel(0, 0, 0).unwrap(), &0.0f32);
 /// assert_eq!(image_f32.get_pixel(1, 0, 0).unwrap(), &1.0f32);
 /// ```
-pub fn cast_and_scale<T, U, const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<T, C, A1>,
-    dst: &mut Image<U, C, A2>,
+pub fn cast_and_scale<T, U, const C: usize>(
+    src: &Image<T, C>,
+    dst: &mut Image<U, C>,
     scale: U,
 ) -> Result<(), ImageError>
 where
@@ -65,21 +65,20 @@ where
 mod tests {
     use super::*;
     use crate::image::ImageSize;
-    use kornia_tensor::CpuAllocator;
+    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_cast_and_scale() -> Result<(), ImageError> {
-        let image = Image::<u8, 3, CpuAllocator>::new(
+        let image = Image::<u8, 3>::new(
             ImageSize {
                 height: 2,
                 width: 1,
             },
             vec![0u8, 0, 255, 0, 0, 255],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut image_f64: Image<f64, 3, CpuAllocator> =
-            Image::from_size_val(image.size(), 0.0, CpuAllocator)?;
+        let mut image_f64: Image<f64, 3> = Image::from_size_val(image.size(), 0.0, host_alloc())?;
 
         super::cast_and_scale(&image, &mut image_f64, 1. / 255.0)?;
 

--- a/crates/kornia-imgproc/README.md
+++ b/crates/kornia-imgproc/README.md
@@ -38,18 +38,16 @@ kornia-imgproc = "0.1.0"
 ```rust
 use kornia_image::{Image, ImageSize};
 use kornia_imgproc::normalize::normalize_mean_std;
-use kornia_tensor::host_alloc;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // 1. Create a dummy f32 image
     let src = Image::<f32, 3>::new(
         ImageSize { width: 100, height: 100 },
-        vec![0.5f32; 100 * 100 * 3],
-        host_alloc()
+        vec![0.5f32; 100 * 100 * 3]
     )?;
 
     // 2. Normalize with mean and std
-    let mut dst = Image::<f32, 3>::from_size_val(src.size(), 0.0, host_alloc())?;
+    let mut dst = Image::<f32, 3>::from_size_val(src.size(), 0.0)?;
     let mean = [0.485, 0.456, 0.406];
     let std = [0.229, 0.224, 0.225];
 
@@ -65,17 +63,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```rust
 use kornia_image::{Image, ImageSize};
 use kornia_imgproc::color::{Rgb8, Gray8, ConvertColor};
-use kornia_tensor::host_alloc;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rgb = Rgb8::new(
         ImageSize { width: 10, height: 10 },
-        vec![0u8; 10 * 10 * 3],
-        host_alloc()
+        vec![0u8; 10 * 10 * 3]
     )?;
 
     // Convert RGB to Grayscale
-    let mut gray = Gray8::from_size_val(rgb.size(), 0, host_alloc())?;
+    let mut gray = Gray8::from_size_val(rgb.size(), 0)?;
     rgb.convert(&mut gray)?;
 
     assert_eq!(gray.num_channels(), 1);

--- a/crates/kornia-imgproc/README.md
+++ b/crates/kornia-imgproc/README.md
@@ -36,19 +36,20 @@ kornia-imgproc = "0.1.0"
 ### Normalizing an Image
 
 ```rust
-use kornia_image::{Image, ImageSize, allocator::CpuAllocator};
+use kornia_image::{Image, ImageSize};
 use kornia_imgproc::normalize::normalize_mean_std;
+use kornia_tensor::host_alloc;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // 1. Create a dummy f32 image
-    let src = Image::<f32, 3, _>::new(
+    let src = Image::<f32, 3>::new(
         ImageSize { width: 100, height: 100 },
         vec![0.5f32; 100 * 100 * 3],
-        CpuAllocator
+        host_alloc()
     )?;
 
     // 2. Normalize with mean and std
-    let mut dst = Image::<f32, 3, _>::from_size_val(src.size(), 0.0, CpuAllocator)?;
+    let mut dst = Image::<f32, 3>::from_size_val(src.size(), 0.0, host_alloc())?;
     let mean = [0.485, 0.456, 0.406];
     let std = [0.229, 0.224, 0.225];
 
@@ -62,18 +63,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Color Conversion
 
 ```rust
-use kornia_image::{Image, ImageSize, allocator::CpuAllocator};
+use kornia_image::{Image, ImageSize};
 use kornia_imgproc::color::{Rgb8, Gray8, ConvertColor};
+use kornia_tensor::host_alloc;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rgb = Rgb8::new(
         ImageSize { width: 10, height: 10 },
         vec![0u8; 10 * 10 * 3],
-        CpuAllocator
+        host_alloc()
     )?;
 
     // Convert RGB to Grayscale
-    let mut gray = Gray8::from_size_val(rgb.size(), 0, CpuAllocator)?;
+    let mut gray = Gray8::from_size_val(rgb.size(), 0, host_alloc())?;
     rgb.convert(&mut gray)?;
 
     assert_eq!(gray.num_channels(), 1);

--- a/crates/kornia-imgproc/SIMD.md
+++ b/crates/kornia-imgproc/SIMD.md
@@ -67,16 +67,16 @@ mod sealed { pub trait Sealed {} }
 
 pub trait GrayFromRgb: sealed::Sealed + Sized {
     #[doc(hidden)]
-    fn gray_from_rgb_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<Self, 3, A1>,
-        dst: &mut Image<Self, 1, A2>,
+    fn gray_from_rgb_impl(
+        src: &Image<Self, 3>,
+        dst: &mut Image<Self, 1>,
     ) -> Result<(), ImageError>;
 }
 
 impl sealed::Sealed for u8 {}
 impl GrayFromRgb for u8 {
-    fn gray_from_rgb_impl<A1, A2>(src: &Image<u8, 3, A1>, dst: &mut Image<u8, 1, A2>)
-        -> Result<(), ImageError> where A1: ImageAllocator, A2: ImageAllocator
+    fn gray_from_rgb_impl(src: &Image<u8, 3>, dst: &mut Image<u8, 1>)
+        -> Result<(), ImageError>
     {
         check_size(src, dst)?;
         kernels::rgb_to_gray_u8(src.as_slice(), dst.as_slice_mut(), src.rows() * src.cols());
@@ -86,9 +86,9 @@ impl GrayFromRgb for u8 {
 // impl for f32 → kernels::rgb_to_gray_f32 (NEON/AVX2+FMA)
 // impl for f64 → portable scalar
 
-pub fn gray_from_rgb<T: GrayFromRgb, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<T, 3, A1>,
-    dst: &mut Image<T, 1, A2>,
+pub fn gray_from_rgb<T: GrayFromRgb>(
+    src: &Image<T, 3>,
+    dst: &mut Image<T, 1>,
 ) -> Result<(), ImageError> {
     T::gray_from_rgb_impl(src, dst)
 }
@@ -106,9 +106,9 @@ Extract the repeated `src.size() != dst.size()` boilerplate into a private `chec
 
 ```rust
 #[inline]
-fn check_size<T, U, const C1: usize, const C2: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<T, C1, A1>,
-    dst: &Image<U, C2, A2>,
+fn check_size<T, U, const C1: usize, const C2: usize>(
+    src: &Image<T, C1>,
+    dst: &Image<U, C2>,
 ) -> Result<(), ImageError> {
     if src.size() != dst.size() {
         return Err(ImageError::InvalidImageSize(

--- a/crates/kornia-imgproc/benches/bench_color.rs
+++ b/crates/kornia-imgproc/benches/bench_color.rs
@@ -1,12 +1,12 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use kornia_image::Image;
 use kornia_imgproc::color::{gray_from_rgb, gray_from_rgb_u8};
-use kornia_tensor::CpuAllocator;
+use kornia_tensor::host_alloc;
 
 // vanilla version
 fn gray_vanilla_get_unchecked(
-    src: &Image<f32, 3, CpuAllocator>,
-    dst: &mut Image<f32, 1, CpuAllocator>,
+    src: &Image<f32, 3>,
+    dst: &mut Image<f32, 1>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let data = dst.as_slice_mut();
     let (cols, _rows) = (src.cols(), src.rows());
@@ -24,8 +24,8 @@ fn gray_vanilla_get_unchecked(
 }
 
 fn gray_ndarray_zip_par(
-    src: &Image<f32, 3, CpuAllocator>,
-    dst: &mut Image<f32, 1, CpuAllocator>,
+    src: &Image<f32, 3>,
+    dst: &mut Image<f32, 1>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     const RW: f32 = 76. / 255.;
     const GW: f32 = 150. / 255.;
@@ -52,7 +52,7 @@ fn gray_ndarray_zip_par(
     Ok(())
 }
 
-fn gray_image_crate(image: &Image<u8, 3, CpuAllocator>) -> Image<u8, 1, CpuAllocator> {
+fn gray_image_crate(image: &Image<u8, 3>) -> Image<u8, 1> {
     let image_data = image.as_slice();
     let rgb = image::RgbImage::from_raw(
         image.size().width as u32,
@@ -64,7 +64,7 @@ fn gray_image_crate(image: &Image<u8, 3, CpuAllocator>) -> Image<u8, 1, CpuAlloc
 
     let image_gray = image_crate.grayscale();
 
-    Image::new(image.size(), image_gray.into_bytes(), CpuAllocator).unwrap()
+    Image::new(image.size(), image_gray.into_bytes(), host_alloc()).unwrap()
 }
 
 fn bench_grayscale(c: &mut Criterion) {
@@ -79,12 +79,12 @@ fn bench_grayscale(c: &mut Criterion) {
         let image_data = vec![0u8; width * height * 3];
         let image_size = [*width, *height].into();
 
-        let image_u8 = Image::new(image_size, image_data, CpuAllocator).unwrap();
+        let image_u8 = Image::new(image_size, image_data, host_alloc()).unwrap();
         let image_f32 = image_u8.clone().cast::<f32>().unwrap();
 
         // output image
-        let gray_f32 = Image::from_size_val(image_size, 0.0, CpuAllocator).unwrap();
-        let gray_u8 = Image::from_size_val(image_size, 0, CpuAllocator).unwrap();
+        let gray_f32 = Image::from_size_val(image_size, 0.0, host_alloc()).unwrap();
+        let gray_u8 = Image::from_size_val(image_size, 0, host_alloc()).unwrap();
 
         group.bench_with_input(
             BenchmarkId::new("vanilla_unchecked", &parameter_string),

--- a/crates/kornia-imgproc/benches/bench_color.rs
+++ b/crates/kornia-imgproc/benches/bench_color.rs
@@ -1,7 +1,6 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use kornia_image::Image;
 use kornia_imgproc::color::{gray_from_rgb, gray_from_rgb_u8};
-use kornia_tensor::host_alloc;
 
 // vanilla version
 fn gray_vanilla_get_unchecked(
@@ -64,7 +63,7 @@ fn gray_image_crate(image: &Image<u8, 3>) -> Image<u8, 1> {
 
     let image_gray = image_crate.grayscale();
 
-    Image::new(image.size(), image_gray.into_bytes(), host_alloc()).unwrap()
+    Image::new(image.size(), image_gray.into_bytes()).unwrap()
 }
 
 fn bench_grayscale(c: &mut Criterion) {
@@ -79,12 +78,12 @@ fn bench_grayscale(c: &mut Criterion) {
         let image_data = vec![0u8; width * height * 3];
         let image_size = [*width, *height].into();
 
-        let image_u8 = Image::new(image_size, image_data, host_alloc()).unwrap();
+        let image_u8 = Image::new(image_size, image_data).unwrap();
         let image_f32 = image_u8.clone().cast::<f32>().unwrap();
 
         // output image
-        let gray_f32 = Image::from_size_val(image_size, 0.0, host_alloc()).unwrap();
-        let gray_u8 = Image::from_size_val(image_size, 0, host_alloc()).unwrap();
+        let gray_f32 = Image::from_size_val(image_size, 0.0).unwrap();
+        let gray_u8 = Image::from_size_val(image_size, 0).unwrap();
 
         group.bench_with_input(
             BenchmarkId::new("vanilla_unchecked", &parameter_string),

--- a/crates/kornia-imgproc/benches/bench_contours.rs
+++ b/crates/kornia-imgproc/benches/bench_contours.rs
@@ -3,7 +3,6 @@ use kornia_image::{Image, ImageSize};
 use kornia_imgproc::contours::{
     find_contours, ContourApproximationMode, FindContoursExecutor, RetrievalMode,
 };
-use kornia_tensor::host_alloc;
 use opencv::{core, imgproc, prelude::*};
 
 /// Filled square with a margin of size/8 on each side.
@@ -50,7 +49,7 @@ fn make_noise(width: usize, height: usize, seed: u64) -> Vec<u8> {
 }
 
 fn kornia_image(width: usize, height: usize, data: Vec<u8>) -> Image<u8, 1> {
-    Image::<u8, 1>::new(ImageSize { width, height }, data, host_alloc()).expect("kornia image")
+    Image::<u8, 1>::new(ImageSize { width, height }, data).expect("kornia image")
 }
 
 /// OpenCV expects 0/255 for binary images, not 0/1.

--- a/crates/kornia-imgproc/benches/bench_contours.rs
+++ b/crates/kornia-imgproc/benches/bench_contours.rs
@@ -1,8 +1,9 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use kornia_image::{allocator::CpuAllocator, Image, ImageSize};
+use kornia_image::{Image, ImageSize};
 use kornia_imgproc::contours::{
     find_contours, ContourApproximationMode, FindContoursExecutor, RetrievalMode,
 };
+use kornia_tensor::host_alloc;
 use opencv::{core, imgproc, prelude::*};
 
 /// Filled square with a margin of size/8 on each side.
@@ -48,8 +49,8 @@ fn make_noise(width: usize, height: usize, seed: u64) -> Vec<u8> {
         .collect()
 }
 
-fn kornia_image(width: usize, height: usize, data: Vec<u8>) -> Image<u8, 1, CpuAllocator> {
-    Image::<u8, 1, _>::new(ImageSize { width, height }, data, CpuAllocator).expect("kornia image")
+fn kornia_image(width: usize, height: usize, data: Vec<u8>) -> Image<u8, 1> {
+    Image::<u8, 1>::new(ImageSize { width, height }, data, host_alloc()).expect("kornia image")
 }
 
 /// OpenCV expects 0/255 for binary images, not 0/1.
@@ -71,7 +72,7 @@ fn opencv_mat(width: usize, height: usize, data: &[u8]) -> core::Mat {
 fn register_variants(
     group: &mut criterion::BenchmarkGroup<criterion::measurement::WallTime>,
     parameter_string: &str,
-    kornia_img: &Image<u8, 1, CpuAllocator>,
+    kornia_img: &Image<u8, 1>,
     cv_mat: &core::Mat,
 ) {
     group.bench_with_input(

--- a/crates/kornia-imgproc/benches/bench_crop.rs
+++ b/crates/kornia-imgproc/benches/bench_crop.rs
@@ -1,7 +1,6 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
 use kornia_image::{Image, ImageSize};
-use kornia_tensor::host_alloc;
 
 fn bench_resize(c: &mut Criterion) {
     let mut group = c.benchmark_group("Crop");
@@ -14,7 +13,7 @@ fn bench_resize(c: &mut Criterion) {
         // input image
         let image_size = [*width, *height].into();
         let data = vec![0u8; width * height * 3];
-        let image = Image::<u8, 3>::new(image_size, data, host_alloc()).unwrap();
+        let image = Image::<u8, 3>::new(image_size, data).unwrap();
         let (x, y) = (13, 21);
 
         // output image
@@ -23,7 +22,7 @@ fn bench_resize(c: &mut Criterion) {
             height: height / 2,
         };
 
-        let out_u8 = Image::<u8, 3>::from_size_val(new_size, 0, host_alloc()).unwrap();
+        let out_u8 = Image::<u8, 3>::from_size_val(new_size, 0).unwrap();
 
         group.bench_with_input(
             BenchmarkId::new("image_rs", &parameter_string),

--- a/crates/kornia-imgproc/benches/bench_crop.rs
+++ b/crates/kornia-imgproc/benches/bench_crop.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
 use kornia_image::{Image, ImageSize};
-use kornia_tensor::CpuAllocator;
+use kornia_tensor::host_alloc;
 
 fn bench_resize(c: &mut Criterion) {
     let mut group = c.benchmark_group("Crop");
@@ -14,7 +14,7 @@ fn bench_resize(c: &mut Criterion) {
         // input image
         let image_size = [*width, *height].into();
         let data = vec![0u8; width * height * 3];
-        let image = Image::<u8, 3, _>::new(image_size, data, CpuAllocator).unwrap();
+        let image = Image::<u8, 3>::new(image_size, data, host_alloc()).unwrap();
         let (x, y) = (13, 21);
 
         // output image
@@ -23,7 +23,7 @@ fn bench_resize(c: &mut Criterion) {
             height: height / 2,
         };
 
-        let out_u8 = Image::<u8, 3, _>::from_size_val(new_size, 0, CpuAllocator).unwrap();
+        let out_u8 = Image::<u8, 3>::from_size_val(new_size, 0, host_alloc()).unwrap();
 
         group.bench_with_input(
             BenchmarkId::new("image_rs", &parameter_string),

--- a/crates/kornia-imgproc/benches/bench_distance_transform.rs
+++ b/crates/kornia-imgproc/benches/bench_distance_transform.rs
@@ -1,6 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use kornia_image::{allocator::CpuAllocator, Image, ImageSize};
+use kornia_image::{Image, ImageSize};
 use kornia_imgproc::distance_transform::{distance_transform_vanilla, DistanceTransformExecutor};
+use kornia_tensor::host_alloc;
 use opencv::{core, imgproc, prelude::*};
 
 fn bench_distance_transform(c: &mut Criterion) {
@@ -17,13 +18,13 @@ fn bench_distance_transform(c: &mut Criterion) {
             }
         }
 
-        let image = Image::<f32, 1, _>::new(
+        let image = Image::<f32, 1>::new(
             ImageSize {
                 width: *width,
                 height: *height,
             },
             data.clone(),
-            CpuAllocator,
+            host_alloc(),
         )
         .unwrap();
 
@@ -82,13 +83,13 @@ fn bench_distance_transform(c: &mut Criterion) {
             }
         }
 
-        let image = Image::<f32, 1, _>::new(
+        let image = Image::<f32, 1>::new(
             ImageSize {
                 width: *width,
                 height: *height,
             },
             data,
-            CpuAllocator,
+            host_alloc(),
         )
         .unwrap();
 

--- a/crates/kornia-imgproc/benches/bench_distance_transform.rs
+++ b/crates/kornia-imgproc/benches/bench_distance_transform.rs
@@ -1,7 +1,6 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use kornia_image::{Image, ImageSize};
 use kornia_imgproc::distance_transform::{distance_transform_vanilla, DistanceTransformExecutor};
-use kornia_tensor::host_alloc;
 use opencv::{core, imgproc, prelude::*};
 
 fn bench_distance_transform(c: &mut Criterion) {
@@ -24,7 +23,6 @@ fn bench_distance_transform(c: &mut Criterion) {
                 height: *height,
             },
             data.clone(),
-            host_alloc(),
         )
         .unwrap();
 
@@ -89,7 +87,6 @@ fn bench_distance_transform(c: &mut Criterion) {
                 height: *height,
             },
             data,
-            host_alloc(),
         )
         .unwrap();
 

--- a/crates/kornia-imgproc/benches/bench_distortion.rs
+++ b/crates/kornia-imgproc/benches/bench_distortion.rs
@@ -3,7 +3,7 @@ use kornia_imgproc::calibration::{
     distortion::{distort_point_polynomial, undistort_points, PolynomialDistortion, TermCriteria},
     CameraIntrinsic,
 };
-use kornia_tensor::{CpuAllocator, Tensor};
+use kornia_tensor::{host_alloc, Tensor};
 use rand::RngExt;
 use std::hint::black_box;
 
@@ -25,7 +25,7 @@ fn distort_and_project(
     pts: &[(f64, f64)],
     intr: &CameraIntrinsic,
     dist: &PolynomialDistortion,
-) -> Tensor<f64, 2, CpuAllocator> {
+) -> Tensor<f64, 2> {
     let mut data = Vec::with_capacity(pts.len() * 2);
 
     for &(x, y) in pts {
@@ -34,7 +34,7 @@ fn distort_and_project(
         data.push(v);
     }
 
-    Tensor::from_shape_vec([pts.len(), 2], data, CpuAllocator).unwrap()
+    Tensor::from_shape_vec([pts.len(), 2], data, host_alloc()).unwrap()
 }
 
 fn bench_rust(c: &mut Criterion) {
@@ -63,7 +63,7 @@ fn bench_rust(c: &mut Criterion) {
 
     let pts = gen_pixel_points(10000, 640.0, 480.0);
     let src = distort_and_project(&pts, &intr, &dist);
-    let mut dst = Tensor::<f64, 2, _>::zeros([10000, 2], CpuAllocator);
+    let mut dst = Tensor::<f64, 2>::zeros([10000, 2], host_alloc());
 
     c.bench_function("undistort_rust", |b| {
         b.iter(|| {

--- a/crates/kornia-imgproc/benches/bench_distortion.rs
+++ b/crates/kornia-imgproc/benches/bench_distortion.rs
@@ -3,7 +3,7 @@ use kornia_imgproc::calibration::{
     distortion::{distort_point_polynomial, undistort_points, PolynomialDistortion, TermCriteria},
     CameraIntrinsic,
 };
-use kornia_tensor::{host_alloc, Tensor};
+use kornia_tensor::Tensor;
 use rand::RngExt;
 use std::hint::black_box;
 
@@ -34,7 +34,7 @@ fn distort_and_project(
         data.push(v);
     }
 
-    Tensor::from_shape_vec([pts.len(), 2], data, host_alloc()).unwrap()
+    Tensor::from_shape_vec([pts.len(), 2], data).unwrap()
 }
 
 fn bench_rust(c: &mut Criterion) {
@@ -63,7 +63,7 @@ fn bench_rust(c: &mut Criterion) {
 
     let pts = gen_pixel_points(10000, 640.0, 480.0);
     let src = distort_and_project(&pts, &intr, &dist);
-    let mut dst = Tensor::<f64, 2>::zeros([10000, 2], host_alloc());
+    let mut dst = Tensor::<f64, 2>::zeros([10000, 2]);
 
     c.bench_function("undistort_rust", |b| {
         b.iter(|| {

--- a/crates/kornia-imgproc/benches/bench_draw.rs
+++ b/crates/kornia-imgproc/benches/bench_draw.rs
@@ -1,7 +1,6 @@
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use kornia_image::Image;
 use kornia_imgproc::draw::{draw_line, draw_polygon};
-use kornia_tensor::host_alloc;
 
 fn bench_draw(c: &mut Criterion) {
     let sizes = [(512, 512), (1024, 1024)];
@@ -29,7 +28,7 @@ fn bench_draw(c: &mut Criterion) {
                     &thickness,
                     |b, &t| {
                         b.iter_batched(
-                            || Image::<u8, 1>::from_size_val(image_size, 0, host_alloc()).unwrap(),
+                            || Image::<u8, 1>::from_size_val(image_size, 0).unwrap(),
                             |mut img| {
                                 draw_line(&mut img, p0_h, p1_h, color, *t); // Routine
                             },
@@ -44,7 +43,7 @@ fn bench_draw(c: &mut Criterion) {
                     &thickness,
                     |b, &t| {
                         b.iter_batched(
-                            || Image::<u8, 1>::from_size_val(image_size, 0, host_alloc()).unwrap(),
+                            || Image::<u8, 1>::from_size_val(image_size, 0).unwrap(),
                             |mut img| draw_line(&mut img, p0_d, p1_d, color, *t),
                             BatchSize::LargeInput,
                         )
@@ -92,7 +91,7 @@ fn bench_draw(c: &mut Criterion) {
                     &thickness,
                     |b, &t| {
                         b.iter_batched(
-                            || Image::<u8, 1>::from_size_val(image_size, 0, host_alloc()).unwrap(),
+                            || Image::<u8, 1>::from_size_val(image_size, 0).unwrap(),
                             |mut img| draw_polygon(&mut img, &bbox_points, color, *t),
                             BatchSize::LargeInput,
                         )
@@ -105,7 +104,7 @@ fn bench_draw(c: &mut Criterion) {
                     &thickness,
                     |b, &t| {
                         b.iter_batched(
-                            || Image::<u8, 1>::from_size_val(image_size, 0, host_alloc()).unwrap(),
+                            || Image::<u8, 1>::from_size_val(image_size, 0).unwrap(),
                             |mut img| draw_polygon(&mut img, &circle_points, color, *t),
                             BatchSize::LargeInput,
                         )

--- a/crates/kornia-imgproc/benches/bench_draw.rs
+++ b/crates/kornia-imgproc/benches/bench_draw.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use kornia_image::Image;
 use kornia_imgproc::draw::{draw_line, draw_polygon};
-use kornia_tensor::CpuAllocator;
+use kornia_tensor::host_alloc;
 
 fn bench_draw(c: &mut Criterion) {
     let sizes = [(512, 512), (1024, 1024)];
@@ -29,10 +29,7 @@ fn bench_draw(c: &mut Criterion) {
                     &thickness,
                     |b, &t| {
                         b.iter_batched(
-                            || {
-                                Image::<u8, 1, _>::from_size_val(image_size, 0, CpuAllocator)
-                                    .unwrap()
-                            },
+                            || Image::<u8, 1>::from_size_val(image_size, 0, host_alloc()).unwrap(),
                             |mut img| {
                                 draw_line(&mut img, p0_h, p1_h, color, *t); // Routine
                             },
@@ -47,10 +44,7 @@ fn bench_draw(c: &mut Criterion) {
                     &thickness,
                     |b, &t| {
                         b.iter_batched(
-                            || {
-                                Image::<u8, 1, _>::from_size_val(image_size, 0, CpuAllocator)
-                                    .unwrap()
-                            },
+                            || Image::<u8, 1>::from_size_val(image_size, 0, host_alloc()).unwrap(),
                             |mut img| draw_line(&mut img, p0_d, p1_d, color, *t),
                             BatchSize::LargeInput,
                         )
@@ -98,10 +92,7 @@ fn bench_draw(c: &mut Criterion) {
                     &thickness,
                     |b, &t| {
                         b.iter_batched(
-                            || {
-                                Image::<u8, 1, _>::from_size_val(image_size, 0, CpuAllocator)
-                                    .unwrap()
-                            },
+                            || Image::<u8, 1>::from_size_val(image_size, 0, host_alloc()).unwrap(),
                             |mut img| draw_polygon(&mut img, &bbox_points, color, *t),
                             BatchSize::LargeInput,
                         )
@@ -114,10 +105,7 @@ fn bench_draw(c: &mut Criterion) {
                     &thickness,
                     |b, &t| {
                         b.iter_batched(
-                            || {
-                                Image::<u8, 1, _>::from_size_val(image_size, 0, CpuAllocator)
-                                    .unwrap()
-                            },
+                            || Image::<u8, 1>::from_size_val(image_size, 0, host_alloc()).unwrap(),
                             |mut img| draw_polygon(&mut img, &circle_points, color, *t),
                             BatchSize::LargeInput,
                         )

--- a/crates/kornia-imgproc/benches/bench_features.rs
+++ b/crates/kornia-imgproc/benches/bench_features.rs
@@ -6,7 +6,6 @@ use kornia_imgproc::{
     color::gray_from_rgb_u8, features::*, interpolation::InterpolationMode, resize::resize_fast_rgb,
 };
 use kornia_io::functional as io;
-use kornia_tensor::host_alloc;
 use rand::RngExt;
 
 fn bench_fast_corner_detect(c: &mut Criterion) {
@@ -17,13 +16,13 @@ fn bench_fast_corner_detect(c: &mut Criterion) {
     let img_rgb8 = io::read_image_any_rgb8(img_path).unwrap();
 
     let new_size = [1920, 1080].into();
-    let mut img_resized = Image::from_size_val(new_size, 0, host_alloc()).unwrap();
+    let mut img_resized = Image::from_size_val(new_size, 0).unwrap();
     resize_fast_rgb(&img_rgb8, &mut img_resized, InterpolationMode::Bilinear).unwrap();
 
-    let mut img_gray8 = Image::from_size_val(new_size, 0, host_alloc()).unwrap();
+    let mut img_gray8 = Image::from_size_val(new_size, 0).unwrap();
     gray_from_rgb_u8(&img_resized, &mut img_gray8).unwrap();
 
-    let mut img_grayf32 = Image::from_size_val(new_size, 0.0, host_alloc()).unwrap();
+    let mut img_grayf32 = Image::from_size_val(new_size, 0.0).unwrap();
     img_gray8
         .as_slice()
         .iter()
@@ -82,11 +81,10 @@ fn bench_harris_response(c: &mut Criterion) {
             .collect();
         let image_size = [*width, *height].into();
 
-        let image_f32: Image<f32, 1> = Image::new(image_size, image_data, host_alloc()).unwrap();
+        let image_f32: Image<f32, 1> = Image::new(image_size, image_data).unwrap();
 
         // output image
-        let response_f32: Image<f32, 1> =
-            Image::from_size_val(image_size, 0.0, host_alloc()).unwrap();
+        let response_f32: Image<f32, 1> = Image::from_size_val(image_size, 0.0).unwrap();
         let mut harris_response = HarrisResponse::new(image_size);
 
         group.bench_with_input(
@@ -109,10 +107,8 @@ fn bench_dog_response(c: &mut Criterion) {
     for (width, height) in test_sizes.iter() {
         group.throughput(criterion::Throughput::Elements((*width * *height) as u64));
 
-        let src =
-            Image::<f32, 1>::from_size_val([*width, *height].into(), 1.0, host_alloc()).unwrap();
-        let mut dst =
-            Image::<f32, 1>::from_size_val([*width, *height].into(), 0.0, host_alloc()).unwrap();
+        let src = Image::<f32, 1>::from_size_val([*width, *height].into(), 1.0).unwrap();
+        let mut dst = Image::<f32, 1>::from_size_val([*width, *height].into(), 0.0).unwrap();
 
         // Benchmark DoG response (serial version)
         group.bench_with_input(
@@ -139,7 +135,7 @@ fn load_mh01_gray_f32(name: &str) -> Image<f32, 1> {
     let img_path =
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("../../tests/data/{name}"));
     let img = kornia_io::png::read_image_png_mono8(&img_path).expect("failed to read test PNG");
-    let mut dst = Image::from_size_val(img.0.size(), 0.0f32, host_alloc()).expect("alloc failed");
+    let mut dst = Image::from_size_val(img.0.size(), 0.0f32).expect("alloc failed");
     img.0
         .as_slice()
         .iter()

--- a/crates/kornia-imgproc/benches/bench_features.rs
+++ b/crates/kornia-imgproc/benches/bench_features.rs
@@ -6,7 +6,7 @@ use kornia_imgproc::{
     color::gray_from_rgb_u8, features::*, interpolation::InterpolationMode, resize::resize_fast_rgb,
 };
 use kornia_io::functional as io;
-use kornia_tensor::CpuAllocator;
+use kornia_tensor::host_alloc;
 use rand::RngExt;
 
 fn bench_fast_corner_detect(c: &mut Criterion) {
@@ -17,13 +17,13 @@ fn bench_fast_corner_detect(c: &mut Criterion) {
     let img_rgb8 = io::read_image_any_rgb8(img_path).unwrap();
 
     let new_size = [1920, 1080].into();
-    let mut img_resized = Image::from_size_val(new_size, 0, CpuAllocator).unwrap();
+    let mut img_resized = Image::from_size_val(new_size, 0, host_alloc()).unwrap();
     resize_fast_rgb(&img_rgb8, &mut img_resized, InterpolationMode::Bilinear).unwrap();
 
-    let mut img_gray8 = Image::from_size_val(new_size, 0, CpuAllocator).unwrap();
+    let mut img_gray8 = Image::from_size_val(new_size, 0, host_alloc()).unwrap();
     gray_from_rgb_u8(&img_resized, &mut img_gray8).unwrap();
 
-    let mut img_grayf32 = Image::from_size_val(new_size, 0.0, CpuAllocator).unwrap();
+    let mut img_grayf32 = Image::from_size_val(new_size, 0.0, host_alloc()).unwrap();
     img_gray8
         .as_slice()
         .iter()
@@ -82,11 +82,11 @@ fn bench_harris_response(c: &mut Criterion) {
             .collect();
         let image_size = [*width, *height].into();
 
-        let image_f32: Image<f32, 1, _> = Image::new(image_size, image_data, CpuAllocator).unwrap();
+        let image_f32: Image<f32, 1> = Image::new(image_size, image_data, host_alloc()).unwrap();
 
         // output image
-        let response_f32: Image<f32, 1, _> =
-            Image::from_size_val(image_size, 0.0, CpuAllocator).unwrap();
+        let response_f32: Image<f32, 1> =
+            Image::from_size_val(image_size, 0.0, host_alloc()).unwrap();
         let mut harris_response = HarrisResponse::new(image_size);
 
         group.bench_with_input(
@@ -110,9 +110,9 @@ fn bench_dog_response(c: &mut Criterion) {
         group.throughput(criterion::Throughput::Elements((*width * *height) as u64));
 
         let src =
-            Image::<f32, 1, _>::from_size_val([*width, *height].into(), 1.0, CpuAllocator).unwrap();
+            Image::<f32, 1>::from_size_val([*width, *height].into(), 1.0, host_alloc()).unwrap();
         let mut dst =
-            Image::<f32, 1, _>::from_size_val([*width, *height].into(), 0.0, CpuAllocator).unwrap();
+            Image::<f32, 1>::from_size_val([*width, *height].into(), 0.0, host_alloc()).unwrap();
 
         // Benchmark DoG response (serial version)
         group.bench_with_input(
@@ -135,11 +135,11 @@ fn bench_dog_response(c: &mut Criterion) {
     group.finish();
 }
 
-fn load_mh01_gray_f32(name: &str) -> Image<f32, 1, CpuAllocator> {
+fn load_mh01_gray_f32(name: &str) -> Image<f32, 1> {
     let img_path =
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!("../../tests/data/{name}"));
     let img = kornia_io::png::read_image_png_mono8(&img_path).expect("failed to read test PNG");
-    let mut dst = Image::from_size_val(img.0.size(), 0.0f32, CpuAllocator).expect("alloc failed");
+    let mut dst = Image::from_size_val(img.0.size(), 0.0f32, host_alloc()).expect("alloc failed");
     img.0
         .as_slice()
         .iter()

--- a/crates/kornia-imgproc/benches/bench_filters.rs
+++ b/crates/kornia-imgproc/benches/bench_filters.rs
@@ -5,7 +5,6 @@ use kornia_imgproc::filter::{box_blur_fast, gaussian_blur, kernels, separable_fi
 
 use image::RgbImage;
 use imageproc::filter::gaussian_blur_f32;
-use kornia_tensor::host_alloc;
 
 fn gaussian_blur_u8<const C: usize>(
     src: &Image<u8, C>,
@@ -33,11 +32,11 @@ fn bench_filters(c: &mut Criterion) {
             let image_data = vec![0f32; width * height * 3];
             let image_size = [*width, *height].into();
 
-            let image_f32 = Image::<_, 3>::new(image_size, image_data, host_alloc()).unwrap();
+            let image_f32 = Image::<_, 3>::new(image_size, image_data).unwrap();
             let image_u8 = image_f32.cast::<u8>().unwrap();
 
             // output image
-            let output_f32 = Image::<_, 3>::from_size_val(image_size, 0.0, host_alloc()).unwrap();
+            let output_f32 = Image::<_, 3>::from_size_val(image_size, 0.0).unwrap();
             let output_u8 = output_f32.cast::<u8>().unwrap();
 
             group.bench_with_input(

--- a/crates/kornia-imgproc/benches/bench_filters.rs
+++ b/crates/kornia-imgproc/benches/bench_filters.rs
@@ -5,11 +5,11 @@ use kornia_imgproc::filter::{box_blur_fast, gaussian_blur, kernels, separable_fi
 
 use image::RgbImage;
 use imageproc::filter::gaussian_blur_f32;
-use kornia_tensor::CpuAllocator;
+use kornia_tensor::host_alloc;
 
 fn gaussian_blur_u8<const C: usize>(
-    src: &Image<u8, C, CpuAllocator>,
-    dst: &mut Image<u8, C, CpuAllocator>,
+    src: &Image<u8, C>,
+    dst: &mut Image<u8, C>,
     kernel_size: usize,
     sigma: f32,
 ) -> Result<(), ImageError> {
@@ -33,12 +33,11 @@ fn bench_filters(c: &mut Criterion) {
             let image_data = vec![0f32; width * height * 3];
             let image_size = [*width, *height].into();
 
-            let image_f32 = Image::<_, 3, _>::new(image_size, image_data, CpuAllocator).unwrap();
+            let image_f32 = Image::<_, 3>::new(image_size, image_data, host_alloc()).unwrap();
             let image_u8 = image_f32.cast::<u8>().unwrap();
 
             // output image
-            let output_f32 =
-                Image::<_, 3, _>::from_size_val(image_size, 0.0, CpuAllocator).unwrap();
+            let output_f32 = Image::<_, 3>::from_size_val(image_size, 0.0, host_alloc()).unwrap();
             let output_u8 = output_f32.cast::<u8>().unwrap();
 
             group.bench_with_input(

--- a/crates/kornia-imgproc/benches/bench_flip.rs
+++ b/crates/kornia-imgproc/benches/bench_flip.rs
@@ -3,13 +3,13 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use kornia_image::Image;
 use kornia_imgproc::flip;
 
-use kornia_tensor::CpuAllocator;
+use kornia_tensor::host_alloc;
 use rayon::{
     iter::{IndexedParallelIterator, ParallelIterator},
     slice::{ParallelSlice, ParallelSliceMut},
 };
 
-fn par_par_slicecopy(src: &Image<f32, 3, CpuAllocator>, dst: &mut Image<f32, 3, CpuAllocator>) {
+fn par_par_slicecopy(src: &Image<f32, 3>, dst: &mut Image<f32, 3>) {
     dst.as_slice_mut()
         .par_chunks_exact_mut(src.cols() * 3)
         .zip_eq(src.as_slice().par_chunks_exact(src.cols() * 3))
@@ -23,7 +23,7 @@ fn par_par_slicecopy(src: &Image<f32, 3, CpuAllocator>, dst: &mut Image<f32, 3, 
         });
 }
 
-fn par_loop_loop(src: &Image<f32, 3, CpuAllocator>, dst: &mut Image<f32, 3, CpuAllocator>) {
+fn par_loop_loop(src: &Image<f32, 3>, dst: &mut Image<f32, 3>) {
     dst.as_slice_mut()
         .par_chunks_exact_mut(src.cols() * 3)
         .zip_eq(src.as_slice().par_chunks_exact(src.cols() * 3))
@@ -39,7 +39,7 @@ fn par_loop_loop(src: &Image<f32, 3, CpuAllocator>, dst: &mut Image<f32, 3, CpuA
         });
 }
 
-fn par_loop_slicecopy(src: &Image<f32, 3, CpuAllocator>, dst: &mut Image<f32, 3, CpuAllocator>) {
+fn par_loop_slicecopy(src: &Image<f32, 3>, dst: &mut Image<f32, 3>) {
     dst.as_slice_mut()
         .par_chunks_exact_mut(src.cols() * 3)
         .zip_eq(src.as_slice().par_chunks_exact(src.cols() * 3))
@@ -53,7 +53,7 @@ fn par_loop_slicecopy(src: &Image<f32, 3, CpuAllocator>, dst: &mut Image<f32, 3,
         });
 }
 
-fn par_seq_slicecopy(src: &Image<f32, 3, CpuAllocator>, dst: &mut Image<f32, 3, CpuAllocator>) {
+fn par_seq_slicecopy(src: &Image<f32, 3>, dst: &mut Image<f32, 3>) {
     dst.as_slice_mut()
         .par_chunks_exact_mut(src.cols() * 3)
         .zip_eq(src.as_slice().par_chunks_exact(src.cols() * 3))
@@ -77,12 +77,12 @@ fn bench_flip(c: &mut Criterion) {
 
         // input image
         let image_size = [*width, *height].into();
-        let image = Image::<u8, 3, _>::new(image_size, vec![0u8; width * height * 3], CpuAllocator)
-            .unwrap();
+        let image =
+            Image::<u8, 3>::new(image_size, vec![0u8; width * height * 3], host_alloc()).unwrap();
         let image_f32 = image.clone().cast::<f32>().unwrap();
 
         // output image
-        let output = Image::<f32, 3, _>::from_size_val(image_size, 0.0, CpuAllocator).unwrap();
+        let output = Image::<f32, 3>::from_size_val(image_size, 0.0, host_alloc()).unwrap();
 
         group.bench_with_input(
             BenchmarkId::new("par_par_slicecopy", &parameter_string),

--- a/crates/kornia-imgproc/benches/bench_flip.rs
+++ b/crates/kornia-imgproc/benches/bench_flip.rs
@@ -3,7 +3,6 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use kornia_image::Image;
 use kornia_imgproc::flip;
 
-use kornia_tensor::host_alloc;
 use rayon::{
     iter::{IndexedParallelIterator, ParallelIterator},
     slice::{ParallelSlice, ParallelSliceMut},
@@ -77,12 +76,11 @@ fn bench_flip(c: &mut Criterion) {
 
         // input image
         let image_size = [*width, *height].into();
-        let image =
-            Image::<u8, 3>::new(image_size, vec![0u8; width * height * 3], host_alloc()).unwrap();
+        let image = Image::<u8, 3>::new(image_size, vec![0u8; width * height * 3]).unwrap();
         let image_f32 = image.clone().cast::<f32>().unwrap();
 
         // output image
-        let output = Image::<f32, 3>::from_size_val(image_size, 0.0, host_alloc()).unwrap();
+        let output = Image::<f32, 3>::from_size_val(image_size, 0.0).unwrap();
 
         group.bench_with_input(
             BenchmarkId::new("par_par_slicecopy", &parameter_string),

--- a/crates/kornia-imgproc/benches/bench_gradient.rs
+++ b/crates/kornia-imgproc/benches/bench_gradient.rs
@@ -4,7 +4,7 @@ use kornia_image::Image;
 use kornia_imgproc::filter::{
     spatial_gradient_float, spatial_gradient_float_parallel, spatial_gradient_float_parallel_row,
 };
-use kornia_tensor::CpuAllocator;
+use kornia_tensor::host_alloc;
 
 fn bench_gradient(c: &mut Criterion) {
     let mut group = c.benchmark_group("Spatial Gradient Float");
@@ -18,11 +18,11 @@ fn bench_gradient(c: &mut Criterion) {
         let image_data = vec![0f32; width * height * 3];
         let image_size = [*width, *height].into();
 
-        let image = Image::<_, 3, _>::new(image_size, image_data, CpuAllocator).unwrap();
+        let image = Image::<_, 3>::new(image_size, image_data, host_alloc()).unwrap();
 
         // output image
-        let output_dx = Image::from_size_val(image.size(), 0.0, CpuAllocator).unwrap();
-        let output_dy = Image::from_size_val(image.size(), 0.0, CpuAllocator).unwrap();
+        let output_dx = Image::from_size_val(image.size(), 0.0, host_alloc()).unwrap();
+        let output_dy = Image::from_size_val(image.size(), 0.0, host_alloc()).unwrap();
 
         group.bench_with_input(
             BenchmarkId::new("spatial_gradient_float", &parameter_string),

--- a/crates/kornia-imgproc/benches/bench_gradient.rs
+++ b/crates/kornia-imgproc/benches/bench_gradient.rs
@@ -4,7 +4,6 @@ use kornia_image::Image;
 use kornia_imgproc::filter::{
     spatial_gradient_float, spatial_gradient_float_parallel, spatial_gradient_float_parallel_row,
 };
-use kornia_tensor::host_alloc;
 
 fn bench_gradient(c: &mut Criterion) {
     let mut group = c.benchmark_group("Spatial Gradient Float");
@@ -18,11 +17,11 @@ fn bench_gradient(c: &mut Criterion) {
         let image_data = vec![0f32; width * height * 3];
         let image_size = [*width, *height].into();
 
-        let image = Image::<_, 3>::new(image_size, image_data, host_alloc()).unwrap();
+        let image = Image::<_, 3>::new(image_size, image_data).unwrap();
 
         // output image
-        let output_dx = Image::from_size_val(image.size(), 0.0, host_alloc()).unwrap();
-        let output_dy = Image::from_size_val(image.size(), 0.0, host_alloc()).unwrap();
+        let output_dx = Image::from_size_val(image.size(), 0.0).unwrap();
+        let output_dy = Image::from_size_val(image.size(), 0.0).unwrap();
 
         group.bench_with_input(
             BenchmarkId::new("spatial_gradient_float", &parameter_string),

--- a/crates/kornia-imgproc/benches/bench_metrics.rs
+++ b/crates/kornia-imgproc/benches/bench_metrics.rs
@@ -2,7 +2,6 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
 use kornia_image::Image;
 use kornia_imgproc::metrics;
-use kornia_tensor::host_alloc;
 
 fn bench_mse(c: &mut Criterion) {
     let mut group = c.benchmark_group("mse");
@@ -14,8 +13,7 @@ fn bench_mse(c: &mut Criterion) {
 
         // input image
         let image_size = [*width, *height].into();
-        let image =
-            Image::<u8, 3>::new(image_size, vec![0u8; width * height * 3], host_alloc()).unwrap();
+        let image = Image::<u8, 3>::new(image_size, vec![0u8; width * height * 3]).unwrap();
         let image_f32 = image.cast::<f32>().unwrap();
 
         group.bench_with_input(

--- a/crates/kornia-imgproc/benches/bench_metrics.rs
+++ b/crates/kornia-imgproc/benches/bench_metrics.rs
@@ -2,7 +2,7 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
 use kornia_image::Image;
 use kornia_imgproc::metrics;
-use kornia_tensor::CpuAllocator;
+use kornia_tensor::host_alloc;
 
 fn bench_mse(c: &mut Criterion) {
     let mut group = c.benchmark_group("mse");
@@ -14,8 +14,8 @@ fn bench_mse(c: &mut Criterion) {
 
         // input image
         let image_size = [*width, *height].into();
-        let image = Image::<u8, 3, _>::new(image_size, vec![0u8; width * height * 3], CpuAllocator)
-            .unwrap();
+        let image =
+            Image::<u8, 3>::new(image_size, vec![0u8; width * height * 3], host_alloc()).unwrap();
         let image_f32 = image.cast::<f32>().unwrap();
 
         group.bench_with_input(

--- a/crates/kornia-imgproc/benches/bench_morphology.rs
+++ b/crates/kornia-imgproc/benches/bench_morphology.rs
@@ -3,7 +3,7 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use kornia_image::Image;
 use kornia_imgproc::morphology::{close, dilate, erode, open, Kernel, KernelShape};
 use kornia_imgproc::padding::PaddingMode;
-use kornia_tensor::CpuAllocator;
+use kornia_tensor::host_alloc;
 
 fn bench_morphology(c: &mut Criterion) {
     let mut group = c.benchmark_group("Morphology");
@@ -13,8 +13,8 @@ fn bench_morphology(c: &mut Criterion) {
             let parameter_string = format!("{width}x{height}_k{kernel_size}");
             let image_size = [*width, *height].into();
 
-            let image = Image::<u8, 1, _>::from_size_val(image_size, 128, CpuAllocator).unwrap();
-            let dst = Image::<u8, 1, _>::from_size_val(image_size, 0, CpuAllocator).unwrap();
+            let image = Image::<u8, 1>::from_size_val(image_size, 128, host_alloc()).unwrap();
+            let dst = Image::<u8, 1>::from_size_val(image_size, 0, host_alloc()).unwrap();
 
             let kernel = Kernel::new(KernelShape::Box { size: *kernel_size });
 

--- a/crates/kornia-imgproc/benches/bench_morphology.rs
+++ b/crates/kornia-imgproc/benches/bench_morphology.rs
@@ -3,7 +3,6 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use kornia_image::Image;
 use kornia_imgproc::morphology::{close, dilate, erode, open, Kernel, KernelShape};
 use kornia_imgproc::padding::PaddingMode;
-use kornia_tensor::host_alloc;
 
 fn bench_morphology(c: &mut Criterion) {
     let mut group = c.benchmark_group("Morphology");
@@ -13,8 +12,8 @@ fn bench_morphology(c: &mut Criterion) {
             let parameter_string = format!("{width}x{height}_k{kernel_size}");
             let image_size = [*width, *height].into();
 
-            let image = Image::<u8, 1>::from_size_val(image_size, 128, host_alloc()).unwrap();
-            let dst = Image::<u8, 1>::from_size_val(image_size, 0, host_alloc()).unwrap();
+            let image = Image::<u8, 1>::from_size_val(image_size, 128).unwrap();
+            let dst = Image::<u8, 1>::from_size_val(image_size, 0).unwrap();
 
             let kernel = Kernel::new(KernelShape::Box { size: *kernel_size });
 

--- a/crates/kornia-imgproc/benches/bench_optical_flow.rs
+++ b/crates/kornia-imgproc/benches/bench_optical_flow.rs
@@ -1,17 +1,18 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use kornia_image::{allocator::CpuAllocator, Image, ImageSize};
+use kornia_image::{Image, ImageSize};
 #[cfg(feature = "opencv_bench")]
 use kornia_imgproc::optical_flow_pyr_lk::{
     build_lk_precomputed, calc_optical_flow_pyr_lk_with_precomputed,
 };
 use kornia_imgproc::optical_flow_pyr_lk::{calc_optical_flow_pyr_lk, PyrLKParams};
+use kornia_tensor::host_alloc;
 #[cfg(feature = "opencv_bench")]
 use std::hint::black_box;
 
 #[cfg(feature = "opencv_bench")]
 use opencv::{core, prelude::*, video};
 
-type GrayImage = Image<f32, 1, CpuAllocator>;
+type GrayImage = Image<f32, 1>;
 
 fn make_synthetic_pair(
     size: usize,
@@ -24,7 +25,7 @@ fn make_synthetic_pair(
         width: size,
         height: size,
     };
-    let mut img1 = GrayImage::from_size_val(img_size, 0.0, CpuAllocator).unwrap();
+    let mut img1 = GrayImage::from_size_val(img_size, 0.0, host_alloc()).unwrap();
     for y in 0..size {
         for x in 0..size {
             let cx = size as f32 / 2.0;
@@ -37,7 +38,7 @@ fn make_synthetic_pair(
         }
     }
 
-    let mut img2 = GrayImage::from_size_val(img_size, 0.0, CpuAllocator).unwrap();
+    let mut img2 = GrayImage::from_size_val(img_size, 0.0, host_alloc()).unwrap();
     for y in 0..size {
         for x in 0..size {
             let cx = size as f32 / 2.0 + dx;

--- a/crates/kornia-imgproc/benches/bench_optical_flow.rs
+++ b/crates/kornia-imgproc/benches/bench_optical_flow.rs
@@ -5,7 +5,6 @@ use kornia_imgproc::optical_flow_pyr_lk::{
     build_lk_precomputed, calc_optical_flow_pyr_lk_with_precomputed,
 };
 use kornia_imgproc::optical_flow_pyr_lk::{calc_optical_flow_pyr_lk, PyrLKParams};
-use kornia_tensor::host_alloc;
 #[cfg(feature = "opencv_bench")]
 use std::hint::black_box;
 
@@ -25,7 +24,7 @@ fn make_synthetic_pair(
         width: size,
         height: size,
     };
-    let mut img1 = GrayImage::from_size_val(img_size, 0.0, host_alloc()).unwrap();
+    let mut img1 = GrayImage::from_size_val(img_size, 0.0).unwrap();
     for y in 0..size {
         for x in 0..size {
             let cx = size as f32 / 2.0;
@@ -38,7 +37,7 @@ fn make_synthetic_pair(
         }
     }
 
-    let mut img2 = GrayImage::from_size_val(img_size, 0.0, host_alloc()).unwrap();
+    let mut img2 = GrayImage::from_size_val(img_size, 0.0).unwrap();
     for y in 0..size {
         for x in 0..size {
             let cx = size as f32 / 2.0 + dx;

--- a/crates/kornia-imgproc/benches/bench_pyramid.rs
+++ b/crates/kornia-imgproc/benches/bench_pyramid.rs
@@ -2,7 +2,7 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
 use kornia_image::Image;
 use kornia_imgproc::pyramid::{pyrdown_f32, pyrdown_u8, pyrup_f32, pyrup_u8};
-use kornia_tensor::CpuAllocator;
+use kornia_tensor::host_alloc;
 
 fn bench_pyramid(c: &mut Criterion) {
     let mut group = c.benchmark_group("Pyramid Operations");
@@ -17,11 +17,11 @@ fn bench_pyramid(c: &mut Criterion) {
             .map(|x| x as f32)
             .collect();
         let small_image =
-            Image::<f32, 1, _>::new(small_image_size, small_image_data, CpuAllocator).unwrap();
+            Image::<f32, 1>::new(small_image_size, small_image_data, host_alloc()).unwrap();
 
         let image_size = [*width, *height].into();
 
-        let up_image = Image::<f32, 1, _>::from_size_val(image_size, 0.0, CpuAllocator).unwrap();
+        let up_image = Image::<f32, 1>::from_size_val(image_size, 0.0, host_alloc()).unwrap();
 
         group.bench_with_input(
             BenchmarkId::new("pyrup_f32", &parameter_string),
@@ -39,8 +39,8 @@ fn bench_pyramid(c: &mut Criterion) {
             .map(|x| x as f32)
             .collect();
         let small_image_3c =
-            Image::<f32, 3, _>::new(small_image_size, small_image_data_3c, CpuAllocator).unwrap();
-        let up_image_3c = Image::<f32, 3, _>::from_size_val(image_size, 0.0, CpuAllocator).unwrap();
+            Image::<f32, 3>::new(small_image_size, small_image_data_3c, host_alloc()).unwrap();
+        let up_image_3c = Image::<f32, 3>::from_size_val(image_size, 0.0, host_alloc()).unwrap();
 
         group.bench_with_input(
             BenchmarkId::new("pyrup_f32_3c", &parameter_string),
@@ -57,11 +57,11 @@ fn bench_pyramid(c: &mut Criterion) {
         let large_image_size = [*width, *height].into();
         let large_image_data = (0..((*width) * (*height))).map(|x| x as f32).collect();
         let large_image =
-            Image::<f32, 1, _>::new(large_image_size, large_image_data, CpuAllocator).unwrap();
+            Image::<f32, 1>::new(large_image_size, large_image_data, host_alloc()).unwrap();
 
         let down_image_size = [(*width).div_ceil(2), (*height).div_ceil(2)].into();
         let down_image =
-            Image::<f32, 1, _>::from_size_val(down_image_size, 0.0, CpuAllocator).unwrap();
+            Image::<f32, 1>::from_size_val(down_image_size, 0.0, host_alloc()).unwrap();
 
         group.bench_with_input(
             BenchmarkId::new("pyrdown_f32", &parameter_string),
@@ -77,9 +77,9 @@ fn bench_pyramid(c: &mut Criterion) {
         // For multi-channel images
         let large_image_data_3c = (0..((*width) * (*height) * 3)).map(|x| x as f32).collect();
         let large_image_3c =
-            Image::<f32, 3, _>::new(large_image_size, large_image_data_3c, CpuAllocator).unwrap();
+            Image::<f32, 3>::new(large_image_size, large_image_data_3c, host_alloc()).unwrap();
         let down_image_3c =
-            Image::<f32, 3, _>::from_size_val(down_image_size, 0.0, CpuAllocator).unwrap();
+            Image::<f32, 3>::from_size_val(down_image_size, 0.0, host_alloc()).unwrap();
 
         group.bench_with_input(
             BenchmarkId::new("pyrdown_f32_3c", &parameter_string),
@@ -110,9 +110,9 @@ fn bench_pyramid_u8(c: &mut Criterion) {
             .map(|x| (x % 256) as u8)
             .collect();
         let small_image_u8 =
-            Image::<u8, 1, _>::new(small_image_size, small_image_data_u8, CpuAllocator).unwrap();
+            Image::<u8, 1>::new(small_image_size, small_image_data_u8, host_alloc()).unwrap();
         let image_size = [*width, *height].into();
-        let up_image_u8 = Image::<u8, 1, _>::from_size_val(image_size, 0, CpuAllocator).unwrap();
+        let up_image_u8 = Image::<u8, 1>::from_size_val(image_size, 0, host_alloc()).unwrap();
 
         group.bench_with_input(
             BenchmarkId::new("pyrup_u8", &parameter_string),
@@ -130,8 +130,8 @@ fn bench_pyramid_u8(c: &mut Criterion) {
             .map(|x| (x % 256) as u8)
             .collect();
         let small_image_u8_3c =
-            Image::<u8, 3, _>::new(small_image_size, small_image_data_u8_3c, CpuAllocator).unwrap();
-        let up_image_u8_3c = Image::<u8, 3, _>::from_size_val(image_size, 0, CpuAllocator).unwrap();
+            Image::<u8, 3>::new(small_image_size, small_image_data_u8_3c, host_alloc()).unwrap();
+        let up_image_u8_3c = Image::<u8, 3>::from_size_val(image_size, 0, host_alloc()).unwrap();
 
         group.bench_with_input(
             BenchmarkId::new("pyrup_u8_3c", &parameter_string),
@@ -149,11 +149,11 @@ fn bench_pyramid_u8(c: &mut Criterion) {
             .map(|x| (x % 256) as u8)
             .collect();
         let large_image_u8 =
-            Image::<u8, 1, _>::new(large_image_size, large_image_data_u8, CpuAllocator).unwrap();
+            Image::<u8, 1>::new(large_image_size, large_image_data_u8, host_alloc()).unwrap();
 
         let down_image_size = [(*width).div_ceil(2), (*height).div_ceil(2)].into();
         let down_image_u8 =
-            Image::<u8, 1, _>::from_size_val(down_image_size, 0, CpuAllocator).unwrap();
+            Image::<u8, 1>::from_size_val(down_image_size, 0, host_alloc()).unwrap();
 
         group.bench_with_input(
             BenchmarkId::new("pyrdown_u8", &parameter_string),
@@ -171,9 +171,9 @@ fn bench_pyramid_u8(c: &mut Criterion) {
             .map(|x| (x % 256) as u8)
             .collect();
         let large_image_u8_3c =
-            Image::<u8, 3, _>::new(large_image_size, large_image_data_u8_3c, CpuAllocator).unwrap();
+            Image::<u8, 3>::new(large_image_size, large_image_data_u8_3c, host_alloc()).unwrap();
         let down_image_u8_3c =
-            Image::<u8, 3, _>::from_size_val(down_image_size, 0, CpuAllocator).unwrap();
+            Image::<u8, 3>::from_size_val(down_image_size, 0, host_alloc()).unwrap();
 
         group.bench_with_input(
             BenchmarkId::new("pyrdown_u8_3c", &parameter_string),

--- a/crates/kornia-imgproc/benches/bench_pyramid.rs
+++ b/crates/kornia-imgproc/benches/bench_pyramid.rs
@@ -2,7 +2,6 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
 use kornia_image::Image;
 use kornia_imgproc::pyramid::{pyrdown_f32, pyrdown_u8, pyrup_f32, pyrup_u8};
-use kornia_tensor::host_alloc;
 
 fn bench_pyramid(c: &mut Criterion) {
     let mut group = c.benchmark_group("Pyramid Operations");
@@ -16,12 +15,11 @@ fn bench_pyramid(c: &mut Criterion) {
         let small_image_data = (0..((*width / 2) * (*height / 2)))
             .map(|x| x as f32)
             .collect();
-        let small_image =
-            Image::<f32, 1>::new(small_image_size, small_image_data, host_alloc()).unwrap();
+        let small_image = Image::<f32, 1>::new(small_image_size, small_image_data).unwrap();
 
         let image_size = [*width, *height].into();
 
-        let up_image = Image::<f32, 1>::from_size_val(image_size, 0.0, host_alloc()).unwrap();
+        let up_image = Image::<f32, 1>::from_size_val(image_size, 0.0).unwrap();
 
         group.bench_with_input(
             BenchmarkId::new("pyrup_f32", &parameter_string),
@@ -38,9 +36,8 @@ fn bench_pyramid(c: &mut Criterion) {
         let small_image_data_3c = (0..((*width / 2) * (*height / 2) * 3))
             .map(|x| x as f32)
             .collect();
-        let small_image_3c =
-            Image::<f32, 3>::new(small_image_size, small_image_data_3c, host_alloc()).unwrap();
-        let up_image_3c = Image::<f32, 3>::from_size_val(image_size, 0.0, host_alloc()).unwrap();
+        let small_image_3c = Image::<f32, 3>::new(small_image_size, small_image_data_3c).unwrap();
+        let up_image_3c = Image::<f32, 3>::from_size_val(image_size, 0.0).unwrap();
 
         group.bench_with_input(
             BenchmarkId::new("pyrup_f32_3c", &parameter_string),
@@ -56,12 +53,10 @@ fn bench_pyramid(c: &mut Criterion) {
         // Benchmark pyrdown (downsampling)
         let large_image_size = [*width, *height].into();
         let large_image_data = (0..((*width) * (*height))).map(|x| x as f32).collect();
-        let large_image =
-            Image::<f32, 1>::new(large_image_size, large_image_data, host_alloc()).unwrap();
+        let large_image = Image::<f32, 1>::new(large_image_size, large_image_data).unwrap();
 
         let down_image_size = [(*width).div_ceil(2), (*height).div_ceil(2)].into();
-        let down_image =
-            Image::<f32, 1>::from_size_val(down_image_size, 0.0, host_alloc()).unwrap();
+        let down_image = Image::<f32, 1>::from_size_val(down_image_size, 0.0).unwrap();
 
         group.bench_with_input(
             BenchmarkId::new("pyrdown_f32", &parameter_string),
@@ -76,10 +71,8 @@ fn bench_pyramid(c: &mut Criterion) {
 
         // For multi-channel images
         let large_image_data_3c = (0..((*width) * (*height) * 3)).map(|x| x as f32).collect();
-        let large_image_3c =
-            Image::<f32, 3>::new(large_image_size, large_image_data_3c, host_alloc()).unwrap();
-        let down_image_3c =
-            Image::<f32, 3>::from_size_val(down_image_size, 0.0, host_alloc()).unwrap();
+        let large_image_3c = Image::<f32, 3>::new(large_image_size, large_image_data_3c).unwrap();
+        let down_image_3c = Image::<f32, 3>::from_size_val(down_image_size, 0.0).unwrap();
 
         group.bench_with_input(
             BenchmarkId::new("pyrdown_f32_3c", &parameter_string),
@@ -109,10 +102,9 @@ fn bench_pyramid_u8(c: &mut Criterion) {
         let small_image_data_u8 = (0..((*width / 2) * (*height / 2)))
             .map(|x| (x % 256) as u8)
             .collect();
-        let small_image_u8 =
-            Image::<u8, 1>::new(small_image_size, small_image_data_u8, host_alloc()).unwrap();
+        let small_image_u8 = Image::<u8, 1>::new(small_image_size, small_image_data_u8).unwrap();
         let image_size = [*width, *height].into();
-        let up_image_u8 = Image::<u8, 1>::from_size_val(image_size, 0, host_alloc()).unwrap();
+        let up_image_u8 = Image::<u8, 1>::from_size_val(image_size, 0).unwrap();
 
         group.bench_with_input(
             BenchmarkId::new("pyrup_u8", &parameter_string),
@@ -130,8 +122,8 @@ fn bench_pyramid_u8(c: &mut Criterion) {
             .map(|x| (x % 256) as u8)
             .collect();
         let small_image_u8_3c =
-            Image::<u8, 3>::new(small_image_size, small_image_data_u8_3c, host_alloc()).unwrap();
-        let up_image_u8_3c = Image::<u8, 3>::from_size_val(image_size, 0, host_alloc()).unwrap();
+            Image::<u8, 3>::new(small_image_size, small_image_data_u8_3c).unwrap();
+        let up_image_u8_3c = Image::<u8, 3>::from_size_val(image_size, 0).unwrap();
 
         group.bench_with_input(
             BenchmarkId::new("pyrup_u8_3c", &parameter_string),
@@ -148,12 +140,10 @@ fn bench_pyramid_u8(c: &mut Criterion) {
         let large_image_data_u8 = (0..((*width) * (*height)))
             .map(|x| (x % 256) as u8)
             .collect();
-        let large_image_u8 =
-            Image::<u8, 1>::new(large_image_size, large_image_data_u8, host_alloc()).unwrap();
+        let large_image_u8 = Image::<u8, 1>::new(large_image_size, large_image_data_u8).unwrap();
 
         let down_image_size = [(*width).div_ceil(2), (*height).div_ceil(2)].into();
-        let down_image_u8 =
-            Image::<u8, 1>::from_size_val(down_image_size, 0, host_alloc()).unwrap();
+        let down_image_u8 = Image::<u8, 1>::from_size_val(down_image_size, 0).unwrap();
 
         group.bench_with_input(
             BenchmarkId::new("pyrdown_u8", &parameter_string),
@@ -171,9 +161,8 @@ fn bench_pyramid_u8(c: &mut Criterion) {
             .map(|x| (x % 256) as u8)
             .collect();
         let large_image_u8_3c =
-            Image::<u8, 3>::new(large_image_size, large_image_data_u8_3c, host_alloc()).unwrap();
-        let down_image_u8_3c =
-            Image::<u8, 3>::from_size_val(down_image_size, 0, host_alloc()).unwrap();
+            Image::<u8, 3>::new(large_image_size, large_image_data_u8_3c).unwrap();
+        let down_image_u8_3c = Image::<u8, 3>::from_size_val(down_image_size, 0).unwrap();
 
         group.bench_with_input(
             BenchmarkId::new("pyrdown_u8_3c", &parameter_string),

--- a/crates/kornia-imgproc/benches/bench_resize.rs
+++ b/crates/kornia-imgproc/benches/bench_resize.rs
@@ -2,12 +2,9 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
 use kornia_image::{Image, ImageSize};
 use kornia_imgproc::{interpolation::InterpolationMode, resize};
-use kornia_tensor::CpuAllocator;
+use kornia_tensor::host_alloc;
 
-fn resize_image_crate(
-    image: Image<u8, 3, CpuAllocator>,
-    new_size: ImageSize,
-) -> Image<u8, 3, CpuAllocator> {
+fn resize_image_crate(image: Image<u8, 3>, new_size: ImageSize) -> Image<u8, 3> {
     let image_data = image.as_slice();
     let rgb = image::RgbImage::from_raw(
         image.size().width as u32,
@@ -23,10 +20,10 @@ fn resize_image_crate(
         image::imageops::FilterType::Nearest,
     );
     let data = image_resized.into_rgb8().into_raw();
-    Image::new(new_size, data, CpuAllocator).unwrap()
+    Image::new(new_size, data, host_alloc()).unwrap()
 }
 
-fn resize_ndarray_zip(src: &Image<f32, 3, CpuAllocator>, dst: &mut Image<f32, 3, CpuAllocator>) {
+fn resize_ndarray_zip(src: &Image<f32, 3>, dst: &mut Image<f32, 3>) {
     // create a grid of x and y coordinates for the output image
     // and interpolate the values from the input image.
     let x = ndarray::Array::linspace(0., (src.width() - 1) as f32, dst.width())
@@ -91,8 +88,8 @@ fn bench_resize(c: &mut Criterion) {
 
         // input image
         let image_size = [*width, *height].into();
-        let image = Image::<u8, 3, _>::new(image_size, vec![0u8; width * height * 3], CpuAllocator)
-            .unwrap();
+        let image =
+            Image::<u8, 3>::new(image_size, vec![0u8; width * height * 3], host_alloc()).unwrap();
         let image_f32 = image.clone().cast::<f32>().unwrap();
 
         // output image
@@ -101,8 +98,8 @@ fn bench_resize(c: &mut Criterion) {
             height: height / 2,
         };
 
-        let out_f32 = Image::<f32, 3, _>::from_size_val(new_size, 0.0, CpuAllocator).unwrap();
-        let out_u8 = Image::<u8, 3, _>::from_size_val(new_size, 0, CpuAllocator).unwrap();
+        let out_f32 = Image::<f32, 3>::from_size_val(new_size, 0.0, host_alloc()).unwrap();
+        let out_u8 = Image::<u8, 3>::from_size_val(new_size, 0, host_alloc()).unwrap();
 
         group.bench_with_input(
             BenchmarkId::new("image_rs", &parameter_string),

--- a/crates/kornia-imgproc/benches/bench_resize.rs
+++ b/crates/kornia-imgproc/benches/bench_resize.rs
@@ -2,7 +2,6 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
 use kornia_image::{Image, ImageSize};
 use kornia_imgproc::{interpolation::InterpolationMode, resize};
-use kornia_tensor::host_alloc;
 
 fn resize_image_crate(image: Image<u8, 3>, new_size: ImageSize) -> Image<u8, 3> {
     let image_data = image.as_slice();
@@ -20,7 +19,7 @@ fn resize_image_crate(image: Image<u8, 3>, new_size: ImageSize) -> Image<u8, 3> 
         image::imageops::FilterType::Nearest,
     );
     let data = image_resized.into_rgb8().into_raw();
-    Image::new(new_size, data, host_alloc()).unwrap()
+    Image::new(new_size, data).unwrap()
 }
 
 fn resize_ndarray_zip(src: &Image<f32, 3>, dst: &mut Image<f32, 3>) {
@@ -88,8 +87,7 @@ fn bench_resize(c: &mut Criterion) {
 
         // input image
         let image_size = [*width, *height].into();
-        let image =
-            Image::<u8, 3>::new(image_size, vec![0u8; width * height * 3], host_alloc()).unwrap();
+        let image = Image::<u8, 3>::new(image_size, vec![0u8; width * height * 3]).unwrap();
         let image_f32 = image.clone().cast::<f32>().unwrap();
 
         // output image
@@ -98,8 +96,8 @@ fn bench_resize(c: &mut Criterion) {
             height: height / 2,
         };
 
-        let out_f32 = Image::<f32, 3>::from_size_val(new_size, 0.0, host_alloc()).unwrap();
-        let out_u8 = Image::<u8, 3>::from_size_val(new_size, 0, host_alloc()).unwrap();
+        let out_f32 = Image::<f32, 3>::from_size_val(new_size, 0.0).unwrap();
+        let out_u8 = Image::<u8, 3>::from_size_val(new_size, 0).unwrap();
 
         group.bench_with_input(
             BenchmarkId::new("image_rs", &parameter_string),

--- a/crates/kornia-imgproc/benches/bench_warp.rs
+++ b/crates/kornia-imgproc/benches/bench_warp.rs
@@ -5,7 +5,6 @@ use kornia_imgproc::{
     interpolation::InterpolationMode,
     warp::{get_rotation_matrix2d, warp_affine, warp_perspective},
 };
-use kornia_tensor::host_alloc;
 
 fn bench_warp_affine(c: &mut Criterion) {
     let mut group = c.benchmark_group("WarpAffine");
@@ -17,12 +16,11 @@ fn bench_warp_affine(c: &mut Criterion) {
 
         // input image
         let image_size = [*width, *height].into();
-        let image =
-            Image::<u8, 3>::new(image_size, vec![0u8; width * height * 3], host_alloc()).unwrap();
+        let image = Image::<u8, 3>::new(image_size, vec![0u8; width * height * 3]).unwrap();
         let image_f32 = image.clone().cast::<f32>().unwrap();
 
         // output image
-        let output = Image::<f32, 3>::from_size_val(image_size, 0.0, host_alloc()).unwrap();
+        let output = Image::<f32, 3>::from_size_val(image_size, 0.0).unwrap();
         let m = get_rotation_matrix2d((*width as f32 / 2.0, *height as f32 / 2.0), 45.0, 1.0);
 
         group.bench_with_input(
@@ -54,12 +52,11 @@ fn bench_warp_perspective(c: &mut Criterion) {
 
         // input image
         let image_size = [*width, *height].into();
-        let image =
-            Image::<u8, 3>::new(image_size, vec![0u8; width * height * 3], host_alloc()).unwrap();
+        let image = Image::<u8, 3>::new(image_size, vec![0u8; width * height * 3]).unwrap();
         let image_f32 = image.clone().cast::<f32>().unwrap();
 
         // output image
-        let output = Image::<f32, 3>::from_size_val(image_size, 0.0, host_alloc()).unwrap();
+        let output = Image::<f32, 3>::from_size_val(image_size, 0.0).unwrap();
         let m = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
 
         group.bench_with_input(

--- a/crates/kornia-imgproc/benches/bench_warp.rs
+++ b/crates/kornia-imgproc/benches/bench_warp.rs
@@ -5,7 +5,7 @@ use kornia_imgproc::{
     interpolation::InterpolationMode,
     warp::{get_rotation_matrix2d, warp_affine, warp_perspective},
 };
-use kornia_tensor::CpuAllocator;
+use kornia_tensor::host_alloc;
 
 fn bench_warp_affine(c: &mut Criterion) {
     let mut group = c.benchmark_group("WarpAffine");
@@ -17,17 +17,12 @@ fn bench_warp_affine(c: &mut Criterion) {
 
         // input image
         let image_size = [*width, *height].into();
-        let image = Image::<u8, 3, CpuAllocator>::new(
-            image_size,
-            vec![0u8; width * height * 3],
-            CpuAllocator,
-        )
-        .unwrap();
+        let image =
+            Image::<u8, 3>::new(image_size, vec![0u8; width * height * 3], host_alloc()).unwrap();
         let image_f32 = image.clone().cast::<f32>().unwrap();
 
         // output image
-        let output =
-            Image::<f32, 3, CpuAllocator>::from_size_val(image_size, 0.0, CpuAllocator).unwrap();
+        let output = Image::<f32, 3>::from_size_val(image_size, 0.0, host_alloc()).unwrap();
         let m = get_rotation_matrix2d((*width as f32 / 2.0, *height as f32 / 2.0), 45.0, 1.0);
 
         group.bench_with_input(
@@ -59,12 +54,12 @@ fn bench_warp_perspective(c: &mut Criterion) {
 
         // input image
         let image_size = [*width, *height].into();
-        let image = Image::<u8, 3, _>::new(image_size, vec![0u8; width * height * 3], CpuAllocator)
-            .unwrap();
+        let image =
+            Image::<u8, 3>::new(image_size, vec![0u8; width * height * 3], host_alloc()).unwrap();
         let image_f32 = image.clone().cast::<f32>().unwrap();
 
         // output image
-        let output = Image::<f32, 3, _>::from_size_val(image_size, 0.0, CpuAllocator).unwrap();
+        let output = Image::<f32, 3>::from_size_val(image_size, 0.0, host_alloc()).unwrap();
         let m = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
 
         group.bench_with_input(

--- a/crates/kornia-imgproc/examples/bench_contours_min.rs
+++ b/crates/kornia-imgproc/examples/bench_contours_min.rs
@@ -3,8 +3,9 @@
 //!
 //! Usage: cargo run --release --example bench_contours_min -p kornia-imgproc
 
-use kornia_image::{allocator::CpuAllocator, Image, ImageSize};
+use kornia_image::{Image, ImageSize};
 use kornia_imgproc::contours::{ContourApproximationMode, FindContoursExecutor, RetrievalMode};
+use kornia_tensor::host_alloc;
 use std::time::Instant;
 
 const SIZES: &[(usize, usize)] = &[
@@ -73,13 +74,13 @@ fn run_one(
     retrieval: RetrievalMode,
     approx: ContourApproximationMode,
 ) {
-    let img = Image::<u8, 1, _>::new(
+    let img = Image::<u8, 1>::new(
         ImageSize {
             width: w,
             height: h,
         },
         data,
-        CpuAllocator,
+        host_alloc(),
     )
     .expect("kornia image");
     let mut exec = FindContoursExecutor::new();
@@ -133,24 +134,24 @@ fn load_test_image(path: &str) -> Option<(usize, usize, Vec<u8>)> {
     let rgb = kornia_io::png::read_image_png_rgb8(path).ok()?;
     let (w, h) = (rgb.width(), rgb.height());
     // 2. RGB → gray via kornia-imgproc
-    let mut gray = Image::<u8, 1, _>::from_size_val(
+    let mut gray = Image::<u8, 1>::from_size_val(
         ImageSize {
             width: w,
             height: h,
         },
         0,
-        CpuAllocator,
+        host_alloc(),
     )
     .unwrap();
     kornia_imgproc::color::gray_from_rgb_u8(&rgb, &mut gray).ok()?;
     // 3. Binarize at threshold 127 → 0 or 1 (matches bench_contours.rs convention)
-    let mut bw = Image::<u8, 1, _>::from_size_val(
+    let mut bw = Image::<u8, 1>::from_size_val(
         ImageSize {
             width: w,
             height: h,
         },
         0,
-        CpuAllocator,
+        host_alloc(),
     )
     .unwrap();
     kornia_imgproc::threshold::threshold_binary(&gray, &mut bw, 127, 1).ok()?;

--- a/crates/kornia-imgproc/examples/bench_contours_min.rs
+++ b/crates/kornia-imgproc/examples/bench_contours_min.rs
@@ -5,7 +5,6 @@
 
 use kornia_image::{Image, ImageSize};
 use kornia_imgproc::contours::{ContourApproximationMode, FindContoursExecutor, RetrievalMode};
-use kornia_tensor::host_alloc;
 use std::time::Instant;
 
 const SIZES: &[(usize, usize)] = &[
@@ -80,7 +79,6 @@ fn run_one(
             height: h,
         },
         data,
-        host_alloc(),
     )
     .expect("kornia image");
     let mut exec = FindContoursExecutor::new();
@@ -140,7 +138,6 @@ fn load_test_image(path: &str) -> Option<(usize, usize, Vec<u8>)> {
             height: h,
         },
         0,
-        host_alloc(),
     )
     .unwrap();
     kornia_imgproc::color::gray_from_rgb_u8(&rgb, &mut gray).ok()?;
@@ -151,7 +148,6 @@ fn load_test_image(path: &str) -> Option<(usize, usize, Vec<u8>)> {
             height: h,
         },
         0,
-        host_alloc(),
     )
     .unwrap();
     kornia_imgproc::threshold::threshold_binary(&gray, &mut bw, 127, 1).ok()?;

--- a/crates/kornia-imgproc/examples/bench_fused_preprocess.rs
+++ b/crates/kornia-imgproc/examples/bench_fused_preprocess.rs
@@ -4,11 +4,12 @@
 
 use std::time::Instant;
 
-use kornia_image::{allocator::CpuAllocator, Image, ImageSize};
+use kornia_image::{Image, ImageSize};
 use kornia_imgproc::interpolation::InterpolationMode;
 use kornia_imgproc::resize::{
     resize_fast_rgb, resize_normalize_to_tensor_u8_to_f32, NormalizeParams,
 };
+use kornia_tensor::host_alloc;
 
 fn main() {
     let src_w = 1920;
@@ -17,13 +18,13 @@ fn main() {
     let dst_h = src_h / 2;
 
     let src_bytes: Vec<u8> = (0..src_w * src_h * 3).map(|i| (i % 251) as u8).collect();
-    let src_img = Image::<u8, 3, _>::new(
+    let src_img = Image::<u8, 3>::new(
         ImageSize {
             width: src_w,
             height: src_h,
         },
         src_bytes.clone(),
-        CpuAllocator,
+        host_alloc(),
     )
     .unwrap();
 
@@ -31,13 +32,13 @@ fn main() {
     let std = [0.229f32, 0.224, 0.225];
     let params = NormalizeParams::<3>::from_mean_std(mean, std);
 
-    let mut dst_u8 = Image::<u8, 3, _>::from_size_val(
+    let mut dst_u8 = Image::<u8, 3>::from_size_val(
         ImageSize {
             width: dst_w,
             height: dst_h,
         },
         0u8,
-        CpuAllocator,
+        host_alloc(),
     )
     .unwrap();
     let mut dst_chw_f32 = vec![0f32; 3 * dst_h * dst_w];

--- a/crates/kornia-imgproc/examples/bench_fused_preprocess.rs
+++ b/crates/kornia-imgproc/examples/bench_fused_preprocess.rs
@@ -9,7 +9,6 @@ use kornia_imgproc::interpolation::InterpolationMode;
 use kornia_imgproc::resize::{
     resize_fast_rgb, resize_normalize_to_tensor_u8_to_f32, NormalizeParams,
 };
-use kornia_tensor::host_alloc;
 
 fn main() {
     let src_w = 1920;
@@ -24,7 +23,6 @@ fn main() {
             height: src_h,
         },
         src_bytes.clone(),
-        host_alloc(),
     )
     .unwrap();
 
@@ -38,7 +36,6 @@ fn main() {
             height: dst_h,
         },
         0u8,
-        host_alloc(),
     )
     .unwrap();
     let mut dst_chw_f32 = vec![0f32; 3 * dst_h * dst_w];

--- a/crates/kornia-imgproc/examples/color_conversion_typed.rs
+++ b/crates/kornia-imgproc/examples/color_conversion_typed.rs
@@ -1,9 +1,9 @@
-use kornia_image::allocator::CpuAllocator;
 use kornia_image::ImageSize;
 use kornia_imgproc::color::{
     Bgr8, Bgra8, ConvertColor, ConvertColorWithBackground, Gray8, Grayf32, Hsvf32, Rgb8, Rgba8,
     Rgbf32,
 };
+use kornia_tensor::host_alloc;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("=== Type-Safe Color Conversion API Demo ===\n");
@@ -21,10 +21,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             0, 0, 255, // Blue
             128, 128, 128, // Gray
         ],
-        CpuAllocator,
+        host_alloc(),
     )?;
 
-    let mut gray = Gray8::from_size_val(rgb.size(), 0, CpuAllocator)?;
+    let mut gray = Gray8::from_size_val(rgb.size(), 0, host_alloc())?;
 
     rgb.convert(&mut gray)?;
 
@@ -39,10 +39,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             height: 1,
         },
         vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
-        CpuAllocator,
+        host_alloc(),
     )?;
 
-    let mut gray_f32 = Grayf32::from_size_val(rgb_f32.size(), 0.0, CpuAllocator)?;
+    let mut gray_f32 = Grayf32::from_size_val(rgb_f32.size(), 0.0, host_alloc())?;
 
     rgb_f32.convert(&mut gray_f32)?;
 
@@ -50,7 +50,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // === Example 3: Grayscale to RGB ===
     println!("3. Grayscale -> RGB");
-    let mut rgb_from_gray = Rgb8::from_size_val(gray.size(), 0, CpuAllocator)?;
+    let mut rgb_from_gray = Rgb8::from_size_val(gray.size(), 0, host_alloc())?;
     gray.convert(&mut rgb_from_gray)?;
 
     println!(
@@ -66,10 +66,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             height: 1,
         },
         vec![255, 128, 64], // R=255, G=128, B=64
-        CpuAllocator,
+        host_alloc(),
     )?;
 
-    let mut bgr = Bgr8::from_size_val(rgb_test.size(), 0, CpuAllocator)?;
+    let mut bgr = Bgr8::from_size_val(rgb_test.size(), 0, host_alloc())?;
 
     rgb_test.convert(&mut bgr)?;
 
@@ -81,7 +81,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // === Example 5: BGR to RGB ===
     println!("5. BGR -> RGB");
-    let mut rgb_back = Rgb8::from_size_val(bgr.size(), 0, CpuAllocator)?;
+    let mut rgb_back = Rgb8::from_size_val(bgr.size(), 0, host_alloc())?;
     bgr.convert(&mut rgb_back)?;
 
     let rgb_data = rgb_back.as_slice();
@@ -98,10 +98,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             height: 1,
         },
         vec![255.0, 0.0, 0.0], // Pure red
-        CpuAllocator,
+        host_alloc(),
     )?;
 
-    let mut hsv = Hsvf32::from_size_val(rgb_for_hsv.size(), 0.0, CpuAllocator)?;
+    let mut hsv = Hsvf32::from_size_val(rgb_for_hsv.size(), 0.0, host_alloc())?;
 
     rgb_for_hsv.convert(&mut hsv)?;
 
@@ -115,10 +115,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             height: 1,
         },
         vec![255, 128, 64, 200], // RGB + alpha
-        CpuAllocator,
+        host_alloc(),
     )?;
 
-    let mut rgb_no_alpha = Rgb8::from_size_val(rgba.size(), 0, CpuAllocator)?;
+    let mut rgb_no_alpha = Rgb8::from_size_val(rgba.size(), 0, host_alloc())?;
 
     rgba.convert(&mut rgb_no_alpha)?;
 
@@ -136,10 +136,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             height: 1,
         },
         vec![255, 0, 0, 128], // Red with 50% alpha
-        CpuAllocator,
+        host_alloc(),
     )?;
 
-    let mut rgb_blended = Rgb8::from_size_val(rgba_blend.size(), 0, CpuAllocator)?;
+    let mut rgb_blended = Rgb8::from_size_val(rgba_blend.size(), 0, host_alloc())?;
 
     // Blend with gray background [100, 100, 100]
     rgba_blend.convert_with_bg(&mut rgb_blended, Some([100, 100, 100]))?;
@@ -159,10 +159,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             height: 1,
         },
         vec![64, 128, 255, 255], // BGRA
-        CpuAllocator,
+        host_alloc(),
     )?;
 
-    let mut rgb_from_bgra = Rgb8::from_size_val(bgra.size(), 0, CpuAllocator)?;
+    let mut rgb_from_bgra = Rgb8::from_size_val(bgra.size(), 0, host_alloc())?;
 
     bgra.convert(&mut rgb_from_bgra)?;
 
@@ -180,7 +180,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             height: 10,
         },
         vec![0; 10 * 10 * 3],
-        CpuAllocator,
+        host_alloc(),
     )?;
 
     // Deref allows direct access to Image methods

--- a/crates/kornia-imgproc/examples/color_conversion_typed.rs
+++ b/crates/kornia-imgproc/examples/color_conversion_typed.rs
@@ -3,7 +3,6 @@ use kornia_imgproc::color::{
     Bgr8, Bgra8, ConvertColor, ConvertColorWithBackground, Gray8, Grayf32, Hsvf32, Rgb8, Rgba8,
     Rgbf32,
 };
-use kornia_tensor::host_alloc;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("=== Type-Safe Color Conversion API Demo ===\n");
@@ -21,10 +20,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             0, 0, 255, // Blue
             128, 128, 128, // Gray
         ],
-        host_alloc(),
     )?;
 
-    let mut gray = Gray8::from_size_val(rgb.size(), 0, host_alloc())?;
+    let mut gray = Gray8::from_size_val(rgb.size(), 0)?;
 
     rgb.convert(&mut gray)?;
 
@@ -39,10 +37,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             height: 1,
         },
         vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
-        host_alloc(),
     )?;
 
-    let mut gray_f32 = Grayf32::from_size_val(rgb_f32.size(), 0.0, host_alloc())?;
+    let mut gray_f32 = Grayf32::from_size_val(rgb_f32.size(), 0.0)?;
 
     rgb_f32.convert(&mut gray_f32)?;
 
@@ -50,7 +47,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // === Example 3: Grayscale to RGB ===
     println!("3. Grayscale -> RGB");
-    let mut rgb_from_gray = Rgb8::from_size_val(gray.size(), 0, host_alloc())?;
+    let mut rgb_from_gray = Rgb8::from_size_val(gray.size(), 0)?;
     gray.convert(&mut rgb_from_gray)?;
 
     println!(
@@ -66,10 +63,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             height: 1,
         },
         vec![255, 128, 64], // R=255, G=128, B=64
-        host_alloc(),
     )?;
 
-    let mut bgr = Bgr8::from_size_val(rgb_test.size(), 0, host_alloc())?;
+    let mut bgr = Bgr8::from_size_val(rgb_test.size(), 0)?;
 
     rgb_test.convert(&mut bgr)?;
 
@@ -81,7 +77,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // === Example 5: BGR to RGB ===
     println!("5. BGR -> RGB");
-    let mut rgb_back = Rgb8::from_size_val(bgr.size(), 0, host_alloc())?;
+    let mut rgb_back = Rgb8::from_size_val(bgr.size(), 0)?;
     bgr.convert(&mut rgb_back)?;
 
     let rgb_data = rgb_back.as_slice();
@@ -98,10 +94,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             height: 1,
         },
         vec![255.0, 0.0, 0.0], // Pure red
-        host_alloc(),
     )?;
 
-    let mut hsv = Hsvf32::from_size_val(rgb_for_hsv.size(), 0.0, host_alloc())?;
+    let mut hsv = Hsvf32::from_size_val(rgb_for_hsv.size(), 0.0)?;
 
     rgb_for_hsv.convert(&mut hsv)?;
 
@@ -115,10 +110,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             height: 1,
         },
         vec![255, 128, 64, 200], // RGB + alpha
-        host_alloc(),
     )?;
 
-    let mut rgb_no_alpha = Rgb8::from_size_val(rgba.size(), 0, host_alloc())?;
+    let mut rgb_no_alpha = Rgb8::from_size_val(rgba.size(), 0)?;
 
     rgba.convert(&mut rgb_no_alpha)?;
 
@@ -136,10 +130,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             height: 1,
         },
         vec![255, 0, 0, 128], // Red with 50% alpha
-        host_alloc(),
     )?;
 
-    let mut rgb_blended = Rgb8::from_size_val(rgba_blend.size(), 0, host_alloc())?;
+    let mut rgb_blended = Rgb8::from_size_val(rgba_blend.size(), 0)?;
 
     // Blend with gray background [100, 100, 100]
     rgba_blend.convert_with_bg(&mut rgb_blended, Some([100, 100, 100]))?;
@@ -159,10 +152,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             height: 1,
         },
         vec![64, 128, 255, 255], // BGRA
-        host_alloc(),
     )?;
 
-    let mut rgb_from_bgra = Rgb8::from_size_val(bgra.size(), 0, host_alloc())?;
+    let mut rgb_from_bgra = Rgb8::from_size_val(bgra.size(), 0)?;
 
     bgra.convert(&mut rgb_from_bgra)?;
 
@@ -180,7 +172,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             height: 10,
         },
         vec![0; 10 * 10 * 3],
-        host_alloc(),
     )?;
 
     // Deref allows direct access to Image methods

--- a/crates/kornia-imgproc/examples/count_ext.rs
+++ b/crates/kornia-imgproc/examples/count_ext.rs
@@ -1,27 +1,28 @@
-use kornia_image::{allocator::CpuAllocator, Image, ImageSize};
+use kornia_image::{Image, ImageSize};
 use kornia_imgproc::contours::{find_contours, ContourApproximationMode, RetrievalMode};
+use kornia_tensor::host_alloc;
 
 fn main() {
     let path = std::env::args().nth(1).unwrap();
     let rgb = kornia_io::png::read_image_png_rgb8(&path).unwrap();
     let (w, h) = (rgb.width(), rgb.height());
-    let mut gray = Image::<u8, 1, _>::from_size_val(
+    let mut gray = Image::<u8, 1>::from_size_val(
         ImageSize {
             width: w,
             height: h,
         },
         0,
-        CpuAllocator,
+        host_alloc(),
     )
     .unwrap();
     kornia_imgproc::color::gray_from_rgb_u8(&rgb, &mut gray).unwrap();
-    let mut bw = Image::<u8, 1, _>::from_size_val(
+    let mut bw = Image::<u8, 1>::from_size_val(
         ImageSize {
             width: w,
             height: h,
         },
         0,
-        CpuAllocator,
+        host_alloc(),
     )
     .unwrap();
     kornia_imgproc::threshold::threshold_binary(&gray, &mut bw, 127, 1).unwrap();

--- a/crates/kornia-imgproc/examples/count_ext.rs
+++ b/crates/kornia-imgproc/examples/count_ext.rs
@@ -1,6 +1,5 @@
 use kornia_image::{Image, ImageSize};
 use kornia_imgproc::contours::{find_contours, ContourApproximationMode, RetrievalMode};
-use kornia_tensor::host_alloc;
 
 fn main() {
     let path = std::env::args().nth(1).unwrap();
@@ -12,7 +11,6 @@ fn main() {
             height: h,
         },
         0,
-        host_alloc(),
     )
     .unwrap();
     kornia_imgproc::color::gray_from_rgb_u8(&rgb, &mut gray).unwrap();
@@ -22,7 +20,6 @@ fn main() {
             height: h,
         },
         0,
-        host_alloc(),
     )
     .unwrap();
     kornia_imgproc::threshold::threshold_binary(&gray, &mut bw, 127, 1).unwrap();

--- a/crates/kornia-imgproc/examples/dump_contours.rs
+++ b/crates/kornia-imgproc/examples/dump_contours.rs
@@ -4,7 +4,6 @@
 
 use kornia_image::{Image, ImageSize};
 use kornia_imgproc::contours::{find_contours, ContourApproximationMode, RetrievalMode};
-use kornia_tensor::host_alloc;
 use std::env;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -40,7 +39,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             height: h,
         },
         0,
-        host_alloc(),
     )?;
     kornia_imgproc::color::gray_from_rgb_u8(&rgb, &mut gray)?;
     let mut bw = Image::<u8, 1>::from_size_val(
@@ -49,7 +47,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             height: h,
         },
         0,
-        host_alloc(),
     )?;
     kornia_imgproc::threshold::threshold_binary(&gray, &mut bw, 127, 1)?;
 

--- a/crates/kornia-imgproc/examples/dump_contours.rs
+++ b/crates/kornia-imgproc/examples/dump_contours.rs
@@ -2,8 +2,9 @@
 //! Usage: dump_contours <png_path> <external|list> <simple|none>
 //! Used by check_correctness.py to compare bit-exact against cv2.findContours.
 
-use kornia_image::{allocator::CpuAllocator, Image, ImageSize};
+use kornia_image::{Image, ImageSize};
 use kornia_imgproc::contours::{find_contours, ContourApproximationMode, RetrievalMode};
+use kornia_tensor::host_alloc;
 use std::env;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -33,22 +34,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Load via kornia, threshold via kornia, then find_contours.
     let rgb = kornia_io::png::read_image_png_rgb8(path)?;
     let (w, h) = (rgb.width(), rgb.height());
-    let mut gray = Image::<u8, 1, _>::from_size_val(
+    let mut gray = Image::<u8, 1>::from_size_val(
         ImageSize {
             width: w,
             height: h,
         },
         0,
-        CpuAllocator,
+        host_alloc(),
     )?;
     kornia_imgproc::color::gray_from_rgb_u8(&rgb, &mut gray)?;
-    let mut bw = Image::<u8, 1, _>::from_size_val(
+    let mut bw = Image::<u8, 1>::from_size_val(
         ImageSize {
             width: w,
             height: h,
         },
         0,
-        CpuAllocator,
+        host_alloc(),
     )?;
     kornia_imgproc::threshold::threshold_binary(&gray, &mut bw, 127, 1)?;
 

--- a/crates/kornia-imgproc/examples/synth_ext_count.rs
+++ b/crates/kornia-imgproc/examples/synth_ext_count.rs
@@ -1,7 +1,6 @@
 //! Try various synthetic patterns and report kornia EXT count vs expected.
 use kornia_image::{Image, ImageSize};
 use kornia_imgproc::contours::{find_contours, ContourApproximationMode, RetrievalMode};
-use kornia_tensor::host_alloc;
 
 fn count_ext(data: &[u8], w: usize, h: usize) -> usize {
     let img = Image::<u8, 1>::new(
@@ -10,7 +9,6 @@ fn count_ext(data: &[u8], w: usize, h: usize) -> usize {
             height: h,
         },
         data.to_vec(),
-        host_alloc(),
     )
     .unwrap();
     let r = find_contours(

--- a/crates/kornia-imgproc/examples/synth_ext_count.rs
+++ b/crates/kornia-imgproc/examples/synth_ext_count.rs
@@ -1,15 +1,16 @@
 //! Try various synthetic patterns and report kornia EXT count vs expected.
-use kornia_image::{allocator::CpuAllocator, Image, ImageSize};
+use kornia_image::{Image, ImageSize};
 use kornia_imgproc::contours::{find_contours, ContourApproximationMode, RetrievalMode};
+use kornia_tensor::host_alloc;
 
 fn count_ext(data: &[u8], w: usize, h: usize) -> usize {
-    let img = Image::<u8, 1, _>::new(
+    let img = Image::<u8, 1>::new(
         ImageSize {
             width: w,
             height: h,
         },
         data.to_vec(),
-        CpuAllocator,
+        host_alloc(),
     )
     .unwrap();
     let r = find_contours(

--- a/crates/kornia-imgproc/src/calibration/distortion.rs
+++ b/crates/kornia-imgproc/src/calibration/distortion.rs
@@ -432,8 +432,8 @@ pub struct UndistortResults {
 ///   implemented in [`apply_r_and_p`].
 ///
 /// # Arguments
-/// * `src` - Input Tensor<f64, 2, A> with shape [N, 2] containing distorted pixel coords (u,v)
-/// * `dst` - Output Tensor<f64, 2, A> with shape [N, 2] (will be overwritten)
+/// * `src` - Input Tensor<f64, 2> with shape [N, 2] containing distorted pixel coords (u,v)
+/// * `dst` - Output Tensor<f64, 2> with shape [N, 2] (will be overwritten)
 /// * `intrinsic` - camera intrinsic parameters in a struct [`CameraIntrinsic`]
 /// * `distortion` - polynomial distortion model parameters in a struct [`PolynomialDistortion`]
 /// * `r_opt` - optional [`Mat3F64`] rectification matrix R (3x3) (or None)

--- a/crates/kornia-imgproc/src/calibration/distortion.rs
+++ b/crates/kornia-imgproc/src/calibration/distortion.rs
@@ -468,11 +468,11 @@ pub struct UndistortResults {
 ///
 /// # Example:
 /// ```rust
-/// use kornia_tensor::{host_alloc, Tensor};
 /// use kornia_imgproc::calibration::{CameraIntrinsic, distortion::{PolynomialDistortion, undistort_points, TermCriteria}};
+/// use kornia_tensor::Tensor;
 /// // distorted points
-/// let src = Tensor::<f64, 2>::from_shape_vec([2, 2], vec![320.0, 240.0, 100.0,  50.0], host_alloc()).unwrap();
-/// let mut dst = Tensor::<f64, 2>::from_shape_vec([2, 2], vec![0.0; 4], host_alloc()).unwrap();
+/// let src = Tensor::<f64, 2>::from_shape_vec([2, 2], vec![320.0, 240.0, 100.0,  50.0]).unwrap();
+/// let mut dst = Tensor::<f64, 2>::from_shape_vec([2, 2], vec![0.0; 4]).unwrap();
 ///
 /// // intrinsics
 /// let intr = CameraIntrinsic {
@@ -597,7 +597,6 @@ pub fn undistort_points(
 mod tests {
     use super::*;
     use kornia_image::ImageSize;
-    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_distort_point_polynomial() {
@@ -758,8 +757,8 @@ mod tests {
         for &(x, y) in &pts {
             let (u, v) = distort_point_polynomial(x, y, &intr, &dist);
 
-            let src = Tensor::<f64, 2>::from_shape_vec([1, 2], vec![u, v], host_alloc()).unwrap();
-            let mut dst = Tensor::<f64, 2>::from_shape_val([1, 2], 0.0, host_alloc());
+            let src = Tensor::<f64, 2>::from_shape_vec([1, 2], vec![u, v]).unwrap();
+            let mut dst = Tensor::<f64, 2>::from_shape_val([1, 2], 0.0);
 
             undistort_points(&src, &mut dst, &intr, &dist, None, None, None, c).unwrap();
 
@@ -789,8 +788,8 @@ mod tests {
         for &(x, y) in &pts {
             let (u, v) = distort_point_polynomial(x, y, &intr, &dist);
 
-            let src = Tensor::<f64, 2>::from_shape_vec([1, 2], vec![u, v], host_alloc()).unwrap();
-            let mut dst = Tensor::<f64, 2>::from_shape_val([1, 2], 0.0, host_alloc());
+            let src = Tensor::<f64, 2>::from_shape_vec([1, 2], vec![u, v]).unwrap();
+            let mut dst = Tensor::<f64, 2>::from_shape_val([1, 2], 0.0);
 
             undistort_points(&src, &mut dst, &intr, &dist, None, None, None, c).unwrap();
 
@@ -814,9 +813,8 @@ mod tests {
 
         let (u, v) = distort_point_polynomial(x, y, &intr, &dist);
 
-        let src = Tensor::<f64, 2>::from_shape_vec([1, 2], vec![u, v], host_alloc()).unwrap();
-        let mut dst =
-            Tensor::<f64, 2>::from_shape_vec([1, 2], vec![0.0, 0.0], host_alloc()).unwrap();
+        let src = Tensor::<f64, 2>::from_shape_vec([1, 2], vec![u, v]).unwrap();
+        let mut dst = Tensor::<f64, 2>::from_shape_vec([1, 2], vec![0.0, 0.0]).unwrap();
 
         let p34_arr = [
             intr.fx, 0.0, 0.0, 0.0, 0.0, intr.fy, 0.0, 0.0, intr.cx, intr.cy, 1.0, 0.0,
@@ -859,10 +857,9 @@ mod tests {
 
         let (u, v) = distort_point_polynomial(x, y, &intr, &dist);
 
-        let src = Tensor::<f64, 2>::from_shape_vec([1, 2], vec![u, v], host_alloc()).unwrap();
+        let src = Tensor::<f64, 2>::from_shape_vec([1, 2], vec![u, v]).unwrap();
 
-        let mut dst =
-            Tensor::<f64, 2>::from_shape_vec([1, 2], vec![0.0, 0.0], host_alloc()).unwrap();
+        let mut dst = Tensor::<f64, 2>::from_shape_vec([1, 2], vec![0.0, 0.0]).unwrap();
 
         let theta = 5.0_f64.to_radians();
         let r = Mat3F64::from_cols_array(&[
@@ -916,8 +913,8 @@ mod tests {
 
     #[test]
     fn test_shape_error() {
-        let src = Tensor::<f64, 2>::from_shape_vec([1, 3], vec![1., 2., 3.], host_alloc()).unwrap();
-        let mut dst = Tensor::<f64, 2>::from_shape_vec([1, 2], vec![0., 0.], host_alloc()).unwrap();
+        let src = Tensor::<f64, 2>::from_shape_vec([1, 3], vec![1., 2., 3.]).unwrap();
+        let mut dst = Tensor::<f64, 2>::from_shape_vec([1, 2], vec![0., 0.]).unwrap();
 
         let r = undistort_points(
             &src,

--- a/crates/kornia-imgproc/src/calibration/distortion.rs
+++ b/crates/kornia-imgproc/src/calibration/distortion.rs
@@ -2,7 +2,7 @@ use super::{CameraExtrinsic, CameraIntrinsic};
 use crate::interpolation::grid::meshgrid_from_fn;
 use kornia_algebra::{Mat3F64, Mat4F64, Vec3F64, Vec4F64};
 use kornia_image::ImageSize;
-use kornia_tensor::{CpuTensor2, Tensor, TensorAllocator, TensorError};
+use kornia_tensor::{CpuTensor2, Tensor, TensorError};
 use rayon::prelude::*;
 
 /// Represents the polynomial distortion parameters of a camera using the Brown-Conrady model.
@@ -468,11 +468,11 @@ pub struct UndistortResults {
 ///
 /// # Example:
 /// ```rust
-/// use kornia_tensor::{CpuAllocator, Tensor};
+/// use kornia_tensor::{host_alloc, Tensor};
 /// use kornia_imgproc::calibration::{CameraIntrinsic, distortion::{PolynomialDistortion, undistort_points, TermCriteria}};
 /// // distorted points
-/// let src = Tensor::<f64, 2, _>::from_shape_vec([2, 2], vec![320.0, 240.0, 100.0,  50.0], CpuAllocator).unwrap();
-/// let mut dst = Tensor::<f64, 2, _>::from_shape_vec([2, 2], vec![0.0; 4], CpuAllocator).unwrap();
+/// let src = Tensor::<f64, 2>::from_shape_vec([2, 2], vec![320.0, 240.0, 100.0,  50.0], host_alloc()).unwrap();
+/// let mut dst = Tensor::<f64, 2>::from_shape_vec([2, 2], vec![0.0; 4], host_alloc()).unwrap();
 ///
 /// // intrinsics
 /// let intr = CameraIntrinsic {
@@ -501,9 +501,9 @@ pub struct UndistortResults {
 /// // dst[[i,0]], dst[[i,1]] now contain the undistorted normalized coordinates.
 /// ```
 #[allow(clippy::too_many_arguments)]
-pub fn undistort_points<A: TensorAllocator>(
-    src: &Tensor<f64, 2, A>,
-    dst: &mut Tensor<f64, 2, A>,
+pub fn undistort_points(
+    src: &Tensor<f64, 2>,
+    dst: &mut Tensor<f64, 2>,
     intrinsic: &CameraIntrinsic,
     distortion: &PolynomialDistortion,
     r_opt: Option<&Mat3F64>,
@@ -597,7 +597,7 @@ pub fn undistort_points<A: TensorAllocator>(
 mod tests {
     use super::*;
     use kornia_image::ImageSize;
-    use kornia_tensor::CpuAllocator;
+    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_distort_point_polynomial() {
@@ -758,9 +758,8 @@ mod tests {
         for &(x, y) in &pts {
             let (u, v) = distort_point_polynomial(x, y, &intr, &dist);
 
-            let src =
-                Tensor::<f64, 2, _>::from_shape_vec([1, 2], vec![u, v], CpuAllocator).unwrap();
-            let mut dst = Tensor::<f64, 2, _>::from_shape_val([1, 2], 0.0, CpuAllocator);
+            let src = Tensor::<f64, 2>::from_shape_vec([1, 2], vec![u, v], host_alloc()).unwrap();
+            let mut dst = Tensor::<f64, 2>::from_shape_val([1, 2], 0.0, host_alloc());
 
             undistort_points(&src, &mut dst, &intr, &dist, None, None, None, c).unwrap();
 
@@ -790,9 +789,8 @@ mod tests {
         for &(x, y) in &pts {
             let (u, v) = distort_point_polynomial(x, y, &intr, &dist);
 
-            let src =
-                Tensor::<f64, 2, _>::from_shape_vec([1, 2], vec![u, v], CpuAllocator).unwrap();
-            let mut dst = Tensor::<f64, 2, _>::from_shape_val([1, 2], 0.0, CpuAllocator);
+            let src = Tensor::<f64, 2>::from_shape_vec([1, 2], vec![u, v], host_alloc()).unwrap();
+            let mut dst = Tensor::<f64, 2>::from_shape_val([1, 2], 0.0, host_alloc());
 
             undistort_points(&src, &mut dst, &intr, &dist, None, None, None, c).unwrap();
 
@@ -816,9 +814,9 @@ mod tests {
 
         let (u, v) = distort_point_polynomial(x, y, &intr, &dist);
 
-        let src = Tensor::<f64, 2, _>::from_shape_vec([1, 2], vec![u, v], CpuAllocator).unwrap();
+        let src = Tensor::<f64, 2>::from_shape_vec([1, 2], vec![u, v], host_alloc()).unwrap();
         let mut dst =
-            Tensor::<f64, 2, _>::from_shape_vec([1, 2], vec![0.0, 0.0], CpuAllocator).unwrap();
+            Tensor::<f64, 2>::from_shape_vec([1, 2], vec![0.0, 0.0], host_alloc()).unwrap();
 
         let p34_arr = [
             intr.fx, 0.0, 0.0, 0.0, 0.0, intr.fy, 0.0, 0.0, intr.cx, intr.cy, 1.0, 0.0,
@@ -861,10 +859,10 @@ mod tests {
 
         let (u, v) = distort_point_polynomial(x, y, &intr, &dist);
 
-        let src = Tensor::<f64, 2, _>::from_shape_vec([1, 2], vec![u, v], CpuAllocator).unwrap();
+        let src = Tensor::<f64, 2>::from_shape_vec([1, 2], vec![u, v], host_alloc()).unwrap();
 
         let mut dst =
-            Tensor::<f64, 2, _>::from_shape_vec([1, 2], vec![0.0, 0.0], CpuAllocator).unwrap();
+            Tensor::<f64, 2>::from_shape_vec([1, 2], vec![0.0, 0.0], host_alloc()).unwrap();
 
         let theta = 5.0_f64.to_radians();
         let r = Mat3F64::from_cols_array(&[
@@ -918,10 +916,8 @@ mod tests {
 
     #[test]
     fn test_shape_error() {
-        let src =
-            Tensor::<f64, 2, _>::from_shape_vec([1, 3], vec![1., 2., 3.], CpuAllocator).unwrap();
-        let mut dst =
-            Tensor::<f64, 2, _>::from_shape_vec([1, 2], vec![0., 0.], CpuAllocator).unwrap();
+        let src = Tensor::<f64, 2>::from_shape_vec([1, 3], vec![1., 2., 3.], host_alloc()).unwrap();
+        let mut dst = Tensor::<f64, 2>::from_shape_vec([1, 2], vec![0., 0.], host_alloc()).unwrap();
 
         let r = undistort_points(
             &src,

--- a/crates/kornia-imgproc/src/color/bayer/kernels.rs
+++ b/crates/kornia-imgproc/src/color/bayer/kernels.rs
@@ -316,18 +316,20 @@ unsafe fn avg4_u8(
     c: std::arch::aarch64::uint8x16_t,
     d: std::arch::aarch64::uint8x16_t,
 ) -> std::arch::aarch64::uint8x16_t {
-    use std::arch::aarch64::*;
-    // low/high 8-lane halves widened to u16, summed, then vrshrn (rounding
-    // narrowing shift right) by 2 == (sum + 2) >> 2.
-    let lo = vaddq_u16(
-        vaddl_u8(vget_low_u8(a), vget_low_u8(b)),
-        vaddl_u8(vget_low_u8(c), vget_low_u8(d)),
-    );
-    let hi = vaddq_u16(
-        vaddl_u8(vget_high_u8(a), vget_high_u8(b)),
-        vaddl_u8(vget_high_u8(c), vget_high_u8(d)),
-    );
-    vcombine_u8(vrshrn_n_u16::<2>(lo), vrshrn_n_u16::<2>(hi))
+    unsafe {
+        use std::arch::aarch64::*;
+        // low/high 8-lane halves widened to u16, summed, then vrshrn (rounding
+        // narrowing shift right) by 2 == (sum + 2) >> 2.
+        let lo = vaddq_u16(
+            vaddl_u8(vget_low_u8(a), vget_low_u8(b)),
+            vaddl_u8(vget_low_u8(c), vget_low_u8(d)),
+        );
+        let hi = vaddq_u16(
+            vaddl_u8(vget_high_u8(a), vget_high_u8(b)),
+            vaddl_u8(vget_high_u8(c), vget_high_u8(d)),
+        );
+        vcombine_u8(vrshrn_n_u16::<2>(lo), vrshrn_n_u16::<2>(hi))
+    }
 }
 
 /// Assemble (R,G,B) for a register of same-phase pixels (uniform cell).

--- a/crates/kornia-imgproc/src/color/bayer/mod.rs
+++ b/crates/kornia-imgproc/src/color/bayer/mod.rs
@@ -28,11 +28,10 @@ mod kernels;
 /// use kornia_image::{Image, ImageSize};
 /// use kornia_image::color_spaces::BayerPattern;
 /// use kornia_imgproc::color::rgb_from_bayer;
-/// use kornia_tensor::host_alloc;
 ///
 /// let mosaic = Image::<u8, 1>::from_size_val(
-///     ImageSize { width: 4, height: 4 }, 128, host_alloc()).unwrap();
-/// let mut rgb = Image::<u8, 3>::from_size_val(mosaic.size(), 0, host_alloc()).unwrap();
+///     ImageSize { width: 4, height: 4 }, 128).unwrap();
+/// let mut rgb = Image::<u8, 3>::from_size_val(mosaic.size(), 0).unwrap();
 /// rgb_from_bayer(&mosaic, BayerPattern::Rggb, &mut rgb).unwrap();
 /// ```
 pub fn rgb_from_bayer(
@@ -72,7 +71,6 @@ pub fn rgb_from_bayer8(src: &Bayer8, dst: &mut Image<u8, 3>) -> Result<(), Image
 mod tests {
     use super::*;
     use kornia_image::ImageSize;
-    use kornia_tensor::host_alloc;
 
     const PATTERNS: [BayerPattern; 4] = [
         BayerPattern::Rggb,
@@ -88,10 +86,9 @@ mod tests {
                 height: h,
             },
             data.to_vec(),
-            host_alloc(),
         )
         .unwrap();
-        let mut dst = Image::<u8, 3>::from_size_val(src.size(), 0, host_alloc()).unwrap();
+        let mut dst = Image::<u8, 3>::from_size_val(src.size(), 0).unwrap();
         rgb_from_bayer(&src, p, &mut dst).unwrap();
         dst.as_slice().to_vec()
     }
@@ -181,7 +178,6 @@ mod tests {
                 height: 4,
             },
             0,
-            host_alloc(),
         )
         .unwrap();
         let mut dst = Image::<u8, 3>::from_size_val(
@@ -190,7 +186,6 @@ mod tests {
                 height: 4,
             },
             0,
-            host_alloc(),
         )
         .unwrap();
         assert!(rgb_from_bayer(&src, BayerPattern::Rggb, &mut dst).is_err());

--- a/crates/kornia-imgproc/src/color/bayer/mod.rs
+++ b/crates/kornia-imgproc/src/color/bayer/mod.rs
@@ -5,7 +5,6 @@
 //! result. See [`kernels`] for the per-cell interpolation rules.
 
 use kornia_image::{
-    allocator::ImageAllocator,
     color_spaces::{Bayer8, BayerPattern},
     Image, ImageError,
 };
@@ -26,19 +25,20 @@ mod kernels;
 ///
 /// # Example
 /// ```
-/// use kornia_image::{Image, ImageSize, allocator::CpuAllocator};
+/// use kornia_image::{Image, ImageSize};
 /// use kornia_image::color_spaces::BayerPattern;
 /// use kornia_imgproc::color::rgb_from_bayer;
+/// use kornia_tensor::host_alloc;
 ///
-/// let mosaic = Image::<u8, 1, _>::from_size_val(
-///     ImageSize { width: 4, height: 4 }, 128, CpuAllocator).unwrap();
-/// let mut rgb = Image::<u8, 3, _>::from_size_val(mosaic.size(), 0, CpuAllocator).unwrap();
+/// let mosaic = Image::<u8, 1>::from_size_val(
+///     ImageSize { width: 4, height: 4 }, 128, host_alloc()).unwrap();
+/// let mut rgb = Image::<u8, 3>::from_size_val(mosaic.size(), 0, host_alloc()).unwrap();
 /// rgb_from_bayer(&mosaic, BayerPattern::Rggb, &mut rgb).unwrap();
 /// ```
-pub fn rgb_from_bayer<A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<u8, 1, A1>,
+pub fn rgb_from_bayer(
+    src: &Image<u8, 1>,
     pattern: BayerPattern,
-    dst: &mut Image<u8, 3, A2>,
+    dst: &mut Image<u8, 3>,
 ) -> Result<(), ImageError> {
     if src.size() != dst.size() {
         return Err(ImageError::InvalidImageSize(
@@ -64,10 +64,7 @@ pub fn rgb_from_bayer<A1: ImageAllocator, A2: ImageAllocator>(
 ///
 /// # Errors
 /// Returns [`ImageError::InvalidImageSize`] if `src` and `dst` differ in size.
-pub fn rgb_from_bayer8<A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Bayer8<A1>,
-    dst: &mut Image<u8, 3, A2>,
-) -> Result<(), ImageError> {
+pub fn rgb_from_bayer8(src: &Bayer8, dst: &mut Image<u8, 3>) -> Result<(), ImageError> {
     rgb_from_bayer(src.as_image(), src.pattern, dst)
 }
 
@@ -75,7 +72,7 @@ pub fn rgb_from_bayer8<A1: ImageAllocator, A2: ImageAllocator>(
 mod tests {
     use super::*;
     use kornia_image::ImageSize;
-    use kornia_tensor::CpuAllocator;
+    use kornia_tensor::host_alloc;
 
     const PATTERNS: [BayerPattern; 4] = [
         BayerPattern::Rggb,
@@ -85,16 +82,16 @@ mod tests {
     ];
 
     fn demosaic(data: &[u8], w: usize, h: usize, p: BayerPattern) -> Vec<u8> {
-        let src = Image::<u8, 1, _>::new(
+        let src = Image::<u8, 1>::new(
             ImageSize {
                 width: w,
                 height: h,
             },
             data.to_vec(),
-            CpuAllocator,
+            host_alloc(),
         )
         .unwrap();
-        let mut dst = Image::<u8, 3, _>::from_size_val(src.size(), 0, CpuAllocator).unwrap();
+        let mut dst = Image::<u8, 3>::from_size_val(src.size(), 0, host_alloc()).unwrap();
         rgb_from_bayer(&src, p, &mut dst).unwrap();
         dst.as_slice().to_vec()
     }
@@ -178,22 +175,22 @@ mod tests {
 
     #[test]
     fn size_mismatch_errors() {
-        let src = Image::<u8, 1, _>::from_size_val(
+        let src = Image::<u8, 1>::from_size_val(
             ImageSize {
                 width: 4,
                 height: 4,
             },
             0,
-            CpuAllocator,
+            host_alloc(),
         )
         .unwrap();
-        let mut dst = Image::<u8, 3, _>::from_size_val(
+        let mut dst = Image::<u8, 3>::from_size_val(
             ImageSize {
                 width: 5,
                 height: 4,
             },
             0,
-            CpuAllocator,
+            host_alloc(),
         )
         .unwrap();
         assert!(rgb_from_bayer(&src, BayerPattern::Rggb, &mut dst).is_err());

--- a/crates/kornia-imgproc/src/color/cie/kernels.rs
+++ b/crates/kornia-imgproc/src/color/cie/kernels.rs
@@ -343,32 +343,36 @@ fn rgb_from_luv_px(l: f32, u: f32, v: f32) -> (f32, f32, f32) {
 #[cfg(target_arch = "aarch64")]
 #[inline]
 unsafe fn srgb_to_linear_v(x: float32x4_t) -> float32x4_t {
-    let x = vmaxq_f32(x, vdupq_n_f32(0.0));
-    let lin = vmulq_f32(x, vdupq_n_f32(transfer::SRGB_INV_1292));
-    let t = vmulq_f32(
-        vaddq_f32(x, vdupq_n_f32(transfer::SRGB_A)),
-        vdupq_n_f32(transfer::SRGB_INV_1055),
-    );
-    let powed = transfer::pow_f32x4(t, vdupq_n_f32(transfer::SRGB_GAMMA));
-    let mask = vcleq_f32(x, vdupq_n_f32(transfer::SRGB_THRESH));
-    vbslq_f32(mask, lin, powed)
+    unsafe {
+        let x = vmaxq_f32(x, vdupq_n_f32(0.0));
+        let lin = vmulq_f32(x, vdupq_n_f32(transfer::SRGB_INV_1292));
+        let t = vmulq_f32(
+            vaddq_f32(x, vdupq_n_f32(transfer::SRGB_A)),
+            vdupq_n_f32(transfer::SRGB_INV_1055),
+        );
+        let powed = transfer::pow_f32x4(t, vdupq_n_f32(transfer::SRGB_GAMMA));
+        let mask = vcleq_f32(x, vdupq_n_f32(transfer::SRGB_THRESH));
+        vbslq_f32(mask, lin, powed)
+    }
 }
 
 /// NEON linear→sRGB on a vector (per channel).
 #[cfg(target_arch = "aarch64")]
 #[inline]
 unsafe fn linear_to_srgb_v(l: float32x4_t) -> float32x4_t {
-    let l = vmaxq_f32(l, vdupq_n_f32(0.0));
-    let lin = vmulq_f32(l, vdupq_n_f32(transfer::SRGB_1292));
-    let powed = vsubq_f32(
-        vmulq_f32(
-            vdupq_n_f32(transfer::SRGB_1055),
-            transfer::pow_f32x4(l, vdupq_n_f32(transfer::SRGB_INV_GAMMA)),
-        ),
-        vdupq_n_f32(transfer::SRGB_A),
-    );
-    let mask = vcleq_f32(l, vdupq_n_f32(transfer::SRGB_INV_THRESH));
-    vbslq_f32(mask, lin, powed)
+    unsafe {
+        let l = vmaxq_f32(l, vdupq_n_f32(0.0));
+        let lin = vmulq_f32(l, vdupq_n_f32(transfer::SRGB_1292));
+        let powed = vsubq_f32(
+            vmulq_f32(
+                vdupq_n_f32(transfer::SRGB_1055),
+                transfer::pow_f32x4(l, vdupq_n_f32(transfer::SRGB_INV_GAMMA)),
+            ),
+            vdupq_n_f32(transfer::SRGB_A),
+        );
+        let mask = vcleq_f32(l, vdupq_n_f32(transfer::SRGB_INV_THRESH));
+        vbslq_f32(mask, lin, powed)
+    }
 }
 
 /// NEON 3×3 matrix-vector (row-major `m`) on deinterleaved channel vectors.
@@ -380,48 +384,54 @@ unsafe fn matvec_v(
     b: float32x4_t,
     c: float32x4_t,
 ) -> (float32x4_t, float32x4_t, float32x4_t) {
-    let o0 = vfmaq_f32(
-        vfmaq_f32(vmulq_f32(a, vdupq_n_f32(m[0])), b, vdupq_n_f32(m[1])),
-        c,
-        vdupq_n_f32(m[2]),
-    );
-    let o1 = vfmaq_f32(
-        vfmaq_f32(vmulq_f32(a, vdupq_n_f32(m[3])), b, vdupq_n_f32(m[4])),
-        c,
-        vdupq_n_f32(m[5]),
-    );
-    let o2 = vfmaq_f32(
-        vfmaq_f32(vmulq_f32(a, vdupq_n_f32(m[6])), b, vdupq_n_f32(m[7])),
-        c,
-        vdupq_n_f32(m[8]),
-    );
-    (o0, o1, o2)
+    unsafe {
+        let o0 = vfmaq_f32(
+            vfmaq_f32(vmulq_f32(a, vdupq_n_f32(m[0])), b, vdupq_n_f32(m[1])),
+            c,
+            vdupq_n_f32(m[2]),
+        );
+        let o1 = vfmaq_f32(
+            vfmaq_f32(vmulq_f32(a, vdupq_n_f32(m[3])), b, vdupq_n_f32(m[4])),
+            c,
+            vdupq_n_f32(m[5]),
+        );
+        let o2 = vfmaq_f32(
+            vfmaq_f32(vmulq_f32(a, vdupq_n_f32(m[6])), b, vdupq_n_f32(m[7])),
+            c,
+            vdupq_n_f32(m[8]),
+        );
+        (o0, o1, o2)
+    }
 }
 
 /// NEON Lab `f(t)`: branchless cbrt vs linear segment.
 #[cfg(target_arch = "aarch64")]
 #[inline]
 unsafe fn lab_f_v(t: float32x4_t) -> float32x4_t {
-    let cube = nonlinear::cbrt_f32x4(t);
-    let lin = vaddq_f32(
-        vmulq_f32(t, vdupq_n_f32(LAB_F_SLOPE)),
-        vdupq_n_f32(LAB_F_OFFSET),
-    );
-    let mask = vcgtq_f32(t, vdupq_n_f32(LAB_DELTA));
-    vbslq_f32(mask, cube, lin)
+    unsafe {
+        let cube = nonlinear::cbrt_f32x4(t);
+        let lin = vaddq_f32(
+            vmulq_f32(t, vdupq_n_f32(LAB_F_SLOPE)),
+            vdupq_n_f32(LAB_F_OFFSET),
+        );
+        let mask = vcgtq_f32(t, vdupq_n_f32(LAB_DELTA));
+        vbslq_f32(mask, cube, lin)
+    }
 }
 
 /// NEON Lab `f^{-1}(f)`: branchless `f^3` vs linear segment.
 #[cfg(target_arch = "aarch64")]
 #[inline]
 unsafe fn lab_finv_v(f: float32x4_t) -> float32x4_t {
-    let cube = vmulq_f32(vmulq_f32(f, f), f);
-    let lin = vmulq_f32(
-        vdupq_n_f32(LAB_FINV_SLOPE),
-        vsubq_f32(f, vdupq_n_f32(LAB_F_OFFSET)),
-    );
-    let mask = vcgtq_f32(f, vdupq_n_f32(LAB_FINV_THRESH));
-    vbslq_f32(mask, cube, lin)
+    unsafe {
+        let cube = vmulq_f32(vmulq_f32(f, f), f);
+        let lin = vmulq_f32(
+            vdupq_n_f32(LAB_FINV_SLOPE),
+            vsubq_f32(f, vdupq_n_f32(LAB_F_OFFSET)),
+        );
+        let mask = vcgtq_f32(f, vdupq_n_f32(LAB_FINV_THRESH));
+        vbslq_f32(mask, cube, lin)
+    }
 }
 
 // ===== generic NEON driver ==========================================================
@@ -439,33 +449,35 @@ unsafe fn neon_drive(
     f: impl Fn(float32x4x3_t) -> float32x4x3_t,
     scalar_px: impl Fn(f32, f32, f32) -> (f32, f32, f32),
 ) {
-    let sp = src.as_ptr();
-    let dp = dst.as_mut_ptr();
-    let mut i = 0usize;
-    let bulk8 = npixels & !7;
-    while i < bulk8 {
-        // Two independent loads/transforms — no data dependency between them, so the
-        // out-of-order core overlaps the two pow/cbrt chains.
-        let p0 = vld3q_f32(sp.add(i * 3));
-        let p1 = vld3q_f32(sp.add((i + 4) * 3));
-        let o0 = f(p0);
-        let o1 = f(p1);
-        vst3q_f32(dp.add(i * 3), o0);
-        vst3q_f32(dp.add((i + 4) * 3), o1);
-        i += 8;
-    }
-    if i + 4 <= npixels {
-        let p = vld3q_f32(sp.add(i * 3));
-        vst3q_f32(dp.add(i * 3), f(p));
-        i += 4;
-    }
-    while i < npixels {
-        let si = i * 3;
-        let (o0, o1, o2) = scalar_px(*sp.add(si), *sp.add(si + 1), *sp.add(si + 2));
-        *dp.add(si) = o0;
-        *dp.add(si + 1) = o1;
-        *dp.add(si + 2) = o2;
-        i += 1;
+    unsafe {
+        let sp = src.as_ptr();
+        let dp = dst.as_mut_ptr();
+        let mut i = 0usize;
+        let bulk8 = npixels & !7;
+        while i < bulk8 {
+            // Two independent loads/transforms — no data dependency between them, so the
+            // out-of-order core overlaps the two pow/cbrt chains.
+            let p0 = vld3q_f32(sp.add(i * 3));
+            let p1 = vld3q_f32(sp.add((i + 4) * 3));
+            let o0 = f(p0);
+            let o1 = f(p1);
+            vst3q_f32(dp.add(i * 3), o0);
+            vst3q_f32(dp.add((i + 4) * 3), o1);
+            i += 8;
+        }
+        if i + 4 <= npixels {
+            let p = vld3q_f32(sp.add(i * 3));
+            vst3q_f32(dp.add(i * 3), f(p));
+            i += 4;
+        }
+        while i < npixels {
+            let si = i * 3;
+            let (o0, o1, o2) = scalar_px(*sp.add(si), *sp.add(si + 1), *sp.add(si + 2));
+            *dp.add(si) = o0;
+            *dp.add(si + 1) = o1;
+            *dp.add(si + 2) = o2;
+            i += 1;
+        }
     }
 }
 
@@ -490,7 +502,7 @@ fn scalar_drive(
 // Each follows the 4-layer pattern: slice entry → strip dispatch → cfg leaf.
 
 macro_rules! cie_kernel {
-    ($name:ident, $neon_body:expr, $scalar_px:path) => {
+    ($name:ident, $neon_body:expr_2021, $scalar_px:path) => {
         pub fn $name(src: &[f32], dst: &mut [f32], npixels: usize) {
             debug_assert!(src.len() >= npixels * 3);
             debug_assert!(dst.len() >= npixels * 3);

--- a/crates/kornia-imgproc/src/color/cie/mod.rs
+++ b/crates/kornia-imgproc/src/color/cie/mod.rs
@@ -159,7 +159,6 @@ f32_wrapper!(rgb_from_luv_f32, rgb_from_luv, "f32 [`rgb_from_luv`].");
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::host_alloc;
 
     // Build an f32 RGB image and its f64 twin from the same [0,1] samples.
     fn pair(w: usize, h: usize) -> (Vec<f32>, Vec<f64>) {
@@ -185,10 +184,10 @@ mod tests {
             width: w,
             height: h,
         };
-        let src32 = Image::<f32, 3>::new(size, f32v, host_alloc())?;
-        let src64 = Image::<f64, 3>::new(size, f64v, host_alloc())?;
-        let mut out32 = Image::<f32, 3>::from_size_val(size, 0.0, host_alloc())?;
-        let mut out64 = Image::<f64, 3>::from_size_val(size, 0.0, host_alloc())?;
+        let src32 = Image::<f32, 3>::new(size, f32v)?;
+        let src64 = Image::<f64, 3>::new(size, f64v)?;
+        let mut out32 = Image::<f32, 3>::from_size_val(size, 0.0)?;
+        let mut out64 = Image::<f64, 3>::from_size_val(size, 0.0)?;
         fwd_f32(&src32, &mut out32)?;
         fwd_f64(&src64, &mut out64)?;
         for (i, (a, b)) in out32
@@ -221,9 +220,9 @@ mod tests {
             width: w,
             height: h,
         };
-        let src = Image::<f32, 3>::new(size, f32v, host_alloc())?;
-        let mut mid = Image::<f32, 3>::from_size_val(size, 0.0, host_alloc())?;
-        let mut back = Image::<f32, 3>::from_size_val(size, 0.0, host_alloc())?;
+        let src = Image::<f32, 3>::new(size, f32v)?;
+        let mut mid = Image::<f32, 3>::from_size_val(size, 0.0)?;
+        let mut back = Image::<f32, 3>::from_size_val(size, 0.0)?;
         fwd(&src, &mut mid)?;
         rev(&mid, &mut back)?;
         for (a, b) in src.as_slice().iter().zip(back.as_slice().iter()) {
@@ -303,14 +302,14 @@ mod tests {
             width: 2,
             height: 1,
         };
-        let src = Image::<f32, 3>::new(size, vec![0.0, 0.0, 0.0, 1.0, 1.0, 1.0], host_alloc())?;
+        let src = Image::<f32, 3>::new(size, vec![0.0, 0.0, 0.0, 1.0, 1.0, 1.0])?;
         for conv in [
             super::linear_rgb_from_rgb as fn(&_, &mut _) -> _,
             super::xyz_from_rgb,
             super::lab_from_rgb,
             super::luv_from_rgb,
         ] {
-            let mut out = Image::<f32, 3>::from_size_val(size, 0.0, host_alloc())?;
+            let mut out = Image::<f32, 3>::from_size_val(size, 0.0)?;
             conv(&src, &mut out)?;
             for v in out.as_slice() {
                 assert!(v.is_finite(), "NaN/inf in output: {v}");
@@ -329,9 +328,9 @@ mod tests {
             width: w,
             height: h,
         };
-        let src = Image::<f32, 3>::new(size, data, host_alloc())?;
-        let mut mid = Image::<f32, 3>::from_size_val(size, 0.0, host_alloc())?;
-        let mut back = Image::<f32, 3>::from_size_val(size, 0.0, host_alloc())?;
+        let src = Image::<f32, 3>::new(size, data)?;
+        let mut mid = Image::<f32, 3>::from_size_val(size, 0.0)?;
+        let mut back = Image::<f32, 3>::from_size_val(size, 0.0)?;
         super::lab_from_rgb(&src, &mut mid)?;
         super::rgb_from_lab(&mid, &mut back)?;
         for (a, b) in src.as_slice().iter().zip(back.as_slice().iter()) {

--- a/crates/kornia-imgproc/src/color/cie/mod.rs
+++ b/crates/kornia-imgproc/src/color/cie/mod.rs
@@ -11,7 +11,7 @@
 //! Luv `L∈[0,100]`.
 
 use crate::parallel;
-use kornia_image::{allocator::ImageAllocator, Image, ImageError};
+use kornia_image::{Image, ImageError};
 
 mod kernels;
 mod nonlinear;
@@ -25,21 +25,15 @@ use crate::color::kernel_common::{check_size, sealed};
 // `cie_conv!` stamps out the trait, both impls, and the public dispatch fn.
 
 macro_rules! cie_conv {
-    ($trait:ident, $method:ident, $pub_fn:ident, $f32_kernel:path, $f64_oracle:path, $doc:expr) => {
+    ($trait:ident, $method:ident, $pub_fn:ident, $f32_kernel:path, $f64_oracle:path, $doc:expr_2021) => {
         #[doc = $doc]
         pub trait $trait: sealed::Sealed + Sized {
             #[doc(hidden)]
-            fn $method<A1: ImageAllocator, A2: ImageAllocator>(
-                src: &Image<Self, 3, A1>,
-                dst: &mut Image<Self, 3, A2>,
-            ) -> Result<(), ImageError>;
+            fn $method(src: &Image<Self, 3>, dst: &mut Image<Self, 3>) -> Result<(), ImageError>;
         }
 
         impl $trait for f32 {
-            fn $method<A1: ImageAllocator, A2: ImageAllocator>(
-                src: &Image<f32, 3, A1>,
-                dst: &mut Image<f32, 3, A2>,
-            ) -> Result<(), ImageError> {
+            fn $method(src: &Image<f32, 3>, dst: &mut Image<f32, 3>) -> Result<(), ImageError> {
                 check_size(src, dst)?;
                 $f32_kernel(src.as_slice(), dst.as_slice_mut(), src.rows() * src.cols());
                 Ok(())
@@ -47,10 +41,7 @@ macro_rules! cie_conv {
         }
 
         impl $trait for f64 {
-            fn $method<A1: ImageAllocator, A2: ImageAllocator>(
-                src: &Image<f64, 3, A1>,
-                dst: &mut Image<f64, 3, A2>,
-            ) -> Result<(), ImageError> {
+            fn $method(src: &Image<f64, 3>, dst: &mut Image<f64, 3>) -> Result<(), ImageError> {
                 check_size(src, dst)?;
                 parallel::par_iter_rows(src, dst, |s, d| {
                     let (a, b, c) = $f64_oracle(s[0], s[1], s[2]);
@@ -63,14 +54,9 @@ macro_rules! cie_conv {
         }
 
         #[doc = $doc]
-        pub fn $pub_fn<T, A1, A2>(
-            src: &Image<T, 3, A1>,
-            dst: &mut Image<T, 3, A2>,
-        ) -> Result<(), ImageError>
+        pub fn $pub_fn<T>(src: &Image<T, 3>, dst: &mut Image<T, 3>) -> Result<(), ImageError>
         where
             T: $trait,
-            A1: ImageAllocator,
-            A2: ImageAllocator,
         {
             T::$method(src, dst)
         }
@@ -145,12 +131,9 @@ cie_conv!(
 // ===== thin f32 wrappers ============================================================
 
 macro_rules! f32_wrapper {
-    ($name:ident, $generic:ident, $doc:expr) => {
+    ($name:ident, $generic:ident, $doc:expr_2021) => {
         #[doc = $doc]
-        pub fn $name<A1: ImageAllocator, A2: ImageAllocator>(
-            src: &Image<f32, 3, A1>,
-            dst: &mut Image<f32, 3, A2>,
-        ) -> Result<(), ImageError> {
+        pub fn $name(src: &Image<f32, 3>, dst: &mut Image<f32, 3>) -> Result<(), ImageError> {
             $generic(src, dst)
         }
     };
@@ -176,7 +159,7 @@ f32_wrapper!(rgb_from_luv_f32, rgb_from_luv, "f32 [`rgb_from_luv`].");
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::CpuAllocator;
+    use kornia_tensor::host_alloc;
 
     // Build an f32 RGB image and its f64 twin from the same [0,1] samples.
     fn pair(w: usize, h: usize) -> (Vec<f32>, Vec<f64>) {
@@ -187,8 +170,7 @@ mod tests {
     }
 
     // Conversion fn-pointer aliases (keep clippy::type_complexity quiet in test helpers).
-    type ConvFn<T> =
-        fn(&Image<T, 3, CpuAllocator>, &mut Image<T, 3, CpuAllocator>) -> Result<(), ImageError>;
+    type ConvFn<T> = fn(&Image<T, 3>, &mut Image<T, 3>) -> Result<(), ImageError>;
 
     // Generic: f32-SIMD vs f64-scalar for one forward conversion.
     fn check_simd_vs_scalar(
@@ -203,10 +185,10 @@ mod tests {
             width: w,
             height: h,
         };
-        let src32 = Image::<f32, 3, _>::new(size, f32v, CpuAllocator)?;
-        let src64 = Image::<f64, 3, _>::new(size, f64v, CpuAllocator)?;
-        let mut out32 = Image::<f32, 3, _>::from_size_val(size, 0.0, CpuAllocator)?;
-        let mut out64 = Image::<f64, 3, _>::from_size_val(size, 0.0, CpuAllocator)?;
+        let src32 = Image::<f32, 3>::new(size, f32v, host_alloc())?;
+        let src64 = Image::<f64, 3>::new(size, f64v, host_alloc())?;
+        let mut out32 = Image::<f32, 3>::from_size_val(size, 0.0, host_alloc())?;
+        let mut out64 = Image::<f64, 3>::from_size_val(size, 0.0, host_alloc())?;
         fwd_f32(&src32, &mut out32)?;
         fwd_f64(&src64, &mut out64)?;
         for (i, (a, b)) in out32
@@ -239,9 +221,9 @@ mod tests {
             width: w,
             height: h,
         };
-        let src = Image::<f32, 3, _>::new(size, f32v, CpuAllocator)?;
-        let mut mid = Image::<f32, 3, _>::from_size_val(size, 0.0, CpuAllocator)?;
-        let mut back = Image::<f32, 3, _>::from_size_val(size, 0.0, CpuAllocator)?;
+        let src = Image::<f32, 3>::new(size, f32v, host_alloc())?;
+        let mut mid = Image::<f32, 3>::from_size_val(size, 0.0, host_alloc())?;
+        let mut back = Image::<f32, 3>::from_size_val(size, 0.0, host_alloc())?;
         fwd(&src, &mut mid)?;
         rev(&mid, &mut back)?;
         for (a, b) in src.as_slice().iter().zip(back.as_slice().iter()) {
@@ -321,14 +303,14 @@ mod tests {
             width: 2,
             height: 1,
         };
-        let src = Image::<f32, 3, _>::new(size, vec![0.0, 0.0, 0.0, 1.0, 1.0, 1.0], CpuAllocator)?;
+        let src = Image::<f32, 3>::new(size, vec![0.0, 0.0, 0.0, 1.0, 1.0, 1.0], host_alloc())?;
         for conv in [
             super::linear_rgb_from_rgb as fn(&_, &mut _) -> _,
             super::xyz_from_rgb,
             super::lab_from_rgb,
             super::luv_from_rgb,
         ] {
-            let mut out = Image::<f32, 3, _>::from_size_val(size, 0.0, CpuAllocator)?;
+            let mut out = Image::<f32, 3>::from_size_val(size, 0.0, host_alloc())?;
             conv(&src, &mut out)?;
             for v in out.as_slice() {
                 assert!(v.is_finite(), "NaN/inf in output: {v}");
@@ -347,9 +329,9 @@ mod tests {
             width: w,
             height: h,
         };
-        let src = Image::<f32, 3, _>::new(size, data, CpuAllocator)?;
-        let mut mid = Image::<f32, 3, _>::from_size_val(size, 0.0, CpuAllocator)?;
-        let mut back = Image::<f32, 3, _>::from_size_val(size, 0.0, CpuAllocator)?;
+        let src = Image::<f32, 3>::new(size, data, host_alloc())?;
+        let mut mid = Image::<f32, 3>::from_size_val(size, 0.0, host_alloc())?;
+        let mut back = Image::<f32, 3>::from_size_val(size, 0.0, host_alloc())?;
         super::lab_from_rgb(&src, &mut mid)?;
         super::rgb_from_lab(&mid, &mut back)?;
         for (a, b) in src.as_slice().iter().zip(back.as_slice().iter()) {

--- a/crates/kornia-imgproc/src/color/cie/nonlinear.rs
+++ b/crates/kornia-imgproc/src/color/cie/nonlinear.rs
@@ -16,27 +16,29 @@ use std::arch::aarch64::*;
 #[cfg(target_arch = "aarch64")]
 #[inline]
 pub(crate) unsafe fn cbrt_f32x4(x: float32x4_t) -> float32x4_t {
-    let bits = vreinterpretq_u32_f32(x);
-    // Seed y0 = bitcast(bits/3 + magic) ≈ 2^(e/3); the magic constant restores the
-    // exponent bias and gives a good first-order mantissa guess.
-    let seed_bits = vaddq_u32(
-        vcvtq_u32_f32(vmulq_f32(vcvtq_f32_u32(bits), vdupq_n_f32(1.0 / 3.0))),
-        vdupq_n_u32(0x2a51_4067),
-    );
-    let mut y = vreinterpretq_f32_u32(seed_bits);
+    unsafe {
+        let bits = vreinterpretq_u32_f32(x);
+        // Seed y0 = bitcast(bits/3 + magic) ≈ 2^(e/3); the magic constant restores the
+        // exponent bias and gives a good first-order mantissa guess.
+        let seed_bits = vaddq_u32(
+            vcvtq_u32_f32(vmulq_f32(vcvtq_f32_u32(bits), vdupq_n_f32(1.0 / 3.0))),
+            vdupq_n_u32(0x2a51_4067),
+        );
+        let mut y = vreinterpretq_f32_u32(seed_bits);
 
-    // One Halley iteration: y = y*(c + 2x)/(2c + x), c = y^3. Cubic convergence on
-    // the ~4% bit-hack seed gives max rel err ≈ 2.3e-5 — ample for colour (~1e-2),
-    // so a second iteration is wasted work on this hot path.
-    {
-        let c = vmulq_f32(vmulq_f32(y, y), y);
-        let num = vaddq_f32(c, vaddq_f32(x, x)); // c + 2x
-        let den = vaddq_f32(vaddq_f32(c, c), x); // 2c + x
-        y = vmulq_f32(y, vmulq_f32(num, vrecip_f32x4(den)));
+        // One Halley iteration: y = y*(c + 2x)/(2c + x), c = y^3. Cubic convergence on
+        // the ~4% bit-hack seed gives max rel err ≈ 2.3e-5 — ample for colour (~1e-2),
+        // so a second iteration is wasted work on this hot path.
+        {
+            let c = vmulq_f32(vmulq_f32(y, y), y);
+            let num = vaddq_f32(c, vaddq_f32(x, x)); // c + 2x
+            let den = vaddq_f32(vaddq_f32(c, c), x); // 2c + x
+            y = vmulq_f32(y, vmulq_f32(num, vrecip_f32x4(den)));
+        }
+        // Force exact 0 input to 0 output.
+        let is0 = vceqq_f32(x, vdupq_n_f32(0.0));
+        vbslq_f32(is0, vdupq_n_f32(0.0), y)
     }
-    // Force exact 0 input to 0 output.
-    let is0 = vceqq_f32(x, vdupq_n_f32(0.0));
-    vbslq_f32(is0, vdupq_n_f32(0.0), y)
 }
 
 /// NEON reciprocal `1/x` refined by two Newton-Raphson steps (vrecpe seed).
@@ -44,10 +46,12 @@ pub(crate) unsafe fn cbrt_f32x4(x: float32x4_t) -> float32x4_t {
 #[cfg(target_arch = "aarch64")]
 #[inline]
 pub(crate) unsafe fn vrecip_f32x4(x: float32x4_t) -> float32x4_t {
-    let mut r = vrecpeq_f32(x);
-    r = vmulq_f32(r, vrecpsq_f32(x, r));
-    r = vmulq_f32(r, vrecpsq_f32(x, r));
-    r
+    unsafe {
+        let mut r = vrecpeq_f32(x);
+        r = vmulq_f32(r, vrecpsq_f32(x, r));
+        r = vmulq_f32(r, vrecpsq_f32(x, r));
+        r
+    }
 }
 
 /// NEON reciprocal `1/x` with a single Newton-Raphson step (~1e-4 rel) — colour-grade,
@@ -55,8 +59,10 @@ pub(crate) unsafe fn vrecip_f32x4(x: float32x4_t) -> float32x4_t {
 #[cfg(target_arch = "aarch64")]
 #[inline]
 pub(crate) unsafe fn vrecip_fast_f32x4(x: float32x4_t) -> float32x4_t {
-    let r = vrecpeq_f32(x);
-    vmulq_f32(r, vrecpsq_f32(x, r))
+    unsafe {
+        let r = vrecpeq_f32(x);
+        vmulq_f32(r, vrecpsq_f32(x, r))
+    }
 }
 
 #[cfg(test)]

--- a/crates/kornia-imgproc/src/color/cie/transfer.rs
+++ b/crates/kornia-imgproc/src/color/cie/transfer.rs
@@ -55,36 +55,38 @@ pub(crate) fn linear_to_srgb_scalar(l: f32) -> f32 {
 #[inline]
 #[allow(clippy::excessive_precision)] // least-squares fit constants; keep full digits
 unsafe fn log2_f32x4(x: float32x4_t) -> float32x4_t {
-    // Extract exponent: e = ((bits >> 23) & 0xff) - 127.
-    let bits = vreinterpretq_u32_f32(x);
-    let exp = vsubq_s32(
-        vreinterpretq_s32_u32(vshrq_n_u32(bits, 23)),
-        vdupq_n_s32(127),
-    );
-    let e = vcvtq_f32_s32(exp);
+    unsafe {
+        // Extract exponent: e = ((bits >> 23) & 0xff) - 127.
+        let bits = vreinterpretq_u32_f32(x);
+        let exp = vsubq_s32(
+            vreinterpretq_s32_u32(vshrq_n_u32(bits, 23)),
+            vdupq_n_s32(127),
+        );
+        let e = vcvtq_f32_s32(exp);
 
-    // Mantissa m ∈ [1, 2): clear exponent bits, set them to 127 (bias for 2^0).
-    let mant_bits = vorrq_u32(
-        vandq_u32(bits, vdupq_n_u32(0x007f_ffff)),
-        vdupq_n_u32(0x3f80_0000),
-    );
-    let m = vreinterpretq_f32_u32(mant_bits);
+        // Mantissa m ∈ [1, 2): clear exponent bits, set them to 127 (bias for 2^0).
+        let mant_bits = vorrq_u32(
+            vandq_u32(bits, vdupq_n_u32(0x007f_ffff)),
+            vdupq_n_u32(0x3f80_0000),
+        );
+        let m = vreinterpretq_f32_u32(mant_bits);
 
-    // Least-squares fit for log2(m) on [1, 2) (degree-4, Horner). Max abs err
-    // ≈ 2.0e-4 → pow(x,2.4) rel err ≈ 4e-4, far inside the color tolerance (~1e-2).
-    // Degree chosen to match colour precision, not full f32 — this is the hot path.
-    let c0 = vdupq_n_f32(-2.496_773_8);
-    let c1 = vdupq_n_f32(4.028_372_8);
-    let c2 = vdupq_n_f32(-2.081_060_2);
-    let c3 = vdupq_n_f32(0.628_815_73);
-    let c4 = vdupq_n_f32(-0.079_150_366);
-    let mut p = c4;
-    p = vfmaq_f32(c3, p, m);
-    p = vfmaq_f32(c2, p, m);
-    p = vfmaq_f32(c1, p, m);
-    p = vfmaq_f32(c0, p, m);
-    // p ≈ log2(m); add exponent.
-    vaddq_f32(p, e)
+        // Least-squares fit for log2(m) on [1, 2) (degree-4, Horner). Max abs err
+        // ≈ 2.0e-4 → pow(x,2.4) rel err ≈ 4e-4, far inside the color tolerance (~1e-2).
+        // Degree chosen to match colour precision, not full f32 — this is the hot path.
+        let c0 = vdupq_n_f32(-2.496_773_8);
+        let c1 = vdupq_n_f32(4.028_372_8);
+        let c2 = vdupq_n_f32(-2.081_060_2);
+        let c3 = vdupq_n_f32(0.628_815_73);
+        let c4 = vdupq_n_f32(-0.079_150_366);
+        let mut p = c4;
+        p = vfmaq_f32(c3, p, m);
+        p = vfmaq_f32(c2, p, m);
+        p = vfmaq_f32(c1, p, m);
+        p = vfmaq_f32(c0, p, m);
+        // p ≈ log2(m); add exponent.
+        vaddq_f32(p, e)
+    }
 }
 
 /// NEON `exp2(x)` = `2^x`, degree-5 minimax over the fractional part.
@@ -94,33 +96,35 @@ unsafe fn log2_f32x4(x: float32x4_t) -> float32x4_t {
 #[cfg(target_arch = "aarch64")]
 #[inline]
 unsafe fn exp2_f32x4(x: float32x4_t) -> float32x4_t {
-    // Clamp to a sane range so the exponent injection can't overflow.
-    let x = vminq_f32(vmaxq_f32(x, vdupq_n_f32(-126.0)), vdupq_n_f32(126.0));
-    let n = vrndmq_f32(x); // floor(x)
-    let f = vsubq_f32(x, n); // [0, 1)
+    unsafe {
+        // Clamp to a sane range so the exponent injection can't overflow.
+        let x = vminq_f32(vmaxq_f32(x, vdupq_n_f32(-126.0)), vdupq_n_f32(126.0));
+        let n = vrndmq_f32(x); // floor(x)
+        let f = vsubq_f32(x, n); // [0, 1)
 
-    // Least-squares fit for 2^f on [0, 1) (degree-3, Horner). Max abs err ≈ 2.0e-4,
-    // matched to colour precision (see log2 note).
-    let c0 = vdupq_n_f32(0.999_811_96);
-    let c1 = vdupq_n_f32(0.696_838_58);
-    let c2 = vdupq_n_f32(0.224_126_44);
-    let c3 = vdupq_n_f32(0.079_019_94);
-    let mut p = c3;
-    p = vfmaq_f32(c2, p, f);
-    p = vfmaq_f32(c1, p, f);
-    p = vfmaq_f32(c0, p, f); // 2^f
+        // Least-squares fit for 2^f on [0, 1) (degree-3, Horner). Max abs err ≈ 2.0e-4,
+        // matched to colour precision (see log2 note).
+        let c0 = vdupq_n_f32(0.999_811_96);
+        let c1 = vdupq_n_f32(0.696_838_58);
+        let c2 = vdupq_n_f32(0.224_126_44);
+        let c3 = vdupq_n_f32(0.079_019_94);
+        let mut p = c3;
+        p = vfmaq_f32(c2, p, f);
+        p = vfmaq_f32(c1, p, f);
+        p = vfmaq_f32(c0, p, f); // 2^f
 
-    // 2^n via exponent injection: bits = (n + 127) << 23.
-    let ni = vcvtq_s32_f32(n);
-    let pow2n = vreinterpretq_f32_s32(vshlq_n_s32(vaddq_s32(ni, vdupq_n_s32(127)), 23));
-    vmulq_f32(p, pow2n)
+        // 2^n via exponent injection: bits = (n + 127) << 23.
+        let ni = vcvtq_s32_f32(n);
+        let pow2n = vreinterpretq_f32_s32(vshlq_n_s32(vaddq_s32(ni, vdupq_n_s32(127)), 23));
+        vmulq_f32(p, pow2n)
+    }
 }
 
 /// NEON `pow(x, p) = exp2(p · log2(x))` for `x > 0`.
 #[cfg(target_arch = "aarch64")]
 #[inline]
 pub(crate) unsafe fn pow_f32x4(x: float32x4_t, p: float32x4_t) -> float32x4_t {
-    exp2_f32x4(vmulq_f32(p, log2_f32x4(x)))
+    unsafe { exp2_f32x4(vmulq_f32(p, log2_f32x4(x))) }
 }
 
 #[cfg(test)]

--- a/crates/kornia-imgproc/src/color/colormap.rs
+++ b/crates/kornia-imgproc/src/color/colormap.rs
@@ -1,4 +1,4 @@
-use kornia_image::{allocator::ImageAllocator, Image, ImageError};
+use kornia_image::{Image, ImageError};
 
 // ── LUT data ──────────────────────────────────────────────────────────────────
 
@@ -136,19 +136,21 @@ unsafe fn lookup_channel(
     idx128: std::arch::aarch64::uint8x16_t,
     idx192: std::arch::aarch64::uint8x16_t,
 ) -> std::arch::aarch64::uint8x16_t {
-    use std::arch::aarch64::*;
-    // Each vqtbl4q_u8 covers one 64-entry chunk; out-of-range indices produce 0,
-    // so OR-ing the four results gives the correct value for all 256 indices.
-    vorrq_u8(
+    unsafe {
+        use std::arch::aarch64::*;
+        // Each vqtbl4q_u8 covers one 64-entry chunk; out-of-range indices produce 0,
+        // so OR-ing the four results gives the correct value for all 256 indices.
         vorrq_u8(
-            vqtbl4q_u8(vld1q_u8_x4(p), idx),
-            vqtbl4q_u8(vld1q_u8_x4(p.add(64)), idx64),
-        ),
-        vorrq_u8(
-            vqtbl4q_u8(vld1q_u8_x4(p.add(128)), idx128),
-            vqtbl4q_u8(vld1q_u8_x4(p.add(192)), idx192),
-        ),
-    )
+            vorrq_u8(
+                vqtbl4q_u8(vld1q_u8_x4(p), idx),
+                vqtbl4q_u8(vld1q_u8_x4(p.add(64)), idx64),
+            ),
+            vorrq_u8(
+                vqtbl4q_u8(vld1q_u8_x4(p.add(128)), idx128),
+                vqtbl4q_u8(vld1q_u8_x4(p.add(192)), idx192),
+            ),
+        )
+    }
 }
 
 /// NEON kernel (aarch64): 16 pixels/iteration using `vqtbl4q_u8` + `vst3q_u8`.
@@ -162,34 +164,36 @@ unsafe fn lookup_channel(
 /// Caller must ensure `dst.len() >= src.len() * 3`.
 #[cfg(target_arch = "aarch64")]
 unsafe fn apply_neon(src: &[u8], dst: &mut [u8], lut: &ColormapLut) {
-    use std::arch::aarch64::*;
+    unsafe {
+        use std::arch::aarch64::*;
 
-    let off64 = vdupq_n_u8(64);
-    let off128 = vdupq_n_u8(128);
-    let off192 = vdupq_n_u8(192);
+        let off64 = vdupq_n_u8(64);
+        let off128 = vdupq_n_u8(128);
+        let off192 = vdupq_n_u8(192);
 
-    let n = src.len();
-    let mut si = 0usize;
-    let mut di = 0usize;
+        let n = src.len();
+        let mut si = 0usize;
+        let mut di = 0usize;
 
-    while si + 16 <= n {
-        let idx = vld1q_u8(src.as_ptr().add(si));
-        let idx64 = vsubq_u8(idx, off64);
-        let idx128 = vsubq_u8(idx, off128);
-        let idx192 = vsubq_u8(idx, off192);
+        while si + 16 <= n {
+            let idx = vld1q_u8(src.as_ptr().add(si));
+            let idx64 = vsubq_u8(idx, off64);
+            let idx128 = vsubq_u8(idx, off128);
+            let idx192 = vsubq_u8(idx, off192);
 
-        let r = lookup_channel(lut.r.as_ptr(), idx, idx64, idx128, idx192);
-        let g = lookup_channel(lut.g.as_ptr(), idx, idx64, idx128, idx192);
-        let b = lookup_channel(lut.b.as_ptr(), idx, idx64, idx128, idx192);
+            let r = lookup_channel(lut.r.as_ptr(), idx, idx64, idx128, idx192);
+            let g = lookup_channel(lut.g.as_ptr(), idx, idx64, idx128, idx192);
+            let b = lookup_channel(lut.b.as_ptr(), idx, idx64, idx128, idx192);
 
-        vst3q_u8(dst.as_mut_ptr().add(di), uint8x16x3_t(r, g, b));
+            vst3q_u8(dst.as_mut_ptr().add(di), uint8x16x3_t(r, g, b));
 
-        si += 16;
-        di += 48;
+            si += 16;
+            di += 48;
+        }
+
+        // Scalar tail for remaining pixels
+        apply_scalar(&src[si..], &mut dst[di..], lut);
     }
-
-    // Scalar tail for remaining pixels
-    apply_scalar(&src[si..], &mut dst[di..], lut);
 }
 
 /// AVX2 kernel (x86_64): 8 pixels/iteration via a 32-bit gather over a packed
@@ -252,9 +256,9 @@ unsafe fn apply_avx2(src: &[u8], dst: &mut [u8], lut: &ColormapLut) {
 ///
 /// # Errors
 /// Returns `ImageError` if `src` and `dst` sizes do not match.
-pub fn apply_colormap<A: ImageAllocator>(
-    src: &Image<u8, 1, A>,
-    dst: &mut Image<u8, 3, A>,
+pub fn apply_colormap(
+    src: &Image<u8, 1>,
+    dst: &mut Image<u8, 3>,
     colormap: ColormapType,
 ) -> Result<(), ImageError> {
     if src.size() != dst.size() {

--- a/crates/kornia-imgproc/src/color/convert.rs
+++ b/crates/kornia-imgproc/src/color/convert.rs
@@ -17,16 +17,14 @@ use kornia_image::{
 ///
 /// ```
 /// use kornia_image::ImageSize;
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::color::{Rgbf32, Grayf32, ConvertColor};
 ///
 /// let rgb = Rgbf32::from_size_vec(
 ///     ImageSize { width: 4, height: 5 },
 ///     vec![0.5f32; 4 * 5 * 3],
-///     host_alloc()
 /// ).unwrap();
 ///
-/// let mut gray = Grayf32::from_size_val(rgb.size(), 0.0, host_alloc()).unwrap();
+/// let mut gray = Grayf32::from_size_val(rgb.size(), 0.0).unwrap();
 ///
 /// rgb.convert(&mut gray).unwrap();
 /// ```
@@ -196,7 +194,6 @@ impl_convert_with_bg!(Bgra8 => Rgb8, crate::color::rgb_from_bgra);
 mod tests {
     use super::*;
     use kornia_image::ImageSize;
-    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_gray_from_rgb_f32() -> Result<(), ImageError> {
@@ -206,10 +203,9 @@ mod tests {
                 height: 2,
             },
             vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.5, 0.5, 0.5],
-            host_alloc(),
         )?;
 
-        let mut gray = Grayf32::from_size_val(rgb.size(), 0.0, host_alloc())?;
+        let mut gray = Grayf32::from_size_val(rgb.size(), 0.0)?;
 
         rgb.convert(&mut gray)?;
 
@@ -228,10 +224,9 @@ mod tests {
                 height: 1,
             },
             vec![255, 0, 0, 0, 255, 0],
-            host_alloc(),
         )?;
 
-        let mut gray = Gray8::from_size_val(rgb.size(), 0, host_alloc())?;
+        let mut gray = Gray8::from_size_val(rgb.size(), 0)?;
 
         rgb.convert(&mut gray)?;
 
@@ -248,10 +243,9 @@ mod tests {
                 height: 2,
             },
             vec![0.0, 0.5, 1.0, 0.25],
-            host_alloc(),
         )?;
 
-        let mut rgb = Rgbf32::from_size_val(gray.size(), 0.0, host_alloc())?;
+        let mut rgb = Rgbf32::from_size_val(gray.size(), 0.0)?;
 
         gray.convert(&mut rgb)?;
 
@@ -270,10 +264,9 @@ mod tests {
                 height: 1,
             },
             vec![255, 128, 64],
-            host_alloc(),
         )?;
 
-        let mut bgr = Bgr8::from_size_val(rgb.size(), 0, host_alloc())?;
+        let mut bgr = Bgr8::from_size_val(rgb.size(), 0)?;
 
         rgb.convert(&mut bgr)?;
 
@@ -294,10 +287,9 @@ mod tests {
                 height: 1,
             },
             vec![64, 128, 255],
-            host_alloc(),
         )?;
 
-        let mut rgb = Rgb8::from_size_val(bgr.size(), 0, host_alloc())?;
+        let mut rgb = Rgb8::from_size_val(bgr.size(), 0)?;
 
         bgr.convert(&mut rgb)?;
 
@@ -318,11 +310,11 @@ mod tests {
             height: 2,
         };
         let data: Vec<u8> = (0..4 * 2 * 3).map(|v| (v * 7 + 11) as u8).collect();
-        let rgb = Rgb8::from_size_vec(size, data, host_alloc())?;
+        let rgb = Rgb8::from_size_vec(size, data)?;
 
         // YCbCr round-trip
-        let mut ycc = YCbCr8::from_size_val(size, 0, host_alloc())?;
-        let mut back = Rgb8::from_size_val(size, 0, host_alloc())?;
+        let mut ycc = YCbCr8::from_size_val(size, 0)?;
+        let mut back = Rgb8::from_size_val(size, 0)?;
         rgb.convert(&mut ycc)?;
         ycc.convert(&mut back)?;
         for (a, b) in rgb.as_slice().iter().zip(back.as_slice().iter()) {
@@ -330,7 +322,7 @@ mod tests {
         }
 
         // YUV (swapped chroma) must differ from YCbCr in channels 1/2 but round-trip too.
-        let mut yuv = Yuv8::from_size_val(size, 0, host_alloc())?;
+        let mut yuv = Yuv8::from_size_val(size, 0)?;
         rgb.convert(&mut yuv)?;
         assert_eq!(ycc.as_slice()[1], yuv.as_slice()[2]);
         assert_eq!(ycc.as_slice()[2], yuv.as_slice()[1]);
@@ -346,7 +338,7 @@ mod tests {
         };
         // Y=16, U=V=128 -> black (limited range).
         let yuyv = Yuyv8::from_size_vec(size, vec![16, 128, 16, 128])?;
-        let mut rgb = Rgb8::from_size_val(size, 0, host_alloc())?;
+        let mut rgb = Rgb8::from_size_val(size, 0)?;
         yuyv.convert(&mut rgb)?;
         assert_eq!(rgb.as_slice(), &[0, 0, 0, 0, 0, 0]);
         Ok(())
@@ -360,10 +352,9 @@ mod tests {
                 height: 1,
             },
             vec![255.0, 0.0, 0.0],
-            host_alloc(),
         )?;
 
-        let mut hsv = Hsvf32::from_size_val(rgb.size(), 0.0, host_alloc())?;
+        let mut hsv = Hsvf32::from_size_val(rgb.size(), 0.0)?;
 
         rgb.convert(&mut hsv)?;
 
@@ -380,7 +371,6 @@ mod tests {
                 height: 4,
             },
             vec![0u8; 4 * 4 * 3],
-            host_alloc(),
         )?;
 
         // Test that Deref allows us to use Image methods
@@ -400,10 +390,9 @@ mod tests {
                 height: 1,
             },
             vec![255, 128, 64, 255, 100, 50, 25, 128],
-            host_alloc(),
         )?;
 
-        let mut rgb = Rgb8::from_size_val(rgba.size(), 0, host_alloc())?;
+        let mut rgb = Rgb8::from_size_val(rgba.size(), 0)?;
 
         rgba.convert(&mut rgb)?;
 
@@ -426,10 +415,9 @@ mod tests {
                 height: 1,
             },
             vec![255, 0, 0, 128], // Red with 50% alpha
-            host_alloc(),
         )?;
 
-        let mut rgb = Rgb8::from_size_val(rgba.size(), 0, host_alloc())?;
+        let mut rgb = Rgb8::from_size_val(rgba.size(), 0)?;
 
         // Convert with white background
         rgba.convert_with_bg(&mut rgb, Some([100, 100, 100]))?;
@@ -451,10 +439,9 @@ mod tests {
                 height: 1,
             },
             vec![64, 128, 255, 255], // BGR + A
-            host_alloc(),
         )?;
 
-        let mut rgb = Rgb8::from_size_val(bgra.size(), 0, host_alloc())?;
+        let mut rgb = Rgb8::from_size_val(bgra.size(), 0)?;
 
         bgra.convert(&mut rgb)?;
 
@@ -474,9 +461,8 @@ mod tests {
                 height: 1,
             },
             vec![1, 2, 3, 4, 5, 6],
-            host_alloc(),
         )?;
-        let mut rgba = Rgba8::from_size_val(rgb.size(), 0, host_alloc())?;
+        let mut rgba = Rgba8::from_size_val(rgb.size(), 0)?;
         rgb.convert(&mut rgba)?;
         assert_eq!(rgba.as_slice(), &[1, 2, 3, 255, 4, 5, 6, 255]);
         Ok(())
@@ -490,9 +476,8 @@ mod tests {
                 height: 1,
             },
             vec![1, 2, 3, 4, 5, 6],
-            host_alloc(),
         )?;
-        let mut bgra = Bgra8::from_size_val(rgb.size(), 0, host_alloc())?;
+        let mut bgra = Bgra8::from_size_val(rgb.size(), 0)?;
         rgb.convert(&mut bgra)?;
         assert_eq!(bgra.as_slice(), &[3, 2, 1, 255, 6, 5, 4, 255]);
         Ok(())
@@ -509,16 +494,15 @@ mod tests {
                 height: 1,
             },
             vec![255, 0, 0, 0, 255, 0],
-            host_alloc(),
         )?;
 
-        let mut gray = Gray8::from_size_val(rgb.size(), 0, host_alloc())?;
+        let mut gray = Gray8::from_size_val(rgb.size(), 0)?;
 
         rgb.convert(&mut gray)?;
         assert_eq!(gray.num_channels(), 1);
 
         // Test Bgr8
-        let mut bgr = Bgr8::from_size_val(rgb.size(), 0, host_alloc())?;
+        let mut bgr = Bgr8::from_size_val(rgb.size(), 0)?;
         rgb.convert(&mut bgr)?;
         assert_eq!(bgr.num_channels(), 3);
 
@@ -529,9 +513,8 @@ mod tests {
                 height: 1,
             },
             vec![255, 128, 64, 255],
-            host_alloc(),
         )?;
-        let mut rgb_out = Rgb8::from_size_val(rgba.size(), 0, host_alloc())?;
+        let mut rgb_out = Rgb8::from_size_val(rgba.size(), 0)?;
         rgba.convert(&mut rgb_out)?;
 
         assert_eq!(rgb_out.as_slice()[0], 255);
@@ -565,11 +548,7 @@ macro_rules! impl_color_newtype {
     ($newtype:ident, $t:ty) => {
         impl NewColorImage for kornia_image::color_spaces::$newtype {
             fn new_zeroed(size: ImageSize) -> Result<Self, ImageError> {
-                kornia_image::color_spaces::$newtype::from_size_val(
-                    size,
-                    <$t>::default(),
-                    kornia_tensor::host_alloc(),
-                )
+                kornia_image::color_spaces::$newtype::from_size_val(size, <$t>::default())
             }
         }
 
@@ -612,13 +591,11 @@ impl_color_newtype!(Bgraf32, f32);
 ///
 /// ```
 /// use kornia_image::ImageSize;
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::color::{Rgbf32, Hsvf32, ConvertColorExt};
 ///
 /// let rgb = Rgbf32::from_size_vec(
 ///     ImageSize { width: 4, height: 3 },
 ///     vec![0.5f32; 4 * 3 * 3],
-///     host_alloc(),
 /// ).unwrap();
 ///
 /// let hsv: Hsvf32 = rgb.cvt().unwrap();
@@ -649,7 +626,6 @@ mod cvt_color_tests {
     use crate::color::Tagged;
     use kornia_image::color_spaces::Rgbf32;
     use kornia_image::{ColorSpace, DynImage, ImageSize};
-    use kornia_tensor::host_alloc;
 
     #[test]
     fn runtime_cvt_color_returns_tagged_dynimage() {
@@ -657,7 +633,7 @@ mod cvt_color_tests {
             width: 4,
             height: 4,
         };
-        let rgb = Rgbf32::from_size_vec(size, vec![0.5f32; 4 * 4 * 3], host_alloc()).unwrap();
+        let rgb = Rgbf32::from_size_vec(size, vec![0.5f32; 4 * 4 * 3]).unwrap();
         let hsv = rgb.cvt_color(ColorSpace::Hsv).unwrap();
         assert_eq!(hsv.color_space(), ColorSpace::Hsv);
         assert_eq!(hsv.channels(), 3);
@@ -673,7 +649,7 @@ mod cvt_color_tests {
             width: 2,
             height: 2,
         };
-        let rgb = Rgbf32::from_size_vec(size, vec![0.0f32; 2 * 2 * 3], host_alloc()).unwrap();
+        let rgb = Rgbf32::from_size_vec(size, vec![0.0f32; 2 * 2 * 3]).unwrap();
         // Rgb has no direct path to YCbCr? It does — pick a truly illegal target by
         // constructing from a non-Rgb source instead:
         let hsv = rgb.cvt_color(ColorSpace::Hsv).unwrap();
@@ -688,7 +664,6 @@ mod cvt_ext_tests {
     use crate::color::ConvertColorExt;
     use kornia_image::color_spaces::{Grayf32, Hsvf32, Rgbf32};
     use kornia_image::ImageSize;
-    use kornia_tensor::host_alloc;
 
     #[test]
     fn cvt_allocates_and_converts_typed() {
@@ -696,7 +671,7 @@ mod cvt_ext_tests {
             width: 4,
             height: 3,
         };
-        let rgb = Rgbf32::from_size_vec(size, vec![0.5f32; 4 * 3 * 3], host_alloc()).unwrap();
+        let rgb = Rgbf32::from_size_vec(size, vec![0.5f32; 4 * 3 * 3]).unwrap();
         // typed, allocating: no manual dst construction
         let hsv: Hsvf32 = rgb.cvt().unwrap();
         assert_eq!(hsv.size(), size);
@@ -712,7 +687,7 @@ mod cvt_ext_tests {
             height: 8,
         };
         let data: Vec<f32> = (0..8 * 8 * 3).map(|i| (i % 255) as f32 / 255.0).collect();
-        let rgb = Rgbf32::from_size_vec(size, data.clone(), host_alloc()).unwrap();
+        let rgb = Rgbf32::from_size_vec(size, data.clone()).unwrap();
         let hsv: Hsvf32 = rgb.cvt().unwrap();
         let back: Rgbf32 = hsv.cvt().unwrap();
         for (a, b) in data.iter().zip(back.as_slice().iter()) {
@@ -844,7 +819,6 @@ mod legality_drift_tests {
         Rgba8, Rgbf32, Xyzf32, YCbCrf32, Yuvf32,
     };
     use kornia_image::{ColorSpace, ImageSize};
-    use kornia_tensor::host_alloc;
 
     /// All ColorSpace variants enumerated manually (no strum/EnumIter in scope).
     /// 13 variants × 16 source types = 208 (from, to) pairs checked.
@@ -902,57 +876,57 @@ mod legality_drift_tests {
         // ---- f32 sources (is_f32 = true) ----
 
         check_all_targets!(
-            Rgbf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3], host_alloc()).unwrap(),
+            Rgbf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3]).unwrap(),
             ColorSpace::Rgb,
             true
         );
         check_all_targets!(
-            Grayf32::from_size_vec(sz, vec![0.5f32; 2 * 2], host_alloc()).unwrap(),
+            Grayf32::from_size_vec(sz, vec![0.5f32; 2 * 2]).unwrap(),
             ColorSpace::Gray,
             true
         );
         check_all_targets!(
-            Hsvf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3], host_alloc()).unwrap(),
+            Hsvf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3]).unwrap(),
             ColorSpace::Hsv,
             true
         );
         check_all_targets!(
-            Hlsf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3], host_alloc()).unwrap(),
+            Hlsf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3]).unwrap(),
             ColorSpace::Hls,
             true
         );
         check_all_targets!(
-            Labf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3], host_alloc()).unwrap(),
+            Labf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3]).unwrap(),
             ColorSpace::Lab,
             true
         );
         check_all_targets!(
-            Luvf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3], host_alloc()).unwrap(),
+            Luvf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3]).unwrap(),
             ColorSpace::Luv,
             true
         );
         check_all_targets!(
-            Xyzf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3], host_alloc()).unwrap(),
+            Xyzf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3]).unwrap(),
             ColorSpace::Xyz,
             true
         );
         check_all_targets!(
-            LinearRgbf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3], host_alloc()).unwrap(),
+            LinearRgbf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3]).unwrap(),
             ColorSpace::LinearRgb,
             true
         );
         check_all_targets!(
-            YCbCrf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3], host_alloc()).unwrap(),
+            YCbCrf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3]).unwrap(),
             ColorSpace::YCbCr,
             true
         );
         check_all_targets!(
-            Yuvf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3], host_alloc()).unwrap(),
+            Yuvf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3]).unwrap(),
             ColorSpace::Yuv,
             true
         );
         check_all_targets!(
-            Bgrf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3], host_alloc()).unwrap(),
+            Bgrf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3]).unwrap(),
             ColorSpace::Bgr,
             true
         );
@@ -960,27 +934,27 @@ mod legality_drift_tests {
         // ---- u8 sources (is_f32 = false) ----
 
         check_all_targets!(
-            Rgb8::from_size_vec(sz, vec![128u8; 2 * 2 * 3], host_alloc()).unwrap(),
+            Rgb8::from_size_vec(sz, vec![128u8; 2 * 2 * 3]).unwrap(),
             ColorSpace::Rgb,
             false
         );
         check_all_targets!(
-            Gray8::from_size_vec(sz, vec![128u8; 2 * 2], host_alloc()).unwrap(),
+            Gray8::from_size_vec(sz, vec![128u8; 2 * 2]).unwrap(),
             ColorSpace::Gray,
             false
         );
         check_all_targets!(
-            Bgr8::from_size_vec(sz, vec![128u8; 2 * 2 * 3], host_alloc()).unwrap(),
+            Bgr8::from_size_vec(sz, vec![128u8; 2 * 2 * 3]).unwrap(),
             ColorSpace::Bgr,
             false
         );
         check_all_targets!(
-            Rgba8::from_size_vec(sz, vec![128u8; 2 * 2 * 4], host_alloc()).unwrap(),
+            Rgba8::from_size_vec(sz, vec![128u8; 2 * 2 * 4]).unwrap(),
             ColorSpace::Rgba,
             false
         );
         check_all_targets!(
-            Bgra8::from_size_vec(sz, vec![128u8; 2 * 2 * 4], host_alloc()).unwrap(),
+            Bgra8::from_size_vec(sz, vec![128u8; 2 * 2 * 4]).unwrap(),
             ColorSpace::Bgra,
             false
         );

--- a/crates/kornia-imgproc/src/color/convert.rs
+++ b/crates/kornia-imgproc/src/color/convert.rs
@@ -1,5 +1,4 @@
 use kornia_image::{
-    allocator::ImageAllocator,
     color_spaces::{
         Bgr8, Bgra8, Bgraf32, Bgrf32, Gray8, Grayf32, Grayf64, Hlsf32, Hlsf64, Hsvf32, Hsvf64,
         Labf32, Labf64, LinearRgbf32, LinearRgbf64, Luvf32, Luvf64, Nv12, Nv21, Rgb8, Rgba8,
@@ -18,16 +17,16 @@ use kornia_image::{
 ///
 /// ```
 /// use kornia_image::ImageSize;
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::color::{Rgbf32, Grayf32, ConvertColor};
 ///
 /// let rgb = Rgbf32::from_size_vec(
 ///     ImageSize { width: 4, height: 5 },
 ///     vec![0.5f32; 4 * 5 * 3],
-///     CpuAllocator
+///     host_alloc()
 /// ).unwrap();
 ///
-/// let mut gray = Grayf32::from_size_val(rgb.size(), 0.0, CpuAllocator).unwrap();
+/// let mut gray = Grayf32::from_size_val(rgb.size(), 0.0, host_alloc()).unwrap();
 ///
 /// rgb.convert(&mut gray).unwrap();
 /// ```
@@ -39,11 +38,7 @@ pub trait ConvertColor<Dst> {
 /// Macro to implement color conversions
 macro_rules! impl_convert {
     ($src:ty => $dst:ty, $func:path) => {
-        impl<A1, A2> ConvertColor<$dst> for $src
-        where
-            A1: ImageAllocator,
-            A2: ImageAllocator,
-        {
+        impl ConvertColor<$dst> for $src {
             fn convert(&self, dst: &mut $dst) -> Result<(), ImageError> {
                 $func(&self.0, &mut dst.0)
             }
@@ -51,12 +46,8 @@ macro_rules! impl_convert {
     };
 
     // For conversions with optional parameters (like background)
-    ($src:ty => $dst:ty, $func:path, bg: $bg:expr) => {
-        impl<A1, A2> ConvertColor<$dst> for $src
-        where
-            A1: ImageAllocator,
-            A2: ImageAllocator,
-        {
+    ($src:ty => $dst:ty, $func:path, bg: $bg:expr_2021) => {
+        impl ConvertColor<$dst> for $src {
             fn convert(&self, dst: &mut $dst) -> Result<(), ImageError> {
                 $func(&self.0, &mut dst.0, $bg)
             }
@@ -67,11 +58,7 @@ macro_rules! impl_convert {
 /// Macro to implement color conversions with background support
 macro_rules! impl_convert_with_bg {
     ($src:ty => $dst:ty, $func:path) => {
-        impl<A1, A2> ConvertColorWithBackground<$dst> for $src
-        where
-            A1: ImageAllocator,
-            A2: ImageAllocator,
-        {
+        impl ConvertColorWithBackground<$dst> for $src {
             fn convert_with_bg(
                 &self,
                 dst: &mut $dst,
@@ -84,97 +71,93 @@ macro_rules! impl_convert_with_bg {
 }
 
 // ===== Bayer mosaic -> RGB (hand-written: reads the runtime pattern field) =====
-impl<A1, A2> ConvertColor<Rgb8<A2>> for kornia_image::color_spaces::Bayer8<A1>
-where
-    A1: ImageAllocator,
-    A2: ImageAllocator,
-{
-    fn convert(&self, dst: &mut Rgb8<A2>) -> Result<(), ImageError> {
+impl ConvertColor<Rgb8> for kornia_image::color_spaces::Bayer8 {
+    fn convert(&self, dst: &mut Rgb8) -> Result<(), ImageError> {
         crate::color::rgb_from_bayer(self.as_image(), self.pattern, &mut dst.0)
     }
 }
 
 // ===== RGB -> Gray Conversions =====
-impl_convert!(Rgbf32<A1> => Grayf32<A2>, crate::color::gray_from_rgb_f32);
-impl_convert!(Rgbf64<A1> => Grayf64<A2>, crate::color::gray_from_rgb);
-impl_convert!(Rgb8<A1> => Gray8<A2>, crate::color::gray_from_rgb_u8);
+impl_convert!(Rgbf32 => Grayf32, crate::color::gray_from_rgb_f32);
+impl_convert!(Rgbf64 => Grayf64, crate::color::gray_from_rgb);
+impl_convert!(Rgb8 => Gray8, crate::color::gray_from_rgb_u8);
 
 // ===== Gray -> RGB Conversions =====
-impl_convert!(Gray8<A1> => Rgb8<A2>, crate::color::rgb_from_gray);
-impl_convert!(Grayf32<A1> => Rgbf32<A2>, crate::color::rgb_from_gray);
-impl_convert!(Grayf64<A1> => Rgbf64<A2>, crate::color::rgb_from_gray);
+impl_convert!(Gray8 => Rgb8, crate::color::rgb_from_gray);
+impl_convert!(Grayf32 => Rgbf32, crate::color::rgb_from_gray);
+impl_convert!(Grayf64 => Rgbf64, crate::color::rgb_from_gray);
 
 // ===== RGB <-> BGR Conversions =====
-impl_convert!(Rgb8<A1> => Bgr8<A2>, crate::color::bgr_from_rgb);
-impl_convert!(Bgr8<A1> => Rgb8<A2>, crate::color::bgr_from_rgb);
-impl_convert!(Rgbf32<A1> => Bgrf32<A2>, crate::color::bgr_from_rgb);
-impl_convert!(Bgrf32<A1> => Rgbf32<A2>, crate::color::bgr_from_rgb);
+impl_convert!(Rgb8 => Bgr8, crate::color::bgr_from_rgb);
+impl_convert!(Bgr8 => Rgb8, crate::color::bgr_from_rgb);
+impl_convert!(Rgbf32 => Bgrf32, crate::color::bgr_from_rgb);
+impl_convert!(Bgrf32 => Rgbf32, crate::color::bgr_from_rgb);
 
 // ===== RGB <-> HSV Conversions =====
-impl_convert!(Rgbf32<A1> => Hsvf32<A2>, crate::color::hsv_from_rgb);
-impl_convert!(Hsvf32<A1> => Rgbf32<A2>, crate::color::rgb_from_hsv);
-impl_convert!(Rgbf64<A1> => Hsvf64<A2>, crate::color::hsv_from_rgb);
-impl_convert!(Hsvf64<A1> => Rgbf64<A2>, crate::color::rgb_from_hsv);
+impl_convert!(Rgbf32 => Hsvf32, crate::color::hsv_from_rgb);
+impl_convert!(Hsvf32 => Rgbf32, crate::color::rgb_from_hsv);
+impl_convert!(Rgbf64 => Hsvf64, crate::color::hsv_from_rgb);
+impl_convert!(Hsvf64 => Rgbf64, crate::color::rgb_from_hsv);
 
 // ===== RGB <-> HLS Conversions =====
-impl_convert!(Rgbf32<A1> => Hlsf32<A2>, crate::color::hls_from_rgb);
-impl_convert!(Hlsf32<A1> => Rgbf32<A2>, crate::color::rgb_from_hls);
-impl_convert!(Rgbf64<A1> => Hlsf64<A2>, crate::color::hls_from_rgb);
-impl_convert!(Hlsf64<A1> => Rgbf64<A2>, crate::color::rgb_from_hls);
+impl_convert!(Rgbf32 => Hlsf32, crate::color::hls_from_rgb);
+impl_convert!(Hlsf32 => Rgbf32, crate::color::rgb_from_hls);
+impl_convert!(Rgbf64 => Hlsf64, crate::color::hls_from_rgb);
+impl_convert!(Hlsf64 => Rgbf64, crate::color::rgb_from_hls);
 
 // ===== RGB <-> linear-RGB (sRGB transfer) =====
-impl_convert!(Rgbf32<A1> => LinearRgbf32<A2>, crate::color::linear_rgb_from_rgb);
-impl_convert!(LinearRgbf32<A1> => Rgbf32<A2>, crate::color::rgb_from_linear_rgb);
-impl_convert!(Rgbf64<A1> => LinearRgbf64<A2>, crate::color::linear_rgb_from_rgb);
-impl_convert!(LinearRgbf64<A1> => Rgbf64<A2>, crate::color::rgb_from_linear_rgb);
+impl_convert!(Rgbf32 => LinearRgbf32, crate::color::linear_rgb_from_rgb);
+impl_convert!(LinearRgbf32 => Rgbf32, crate::color::rgb_from_linear_rgb);
+impl_convert!(Rgbf64 => LinearRgbf64, crate::color::linear_rgb_from_rgb);
+impl_convert!(LinearRgbf64 => Rgbf64, crate::color::rgb_from_linear_rgb);
 
 // ===== RGB <-> XYZ Conversions =====
-impl_convert!(Rgbf32<A1> => Xyzf32<A2>, crate::color::xyz_from_rgb);
-impl_convert!(Xyzf32<A1> => Rgbf32<A2>, crate::color::rgb_from_xyz);
-impl_convert!(Rgbf64<A1> => Xyzf64<A2>, crate::color::xyz_from_rgb);
-impl_convert!(Xyzf64<A1> => Rgbf64<A2>, crate::color::rgb_from_xyz);
+impl_convert!(Rgbf32 => Xyzf32, crate::color::xyz_from_rgb);
+impl_convert!(Xyzf32 => Rgbf32, crate::color::rgb_from_xyz);
+impl_convert!(Rgbf64 => Xyzf64, crate::color::xyz_from_rgb);
+impl_convert!(Xyzf64 => Rgbf64, crate::color::rgb_from_xyz);
 
 // ===== RGB <-> Lab Conversions =====
-impl_convert!(Rgbf32<A1> => Labf32<A2>, crate::color::lab_from_rgb);
-impl_convert!(Labf32<A1> => Rgbf32<A2>, crate::color::rgb_from_lab);
-impl_convert!(Rgbf64<A1> => Labf64<A2>, crate::color::lab_from_rgb);
-impl_convert!(Labf64<A1> => Rgbf64<A2>, crate::color::rgb_from_lab);
+impl_convert!(Rgbf32 => Labf32, crate::color::lab_from_rgb);
+impl_convert!(Labf32 => Rgbf32, crate::color::rgb_from_lab);
+impl_convert!(Rgbf64 => Labf64, crate::color::lab_from_rgb);
+impl_convert!(Labf64 => Rgbf64, crate::color::rgb_from_lab);
 
 // ===== RGB <-> Luv Conversions =====
-impl_convert!(Rgbf32<A1> => Luvf32<A2>, crate::color::luv_from_rgb);
-impl_convert!(Luvf32<A1> => Rgbf32<A2>, crate::color::rgb_from_luv);
-impl_convert!(Rgbf64<A1> => Luvf64<A2>, crate::color::luv_from_rgb);
-impl_convert!(Luvf64<A1> => Rgbf64<A2>, crate::color::rgb_from_luv);
+impl_convert!(Rgbf32 => Luvf32, crate::color::luv_from_rgb);
+impl_convert!(Luvf32 => Rgbf32, crate::color::rgb_from_luv);
+impl_convert!(Rgbf64 => Luvf64, crate::color::luv_from_rgb);
+impl_convert!(Luvf64 => Rgbf64, crate::color::rgb_from_luv);
 
 // ===== RGB <-> YCbCr Conversions =====
-impl_convert!(Rgb8<A1> => YCbCr8<A2>, crate::color::ycbcr_from_rgb);
-impl_convert!(YCbCr8<A1> => Rgb8<A2>, crate::color::rgb_from_ycbcr);
-impl_convert!(Rgbf32<A1> => YCbCrf32<A2>, crate::color::ycbcr_from_rgb);
-impl_convert!(YCbCrf32<A1> => Rgbf32<A2>, crate::color::rgb_from_ycbcr);
-impl_convert!(Rgbf64<A1> => YCbCrf64<A2>, crate::color::ycbcr_from_rgb);
-impl_convert!(YCbCrf64<A1> => Rgbf64<A2>, crate::color::rgb_from_ycbcr);
+impl_convert!(Rgb8 => YCbCr8, crate::color::ycbcr_from_rgb);
+impl_convert!(YCbCr8 => Rgb8, crate::color::rgb_from_ycbcr);
+impl_convert!(Rgbf32 => YCbCrf32, crate::color::ycbcr_from_rgb);
+impl_convert!(YCbCrf32 => Rgbf32, crate::color::rgb_from_ycbcr);
+impl_convert!(Rgbf64 => YCbCrf64, crate::color::ycbcr_from_rgb);
+impl_convert!(YCbCrf64 => Rgbf64, crate::color::rgb_from_ycbcr);
 
 // ===== RGB <-> YUV (planar 3-channel) Conversions =====
-impl_convert!(Rgb8<A1> => Yuv8<A2>, crate::color::yuv_from_rgb);
-impl_convert!(Yuv8<A1> => Rgb8<A2>, crate::color::rgb_from_yuv);
-impl_convert!(Rgbf32<A1> => Yuvf32<A2>, crate::color::yuv_from_rgb);
-impl_convert!(Yuvf32<A1> => Rgbf32<A2>, crate::color::rgb_from_yuv);
-impl_convert!(Rgbf64<A1> => Yuvf64<A2>, crate::color::yuv_from_rgb);
-impl_convert!(Yuvf64<A1> => Rgbf64<A2>, crate::color::rgb_from_yuv);
+impl_convert!(Rgb8 => Yuv8, crate::color::yuv_from_rgb);
+impl_convert!(Yuv8 => Rgb8, crate::color::rgb_from_yuv);
+impl_convert!(Rgbf32 => Yuvf32, crate::color::yuv_from_rgb);
+impl_convert!(Yuvf32 => Rgbf32, crate::color::rgb_from_yuv);
+impl_convert!(Rgbf64 => Yuvf64, crate::color::yuv_from_rgb);
+impl_convert!(Yuvf64 => Rgbf64, crate::color::rgb_from_yuv);
 
 // ===== RGBA -> RGB Conversions =====
-impl_convert!(Rgba8<A1> => Rgb8<A2>, crate::color::rgb_from_rgba, bg: None);
+impl_convert!(Rgba8 => Rgb8, crate::color::rgb_from_rgba, bg: None);
 
 // ===== BGRA -> RGB Conversions =====
-impl_convert!(Bgra8<A1> => Rgb8<A2>, crate::color::rgb_from_bgra, bg: None);
+impl_convert!(Bgra8 => Rgb8, crate::color::rgb_from_bgra, bg: None);
 
 // ===== RGB -> RGBA Conversions (add opaque alpha) =====
-impl_convert!(Rgb8<A1> => Rgba8<A2>, crate::color::rgba_from_rgb);
-impl_convert!(Rgbf32<A1> => Rgbaf32<A2>, crate::color::rgba_from_rgb);
+impl_convert!(Rgb8 => Rgba8, crate::color::rgba_from_rgb);
+impl_convert!(Rgbf32 => Rgbaf32, crate::color::rgba_from_rgb);
 
 // ===== RGB -> BGRA Conversions (swap R/B + add opaque alpha) =====
-impl_convert!(Rgb8<A1> => Bgra8<A2>, crate::color::bgra_from_rgb);
-impl_convert!(Rgbf32<A1> => Bgraf32<A2>, crate::color::bgra_from_rgb);
+impl_convert!(Rgb8 => Bgra8, crate::color::bgra_from_rgb);
+impl_convert!(Rgbf32 => Bgraf32, crate::color::bgra_from_rgb);
 
 // ===== Video format decode -> RGB (BT.601 limited range) =====
 //
@@ -182,11 +165,8 @@ impl_convert!(Rgbf32<A1> => Bgraf32<A2>, crate::color::bgra_from_rgb);
 // so they get hand-written `ConvertColor` impls (the `impl_convert!` macro assumes `.0`).
 macro_rules! impl_video_decode {
     ($src:ty, $func:path) => {
-        impl<A2> ConvertColor<Rgb8<A2>> for $src
-        where
-            A2: ImageAllocator,
-        {
-            fn convert(&self, dst: &mut Rgb8<A2>) -> Result<(), ImageError> {
+        impl ConvertColor<Rgb8> for $src {
+            fn convert(&self, dst: &mut Rgb8) -> Result<(), ImageError> {
                 $func(self.as_slice(), &mut dst.0)
             }
         }
@@ -209,14 +189,14 @@ pub trait ConvertColorWithBackground<Dst> {
     fn convert_with_bg(&self, dst: &mut Dst, bg: Option<[u8; 3]>) -> Result<(), ImageError>;
 }
 
-impl_convert_with_bg!(Rgba8<A1> => Rgb8<A2>, crate::color::rgb_from_rgba);
-impl_convert_with_bg!(Bgra8<A1> => Rgb8<A2>, crate::color::rgb_from_bgra);
+impl_convert_with_bg!(Rgba8 => Rgb8, crate::color::rgb_from_rgba);
+impl_convert_with_bg!(Bgra8 => Rgb8, crate::color::rgb_from_bgra);
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use kornia_image::ImageSize;
-    use kornia_tensor::CpuAllocator;
+    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_gray_from_rgb_f32() -> Result<(), ImageError> {
@@ -226,10 +206,10 @@ mod tests {
                 height: 2,
             },
             vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.5, 0.5, 0.5],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut gray = Grayf32::from_size_val(rgb.size(), 0.0, CpuAllocator)?;
+        let mut gray = Grayf32::from_size_val(rgb.size(), 0.0, host_alloc())?;
 
         rgb.convert(&mut gray)?;
 
@@ -248,10 +228,10 @@ mod tests {
                 height: 1,
             },
             vec![255, 0, 0, 0, 255, 0],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut gray = Gray8::from_size_val(rgb.size(), 0, CpuAllocator)?;
+        let mut gray = Gray8::from_size_val(rgb.size(), 0, host_alloc())?;
 
         rgb.convert(&mut gray)?;
 
@@ -268,10 +248,10 @@ mod tests {
                 height: 2,
             },
             vec![0.0, 0.5, 1.0, 0.25],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut rgb = Rgbf32::from_size_val(gray.size(), 0.0, CpuAllocator)?;
+        let mut rgb = Rgbf32::from_size_val(gray.size(), 0.0, host_alloc())?;
 
         gray.convert(&mut rgb)?;
 
@@ -290,10 +270,10 @@ mod tests {
                 height: 1,
             },
             vec![255, 128, 64],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut bgr = Bgr8::from_size_val(rgb.size(), 0, CpuAllocator)?;
+        let mut bgr = Bgr8::from_size_val(rgb.size(), 0, host_alloc())?;
 
         rgb.convert(&mut bgr)?;
 
@@ -314,10 +294,10 @@ mod tests {
                 height: 1,
             },
             vec![64, 128, 255],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut rgb = Rgb8::from_size_val(bgr.size(), 0, CpuAllocator)?;
+        let mut rgb = Rgb8::from_size_val(bgr.size(), 0, host_alloc())?;
 
         bgr.convert(&mut rgb)?;
 
@@ -338,11 +318,11 @@ mod tests {
             height: 2,
         };
         let data: Vec<u8> = (0..4 * 2 * 3).map(|v| (v * 7 + 11) as u8).collect();
-        let rgb = Rgb8::from_size_vec(size, data, CpuAllocator)?;
+        let rgb = Rgb8::from_size_vec(size, data, host_alloc())?;
 
         // YCbCr round-trip
-        let mut ycc = YCbCr8::from_size_val(size, 0, CpuAllocator)?;
-        let mut back = Rgb8::from_size_val(size, 0, CpuAllocator)?;
+        let mut ycc = YCbCr8::from_size_val(size, 0, host_alloc())?;
+        let mut back = Rgb8::from_size_val(size, 0, host_alloc())?;
         rgb.convert(&mut ycc)?;
         ycc.convert(&mut back)?;
         for (a, b) in rgb.as_slice().iter().zip(back.as_slice().iter()) {
@@ -350,7 +330,7 @@ mod tests {
         }
 
         // YUV (swapped chroma) must differ from YCbCr in channels 1/2 but round-trip too.
-        let mut yuv = Yuv8::from_size_val(size, 0, CpuAllocator)?;
+        let mut yuv = Yuv8::from_size_val(size, 0, host_alloc())?;
         rgb.convert(&mut yuv)?;
         assert_eq!(ycc.as_slice()[1], yuv.as_slice()[2]);
         assert_eq!(ycc.as_slice()[2], yuv.as_slice()[1]);
@@ -366,7 +346,7 @@ mod tests {
         };
         // Y=16, U=V=128 -> black (limited range).
         let yuyv = Yuyv8::from_size_vec(size, vec![16, 128, 16, 128])?;
-        let mut rgb = Rgb8::from_size_val(size, 0, CpuAllocator)?;
+        let mut rgb = Rgb8::from_size_val(size, 0, host_alloc())?;
         yuyv.convert(&mut rgb)?;
         assert_eq!(rgb.as_slice(), &[0, 0, 0, 0, 0, 0]);
         Ok(())
@@ -380,10 +360,10 @@ mod tests {
                 height: 1,
             },
             vec![255.0, 0.0, 0.0],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut hsv = Hsvf32::from_size_val(rgb.size(), 0.0, CpuAllocator)?;
+        let mut hsv = Hsvf32::from_size_val(rgb.size(), 0.0, host_alloc())?;
 
         rgb.convert(&mut hsv)?;
 
@@ -400,7 +380,7 @@ mod tests {
                 height: 4,
             },
             vec![0u8; 4 * 4 * 3],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         // Test that Deref allows us to use Image methods
@@ -420,10 +400,10 @@ mod tests {
                 height: 1,
             },
             vec![255, 128, 64, 255, 100, 50, 25, 128],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut rgb = Rgb8::from_size_val(rgba.size(), 0, CpuAllocator)?;
+        let mut rgb = Rgb8::from_size_val(rgba.size(), 0, host_alloc())?;
 
         rgba.convert(&mut rgb)?;
 
@@ -446,10 +426,10 @@ mod tests {
                 height: 1,
             },
             vec![255, 0, 0, 128], // Red with 50% alpha
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut rgb = Rgb8::from_size_val(rgba.size(), 0, CpuAllocator)?;
+        let mut rgb = Rgb8::from_size_val(rgba.size(), 0, host_alloc())?;
 
         // Convert with white background
         rgba.convert_with_bg(&mut rgb, Some([100, 100, 100]))?;
@@ -471,10 +451,10 @@ mod tests {
                 height: 1,
             },
             vec![64, 128, 255, 255], // BGR + A
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut rgb = Rgb8::from_size_val(bgra.size(), 0, CpuAllocator)?;
+        let mut rgb = Rgb8::from_size_val(bgra.size(), 0, host_alloc())?;
 
         bgra.convert(&mut rgb)?;
 
@@ -494,9 +474,9 @@ mod tests {
                 height: 1,
             },
             vec![1, 2, 3, 4, 5, 6],
-            CpuAllocator,
+            host_alloc(),
         )?;
-        let mut rgba = Rgba8::from_size_val(rgb.size(), 0, CpuAllocator)?;
+        let mut rgba = Rgba8::from_size_val(rgb.size(), 0, host_alloc())?;
         rgb.convert(&mut rgba)?;
         assert_eq!(rgba.as_slice(), &[1, 2, 3, 255, 4, 5, 6, 255]);
         Ok(())
@@ -510,9 +490,9 @@ mod tests {
                 height: 1,
             },
             vec![1, 2, 3, 4, 5, 6],
-            CpuAllocator,
+            host_alloc(),
         )?;
-        let mut bgra = Bgra8::from_size_val(rgb.size(), 0, CpuAllocator)?;
+        let mut bgra = Bgra8::from_size_val(rgb.size(), 0, host_alloc())?;
         rgb.convert(&mut bgra)?;
         assert_eq!(bgra.as_slice(), &[3, 2, 1, 255, 6, 5, 4, 255]);
         Ok(())
@@ -529,16 +509,16 @@ mod tests {
                 height: 1,
             },
             vec![255, 0, 0, 0, 255, 0],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut gray = Gray8::from_size_val(rgb.size(), 0, CpuAllocator)?;
+        let mut gray = Gray8::from_size_val(rgb.size(), 0, host_alloc())?;
 
         rgb.convert(&mut gray)?;
         assert_eq!(gray.num_channels(), 1);
 
         // Test Bgr8
-        let mut bgr = Bgr8::from_size_val(rgb.size(), 0, CpuAllocator)?;
+        let mut bgr = Bgr8::from_size_val(rgb.size(), 0, host_alloc())?;
         rgb.convert(&mut bgr)?;
         assert_eq!(bgr.num_channels(), 3);
 
@@ -549,9 +529,9 @@ mod tests {
                 height: 1,
             },
             vec![255, 128, 64, 255],
-            CpuAllocator,
+            host_alloc(),
         )?;
-        let mut rgb_out = Rgb8::from_size_val(rgba.size(), 0, CpuAllocator)?;
+        let mut rgb_out = Rgb8::from_size_val(rgba.size(), 0, host_alloc())?;
         rgba.convert(&mut rgb_out)?;
 
         assert_eq!(rgb_out.as_slice()[0], 255);
@@ -583,19 +563,17 @@ pub trait SrcSize {
 /// Emit both `NewColorImage` and `SrcSize` impls for a color-space newtype.
 macro_rules! impl_color_newtype {
     ($newtype:ident, $t:ty) => {
-        impl NewColorImage
-            for kornia_image::color_spaces::$newtype<kornia_image::allocator::CpuAllocator>
-        {
+        impl NewColorImage for kornia_image::color_spaces::$newtype {
             fn new_zeroed(size: ImageSize) -> Result<Self, ImageError> {
                 kornia_image::color_spaces::$newtype::from_size_val(
                     size,
                     <$t>::default(),
-                    kornia_image::allocator::CpuAllocator,
+                    kornia_tensor::host_alloc(),
                 )
             }
         }
 
-        impl<A: ImageAllocator> SrcSize for kornia_image::color_spaces::$newtype<A> {
+        impl SrcSize for kornia_image::color_spaces::$newtype {
             fn src_size(&self) -> ImageSize {
                 self.size()
             }
@@ -634,16 +612,16 @@ impl_color_newtype!(Bgraf32, f32);
 ///
 /// ```
 /// use kornia_image::ImageSize;
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::color::{Rgbf32, Hsvf32, ConvertColorExt};
 ///
 /// let rgb = Rgbf32::from_size_vec(
 ///     ImageSize { width: 4, height: 3 },
 ///     vec![0.5f32; 4 * 3 * 3],
-///     CpuAllocator,
+///     host_alloc(),
 /// ).unwrap();
 ///
-/// let hsv: Hsvf32<_> = rgb.cvt().unwrap();
+/// let hsv: Hsvf32 = rgb.cvt().unwrap();
 /// assert_eq!(hsv.size(), rgb.size());
 /// ```
 pub trait ConvertColorExt {
@@ -669,9 +647,9 @@ impl<Src> ConvertColorExt for Src {
 #[cfg(test)]
 mod cvt_color_tests {
     use crate::color::Tagged;
-    use kornia_image::allocator::CpuAllocator;
     use kornia_image::color_spaces::Rgbf32;
     use kornia_image::{ColorSpace, DynImage, ImageSize};
+    use kornia_tensor::host_alloc;
 
     #[test]
     fn runtime_cvt_color_returns_tagged_dynimage() {
@@ -679,7 +657,7 @@ mod cvt_color_tests {
             width: 4,
             height: 4,
         };
-        let rgb = Rgbf32::from_size_vec(size, vec![0.5f32; 4 * 4 * 3], CpuAllocator).unwrap();
+        let rgb = Rgbf32::from_size_vec(size, vec![0.5f32; 4 * 4 * 3], host_alloc()).unwrap();
         let hsv = rgb.cvt_color(ColorSpace::Hsv).unwrap();
         assert_eq!(hsv.color_space(), ColorSpace::Hsv);
         assert_eq!(hsv.channels(), 3);
@@ -695,11 +673,11 @@ mod cvt_color_tests {
             width: 2,
             height: 2,
         };
-        let rgb = Rgbf32::from_size_vec(size, vec![0.0f32; 2 * 2 * 3], CpuAllocator).unwrap();
+        let rgb = Rgbf32::from_size_vec(size, vec![0.0f32; 2 * 2 * 3], host_alloc()).unwrap();
         // Rgb has no direct path to YCbCr? It does — pick a truly illegal target by
         // constructing from a non-Rgb source instead:
         let hsv = rgb.cvt_color(ColorSpace::Hsv).unwrap();
-        let hsv_typed: kornia_image::color_spaces::Hsvf32<_> = hsv.try_into().unwrap();
+        let hsv_typed: kornia_image::color_spaces::Hsvf32 = hsv.try_into().unwrap();
         let err = hsv_typed.cvt_color(ColorSpace::Lab);
         assert!(err.is_err());
     }
@@ -708,9 +686,9 @@ mod cvt_color_tests {
 #[cfg(test)]
 mod cvt_ext_tests {
     use crate::color::ConvertColorExt;
-    use kornia_image::allocator::CpuAllocator;
     use kornia_image::color_spaces::{Grayf32, Hsvf32, Rgbf32};
     use kornia_image::ImageSize;
+    use kornia_tensor::host_alloc;
 
     #[test]
     fn cvt_allocates_and_converts_typed() {
@@ -718,12 +696,12 @@ mod cvt_ext_tests {
             width: 4,
             height: 3,
         };
-        let rgb = Rgbf32::from_size_vec(size, vec![0.5f32; 4 * 3 * 3], CpuAllocator).unwrap();
+        let rgb = Rgbf32::from_size_vec(size, vec![0.5f32; 4 * 3 * 3], host_alloc()).unwrap();
         // typed, allocating: no manual dst construction
-        let hsv: Hsvf32<_> = rgb.cvt().unwrap();
+        let hsv: Hsvf32 = rgb.cvt().unwrap();
         assert_eq!(hsv.size(), size);
         // channel-changing conversion is natural — Dst encodes C
-        let gray: Grayf32<_> = rgb.cvt().unwrap();
+        let gray: Grayf32 = rgb.cvt().unwrap();
         assert_eq!(gray.num_channels(), 1);
     }
 
@@ -734,9 +712,9 @@ mod cvt_ext_tests {
             height: 8,
         };
         let data: Vec<f32> = (0..8 * 8 * 3).map(|i| (i % 255) as f32 / 255.0).collect();
-        let rgb = Rgbf32::from_size_vec(size, data.clone(), CpuAllocator).unwrap();
-        let hsv: Hsvf32<_> = rgb.cvt().unwrap();
-        let back: Rgbf32<_> = hsv.cvt().unwrap();
+        let rgb = Rgbf32::from_size_vec(size, data.clone(), host_alloc()).unwrap();
+        let hsv: Hsvf32 = rgb.cvt().unwrap();
+        let back: Rgbf32 = hsv.cvt().unwrap();
         for (a, b) in data.iter().zip(back.as_slice().iter()) {
             assert!((a - b).abs() < 1e-3, "round-trip drift {a} vs {b}");
         }
@@ -745,7 +723,6 @@ mod cvt_ext_tests {
 
 // ===== Runtime Tagged dispatch layer =====
 
-use kornia_image::allocator::CpuAllocator;
 use kornia_image::{ColorSpace, DynImage};
 
 /// Runtime, color-space-tagged conversion. The source newtype encodes its
@@ -755,17 +732,17 @@ pub trait Tagged<T> {
     /// This image's color space.
     fn space(&self) -> ColorSpace;
     /// Convert to `to`, returning an owned tagged `DynImage`.
-    fn cvt_color(&self, to: ColorSpace) -> Result<DynImage<T, CpuAllocator>, ImageError>;
+    fn cvt_color(&self, to: ColorSpace) -> Result<DynImage<T>, ImageError>;
 }
 
 /// Generates a `Tagged` impl for one source newtype. Each `to => Dst, Cn`
 /// arm names the destination newtype and the DynImage channel constructor.
 macro_rules! impl_tagged {
-    ($src:ty, $t:ty, $space:expr, { $( $to:ident => $dst:ty , $ctor:ident );* $(;)? }) => {
-        impl<A: ImageAllocator> Tagged<$t> for $src
+    ($src:ty, $t:ty, $space:expr_2021, { $( $to:ident => $dst:ty , $ctor:ident );* $(;)? }) => {
+        impl Tagged<$t> for $src
         where Self: SrcSize {
             fn space(&self) -> ColorSpace { $space }
-            fn cvt_color(&self, to: ColorSpace) -> Result<DynImage<$t, CpuAllocator>, ImageError> {
+            fn cvt_color(&self, to: ColorSpace) -> Result<DynImage<$t>, ImageError> {
                 match to {
                     $( ColorSpace::$to => {
                         let out: $dst = self.cvt()?;
@@ -779,73 +756,73 @@ macro_rules! impl_tagged {
 }
 
 // ---- f32 RGB source: all f32 targets ----
-impl_tagged!(kornia_image::color_spaces::Rgbf32<A>, f32, ColorSpace::Rgb, {
-    Gray      => kornia_image::color_spaces::Grayf32<CpuAllocator>, C1;
-    Bgr       => kornia_image::color_spaces::Bgrf32<CpuAllocator>, C3;
-    Rgba      => kornia_image::color_spaces::Rgbaf32<CpuAllocator>, C4;
-    Bgra      => kornia_image::color_spaces::Bgraf32<CpuAllocator>, C4;
-    Hsv       => kornia_image::color_spaces::Hsvf32<CpuAllocator>, C3;
-    Hls       => kornia_image::color_spaces::Hlsf32<CpuAllocator>, C3;
-    Lab       => kornia_image::color_spaces::Labf32<CpuAllocator>, C3;
-    Luv       => kornia_image::color_spaces::Luvf32<CpuAllocator>, C3;
-    Xyz       => kornia_image::color_spaces::Xyzf32<CpuAllocator>, C3;
-    LinearRgb => kornia_image::color_spaces::LinearRgbf32<CpuAllocator>, C3;
-    YCbCr     => kornia_image::color_spaces::YCbCrf32<CpuAllocator>, C3;
-    Yuv       => kornia_image::color_spaces::Yuvf32<CpuAllocator>, C3;
+impl_tagged!(kornia_image::color_spaces::Rgbf32, f32, ColorSpace::Rgb, {
+    Gray      => kornia_image::color_spaces::Grayf32, C1;
+    Bgr       => kornia_image::color_spaces::Bgrf32, C3;
+    Rgba      => kornia_image::color_spaces::Rgbaf32, C4;
+    Bgra      => kornia_image::color_spaces::Bgraf32, C4;
+    Hsv       => kornia_image::color_spaces::Hsvf32, C3;
+    Hls       => kornia_image::color_spaces::Hlsf32, C3;
+    Lab       => kornia_image::color_spaces::Labf32, C3;
+    Luv       => kornia_image::color_spaces::Luvf32, C3;
+    Xyz       => kornia_image::color_spaces::Xyzf32, C3;
+    LinearRgb => kornia_image::color_spaces::LinearRgbf32, C3;
+    YCbCr     => kornia_image::color_spaces::YCbCrf32, C3;
+    Yuv       => kornia_image::color_spaces::Yuvf32, C3;
 });
 
 // ---- f32 inverse sources back to RGB ----
-impl_tagged!(kornia_image::color_spaces::Hsvf32<A>, f32, ColorSpace::Hsv, {
-    Rgb => kornia_image::color_spaces::Rgbf32<CpuAllocator>, C3;
+impl_tagged!(kornia_image::color_spaces::Hsvf32, f32, ColorSpace::Hsv, {
+    Rgb => kornia_image::color_spaces::Rgbf32, C3;
 });
-impl_tagged!(kornia_image::color_spaces::Hlsf32<A>, f32, ColorSpace::Hls, {
-    Rgb => kornia_image::color_spaces::Rgbf32<CpuAllocator>, C3;
+impl_tagged!(kornia_image::color_spaces::Hlsf32, f32, ColorSpace::Hls, {
+    Rgb => kornia_image::color_spaces::Rgbf32, C3;
 });
-impl_tagged!(kornia_image::color_spaces::Labf32<A>, f32, ColorSpace::Lab, {
-    Rgb => kornia_image::color_spaces::Rgbf32<CpuAllocator>, C3;
+impl_tagged!(kornia_image::color_spaces::Labf32, f32, ColorSpace::Lab, {
+    Rgb => kornia_image::color_spaces::Rgbf32, C3;
 });
-impl_tagged!(kornia_image::color_spaces::Luvf32<A>, f32, ColorSpace::Luv, {
-    Rgb => kornia_image::color_spaces::Rgbf32<CpuAllocator>, C3;
+impl_tagged!(kornia_image::color_spaces::Luvf32, f32, ColorSpace::Luv, {
+    Rgb => kornia_image::color_spaces::Rgbf32, C3;
 });
-impl_tagged!(kornia_image::color_spaces::Xyzf32<A>, f32, ColorSpace::Xyz, {
-    Rgb => kornia_image::color_spaces::Rgbf32<CpuAllocator>, C3;
+impl_tagged!(kornia_image::color_spaces::Xyzf32, f32, ColorSpace::Xyz, {
+    Rgb => kornia_image::color_spaces::Rgbf32, C3;
 });
-impl_tagged!(kornia_image::color_spaces::LinearRgbf32<A>, f32, ColorSpace::LinearRgb, {
-    Rgb => kornia_image::color_spaces::Rgbf32<CpuAllocator>, C3;
+impl_tagged!(kornia_image::color_spaces::LinearRgbf32, f32, ColorSpace::LinearRgb, {
+    Rgb => kornia_image::color_spaces::Rgbf32, C3;
 });
-impl_tagged!(kornia_image::color_spaces::YCbCrf32<A>, f32, ColorSpace::YCbCr, {
-    Rgb => kornia_image::color_spaces::Rgbf32<CpuAllocator>, C3;
+impl_tagged!(kornia_image::color_spaces::YCbCrf32, f32, ColorSpace::YCbCr, {
+    Rgb => kornia_image::color_spaces::Rgbf32, C3;
 });
-impl_tagged!(kornia_image::color_spaces::Yuvf32<A>, f32, ColorSpace::Yuv, {
-    Rgb => kornia_image::color_spaces::Rgbf32<CpuAllocator>, C3;
+impl_tagged!(kornia_image::color_spaces::Yuvf32, f32, ColorSpace::Yuv, {
+    Rgb => kornia_image::color_spaces::Rgbf32, C3;
 });
-impl_tagged!(kornia_image::color_spaces::Bgrf32<A>, f32, ColorSpace::Bgr, {
-    Rgb => kornia_image::color_spaces::Rgbf32<CpuAllocator>, C3;
+impl_tagged!(kornia_image::color_spaces::Bgrf32, f32, ColorSpace::Bgr, {
+    Rgb => kornia_image::color_spaces::Rgbf32, C3;
 });
-impl_tagged!(kornia_image::color_spaces::Grayf32<A>, f32, ColorSpace::Gray, {
-    Rgb => kornia_image::color_spaces::Rgbf32<CpuAllocator>, C3;
+impl_tagged!(kornia_image::color_spaces::Grayf32, f32, ColorSpace::Gray, {
+    Rgb => kornia_image::color_spaces::Rgbf32, C3;
 });
 
 // ---- u8 RGB source: u8-valid targets ----
-impl_tagged!(kornia_image::color_spaces::Rgb8<A>, u8, ColorSpace::Rgb, {
-    Gray  => kornia_image::color_spaces::Gray8<CpuAllocator>, C1;
-    Bgr   => kornia_image::color_spaces::Bgr8<CpuAllocator>, C3;
-    Rgba  => kornia_image::color_spaces::Rgba8<CpuAllocator>, C4;
-    Bgra  => kornia_image::color_spaces::Bgra8<CpuAllocator>, C4;
-    YCbCr => kornia_image::color_spaces::YCbCr8<CpuAllocator>, C3;
-    Yuv   => kornia_image::color_spaces::Yuv8<CpuAllocator>, C3;
+impl_tagged!(kornia_image::color_spaces::Rgb8, u8, ColorSpace::Rgb, {
+    Gray  => kornia_image::color_spaces::Gray8, C1;
+    Bgr   => kornia_image::color_spaces::Bgr8, C3;
+    Rgba  => kornia_image::color_spaces::Rgba8, C4;
+    Bgra  => kornia_image::color_spaces::Bgra8, C4;
+    YCbCr => kornia_image::color_spaces::YCbCr8, C3;
+    Yuv   => kornia_image::color_spaces::Yuv8, C3;
 });
-impl_tagged!(kornia_image::color_spaces::Gray8<A>, u8, ColorSpace::Gray, {
-    Rgb => kornia_image::color_spaces::Rgb8<CpuAllocator>, C3;
+impl_tagged!(kornia_image::color_spaces::Gray8, u8, ColorSpace::Gray, {
+    Rgb => kornia_image::color_spaces::Rgb8, C3;
 });
-impl_tagged!(kornia_image::color_spaces::Bgr8<A>, u8, ColorSpace::Bgr, {
-    Rgb => kornia_image::color_spaces::Rgb8<CpuAllocator>, C3;
+impl_tagged!(kornia_image::color_spaces::Bgr8, u8, ColorSpace::Bgr, {
+    Rgb => kornia_image::color_spaces::Rgb8, C3;
 });
-impl_tagged!(kornia_image::color_spaces::Rgba8<A>, u8, ColorSpace::Rgba, {
-    Rgb => kornia_image::color_spaces::Rgb8<CpuAllocator>, C3;
+impl_tagged!(kornia_image::color_spaces::Rgba8, u8, ColorSpace::Rgba, {
+    Rgb => kornia_image::color_spaces::Rgb8, C3;
 });
-impl_tagged!(kornia_image::color_spaces::Bgra8<A>, u8, ColorSpace::Bgra, {
-    Rgb => kornia_image::color_spaces::Rgb8<CpuAllocator>, C3;
+impl_tagged!(kornia_image::color_spaces::Bgra8, u8, ColorSpace::Bgra, {
+    Rgb => kornia_image::color_spaces::Rgb8, C3;
 });
 
 #[cfg(test)]
@@ -862,12 +839,12 @@ mod legality_drift_tests {
     //! Luv, Xyz, LinearRgb) cannot be produced from u8 source images.
 
     use super::Tagged;
-    use kornia_image::allocator::CpuAllocator;
     use kornia_image::color_spaces::{
         Bgr8, Bgra8, Bgrf32, Gray8, Grayf32, Hlsf32, Hsvf32, Labf32, LinearRgbf32, Luvf32, Rgb8,
         Rgba8, Rgbf32, Xyzf32, YCbCrf32, Yuvf32,
     };
     use kornia_image::{ColorSpace, ImageSize};
+    use kornia_tensor::host_alloc;
 
     /// All ColorSpace variants enumerated manually (no strum/EnumIter in scope).
     /// 13 variants × 16 source types = 208 (from, to) pairs checked.
@@ -897,7 +874,7 @@ mod legality_drift_tests {
     /// Check one source image against every possible target.
     /// `is_f32` controls whether f32-only spaces are considered supported.
     macro_rules! check_all_targets {
-        ($src:expr, $from:expr, $is_f32:expr) => {{
+        ($src:expr_2021, $from:expr_2021, $is_f32:expr_2021) => {{
             let src = $src;
             let from: ColorSpace = $from;
             let is_f32: bool = $is_f32;
@@ -925,57 +902,57 @@ mod legality_drift_tests {
         // ---- f32 sources (is_f32 = true) ----
 
         check_all_targets!(
-            Rgbf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3], CpuAllocator).unwrap(),
+            Rgbf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3], host_alloc()).unwrap(),
             ColorSpace::Rgb,
             true
         );
         check_all_targets!(
-            Grayf32::from_size_vec(sz, vec![0.5f32; 2 * 2], CpuAllocator).unwrap(),
+            Grayf32::from_size_vec(sz, vec![0.5f32; 2 * 2], host_alloc()).unwrap(),
             ColorSpace::Gray,
             true
         );
         check_all_targets!(
-            Hsvf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3], CpuAllocator).unwrap(),
+            Hsvf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3], host_alloc()).unwrap(),
             ColorSpace::Hsv,
             true
         );
         check_all_targets!(
-            Hlsf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3], CpuAllocator).unwrap(),
+            Hlsf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3], host_alloc()).unwrap(),
             ColorSpace::Hls,
             true
         );
         check_all_targets!(
-            Labf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3], CpuAllocator).unwrap(),
+            Labf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3], host_alloc()).unwrap(),
             ColorSpace::Lab,
             true
         );
         check_all_targets!(
-            Luvf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3], CpuAllocator).unwrap(),
+            Luvf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3], host_alloc()).unwrap(),
             ColorSpace::Luv,
             true
         );
         check_all_targets!(
-            Xyzf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3], CpuAllocator).unwrap(),
+            Xyzf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3], host_alloc()).unwrap(),
             ColorSpace::Xyz,
             true
         );
         check_all_targets!(
-            LinearRgbf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3], CpuAllocator).unwrap(),
+            LinearRgbf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3], host_alloc()).unwrap(),
             ColorSpace::LinearRgb,
             true
         );
         check_all_targets!(
-            YCbCrf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3], CpuAllocator).unwrap(),
+            YCbCrf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3], host_alloc()).unwrap(),
             ColorSpace::YCbCr,
             true
         );
         check_all_targets!(
-            Yuvf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3], CpuAllocator).unwrap(),
+            Yuvf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3], host_alloc()).unwrap(),
             ColorSpace::Yuv,
             true
         );
         check_all_targets!(
-            Bgrf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3], CpuAllocator).unwrap(),
+            Bgrf32::from_size_vec(sz, vec![0.5f32; 2 * 2 * 3], host_alloc()).unwrap(),
             ColorSpace::Bgr,
             true
         );
@@ -983,27 +960,27 @@ mod legality_drift_tests {
         // ---- u8 sources (is_f32 = false) ----
 
         check_all_targets!(
-            Rgb8::from_size_vec(sz, vec![128u8; 2 * 2 * 3], CpuAllocator).unwrap(),
+            Rgb8::from_size_vec(sz, vec![128u8; 2 * 2 * 3], host_alloc()).unwrap(),
             ColorSpace::Rgb,
             false
         );
         check_all_targets!(
-            Gray8::from_size_vec(sz, vec![128u8; 2 * 2], CpuAllocator).unwrap(),
+            Gray8::from_size_vec(sz, vec![128u8; 2 * 2], host_alloc()).unwrap(),
             ColorSpace::Gray,
             false
         );
         check_all_targets!(
-            Bgr8::from_size_vec(sz, vec![128u8; 2 * 2 * 3], CpuAllocator).unwrap(),
+            Bgr8::from_size_vec(sz, vec![128u8; 2 * 2 * 3], host_alloc()).unwrap(),
             ColorSpace::Bgr,
             false
         );
         check_all_targets!(
-            Rgba8::from_size_vec(sz, vec![128u8; 2 * 2 * 4], CpuAllocator).unwrap(),
+            Rgba8::from_size_vec(sz, vec![128u8; 2 * 2 * 4], host_alloc()).unwrap(),
             ColorSpace::Rgba,
             false
         );
         check_all_targets!(
-            Bgra8::from_size_vec(sz, vec![128u8; 2 * 2 * 4], CpuAllocator).unwrap(),
+            Bgra8::from_size_vec(sz, vec![128u8; 2 * 2 * 4], host_alloc()).unwrap(),
             ColorSpace::Bgra,
             false
         );

--- a/crates/kornia-imgproc/src/color/gray/mod.rs
+++ b/crates/kornia-imgproc/src/color/gray/mod.rs
@@ -1,5 +1,5 @@
 use crate::parallel;
-use kornia_image::{allocator::ImageAllocator, Image, ImageError};
+use kornia_image::{Image, ImageError};
 
 mod kernels;
 
@@ -18,17 +18,12 @@ use crate::color::kernel_common::{check_size, sealed};
 /// | `f64` | Same weights, portable scalar                 |
 pub trait GrayFromRgb: sealed::Sealed + Sized {
     #[doc(hidden)]
-    fn gray_from_rgb_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<Self, 3, A1>,
-        dst: &mut Image<Self, 1, A2>,
-    ) -> Result<(), ImageError>;
+    fn gray_from_rgb_impl(src: &Image<Self, 3>, dst: &mut Image<Self, 1>)
+        -> Result<(), ImageError>;
 }
 
 impl GrayFromRgb for u8 {
-    fn gray_from_rgb_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<u8, 3, A1>,
-        dst: &mut Image<u8, 1, A2>,
-    ) -> Result<(), ImageError> {
+    fn gray_from_rgb_impl(src: &Image<u8, 3>, dst: &mut Image<u8, 1>) -> Result<(), ImageError> {
         check_size(src, dst)?;
         kernels::gray_from_rgb_u8(src.as_slice(), dst.as_slice_mut(), src.rows() * src.cols());
         Ok(())
@@ -36,10 +31,7 @@ impl GrayFromRgb for u8 {
 }
 
 impl GrayFromRgb for f32 {
-    fn gray_from_rgb_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<f32, 3, A1>,
-        dst: &mut Image<f32, 1, A2>,
-    ) -> Result<(), ImageError> {
+    fn gray_from_rgb_impl(src: &Image<f32, 3>, dst: &mut Image<f32, 1>) -> Result<(), ImageError> {
         check_size(src, dst)?;
         kernels::gray_from_rgb_f32(src.as_slice(), dst.as_slice_mut(), src.rows() * src.cols());
         Ok(())
@@ -47,10 +39,7 @@ impl GrayFromRgb for f32 {
 }
 
 impl GrayFromRgb for f64 {
-    fn gray_from_rgb_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<f64, 3, A1>,
-        dst: &mut Image<f64, 1, A2>,
-    ) -> Result<(), ImageError> {
+    fn gray_from_rgb_impl(src: &Image<f64, 3>, dst: &mut Image<f64, 1>) -> Result<(), ImageError> {
         check_size(src, dst)?;
         parallel::par_iter_rows(src, dst, |src_pixel, dst_pixel| {
             dst_pixel[0] = 0.299 * src_pixel[0] + 0.587 * src_pixel[1] + 0.114 * src_pixel[2];
@@ -93,35 +82,31 @@ impl GrayFromRgb for f64 {
 /// # Example
 ///
 /// ```
-/// use kornia_image::{Image, ImageSize, allocator::CpuAllocator};
+/// use kornia_image::{Image, ImageSize};
 /// use kornia_imgproc::color::gray_from_rgb;
+/// use kornia_tensor::host_alloc;
 ///
 /// // u8 — NEON / AVX2
-/// let rgb = Image::<u8, 3, _>::new(
+/// let rgb = Image::<u8, 3>::new(
 ///     ImageSize { width: 4, height: 5 },
 ///     vec![0u8; 4 * 5 * 3],
-///     CpuAllocator,
+///     host_alloc(),
 /// ).unwrap();
-/// let mut gray = Image::<u8, 1, _>::from_size_val(rgb.size(), 0, CpuAllocator).unwrap();
+/// let mut gray = Image::<u8, 1>::from_size_val(rgb.size(), 0, host_alloc()).unwrap();
 /// gray_from_rgb(&rgb, &mut gray).unwrap();
 ///
 /// // f32 — NEON / AVX2+FMA
-/// let rgb_f32 = Image::<f32, 3, _>::new(
+/// let rgb_f32 = Image::<f32, 3>::new(
 ///     ImageSize { width: 4, height: 5 },
 ///     vec![0f32; 4 * 5 * 3],
-///     CpuAllocator,
+///     host_alloc(),
 /// ).unwrap();
-/// let mut gray_f32 = Image::<f32, 1, _>::from_size_val(rgb_f32.size(), 0.0, CpuAllocator).unwrap();
+/// let mut gray_f32 = Image::<f32, 1>::from_size_val(rgb_f32.size(), 0.0, host_alloc()).unwrap();
 /// gray_from_rgb(&rgb_f32, &mut gray_f32).unwrap();
 /// ```
-pub fn gray_from_rgb<T, A1, A2>(
-    src: &Image<T, 3, A1>,
-    dst: &mut Image<T, 1, A2>,
-) -> Result<(), ImageError>
+pub fn gray_from_rgb<T>(src: &Image<T, 3>, dst: &mut Image<T, 1>) -> Result<(), ImageError>
 where
     T: GrayFromRgb,
-    A1: ImageAllocator,
-    A2: ImageAllocator,
 {
     T::gray_from_rgb_impl(src, dst)
 }
@@ -142,10 +127,7 @@ where
 /// # Errors
 ///
 /// Returns [`ImageError::InvalidImageSize`] if `src` and `dst` differ in size.
-pub fn gray_from_rgb_u8<A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<u8, 3, A1>,
-    dst: &mut Image<u8, 1, A2>,
-) -> Result<(), ImageError> {
+pub fn gray_from_rgb_u8(src: &Image<u8, 3>, dst: &mut Image<u8, 1>) -> Result<(), ImageError> {
     gray_from_rgb(src, dst)
 }
 
@@ -165,10 +147,7 @@ pub fn gray_from_rgb_u8<A1: ImageAllocator, A2: ImageAllocator>(
 /// # Errors
 ///
 /// Returns [`ImageError::InvalidImageSize`] if `src` and `dst` differ in size.
-pub fn gray_from_rgb_f32<A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<f32, 3, A1>,
-    dst: &mut Image<f32, 1, A2>,
-) -> Result<(), ImageError> {
+pub fn gray_from_rgb_f32(src: &Image<f32, 3>, dst: &mut Image<f32, 1>) -> Result<(), ImageError> {
     gray_from_rgb(src, dst)
 }
 
@@ -180,18 +159,13 @@ pub fn gray_from_rgb_f32<A1: ImageAllocator, A2: ImageAllocator>(
 /// `u16`) uses the portable scalar broadcast. Sealed: no external implementations.
 pub trait RgbFromGray: sealed::Sealed + Copy + Send + Sync {
     #[doc(hidden)]
-    fn rgb_from_gray_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<Self, 1, A1>,
-        dst: &mut Image<Self, 3, A2>,
-    ) -> Result<(), ImageError>;
+    fn rgb_from_gray_impl(src: &Image<Self, 1>, dst: &mut Image<Self, 3>)
+        -> Result<(), ImageError>;
 }
 
 // Generic scalar broadcast — the oracle and the path for every non-NEON `T`.
 #[inline]
-fn rgb_from_gray_scalar<T, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<T, 1, A1>,
-    dst: &mut Image<T, 3, A2>,
-) -> Result<(), ImageError>
+fn rgb_from_gray_scalar<T>(src: &Image<T, 1>, dst: &mut Image<T, 3>) -> Result<(), ImageError>
 where
     T: Copy + Send + Sync,
 {
@@ -207,9 +181,9 @@ where
 macro_rules! impl_rgb_from_gray_scalar {
     ($($t:ty),*) => {$(
         impl RgbFromGray for $t {
-            fn rgb_from_gray_impl<A1: ImageAllocator, A2: ImageAllocator>(
-                src: &Image<$t, 1, A1>,
-                dst: &mut Image<$t, 3, A2>,
+            fn rgb_from_gray_impl(
+                src: &Image<$t, 1>,
+                dst: &mut Image<$t, 3>,
             ) -> Result<(), ImageError> {
                 rgb_from_gray_scalar(src, dst)
             }
@@ -219,10 +193,7 @@ macro_rules! impl_rgb_from_gray_scalar {
 impl_rgb_from_gray_scalar!(u16, i32, f64);
 
 impl RgbFromGray for u8 {
-    fn rgb_from_gray_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<u8, 1, A1>,
-        dst: &mut Image<u8, 3, A2>,
-    ) -> Result<(), ImageError> {
+    fn rgb_from_gray_impl(src: &Image<u8, 1>, dst: &mut Image<u8, 3>) -> Result<(), ImageError> {
         check_size(src, dst)?;
         kernels::rgb_from_gray_u8(src.as_slice(), dst.as_slice_mut(), src.rows() * src.cols());
         Ok(())
@@ -230,10 +201,7 @@ impl RgbFromGray for u8 {
 }
 
 impl RgbFromGray for f32 {
-    fn rgb_from_gray_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<f32, 1, A1>,
-        dst: &mut Image<f32, 3, A2>,
-    ) -> Result<(), ImageError> {
+    fn rgb_from_gray_impl(src: &Image<f32, 1>, dst: &mut Image<f32, 3>) -> Result<(), ImageError> {
         check_size(src, dst)?;
         kernels::rgb_from_gray_f32(src.as_slice(), dst.as_slice_mut(), src.rows() * src.cols());
         Ok(())
@@ -264,21 +232,18 @@ impl RgbFromGray for f32 {
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::color::rgb_from_gray;
 ///
-/// let image = Image::<f32, 1, _>::new(
+/// let image = Image::<f32, 1>::new(
 ///     ImageSize { width: 4, height: 5 },
 ///     vec![0f32; 4 * 5 * 1],
-///     CpuAllocator
+///     host_alloc()
 /// ).unwrap();
-/// let mut rgb = Image::<f32, 3, _>::from_size_val(image.size(), 0.0, CpuAllocator).unwrap();
+/// let mut rgb = Image::<f32, 3>::from_size_val(image.size(), 0.0, host_alloc()).unwrap();
 /// rgb_from_gray(&image, &mut rgb).unwrap();
 /// ```
-pub fn rgb_from_gray<T, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<T, 1, A1>,
-    dst: &mut Image<T, 3, A2>,
-) -> Result<(), ImageError>
+pub fn rgb_from_gray<T>(src: &Image<T, 1>, dst: &mut Image<T, 3>) -> Result<(), ImageError>
 where
     T: RgbFromGray,
 {
@@ -289,16 +254,16 @@ where
 mod tests {
     use kornia_image::{ops, Image, ImageSize};
     use kornia_io::jpeg::read_image_jpeg_rgb8;
-    use kornia_tensor::CpuAllocator;
+    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_gray_from_rgb() -> Result<(), Box<dyn std::error::Error>> {
         let image = read_image_jpeg_rgb8("../../tests/data/dog.jpeg")?;
 
-        let mut image_norm = Image::from_size_val(image.size(), 0.0, CpuAllocator)?;
+        let mut image_norm = Image::from_size_val(image.size(), 0.0, host_alloc())?;
         ops::cast_and_scale(&image, &mut image_norm, 1. / 255.0)?;
 
-        let mut gray = Image::<f32, 1, _>::from_size_val(image_norm.size(), 0.0, CpuAllocator)?;
+        let mut gray = Image::<f32, 1>::from_size_val(image_norm.size(), 0.0, host_alloc())?;
         super::gray_from_rgb(&image_norm, &mut gray)?;
 
         assert_eq!(gray.num_channels(), 1);
@@ -321,19 +286,19 @@ mod tests {
                 0.0, 0.0, 0.0,
                 0.0, 0.0, 0.0,
             ],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut gray = Image::<f32, 1, _>::from_size_val(image.size(), 0.0, CpuAllocator)?;
+        let mut gray = Image::<f32, 1>::from_size_val(image.size(), 0.0, host_alloc())?;
         super::gray_from_rgb(&image, &mut gray)?;
 
-        let expected: Image<f32, 1, _> = Image::new(
+        let expected: Image<f32, 1> = Image::new(
             ImageSize {
                 width: 2,
                 height: 3,
             },
             vec![0.299, 0.587, 0.114, 0.0, 0.0, 0.0],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         for (a, b) in gray.as_slice().iter().zip(expected.as_slice().iter()) {
@@ -351,14 +316,14 @@ mod tests {
                 height: 3,
             },
             vec![0.0_f32, 1.0, 2.0, 3.0, 4.0, 5.0],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut rgb = Image::<f32, 3, _>::from_size_val(image.size(), 0.0, CpuAllocator)?;
+        let mut rgb = Image::<f32, 3>::from_size_val(image.size(), 0.0, host_alloc())?;
         super::rgb_from_gray(&image, &mut rgb)?;
 
         #[rustfmt::skip]
-        let expected: Image<f32, 3, _> = Image::new(
+        let expected: Image<f32, 3> = Image::new(
             ImageSize { width: 2, height: 3 },
             vec![
                 0.0, 0.0, 0.0,
@@ -368,7 +333,7 @@ mod tests {
                 4.0, 4.0, 4.0,
                 5.0, 5.0, 5.0,
             ],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         assert_eq!(rgb.as_slice(), expected.as_slice());
@@ -386,8 +351,8 @@ mod tests {
             height: 3,
         };
         let gray: Vec<u8> = (0..21).map(|v| (v * 11 % 256) as u8).collect();
-        let src = Image::<u8, 1, _>::new(size, gray.clone(), CpuAllocator)?;
-        let mut rgb = Image::<u8, 3, _>::from_size_val(size, 0, CpuAllocator)?;
+        let src = Image::<u8, 1>::new(size, gray.clone(), host_alloc())?;
+        let mut rgb = Image::<u8, 3>::from_size_val(size, 0, host_alloc())?;
         super::rgb_from_gray(&src, &mut rgb)?;
         for (i, &g) in gray.iter().enumerate() {
             assert_eq!(rgb.as_slice()[i * 3], g);
@@ -406,8 +371,8 @@ mod tests {
         };
         let npix = 1024 * 1025;
         let gray: Vec<u8> = (0..npix).map(|v| (v % 256) as u8).collect();
-        let src = Image::<u8, 1, _>::new(size, gray.clone(), CpuAllocator)?;
-        let mut rgb = Image::<u8, 3, _>::from_size_val(size, 0, CpuAllocator)?;
+        let src = Image::<u8, 1>::new(size, gray.clone(), host_alloc())?;
+        let mut rgb = Image::<u8, 3>::from_size_val(size, 0, host_alloc())?;
         super::rgb_from_gray(&src, &mut rgb)?;
         for (i, &g) in gray.iter().enumerate() {
             assert_eq!(rgb.as_slice()[i * 3], g, "px {i}");
@@ -425,8 +390,8 @@ mod tests {
         };
         let npix = 1024 * 1025;
         let gray: Vec<f32> = (0..npix).map(|v| (v % 256) as f32 * 0.25).collect();
-        let src = Image::<f32, 1, _>::new(size, gray.clone(), CpuAllocator)?;
-        let mut rgb = Image::<f32, 3, _>::from_size_val(size, 0.0, CpuAllocator)?;
+        let src = Image::<f32, 1>::new(size, gray.clone(), host_alloc())?;
+        let mut rgb = Image::<f32, 3>::from_size_val(size, 0.0, host_alloc())?;
         super::rgb_from_gray(&src, &mut rgb)?;
         for (i, &g) in gray.iter().enumerate() {
             assert_eq!(rgb.as_slice()[i * 3], g, "px {i}");
@@ -444,10 +409,10 @@ mod tests {
                 height: 2,
             },
             vec![0u8, 128, 255, 128, 0, 128],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut gray = Image::<u8, 1, _>::from_size_val(image.size(), 0, CpuAllocator)?;
+        let mut gray = Image::<u8, 1>::from_size_val(image.size(), 0, host_alloc())?;
         // unified entry point dispatches to the u8 NEON/AVX2 kernel
         super::gray_from_rgb(&image, &mut gray)?;
 
@@ -471,10 +436,10 @@ mod tests {
                 1.0,     1.0, 1.0,
                 0.5,     0.5, 0.5,
             ],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut dst = Image::<f32, 1, _>::from_size_val(src.size(), 0.0, CpuAllocator)?;
+        let mut dst = Image::<f32, 1>::from_size_val(src.size(), 0.0, host_alloc())?;
         super::gray_from_rgb(&src, &mut dst)?;
 
         let expected = [0.299_f32, 0.587, 0.114, 0.0, 1.0, 0.5];
@@ -495,15 +460,15 @@ mod tests {
                 height: 3,
             },
             (0..63).map(|v| v as f32 / 62.0).collect::<Vec<_>>(),
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut dst_simd = Image::<f32, 1, _>::from_size_val(src.size(), 0.0, CpuAllocator)?;
-        let mut dst_scalar = Image::<f64, 1, _>::from_size_val(src.size(), 0.0, CpuAllocator)?;
+        let mut dst_simd = Image::<f32, 1>::from_size_val(src.size(), 0.0, host_alloc())?;
+        let mut dst_scalar = Image::<f64, 1>::from_size_val(src.size(), 0.0, host_alloc())?;
         let src_f64 = Image::new(
             src.size(),
             src.as_slice().iter().map(|&v| v as f64).collect::<Vec<_>>(),
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         super::gray_from_rgb(&src, &mut dst_simd)?;
@@ -537,15 +502,15 @@ mod tests {
             (0..npix * 3)
                 .map(|v| (v % 256) as f32 / 255.0)
                 .collect::<Vec<_>>(),
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut dst_simd = Image::<f32, 1, _>::from_size_val(src.size(), 0.0, CpuAllocator)?;
-        let mut dst_scalar = Image::<f64, 1, _>::from_size_val(src.size(), 0.0, CpuAllocator)?;
+        let mut dst_simd = Image::<f32, 1>::from_size_val(src.size(), 0.0, host_alloc())?;
+        let mut dst_scalar = Image::<f64, 1>::from_size_val(src.size(), 0.0, host_alloc())?;
         let src_f64 = Image::new(
             src.size(),
             src.as_slice().iter().map(|&v| v as f64).collect::<Vec<_>>(),
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         super::gray_from_rgb(&src, &mut dst_simd)?;

--- a/crates/kornia-imgproc/src/color/gray/mod.rs
+++ b/crates/kornia-imgproc/src/color/gray/mod.rs
@@ -84,24 +84,21 @@ impl GrayFromRgb for f64 {
 /// ```
 /// use kornia_image::{Image, ImageSize};
 /// use kornia_imgproc::color::gray_from_rgb;
-/// use kornia_tensor::host_alloc;
 ///
 /// // u8 — NEON / AVX2
 /// let rgb = Image::<u8, 3>::new(
 ///     ImageSize { width: 4, height: 5 },
 ///     vec![0u8; 4 * 5 * 3],
-///     host_alloc(),
 /// ).unwrap();
-/// let mut gray = Image::<u8, 1>::from_size_val(rgb.size(), 0, host_alloc()).unwrap();
+/// let mut gray = Image::<u8, 1>::from_size_val(rgb.size(), 0).unwrap();
 /// gray_from_rgb(&rgb, &mut gray).unwrap();
 ///
 /// // f32 — NEON / AVX2+FMA
 /// let rgb_f32 = Image::<f32, 3>::new(
 ///     ImageSize { width: 4, height: 5 },
 ///     vec![0f32; 4 * 5 * 3],
-///     host_alloc(),
 /// ).unwrap();
-/// let mut gray_f32 = Image::<f32, 1>::from_size_val(rgb_f32.size(), 0.0, host_alloc()).unwrap();
+/// let mut gray_f32 = Image::<f32, 1>::from_size_val(rgb_f32.size(), 0.0).unwrap();
 /// gray_from_rgb(&rgb_f32, &mut gray_f32).unwrap();
 /// ```
 pub fn gray_from_rgb<T>(src: &Image<T, 3>, dst: &mut Image<T, 1>) -> Result<(), ImageError>
@@ -232,15 +229,13 @@ impl RgbFromGray for f32 {
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::color::rgb_from_gray;
 ///
 /// let image = Image::<f32, 1>::new(
 ///     ImageSize { width: 4, height: 5 },
 ///     vec![0f32; 4 * 5 * 1],
-///     host_alloc()
 /// ).unwrap();
-/// let mut rgb = Image::<f32, 3>::from_size_val(image.size(), 0.0, host_alloc()).unwrap();
+/// let mut rgb = Image::<f32, 3>::from_size_val(image.size(), 0.0).unwrap();
 /// rgb_from_gray(&image, &mut rgb).unwrap();
 /// ```
 pub fn rgb_from_gray<T>(src: &Image<T, 1>, dst: &mut Image<T, 3>) -> Result<(), ImageError>
@@ -254,16 +249,15 @@ where
 mod tests {
     use kornia_image::{ops, Image, ImageSize};
     use kornia_io::jpeg::read_image_jpeg_rgb8;
-    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_gray_from_rgb() -> Result<(), Box<dyn std::error::Error>> {
         let image = read_image_jpeg_rgb8("../../tests/data/dog.jpeg")?;
 
-        let mut image_norm = Image::from_size_val(image.size(), 0.0, host_alloc())?;
+        let mut image_norm = Image::from_size_val(image.size(), 0.0)?;
         ops::cast_and_scale(&image, &mut image_norm, 1. / 255.0)?;
 
-        let mut gray = Image::<f32, 1>::from_size_val(image_norm.size(), 0.0, host_alloc())?;
+        let mut gray = Image::<f32, 1>::from_size_val(image_norm.size(), 0.0)?;
         super::gray_from_rgb(&image_norm, &mut gray)?;
 
         assert_eq!(gray.num_channels(), 1);
@@ -286,10 +280,9 @@ mod tests {
                 0.0, 0.0, 0.0,
                 0.0, 0.0, 0.0,
             ],
-            host_alloc(),
         )?;
 
-        let mut gray = Image::<f32, 1>::from_size_val(image.size(), 0.0, host_alloc())?;
+        let mut gray = Image::<f32, 1>::from_size_val(image.size(), 0.0)?;
         super::gray_from_rgb(&image, &mut gray)?;
 
         let expected: Image<f32, 1> = Image::new(
@@ -298,7 +291,6 @@ mod tests {
                 height: 3,
             },
             vec![0.299, 0.587, 0.114, 0.0, 0.0, 0.0],
-            host_alloc(),
         )?;
 
         for (a, b) in gray.as_slice().iter().zip(expected.as_slice().iter()) {
@@ -316,10 +308,9 @@ mod tests {
                 height: 3,
             },
             vec![0.0_f32, 1.0, 2.0, 3.0, 4.0, 5.0],
-            host_alloc(),
         )?;
 
-        let mut rgb = Image::<f32, 3>::from_size_val(image.size(), 0.0, host_alloc())?;
+        let mut rgb = Image::<f32, 3>::from_size_val(image.size(), 0.0)?;
         super::rgb_from_gray(&image, &mut rgb)?;
 
         #[rustfmt::skip]
@@ -333,7 +324,6 @@ mod tests {
                 4.0, 4.0, 4.0,
                 5.0, 5.0, 5.0,
             ],
-            host_alloc(),
         )?;
 
         assert_eq!(rgb.as_slice(), expected.as_slice());
@@ -351,8 +341,8 @@ mod tests {
             height: 3,
         };
         let gray: Vec<u8> = (0..21).map(|v| (v * 11 % 256) as u8).collect();
-        let src = Image::<u8, 1>::new(size, gray.clone(), host_alloc())?;
-        let mut rgb = Image::<u8, 3>::from_size_val(size, 0, host_alloc())?;
+        let src = Image::<u8, 1>::new(size, gray.clone())?;
+        let mut rgb = Image::<u8, 3>::from_size_val(size, 0)?;
         super::rgb_from_gray(&src, &mut rgb)?;
         for (i, &g) in gray.iter().enumerate() {
             assert_eq!(rgb.as_slice()[i * 3], g);
@@ -371,8 +361,8 @@ mod tests {
         };
         let npix = 1024 * 1025;
         let gray: Vec<u8> = (0..npix).map(|v| (v % 256) as u8).collect();
-        let src = Image::<u8, 1>::new(size, gray.clone(), host_alloc())?;
-        let mut rgb = Image::<u8, 3>::from_size_val(size, 0, host_alloc())?;
+        let src = Image::<u8, 1>::new(size, gray.clone())?;
+        let mut rgb = Image::<u8, 3>::from_size_val(size, 0)?;
         super::rgb_from_gray(&src, &mut rgb)?;
         for (i, &g) in gray.iter().enumerate() {
             assert_eq!(rgb.as_slice()[i * 3], g, "px {i}");
@@ -390,8 +380,8 @@ mod tests {
         };
         let npix = 1024 * 1025;
         let gray: Vec<f32> = (0..npix).map(|v| (v % 256) as f32 * 0.25).collect();
-        let src = Image::<f32, 1>::new(size, gray.clone(), host_alloc())?;
-        let mut rgb = Image::<f32, 3>::from_size_val(size, 0.0, host_alloc())?;
+        let src = Image::<f32, 1>::new(size, gray.clone())?;
+        let mut rgb = Image::<f32, 3>::from_size_val(size, 0.0)?;
         super::rgb_from_gray(&src, &mut rgb)?;
         for (i, &g) in gray.iter().enumerate() {
             assert_eq!(rgb.as_slice()[i * 3], g, "px {i}");
@@ -409,10 +399,9 @@ mod tests {
                 height: 2,
             },
             vec![0u8, 128, 255, 128, 0, 128],
-            host_alloc(),
         )?;
 
-        let mut gray = Image::<u8, 1>::from_size_val(image.size(), 0, host_alloc())?;
+        let mut gray = Image::<u8, 1>::from_size_val(image.size(), 0)?;
         // unified entry point dispatches to the u8 NEON/AVX2 kernel
         super::gray_from_rgb(&image, &mut gray)?;
 
@@ -436,10 +425,9 @@ mod tests {
                 1.0,     1.0, 1.0,
                 0.5,     0.5, 0.5,
             ],
-            host_alloc(),
         )?;
 
-        let mut dst = Image::<f32, 1>::from_size_val(src.size(), 0.0, host_alloc())?;
+        let mut dst = Image::<f32, 1>::from_size_val(src.size(), 0.0)?;
         super::gray_from_rgb(&src, &mut dst)?;
 
         let expected = [0.299_f32, 0.587, 0.114, 0.0, 1.0, 0.5];
@@ -460,15 +448,13 @@ mod tests {
                 height: 3,
             },
             (0..63).map(|v| v as f32 / 62.0).collect::<Vec<_>>(),
-            host_alloc(),
         )?;
 
-        let mut dst_simd = Image::<f32, 1>::from_size_val(src.size(), 0.0, host_alloc())?;
-        let mut dst_scalar = Image::<f64, 1>::from_size_val(src.size(), 0.0, host_alloc())?;
+        let mut dst_simd = Image::<f32, 1>::from_size_val(src.size(), 0.0)?;
+        let mut dst_scalar = Image::<f64, 1>::from_size_val(src.size(), 0.0)?;
         let src_f64 = Image::new(
             src.size(),
             src.as_slice().iter().map(|&v| v as f64).collect::<Vec<_>>(),
-            host_alloc(),
         )?;
 
         super::gray_from_rgb(&src, &mut dst_simd)?;
@@ -502,15 +488,13 @@ mod tests {
             (0..npix * 3)
                 .map(|v| (v % 256) as f32 / 255.0)
                 .collect::<Vec<_>>(),
-            host_alloc(),
         )?;
 
-        let mut dst_simd = Image::<f32, 1>::from_size_val(src.size(), 0.0, host_alloc())?;
-        let mut dst_scalar = Image::<f64, 1>::from_size_val(src.size(), 0.0, host_alloc())?;
+        let mut dst_simd = Image::<f32, 1>::from_size_val(src.size(), 0.0)?;
+        let mut dst_scalar = Image::<f64, 1>::from_size_val(src.size(), 0.0)?;
         let src_f64 = Image::new(
             src.size(),
             src.as_slice().iter().map(|&v| v as f64).collect::<Vec<_>>(),
-            host_alloc(),
         )?;
 
         super::gray_from_rgb(&src, &mut dst_simd)?;

--- a/crates/kornia-imgproc/src/color/hls/kernels.rs
+++ b/crates/kornia-imgproc/src/color/hls/kernels.rs
@@ -311,27 +311,29 @@ unsafe fn hue2rgb_neon(
     two_third: std::arch::aarch64::float32x4_t,
     one_sixth: std::arch::aarch64::float32x4_t,
 ) -> std::arch::aarch64::float32x4_t {
-    use std::arch::aarch64::*;
-    let zero = vdupq_n_f32(0.0);
-    // wrap t into [0,1): if t<0 t+=1; if t>1 t-=1
-    let t = vbslq_f32(vcltq_f32(t, zero), vaddq_f32(t, v1), t);
-    let t = vbslq_f32(vcgtq_f32(t, v1), vsubq_f32(t, v1), t);
+    unsafe {
+        use std::arch::aarch64::*;
+        let zero = vdupq_n_f32(0.0);
+        // wrap t into [0,1): if t<0 t+=1; if t>1 t-=1
+        let t = vbslq_f32(vcltq_f32(t, zero), vaddq_f32(t, v1), t);
+        let t = vbslq_f32(vcgtq_f32(t, v1), vsubq_f32(t, v1), t);
 
-    let qmp = vsubq_f32(q, p);
-    // branch a: t<1/6 → p + (q-p)*6*t
-    let cand_a = vaddq_f32(p, vmulq_f32(qmp, vmulq_f32(v6, t)));
-    // branch b: t<1/2 → q
-    // branch c: t<2/3 → p + (q-p)*(2/3 - t)*6
-    let cand_c = vaddq_f32(p, vmulq_f32(qmp, vmulq_f32(vsubq_f32(two_third, t), v6)));
-    // branch d (else): p
+        let qmp = vsubq_f32(q, p);
+        // branch a: t<1/6 → p + (q-p)*6*t
+        let cand_a = vaddq_f32(p, vmulq_f32(qmp, vmulq_f32(v6, t)));
+        // branch b: t<1/2 → q
+        // branch c: t<2/3 → p + (q-p)*(2/3 - t)*6
+        let cand_c = vaddq_f32(p, vmulq_f32(qmp, vmulq_f32(vsubq_f32(two_third, t), v6)));
+        // branch d (else): p
 
-    // select from the bottom up: default p, then c if t<2/3, then q if t<1/2, then a if t<1/6
-    let lt_two_third = vcltq_f32(t, two_third);
-    let lt_half = vcltq_f32(t, half);
-    let lt_sixth = vcltq_f32(t, one_sixth);
-    let out = vbslq_f32(lt_two_third, cand_c, p);
-    let out = vbslq_f32(lt_half, q, out);
-    vbslq_f32(lt_sixth, cand_a, out)
+        // select from the bottom up: default p, then c if t<2/3, then q if t<1/2, then a if t<1/6
+        let lt_two_third = vcltq_f32(t, two_third);
+        let lt_half = vcltq_f32(t, half);
+        let lt_sixth = vcltq_f32(t, one_sixth);
+        let out = vbslq_f32(lt_two_third, cand_c, p);
+        let out = vbslq_f32(lt_half, q, out);
+        vbslq_f32(lt_sixth, cand_a, out)
+    }
 }
 
 #[cfg(target_arch = "x86_64")]

--- a/crates/kornia-imgproc/src/color/hls/mod.rs
+++ b/crates/kornia-imgproc/src/color/hls/mod.rs
@@ -141,11 +141,10 @@ fn hue2rgb_f64(p: f64, q: f64, t: f64) -> f64 {
 /// ```
 /// use kornia_image::{Image, ImageSize};
 /// use kornia_imgproc::color::hls_from_rgb;
-/// use kornia_tensor::host_alloc;
 ///
 /// let rgb = Image::<f32, 3>::from_size_val(
-///     ImageSize { width: 4, height: 5 }, 0.0, host_alloc()).unwrap();
-/// let mut hls = Image::<f32, 3>::from_size_val(rgb.size(), 0.0, host_alloc()).unwrap();
+///     ImageSize { width: 4, height: 5 }, 0.0).unwrap();
+/// let mut hls = Image::<f32, 3>::from_size_val(rgb.size(), 0.0).unwrap();
 /// hls_from_rgb(&rgb, &mut hls).unwrap();
 /// ```
 pub fn hls_from_rgb<T>(src: &Image<T, 3>, dst: &mut Image<T, 3>) -> Result<(), ImageError>
@@ -162,11 +161,10 @@ where
 /// ```
 /// use kornia_image::{Image, ImageSize};
 /// use kornia_imgproc::color::rgb_from_hls;
-/// use kornia_tensor::host_alloc;
 ///
 /// let hls = Image::<f32, 3>::from_size_val(
-///     ImageSize { width: 4, height: 5 }, 0.0, host_alloc()).unwrap();
-/// let mut rgb = Image::<f32, 3>::from_size_val(hls.size(), 0.0, host_alloc()).unwrap();
+///     ImageSize { width: 4, height: 5 }, 0.0).unwrap();
+/// let mut rgb = Image::<f32, 3>::from_size_val(hls.size(), 0.0).unwrap();
 /// rgb_from_hls(&hls, &mut rgb).unwrap();
 /// ```
 pub fn rgb_from_hls<T>(src: &Image<T, 3>, dst: &mut Image<T, 3>) -> Result<(), ImageError>
@@ -189,7 +187,6 @@ pub fn rgb_from_hls_f32(src: &Image<f32, 3>, dst: &mut Image<f32, 3>) -> Result<
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::host_alloc;
 
     // Hand-computed via the documented HLS math (channel order [H, L, S]).
     #[test]
@@ -203,7 +200,6 @@ mod tests {
                 height: 1,
             },
             vec![255.0, 0.0, 0.0, 0.0, 255.0, 0.0, 0.0, 0.0, 255.0],
-            host_alloc(),
         )?;
         let expected = [
             // H_out=(H/360)*255, L_out=L*255, S_out=S*255
@@ -217,7 +213,7 @@ mod tests {
             127.5,
             255.0, // blue:  H=240
         ];
-        let mut hls = Image::<f32, 3>::from_size_val(image.size(), 0.0, host_alloc())?;
+        let mut hls = Image::<f32, 3>::from_size_val(image.size(), 0.0)?;
         super::hls_from_rgb(&image, &mut hls)?;
         for (a, b) in hls.as_slice().iter().zip(expected.iter()) {
             assert!((a - b).abs() < 1e-3, "{a} != {b}");
@@ -236,10 +232,9 @@ mod tests {
                 height: 5,
             },
             data,
-            host_alloc(),
         )?;
-        let mut hls = Image::<f32, 3>::from_size_val(src.size(), 0.0, host_alloc())?;
-        let mut back = Image::<f32, 3>::from_size_val(src.size(), 0.0, host_alloc())?;
+        let mut hls = Image::<f32, 3>::from_size_val(src.size(), 0.0)?;
+        let mut back = Image::<f32, 3>::from_size_val(src.size(), 0.0)?;
         super::hls_from_rgb(&src, &mut hls)?;
         super::rgb_from_hls(&hls, &mut back)?;
         for (a, b) in src.as_slice().iter().zip(back.as_slice().iter()) {
@@ -258,15 +253,10 @@ mod tests {
                 height: 3,
             },
             data.clone(),
-            host_alloc(),
         )?;
-        let src64 = Image::<f64, 3>::new(
-            src.size(),
-            data.iter().map(|&v| v as f64).collect(),
-            host_alloc(),
-        )?;
-        let mut simd = Image::<f32, 3>::from_size_val(src.size(), 0.0, host_alloc())?;
-        let mut scalar = Image::<f64, 3>::from_size_val(src.size(), 0.0, host_alloc())?;
+        let src64 = Image::<f64, 3>::new(src.size(), data.iter().map(|&v| v as f64).collect())?;
+        let mut simd = Image::<f32, 3>::from_size_val(src.size(), 0.0)?;
+        let mut scalar = Image::<f64, 3>::from_size_val(src.size(), 0.0)?;
         super::hls_from_rgb(&src, &mut simd)?;
         super::hls_from_rgb(&src64, &mut scalar)?;
         for (a, b) in simd.as_slice().iter().zip(scalar.as_slice().iter()) {
@@ -286,10 +276,9 @@ mod tests {
                 height: h,
             },
             data,
-            host_alloc(),
         )?;
-        let mut hls = Image::<f32, 3>::from_size_val(src.size(), 0.0, host_alloc())?;
-        let mut back = Image::<f32, 3>::from_size_val(src.size(), 0.0, host_alloc())?;
+        let mut hls = Image::<f32, 3>::from_size_val(src.size(), 0.0)?;
+        let mut back = Image::<f32, 3>::from_size_val(src.size(), 0.0)?;
         super::hls_from_rgb(&src, &mut hls)?;
         super::rgb_from_hls(&hls, &mut back)?;
         for (a, b) in src.as_slice().iter().zip(back.as_slice().iter()) {

--- a/crates/kornia-imgproc/src/color/hls/mod.rs
+++ b/crates/kornia-imgproc/src/color/hls/mod.rs
@@ -1,5 +1,5 @@
 use crate::parallel;
-use kornia_image::{allocator::ImageAllocator, Image, ImageError};
+use kornia_image::{Image, ImageError};
 
 mod kernels;
 
@@ -12,36 +12,24 @@ use crate::color::kernel_common::{check_size, sealed};
 /// Implemented for `f32` (NEON / AVX2) and `f64` (portable scalar). Sealed.
 pub trait HlsFromRgb: sealed::Sealed + Sized {
     #[doc(hidden)]
-    fn hls_from_rgb_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<Self, 3, A1>,
-        dst: &mut Image<Self, 3, A2>,
-    ) -> Result<(), ImageError>;
+    fn hls_from_rgb_impl(src: &Image<Self, 3>, dst: &mut Image<Self, 3>) -> Result<(), ImageError>;
 }
 
 /// Compile-time dispatch to the right HLS→RGB kernel for each pixel type.
 pub trait RgbFromHls: sealed::Sealed + Sized {
     #[doc(hidden)]
-    fn rgb_from_hls_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<Self, 3, A1>,
-        dst: &mut Image<Self, 3, A2>,
-    ) -> Result<(), ImageError>;
+    fn rgb_from_hls_impl(src: &Image<Self, 3>, dst: &mut Image<Self, 3>) -> Result<(), ImageError>;
 }
 
 impl HlsFromRgb for f32 {
-    fn hls_from_rgb_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<f32, 3, A1>,
-        dst: &mut Image<f32, 3, A2>,
-    ) -> Result<(), ImageError> {
+    fn hls_from_rgb_impl(src: &Image<f32, 3>, dst: &mut Image<f32, 3>) -> Result<(), ImageError> {
         check_size(src, dst)?;
         kernels::hls_from_rgb_f32(src.as_slice(), dst.as_slice_mut(), src.rows() * src.cols());
         Ok(())
     }
 }
 impl RgbFromHls for f32 {
-    fn rgb_from_hls_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<f32, 3, A1>,
-        dst: &mut Image<f32, 3, A2>,
-    ) -> Result<(), ImageError> {
+    fn rgb_from_hls_impl(src: &Image<f32, 3>, dst: &mut Image<f32, 3>) -> Result<(), ImageError> {
         check_size(src, dst)?;
         kernels::rgb_from_hls_f32(src.as_slice(), dst.as_slice_mut(), src.rows() * src.cols());
         Ok(())
@@ -49,10 +37,7 @@ impl RgbFromHls for f32 {
 }
 
 impl HlsFromRgb for f64 {
-    fn hls_from_rgb_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<f64, 3, A1>,
-        dst: &mut Image<f64, 3, A2>,
-    ) -> Result<(), ImageError> {
+    fn hls_from_rgb_impl(src: &Image<f64, 3>, dst: &mut Image<f64, 3>) -> Result<(), ImageError> {
         check_size(src, dst)?;
         parallel::par_iter_rows(src, dst, |s, d| {
             let (h, l, sa) = hls_from_rgb_scalar_f64(s[0], s[1], s[2]);
@@ -64,10 +49,7 @@ impl HlsFromRgb for f64 {
     }
 }
 impl RgbFromHls for f64 {
-    fn rgb_from_hls_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<f64, 3, A1>,
-        dst: &mut Image<f64, 3, A2>,
-    ) -> Result<(), ImageError> {
+    fn rgb_from_hls_impl(src: &Image<f64, 3>, dst: &mut Image<f64, 3>) -> Result<(), ImageError> {
         check_size(src, dst)?;
         parallel::par_iter_rows(src, dst, |s, d| {
             let (r, g, b) = rgb_from_hls_scalar_f64(s[0], s[1], s[2]);
@@ -157,22 +139,18 @@ fn hue2rgb_f64(p: f64, q: f64, t: f64) -> f64 {
 /// # Example
 ///
 /// ```
-/// use kornia_image::{Image, ImageSize, allocator::CpuAllocator};
+/// use kornia_image::{Image, ImageSize};
 /// use kornia_imgproc::color::hls_from_rgb;
+/// use kornia_tensor::host_alloc;
 ///
-/// let rgb = Image::<f32, 3, _>::from_size_val(
-///     ImageSize { width: 4, height: 5 }, 0.0, CpuAllocator).unwrap();
-/// let mut hls = Image::<f32, 3, _>::from_size_val(rgb.size(), 0.0, CpuAllocator).unwrap();
+/// let rgb = Image::<f32, 3>::from_size_val(
+///     ImageSize { width: 4, height: 5 }, 0.0, host_alloc()).unwrap();
+/// let mut hls = Image::<f32, 3>::from_size_val(rgb.size(), 0.0, host_alloc()).unwrap();
 /// hls_from_rgb(&rgb, &mut hls).unwrap();
 /// ```
-pub fn hls_from_rgb<T, A1, A2>(
-    src: &Image<T, 3, A1>,
-    dst: &mut Image<T, 3, A2>,
-) -> Result<(), ImageError>
+pub fn hls_from_rgb<T>(src: &Image<T, 3>, dst: &mut Image<T, 3>) -> Result<(), ImageError>
 where
     T: HlsFromRgb,
-    A1: ImageAllocator,
-    A2: ImageAllocator,
 {
     T::hls_from_rgb_impl(src, dst)
 }
@@ -182,46 +160,36 @@ where
 /// # Example
 ///
 /// ```
-/// use kornia_image::{Image, ImageSize, allocator::CpuAllocator};
+/// use kornia_image::{Image, ImageSize};
 /// use kornia_imgproc::color::rgb_from_hls;
+/// use kornia_tensor::host_alloc;
 ///
-/// let hls = Image::<f32, 3, _>::from_size_val(
-///     ImageSize { width: 4, height: 5 }, 0.0, CpuAllocator).unwrap();
-/// let mut rgb = Image::<f32, 3, _>::from_size_val(hls.size(), 0.0, CpuAllocator).unwrap();
+/// let hls = Image::<f32, 3>::from_size_val(
+///     ImageSize { width: 4, height: 5 }, 0.0, host_alloc()).unwrap();
+/// let mut rgb = Image::<f32, 3>::from_size_val(hls.size(), 0.0, host_alloc()).unwrap();
 /// rgb_from_hls(&hls, &mut rgb).unwrap();
 /// ```
-pub fn rgb_from_hls<T, A1, A2>(
-    src: &Image<T, 3, A1>,
-    dst: &mut Image<T, 3, A2>,
-) -> Result<(), ImageError>
+pub fn rgb_from_hls<T>(src: &Image<T, 3>, dst: &mut Image<T, 3>) -> Result<(), ImageError>
 where
     T: RgbFromHls,
-    A1: ImageAllocator,
-    A2: ImageAllocator,
 {
     T::rgb_from_hls_impl(src, dst)
 }
 
 /// Convert an RGB f32 image to HLS. Thin wrapper around [`hls_from_rgb`].
-pub fn hls_from_rgb_f32<A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<f32, 3, A1>,
-    dst: &mut Image<f32, 3, A2>,
-) -> Result<(), ImageError> {
+pub fn hls_from_rgb_f32(src: &Image<f32, 3>, dst: &mut Image<f32, 3>) -> Result<(), ImageError> {
     hls_from_rgb(src, dst)
 }
 
 /// Convert an HLS f32 image to RGB. Thin wrapper around [`rgb_from_hls`].
-pub fn rgb_from_hls_f32<A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<f32, 3, A1>,
-    dst: &mut Image<f32, 3, A2>,
-) -> Result<(), ImageError> {
+pub fn rgb_from_hls_f32(src: &Image<f32, 3>, dst: &mut Image<f32, 3>) -> Result<(), ImageError> {
     rgb_from_hls(src, dst)
 }
 
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::CpuAllocator;
+    use kornia_tensor::host_alloc;
 
     // Hand-computed via the documented HLS math (channel order [H, L, S]).
     #[test]
@@ -229,13 +197,13 @@ mod tests {
         // Pure red (255,0,0): max=1,min=0,diff=1,L=0.5,S=1 (L<=0.5 branch),H=0.
         // Pure green (0,255,0): H=120°,L=0.5,S=1.
         // Pure blue (0,0,255): H=240°,L=0.5,S=1.
-        let image = Image::<f32, 3, _>::new(
+        let image = Image::<f32, 3>::new(
             ImageSize {
                 width: 3,
                 height: 1,
             },
             vec![255.0, 0.0, 0.0, 0.0, 255.0, 0.0, 0.0, 0.0, 255.0],
-            CpuAllocator,
+            host_alloc(),
         )?;
         let expected = [
             // H_out=(H/360)*255, L_out=L*255, S_out=S*255
@@ -249,7 +217,7 @@ mod tests {
             127.5,
             255.0, // blue:  H=240
         ];
-        let mut hls = Image::<f32, 3, _>::from_size_val(image.size(), 0.0, CpuAllocator)?;
+        let mut hls = Image::<f32, 3>::from_size_val(image.size(), 0.0, host_alloc())?;
         super::hls_from_rgb(&image, &mut hls)?;
         for (a, b) in hls.as_slice().iter().zip(expected.iter()) {
             assert!((a - b).abs() < 1e-3, "{a} != {b}");
@@ -262,16 +230,16 @@ mod tests {
         // dense-ish sweep; exercises 4-px NEON body + scalar tail (7 px wide)
         let npix = 7 * 5;
         let data: Vec<f32> = (0..npix * 3).map(|v| (v % 256) as f32).collect();
-        let src = Image::<f32, 3, _>::new(
+        let src = Image::<f32, 3>::new(
             ImageSize {
                 width: 7,
                 height: 5,
             },
             data,
-            CpuAllocator,
+            host_alloc(),
         )?;
-        let mut hls = Image::<f32, 3, _>::from_size_val(src.size(), 0.0, CpuAllocator)?;
-        let mut back = Image::<f32, 3, _>::from_size_val(src.size(), 0.0, CpuAllocator)?;
+        let mut hls = Image::<f32, 3>::from_size_val(src.size(), 0.0, host_alloc())?;
+        let mut back = Image::<f32, 3>::from_size_val(src.size(), 0.0, host_alloc())?;
         super::hls_from_rgb(&src, &mut hls)?;
         super::rgb_from_hls(&hls, &mut back)?;
         for (a, b) in src.as_slice().iter().zip(back.as_slice().iter()) {
@@ -284,21 +252,21 @@ mod tests {
     fn f32_simd_matches_f64_scalar() -> Result<(), ImageError> {
         let npix = 7 * 3;
         let data: Vec<f32> = (0..npix * 3).map(|v| (v * 7 % 256) as f32).collect();
-        let src = Image::<f32, 3, _>::new(
+        let src = Image::<f32, 3>::new(
             ImageSize {
                 width: 7,
                 height: 3,
             },
             data.clone(),
-            CpuAllocator,
+            host_alloc(),
         )?;
-        let src64 = Image::<f64, 3, _>::new(
+        let src64 = Image::<f64, 3>::new(
             src.size(),
             data.iter().map(|&v| v as f64).collect(),
-            CpuAllocator,
+            host_alloc(),
         )?;
-        let mut simd = Image::<f32, 3, _>::from_size_val(src.size(), 0.0, CpuAllocator)?;
-        let mut scalar = Image::<f64, 3, _>::from_size_val(src.size(), 0.0, CpuAllocator)?;
+        let mut simd = Image::<f32, 3>::from_size_val(src.size(), 0.0, host_alloc())?;
+        let mut scalar = Image::<f64, 3>::from_size_val(src.size(), 0.0, host_alloc())?;
         super::hls_from_rgb(&src, &mut simd)?;
         super::hls_from_rgb(&src64, &mut scalar)?;
         for (a, b) in simd.as_slice().iter().zip(scalar.as_slice().iter()) {
@@ -312,16 +280,16 @@ mod tests {
         // > PAR_THRESHOLD (1,048,576) to exercise the rayon strip split.
         let (w, h) = (1024, 1025);
         let data: Vec<f32> = (0..w * h * 3).map(|v| (v % 256) as f32).collect();
-        let src = Image::<f32, 3, _>::new(
+        let src = Image::<f32, 3>::new(
             ImageSize {
                 width: w,
                 height: h,
             },
             data,
-            CpuAllocator,
+            host_alloc(),
         )?;
-        let mut hls = Image::<f32, 3, _>::from_size_val(src.size(), 0.0, CpuAllocator)?;
-        let mut back = Image::<f32, 3, _>::from_size_val(src.size(), 0.0, CpuAllocator)?;
+        let mut hls = Image::<f32, 3>::from_size_val(src.size(), 0.0, host_alloc())?;
+        let mut back = Image::<f32, 3>::from_size_val(src.size(), 0.0, host_alloc())?;
         super::hls_from_rgb(&src, &mut hls)?;
         super::rgb_from_hls(&hls, &mut back)?;
         for (a, b) in src.as_slice().iter().zip(back.as_slice().iter()) {

--- a/crates/kornia-imgproc/src/color/hsv/mod.rs
+++ b/crates/kornia-imgproc/src/color/hsv/mod.rs
@@ -119,11 +119,10 @@ fn rgb_from_hsv_scalar_f64(h8: f64, s8: f64, v8: f64) -> (f64, f64, f64) {
 /// ```
 /// use kornia_image::{Image, ImageSize};
 /// use kornia_imgproc::color::hsv_from_rgb;
-/// use kornia_tensor::host_alloc;
 ///
 /// let rgb = Image::<f32, 3>::from_size_val(
-///     ImageSize { width: 4, height: 5 }, 0.0, host_alloc()).unwrap();
-/// let mut hsv = Image::<f32, 3>::from_size_val(rgb.size(), 0.0, host_alloc()).unwrap();
+///     ImageSize { width: 4, height: 5 }, 0.0).unwrap();
+/// let mut hsv = Image::<f32, 3>::from_size_val(rgb.size(), 0.0).unwrap();
 /// hsv_from_rgb(&rgb, &mut hsv).unwrap();
 /// ```
 pub fn hsv_from_rgb<T>(src: &Image<T, 3>, dst: &mut Image<T, 3>) -> Result<(), ImageError>
@@ -140,11 +139,10 @@ where
 /// ```
 /// use kornia_image::{Image, ImageSize};
 /// use kornia_imgproc::color::rgb_from_hsv;
-/// use kornia_tensor::host_alloc;
 ///
 /// let hsv = Image::<f32, 3>::from_size_val(
-///     ImageSize { width: 4, height: 5 }, 0.0, host_alloc()).unwrap();
-/// let mut rgb = Image::<f32, 3>::from_size_val(hsv.size(), 0.0, host_alloc()).unwrap();
+///     ImageSize { width: 4, height: 5 }, 0.0).unwrap();
+/// let mut rgb = Image::<f32, 3>::from_size_val(hsv.size(), 0.0).unwrap();
 /// rgb_from_hsv(&hsv, &mut rgb).unwrap();
 /// ```
 pub fn rgb_from_hsv<T>(src: &Image<T, 3>, dst: &mut Image<T, 3>) -> Result<(), ImageError>
@@ -167,7 +165,6 @@ pub fn rgb_from_hsv_f32(src: &Image<f32, 3>, dst: &mut Image<f32, 3>) -> Result<
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::host_alloc;
 
     #[test]
     fn hsv_from_rgb_regression() -> Result<(), ImageError> {
@@ -180,13 +177,12 @@ mod tests {
                 0.0, 128.0, 255.0, 255.0, 128.0, 0.0, 128.0, 255.0, 0.0, 255.0, 0.0, 128.0, 0.0,
                 128.0, 255.0, 255.0, 128.0, 0.0,
             ],
-            host_alloc(),
         )?;
         let expected = [
             148.66667, 255.0, 255.0, 21.333334, 255.0, 255.0, 63.666668, 255.0, 255.0, 233.66667,
             255.0, 255.0, 148.66667, 255.0, 255.0, 21.333334, 255.0, 255.0,
         ];
-        let mut hsv = Image::<f32, 3>::from_size_val(image.size(), 0.0, host_alloc())?;
+        let mut hsv = Image::<f32, 3>::from_size_val(image.size(), 0.0)?;
         super::hsv_from_rgb(&image, &mut hsv)?;
         for (a, b) in hsv.as_slice().iter().zip(expected.iter()) {
             assert!((a - b).abs() < 1e-3, "{a} != {b}");
@@ -205,10 +201,9 @@ mod tests {
                 height: 5,
             },
             data,
-            host_alloc(),
         )?;
-        let mut hsv = Image::<f32, 3>::from_size_val(src.size(), 0.0, host_alloc())?;
-        let mut back = Image::<f32, 3>::from_size_val(src.size(), 0.0, host_alloc())?;
+        let mut hsv = Image::<f32, 3>::from_size_val(src.size(), 0.0)?;
+        let mut back = Image::<f32, 3>::from_size_val(src.size(), 0.0)?;
         super::hsv_from_rgb(&src, &mut hsv)?;
         super::rgb_from_hsv(&hsv, &mut back)?;
         for (a, b) in src.as_slice().iter().zip(back.as_slice().iter()) {
@@ -227,15 +222,10 @@ mod tests {
                 height: 3,
             },
             data.clone(),
-            host_alloc(),
         )?;
-        let src64 = Image::<f64, 3>::new(
-            src.size(),
-            data.iter().map(|&v| v as f64).collect(),
-            host_alloc(),
-        )?;
-        let mut simd = Image::<f32, 3>::from_size_val(src.size(), 0.0, host_alloc())?;
-        let mut scalar = Image::<f64, 3>::from_size_val(src.size(), 0.0, host_alloc())?;
+        let src64 = Image::<f64, 3>::new(src.size(), data.iter().map(|&v| v as f64).collect())?;
+        let mut simd = Image::<f32, 3>::from_size_val(src.size(), 0.0)?;
+        let mut scalar = Image::<f64, 3>::from_size_val(src.size(), 0.0)?;
         super::hsv_from_rgb(&src, &mut simd)?;
         super::hsv_from_rgb(&src64, &mut scalar)?;
         for (a, b) in simd.as_slice().iter().zip(scalar.as_slice().iter()) {
@@ -255,10 +245,9 @@ mod tests {
                 height: h,
             },
             data,
-            host_alloc(),
         )?;
-        let mut hsv = Image::<f32, 3>::from_size_val(src.size(), 0.0, host_alloc())?;
-        let mut back = Image::<f32, 3>::from_size_val(src.size(), 0.0, host_alloc())?;
+        let mut hsv = Image::<f32, 3>::from_size_val(src.size(), 0.0)?;
+        let mut back = Image::<f32, 3>::from_size_val(src.size(), 0.0)?;
         super::hsv_from_rgb(&src, &mut hsv)?;
         super::rgb_from_hsv(&hsv, &mut back)?;
         for (a, b) in src.as_slice().iter().zip(back.as_slice().iter()) {

--- a/crates/kornia-imgproc/src/color/hsv/mod.rs
+++ b/crates/kornia-imgproc/src/color/hsv/mod.rs
@@ -1,5 +1,5 @@
 use crate::parallel;
-use kornia_image::{allocator::ImageAllocator, Image, ImageError};
+use kornia_image::{Image, ImageError};
 
 mod kernels;
 
@@ -12,36 +12,24 @@ use crate::color::kernel_common::{check_size, sealed};
 /// Implemented for `f32` (NEON / AVX2) and `f64` (portable scalar). Sealed.
 pub trait HsvFromRgb: sealed::Sealed + Sized {
     #[doc(hidden)]
-    fn hsv_from_rgb_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<Self, 3, A1>,
-        dst: &mut Image<Self, 3, A2>,
-    ) -> Result<(), ImageError>;
+    fn hsv_from_rgb_impl(src: &Image<Self, 3>, dst: &mut Image<Self, 3>) -> Result<(), ImageError>;
 }
 
 /// Compile-time dispatch to the right HSV→RGB kernel for each pixel type.
 pub trait RgbFromHsv: sealed::Sealed + Sized {
     #[doc(hidden)]
-    fn rgb_from_hsv_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<Self, 3, A1>,
-        dst: &mut Image<Self, 3, A2>,
-    ) -> Result<(), ImageError>;
+    fn rgb_from_hsv_impl(src: &Image<Self, 3>, dst: &mut Image<Self, 3>) -> Result<(), ImageError>;
 }
 
 impl HsvFromRgb for f32 {
-    fn hsv_from_rgb_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<f32, 3, A1>,
-        dst: &mut Image<f32, 3, A2>,
-    ) -> Result<(), ImageError> {
+    fn hsv_from_rgb_impl(src: &Image<f32, 3>, dst: &mut Image<f32, 3>) -> Result<(), ImageError> {
         check_size(src, dst)?;
         kernels::hsv_from_rgb_f32(src.as_slice(), dst.as_slice_mut(), src.rows() * src.cols());
         Ok(())
     }
 }
 impl RgbFromHsv for f32 {
-    fn rgb_from_hsv_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<f32, 3, A1>,
-        dst: &mut Image<f32, 3, A2>,
-    ) -> Result<(), ImageError> {
+    fn rgb_from_hsv_impl(src: &Image<f32, 3>, dst: &mut Image<f32, 3>) -> Result<(), ImageError> {
         check_size(src, dst)?;
         kernels::rgb_from_hsv_f32(src.as_slice(), dst.as_slice_mut(), src.rows() * src.cols());
         Ok(())
@@ -49,10 +37,7 @@ impl RgbFromHsv for f32 {
 }
 
 impl HsvFromRgb for f64 {
-    fn hsv_from_rgb_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<f64, 3, A1>,
-        dst: &mut Image<f64, 3, A2>,
-    ) -> Result<(), ImageError> {
+    fn hsv_from_rgb_impl(src: &Image<f64, 3>, dst: &mut Image<f64, 3>) -> Result<(), ImageError> {
         check_size(src, dst)?;
         parallel::par_iter_rows(src, dst, |s, d| {
             let (h, sa, v) = hsv_from_rgb_scalar_f64(s[0], s[1], s[2]);
@@ -64,10 +49,7 @@ impl HsvFromRgb for f64 {
     }
 }
 impl RgbFromHsv for f64 {
-    fn rgb_from_hsv_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<f64, 3, A1>,
-        dst: &mut Image<f64, 3, A2>,
-    ) -> Result<(), ImageError> {
+    fn rgb_from_hsv_impl(src: &Image<f64, 3>, dst: &mut Image<f64, 3>) -> Result<(), ImageError> {
         check_size(src, dst)?;
         parallel::par_iter_rows(src, dst, |s, d| {
             let (r, g, b) = rgb_from_hsv_scalar_f64(s[0], s[1], s[2]);
@@ -135,22 +117,18 @@ fn rgb_from_hsv_scalar_f64(h8: f64, s8: f64, v8: f64) -> (f64, f64, f64) {
 /// # Example
 ///
 /// ```
-/// use kornia_image::{Image, ImageSize, allocator::CpuAllocator};
+/// use kornia_image::{Image, ImageSize};
 /// use kornia_imgproc::color::hsv_from_rgb;
+/// use kornia_tensor::host_alloc;
 ///
-/// let rgb = Image::<f32, 3, _>::from_size_val(
-///     ImageSize { width: 4, height: 5 }, 0.0, CpuAllocator).unwrap();
-/// let mut hsv = Image::<f32, 3, _>::from_size_val(rgb.size(), 0.0, CpuAllocator).unwrap();
+/// let rgb = Image::<f32, 3>::from_size_val(
+///     ImageSize { width: 4, height: 5 }, 0.0, host_alloc()).unwrap();
+/// let mut hsv = Image::<f32, 3>::from_size_val(rgb.size(), 0.0, host_alloc()).unwrap();
 /// hsv_from_rgb(&rgb, &mut hsv).unwrap();
 /// ```
-pub fn hsv_from_rgb<T, A1, A2>(
-    src: &Image<T, 3, A1>,
-    dst: &mut Image<T, 3, A2>,
-) -> Result<(), ImageError>
+pub fn hsv_from_rgb<T>(src: &Image<T, 3>, dst: &mut Image<T, 3>) -> Result<(), ImageError>
 where
     T: HsvFromRgb,
-    A1: ImageAllocator,
-    A2: ImageAllocator,
 {
     T::hsv_from_rgb_impl(src, dst)
 }
@@ -160,50 +138,40 @@ where
 /// # Example
 ///
 /// ```
-/// use kornia_image::{Image, ImageSize, allocator::CpuAllocator};
+/// use kornia_image::{Image, ImageSize};
 /// use kornia_imgproc::color::rgb_from_hsv;
+/// use kornia_tensor::host_alloc;
 ///
-/// let hsv = Image::<f32, 3, _>::from_size_val(
-///     ImageSize { width: 4, height: 5 }, 0.0, CpuAllocator).unwrap();
-/// let mut rgb = Image::<f32, 3, _>::from_size_val(hsv.size(), 0.0, CpuAllocator).unwrap();
+/// let hsv = Image::<f32, 3>::from_size_val(
+///     ImageSize { width: 4, height: 5 }, 0.0, host_alloc()).unwrap();
+/// let mut rgb = Image::<f32, 3>::from_size_val(hsv.size(), 0.0, host_alloc()).unwrap();
 /// rgb_from_hsv(&hsv, &mut rgb).unwrap();
 /// ```
-pub fn rgb_from_hsv<T, A1, A2>(
-    src: &Image<T, 3, A1>,
-    dst: &mut Image<T, 3, A2>,
-) -> Result<(), ImageError>
+pub fn rgb_from_hsv<T>(src: &Image<T, 3>, dst: &mut Image<T, 3>) -> Result<(), ImageError>
 where
     T: RgbFromHsv,
-    A1: ImageAllocator,
-    A2: ImageAllocator,
 {
     T::rgb_from_hsv_impl(src, dst)
 }
 
 /// Convert an RGB f32 image to HSV. Thin wrapper around [`hsv_from_rgb`].
-pub fn hsv_from_rgb_f32<A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<f32, 3, A1>,
-    dst: &mut Image<f32, 3, A2>,
-) -> Result<(), ImageError> {
+pub fn hsv_from_rgb_f32(src: &Image<f32, 3>, dst: &mut Image<f32, 3>) -> Result<(), ImageError> {
     hsv_from_rgb(src, dst)
 }
 
 /// Convert an HSV f32 image to RGB. Thin wrapper around [`rgb_from_hsv`].
-pub fn rgb_from_hsv_f32<A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<f32, 3, A1>,
-    dst: &mut Image<f32, 3, A2>,
-) -> Result<(), ImageError> {
+pub fn rgb_from_hsv_f32(src: &Image<f32, 3>, dst: &mut Image<f32, 3>) -> Result<(), ImageError> {
     rgb_from_hsv(src, dst)
 }
 
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::CpuAllocator;
+    use kornia_tensor::host_alloc;
 
     #[test]
     fn hsv_from_rgb_regression() -> Result<(), ImageError> {
-        let image = Image::<f32, 3, _>::new(
+        let image = Image::<f32, 3>::new(
             ImageSize {
                 width: 2,
                 height: 3,
@@ -212,13 +180,13 @@ mod tests {
                 0.0, 128.0, 255.0, 255.0, 128.0, 0.0, 128.0, 255.0, 0.0, 255.0, 0.0, 128.0, 0.0,
                 128.0, 255.0, 255.0, 128.0, 0.0,
             ],
-            CpuAllocator,
+            host_alloc(),
         )?;
         let expected = [
             148.66667, 255.0, 255.0, 21.333334, 255.0, 255.0, 63.666668, 255.0, 255.0, 233.66667,
             255.0, 255.0, 148.66667, 255.0, 255.0, 21.333334, 255.0, 255.0,
         ];
-        let mut hsv = Image::<f32, 3, _>::from_size_val(image.size(), 0.0, CpuAllocator)?;
+        let mut hsv = Image::<f32, 3>::from_size_val(image.size(), 0.0, host_alloc())?;
         super::hsv_from_rgb(&image, &mut hsv)?;
         for (a, b) in hsv.as_slice().iter().zip(expected.iter()) {
             assert!((a - b).abs() < 1e-3, "{a} != {b}");
@@ -231,16 +199,16 @@ mod tests {
         // dense-ish sweep; exercises 4-px NEON body + scalar tail (7 px wide)
         let npix = 7 * 5;
         let data: Vec<f32> = (0..npix * 3).map(|v| (v % 256) as f32).collect();
-        let src = Image::<f32, 3, _>::new(
+        let src = Image::<f32, 3>::new(
             ImageSize {
                 width: 7,
                 height: 5,
             },
             data,
-            CpuAllocator,
+            host_alloc(),
         )?;
-        let mut hsv = Image::<f32, 3, _>::from_size_val(src.size(), 0.0, CpuAllocator)?;
-        let mut back = Image::<f32, 3, _>::from_size_val(src.size(), 0.0, CpuAllocator)?;
+        let mut hsv = Image::<f32, 3>::from_size_val(src.size(), 0.0, host_alloc())?;
+        let mut back = Image::<f32, 3>::from_size_val(src.size(), 0.0, host_alloc())?;
         super::hsv_from_rgb(&src, &mut hsv)?;
         super::rgb_from_hsv(&hsv, &mut back)?;
         for (a, b) in src.as_slice().iter().zip(back.as_slice().iter()) {
@@ -253,21 +221,21 @@ mod tests {
     fn f32_simd_matches_f64_scalar() -> Result<(), ImageError> {
         let npix = 7 * 3;
         let data: Vec<f32> = (0..npix * 3).map(|v| (v * 7 % 256) as f32).collect();
-        let src = Image::<f32, 3, _>::new(
+        let src = Image::<f32, 3>::new(
             ImageSize {
                 width: 7,
                 height: 3,
             },
             data.clone(),
-            CpuAllocator,
+            host_alloc(),
         )?;
-        let src64 = Image::<f64, 3, _>::new(
+        let src64 = Image::<f64, 3>::new(
             src.size(),
             data.iter().map(|&v| v as f64).collect(),
-            CpuAllocator,
+            host_alloc(),
         )?;
-        let mut simd = Image::<f32, 3, _>::from_size_val(src.size(), 0.0, CpuAllocator)?;
-        let mut scalar = Image::<f64, 3, _>::from_size_val(src.size(), 0.0, CpuAllocator)?;
+        let mut simd = Image::<f32, 3>::from_size_val(src.size(), 0.0, host_alloc())?;
+        let mut scalar = Image::<f64, 3>::from_size_val(src.size(), 0.0, host_alloc())?;
         super::hsv_from_rgb(&src, &mut simd)?;
         super::hsv_from_rgb(&src64, &mut scalar)?;
         for (a, b) in simd.as_slice().iter().zip(scalar.as_slice().iter()) {
@@ -281,16 +249,16 @@ mod tests {
         // > PAR_THRESHOLD (1,048,576) to exercise the rayon strip split.
         let (w, h) = (1024, 1025);
         let data: Vec<f32> = (0..w * h * 3).map(|v| (v % 256) as f32).collect();
-        let src = Image::<f32, 3, _>::new(
+        let src = Image::<f32, 3>::new(
             ImageSize {
                 width: w,
                 height: h,
             },
             data,
-            CpuAllocator,
+            host_alloc(),
         )?;
-        let mut hsv = Image::<f32, 3, _>::from_size_val(src.size(), 0.0, CpuAllocator)?;
-        let mut back = Image::<f32, 3, _>::from_size_val(src.size(), 0.0, CpuAllocator)?;
+        let mut hsv = Image::<f32, 3>::from_size_val(src.size(), 0.0, host_alloc())?;
+        let mut back = Image::<f32, 3>::from_size_val(src.size(), 0.0, host_alloc())?;
         super::hsv_from_rgb(&src, &mut hsv)?;
         super::rgb_from_hsv(&hsv, &mut back)?;
         for (a, b) in src.as_slice().iter().zip(back.as_slice().iter()) {

--- a/crates/kornia-imgproc/src/color/kernel_common.rs
+++ b/crates/kornia-imgproc/src/color/kernel_common.rs
@@ -7,14 +7,10 @@
 
 /// Return `Err(ImageError::InvalidImageSize)` when `src` and `dst` sizes differ.
 #[inline]
-pub(crate) fn check_size<T, U, const C1: usize, const C2: usize, A1, A2>(
-    src: &kornia_image::Image<T, C1, A1>,
-    dst: &kornia_image::Image<U, C2, A2>,
-) -> Result<(), kornia_image::ImageError>
-where
-    A1: kornia_image::allocator::ImageAllocator,
-    A2: kornia_image::allocator::ImageAllocator,
-{
+pub(crate) fn check_size<T, U, const C1: usize, const C2: usize>(
+    src: &kornia_image::Image<T, C1>,
+    dst: &kornia_image::Image<U, C2>,
+) -> Result<(), kornia_image::ImageError> {
     if src.size() != dst.size() {
         return Err(kornia_image::ImageError::InvalidImageSize(
             src.cols(),

--- a/crates/kornia-imgproc/src/color/mod.rs
+++ b/crates/kornia-imgproc/src/color/mod.rs
@@ -8,7 +8,7 @@
 //!
 //! ```
 //! use kornia_image::ImageSize;
-//! use kornia_image::allocator::CpuAllocator;
+//! use kornia_tensor::host_alloc;
 //! use kornia_imgproc::color::{Rgb8, Gray8, ConvertColor};
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -16,10 +16,10 @@
 //! let rgb = Rgb8::from_size_vec(
 //!     ImageSize { width: 4, height: 5 },
 //!     vec![128u8; 4 * 5 * 3],
-//!     CpuAllocator
+//!     host_alloc()
 //! )?;
 //!
-//! let mut gray = Gray8::from_size_val(rgb.size(), 0, CpuAllocator)?;
+//! let mut gray = Gray8::from_size_val(rgb.size(), 0, host_alloc())?;
 //!
 //! // Type-safe conversion
 //! rgb.convert(&mut gray)?;
@@ -36,17 +36,17 @@
 //!
 //! ```
 //! use kornia_image::{Image, ImageSize};
-//! use kornia_image::allocator::CpuAllocator;
+//! use kornia_tensor::host_alloc;
 //! use kornia_imgproc::color::gray_from_rgb;
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! let rgb = Image::<f32, 3, _>::new(
+//! let rgb = Image::<f32, 3>::new(
 //!     ImageSize { width: 4, height: 5 },
 //!     vec![0.5f32; 4 * 5 * 3],
-//!     CpuAllocator
+//!     host_alloc()
 //! )?;
 //!
-//! let mut gray = Image::<f32, 1, _>::from_size_val(rgb.size(), 0.0, CpuAllocator)?;
+//! let mut gray = Image::<f32, 1>::from_size_val(rgb.size(), 0.0, host_alloc())?;
 //! gray_from_rgb(&rgb, &mut gray)?;
 //! # Ok(())
 //! # }

--- a/crates/kornia-imgproc/src/color/mod.rs
+++ b/crates/kornia-imgproc/src/color/mod.rs
@@ -8,7 +8,6 @@
 //!
 //! ```
 //! use kornia_image::ImageSize;
-//! use kornia_tensor::host_alloc;
 //! use kornia_imgproc::color::{Rgb8, Gray8, ConvertColor};
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -16,10 +15,9 @@
 //! let rgb = Rgb8::from_size_vec(
 //!     ImageSize { width: 4, height: 5 },
 //!     vec![128u8; 4 * 5 * 3],
-//!     host_alloc()
 //! )?;
 //!
-//! let mut gray = Gray8::from_size_val(rgb.size(), 0, host_alloc())?;
+//! let mut gray = Gray8::from_size_val(rgb.size(), 0)?;
 //!
 //! // Type-safe conversion
 //! rgb.convert(&mut gray)?;
@@ -36,17 +34,15 @@
 //!
 //! ```
 //! use kornia_image::{Image, ImageSize};
-//! use kornia_tensor::host_alloc;
 //! use kornia_imgproc::color::gray_from_rgb;
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let rgb = Image::<f32, 3>::new(
 //!     ImageSize { width: 4, height: 5 },
 //!     vec![0.5f32; 4 * 5 * 3],
-//!     host_alloc()
 //! )?;
 //!
-//! let mut gray = Image::<f32, 1>::from_size_val(rgb.size(), 0.0, host_alloc())?;
+//! let mut gray = Image::<f32, 1>::from_size_val(rgb.size(), 0.0)?;
 //! gray_from_rgb(&rgb, &mut gray)?;
 //! # Ok(())
 //! # }

--- a/crates/kornia-imgproc/src/color/rgb/mod.rs
+++ b/crates/kornia-imgproc/src/color/rgb/mod.rs
@@ -1,5 +1,5 @@
 use crate::parallel;
-use kornia_image::{allocator::ImageAllocator, Image, ImageError};
+use kornia_image::{Image, ImageError};
 
 mod kernels;
 
@@ -14,45 +14,29 @@ use crate::color::kernel_common::{check_size, sealed};
 /// external implementations.
 pub trait ChannelOps: sealed::Sealed + Sized + Copy + Send + Sync {
     #[doc(hidden)]
-    fn bgr_from_rgb_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<Self, 3, A1>,
-        dst: &mut Image<Self, 3, A2>,
-    ) -> Result<(), ImageError>;
+    fn bgr_from_rgb_impl(src: &Image<Self, 3>, dst: &mut Image<Self, 3>) -> Result<(), ImageError>;
 
     #[doc(hidden)]
-    fn rgba_from_rgb_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<Self, 3, A1>,
-        dst: &mut Image<Self, 4, A2>,
-    ) -> Result<(), ImageError>;
+    fn rgba_from_rgb_impl(src: &Image<Self, 3>, dst: &mut Image<Self, 4>)
+        -> Result<(), ImageError>;
 
     #[doc(hidden)]
-    fn bgra_from_rgb_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<Self, 3, A1>,
-        dst: &mut Image<Self, 4, A2>,
-    ) -> Result<(), ImageError>;
+    fn bgra_from_rgb_impl(src: &Image<Self, 3>, dst: &mut Image<Self, 4>)
+        -> Result<(), ImageError>;
 }
 
 impl ChannelOps for u8 {
-    fn bgr_from_rgb_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<u8, 3, A1>,
-        dst: &mut Image<u8, 3, A2>,
-    ) -> Result<(), ImageError> {
+    fn bgr_from_rgb_impl(src: &Image<u8, 3>, dst: &mut Image<u8, 3>) -> Result<(), ImageError> {
         check_size(src, dst)?;
         kernels::bgr_from_rgb_u8(src.as_slice(), dst.as_slice_mut(), src.rows() * src.cols());
         Ok(())
     }
-    fn rgba_from_rgb_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<u8, 3, A1>,
-        dst: &mut Image<u8, 4, A2>,
-    ) -> Result<(), ImageError> {
+    fn rgba_from_rgb_impl(src: &Image<u8, 3>, dst: &mut Image<u8, 4>) -> Result<(), ImageError> {
         check_size(src, dst)?;
         kernels::rgba_from_rgb_u8(src.as_slice(), dst.as_slice_mut(), src.rows() * src.cols());
         Ok(())
     }
-    fn bgra_from_rgb_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<u8, 3, A1>,
-        dst: &mut Image<u8, 4, A2>,
-    ) -> Result<(), ImageError> {
+    fn bgra_from_rgb_impl(src: &Image<u8, 3>, dst: &mut Image<u8, 4>) -> Result<(), ImageError> {
         check_size(src, dst)?;
         kernels::bgra_from_rgb_u8(src.as_slice(), dst.as_slice_mut(), src.rows() * src.cols());
         Ok(())
@@ -60,26 +44,17 @@ impl ChannelOps for u8 {
 }
 
 impl ChannelOps for f32 {
-    fn bgr_from_rgb_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<f32, 3, A1>,
-        dst: &mut Image<f32, 3, A2>,
-    ) -> Result<(), ImageError> {
+    fn bgr_from_rgb_impl(src: &Image<f32, 3>, dst: &mut Image<f32, 3>) -> Result<(), ImageError> {
         check_size(src, dst)?;
         kernels::bgr_from_rgb_f32(src.as_slice(), dst.as_slice_mut(), src.rows() * src.cols());
         Ok(())
     }
-    fn rgba_from_rgb_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<f32, 3, A1>,
-        dst: &mut Image<f32, 4, A2>,
-    ) -> Result<(), ImageError> {
+    fn rgba_from_rgb_impl(src: &Image<f32, 3>, dst: &mut Image<f32, 4>) -> Result<(), ImageError> {
         check_size(src, dst)?;
         kernels::rgba_from_rgb_f32(src.as_slice(), dst.as_slice_mut(), src.rows() * src.cols());
         Ok(())
     }
-    fn bgra_from_rgb_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<f32, 3, A1>,
-        dst: &mut Image<f32, 4, A2>,
-    ) -> Result<(), ImageError> {
+    fn bgra_from_rgb_impl(src: &Image<f32, 3>, dst: &mut Image<f32, 4>) -> Result<(), ImageError> {
         check_size(src, dst)?;
         kernels::bgra_from_rgb_f32(src.as_slice(), dst.as_slice_mut(), src.rows() * src.cols());
         Ok(())
@@ -87,10 +62,7 @@ impl ChannelOps for f32 {
 }
 
 impl ChannelOps for f64 {
-    fn bgr_from_rgb_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<f64, 3, A1>,
-        dst: &mut Image<f64, 3, A2>,
-    ) -> Result<(), ImageError> {
+    fn bgr_from_rgb_impl(src: &Image<f64, 3>, dst: &mut Image<f64, 3>) -> Result<(), ImageError> {
         check_size(src, dst)?;
         parallel::par_iter_rows(src, dst, |s, d| {
             d[0] = s[2];
@@ -99,10 +71,7 @@ impl ChannelOps for f64 {
         });
         Ok(())
     }
-    fn rgba_from_rgb_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<f64, 3, A1>,
-        dst: &mut Image<f64, 4, A2>,
-    ) -> Result<(), ImageError> {
+    fn rgba_from_rgb_impl(src: &Image<f64, 3>, dst: &mut Image<f64, 4>) -> Result<(), ImageError> {
         check_size(src, dst)?;
         parallel::par_iter_rows(src, dst, |s, d| {
             d[0] = s[0];
@@ -112,10 +81,7 @@ impl ChannelOps for f64 {
         });
         Ok(())
     }
-    fn bgra_from_rgb_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<f64, 3, A1>,
-        dst: &mut Image<f64, 4, A2>,
-    ) -> Result<(), ImageError> {
+    fn bgra_from_rgb_impl(src: &Image<f64, 3>, dst: &mut Image<f64, 4>) -> Result<(), ImageError> {
         check_size(src, dst)?;
         parallel::par_iter_rows(src, dst, |s, d| {
             d[0] = s[2];
@@ -144,25 +110,25 @@ impl ChannelOps for f64 {
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::color::rgb_from_rgba;
 ///
-/// let src = Image::<u8, 4, CpuAllocator>::new(ImageSize { width: 3, height: 2 }, vec![
+/// let src = Image::<u8, 4>::new(ImageSize { width: 3, height: 2 }, vec![
 ///     0, 1, 2, 255, // (0, 0)
 ///     3, 4, 5, 255, // (0, 1)
 ///     6, 7, 8, 255, // (0, 2)
 ///     9, 10, 11, 255, // (1, 0)
 ///     12, 13, 14, 255, // (1, 1)
 ///     15, 16, 17, 255, // (1, 2)
-/// ], CpuAllocator).unwrap();
+/// ], host_alloc()).unwrap();
 ///
-/// let mut dst = Image::<u8, 3, CpuAllocator>::new(ImageSize { width: 3, height: 2 }, vec![0; 18], CpuAllocator).unwrap();
+/// let mut dst = Image::<u8, 3>::new(ImageSize { width: 3, height: 2 }, vec![0; 18], host_alloc()).unwrap();
 ///
 /// rgb_from_rgba(&src, &mut dst, None).unwrap();
 /// ```
-pub fn rgb_from_rgba<A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<u8, 4, A1>,
-    dst: &mut Image<u8, 3, A2>,
+pub fn rgb_from_rgba(
+    src: &Image<u8, 4>,
+    dst: &mut Image<u8, 3>,
     background: Option<[u8; 3]>,
 ) -> Result<(), ImageError> {
     if src.size() != dst.size() {
@@ -205,25 +171,25 @@ pub fn rgb_from_rgba<A1: ImageAllocator, A2: ImageAllocator>(
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::color::rgb_from_bgra;
 ///
-/// let src = Image::<u8, 4, CpuAllocator>::new(ImageSize { width: 3, height: 2 }, vec![
+/// let src = Image::<u8, 4>::new(ImageSize { width: 3, height: 2 }, vec![
 ///     0, 1, 2, 255, // (0, 0)
 ///     3, 4, 5, 255, // (0, 1)
 ///     6, 7, 8, 255, // (0, 2)
 ///     9, 10, 11, 255, // (1, 0)
 ///     12, 13, 14, 255, // (1, 1)
 ///     15, 16, 17, 255, // (1, 2)
-/// ], CpuAllocator).unwrap();
+/// ], host_alloc()).unwrap();
 ///
-/// let mut dst = Image::<u8, 3, CpuAllocator>::from_size_val(src.size(), 0, CpuAllocator).unwrap();
+/// let mut dst = Image::<u8, 3>::from_size_val(src.size(), 0, host_alloc()).unwrap();
 ///
 /// rgb_from_bgra(&src, &mut dst, None).unwrap();
 /// ```
-pub fn rgb_from_bgra<A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<u8, 4, A1>,
-    dst: &mut Image<u8, 3, A2>,
+pub fn rgb_from_bgra(
+    src: &Image<u8, 4>,
+    dst: &mut Image<u8, 3>,
     background: Option<[u8; 3]>,
 ) -> Result<(), ImageError> {
     if src.size() != dst.size() {
@@ -268,10 +234,7 @@ pub fn rgb_from_bgra<A1: ImageAllocator, A2: ImageAllocator>(
 /// * `dst` - The output BGR image.
 ///
 /// Precondition: the input and output images must have the same size.
-pub fn bgr_from_rgb<T, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<T, 3, A1>,
-    dst: &mut Image<T, 3, A2>,
-) -> Result<(), ImageError>
+pub fn bgr_from_rgb<T>(src: &Image<T, 3>, dst: &mut Image<T, 3>) -> Result<(), ImageError>
 where
     T: ChannelOps,
 {
@@ -297,21 +260,18 @@ where
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::color::rgba_from_rgb;
 ///
-/// let src = Image::<u8, 3, CpuAllocator>::new(
+/// let src = Image::<u8, 3>::new(
 ///     ImageSize { width: 2, height: 1 },
 ///     vec![1, 2, 3, 4, 5, 6],
-///     CpuAllocator,
+///     host_alloc(),
 /// ).unwrap();
-/// let mut dst = Image::<u8, 4, CpuAllocator>::from_size_val(src.size(), 0, CpuAllocator).unwrap();
+/// let mut dst = Image::<u8, 4>::from_size_val(src.size(), 0, host_alloc()).unwrap();
 /// rgba_from_rgb(&src, &mut dst).unwrap();
 /// ```
-pub fn rgba_from_rgb<T, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<T, 3, A1>,
-    dst: &mut Image<T, 4, A2>,
-) -> Result<(), ImageError>
+pub fn rgba_from_rgb<T>(src: &Image<T, 3>, dst: &mut Image<T, 4>) -> Result<(), ImageError>
 where
     T: ChannelOps,
 {
@@ -335,21 +295,18 @@ where
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::color::bgra_from_rgb;
 ///
-/// let src = Image::<u8, 3, CpuAllocator>::new(
+/// let src = Image::<u8, 3>::new(
 ///     ImageSize { width: 2, height: 1 },
 ///     vec![1, 2, 3, 4, 5, 6],
-///     CpuAllocator,
+///     host_alloc(),
 /// ).unwrap();
-/// let mut dst = Image::<u8, 4, CpuAllocator>::from_size_val(src.size(), 0, CpuAllocator).unwrap();
+/// let mut dst = Image::<u8, 4>::from_size_val(src.size(), 0, host_alloc()).unwrap();
 /// bgra_from_rgb(&src, &mut dst).unwrap();
 /// ```
-pub fn bgra_from_rgb<T, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<T, 3, A1>,
-    dst: &mut Image<T, 4, A2>,
-) -> Result<(), ImageError>
+pub fn bgra_from_rgb<T>(src: &Image<T, 3>, dst: &mut Image<T, 4>) -> Result<(), ImageError>
 where
     T: ChannelOps,
 {
@@ -367,12 +324,13 @@ fn alpha_blend(r: u8, g: u8, b: u8, a: u8, bg: &[u8; 3], rgb: &mut [u8]) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kornia_image::{allocator::CpuAllocator, ImageSize};
+    use kornia_image::ImageSize;
+    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_rgb_from_rgba() -> Result<(), ImageError> {
         // NOTE: verified with opencv
-        let src = Image::<u8, 4, CpuAllocator>::new(
+        let src = Image::<u8, 4>::new(
             ImageSize {
                 width: 3,
                 height: 2,
@@ -385,12 +343,12 @@ mod tests {
                 12, 13, 14, 255, // (1, 1)
                 15, 16, 17, 255, // (1, 2)
             ],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut dst = Image::<u8, 3, CpuAllocator>::from_size_val(src.size(), 0, CpuAllocator)?;
+        let mut dst = Image::<u8, 3>::from_size_val(src.size(), 0, host_alloc())?;
 
-        let expected = Image::<u8, 3, CpuAllocator>::new(
+        let expected = Image::<u8, 3>::new(
             ImageSize {
                 width: 3,
                 height: 2,
@@ -403,7 +361,7 @@ mod tests {
                 12, 13, 14, // (1, 1)
                 15, 16, 17, // (1, 2)
             ],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         rgb_from_rgba(&src, &mut dst, None)?;
@@ -416,24 +374,24 @@ mod tests {
     #[test]
     fn test_rgb_from_rgba_with_background() -> Result<(), ImageError> {
         // NOTE: verified with PIL
-        let src = Image::<u8, 4, CpuAllocator>::new(
+        let src = Image::<u8, 4>::new(
             ImageSize {
                 width: 1,
                 height: 1,
             },
             vec![255, 0, 0, 128],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut dst = Image::<u8, 3, CpuAllocator>::from_size_val(src.size(), 0, CpuAllocator)?;
+        let mut dst = Image::<u8, 3>::from_size_val(src.size(), 0, host_alloc())?;
 
-        let expected = Image::<u8, 3, CpuAllocator>::new(
+        let expected = Image::<u8, 3>::new(
             ImageSize {
                 width: 1,
                 height: 1,
             },
             vec![178, 50, 50],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         rgb_from_rgba(&src, &mut dst, Some([100, 100, 100]))?;
@@ -446,24 +404,24 @@ mod tests {
     #[test]
     fn test_rgb_from_bgra_without_background() -> Result<(), ImageError> {
         // NOTE: verified with opencv
-        let src = Image::<u8, 4, CpuAllocator>::new(
+        let src = Image::<u8, 4>::new(
             ImageSize {
                 width: 1,
                 height: 1,
             },
             vec![0, 0, 255, 128],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut dst = Image::<u8, 3, CpuAllocator>::from_size_val(src.size(), 0, CpuAllocator)?;
+        let mut dst = Image::<u8, 3>::from_size_val(src.size(), 0, host_alloc())?;
 
-        let expected = Image::<u8, 3, CpuAllocator>::new(
+        let expected = Image::<u8, 3>::new(
             ImageSize {
                 width: 1,
                 height: 1,
             },
             vec![255, 0, 0],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         rgb_from_bgra(&src, &mut dst, None)?;
@@ -476,24 +434,24 @@ mod tests {
     #[test]
     fn test_rgb_from_bgra_with_background() -> Result<(), ImageError> {
         // NOTE: verified with opencv
-        let src = Image::<u8, 4, CpuAllocator>::new(
+        let src = Image::<u8, 4>::new(
             ImageSize {
                 width: 1,
                 height: 1,
             },
             vec![0, 0, 255, 128],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut dst = Image::<u8, 3, CpuAllocator>::from_size_val(src.size(), 0, CpuAllocator)?;
+        let mut dst = Image::<u8, 3>::from_size_val(src.size(), 0, host_alloc())?;
 
-        let expected = Image::<u8, 3, CpuAllocator>::new(
+        let expected = Image::<u8, 3>::new(
             ImageSize {
                 width: 1,
                 height: 1,
             },
             vec![178, 50, 50],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         rgb_from_bgra(&src, &mut dst, Some([100, 100, 100]))?;
@@ -516,15 +474,15 @@ mod tests {
                 3.0, 4.0, 5.0,
                 6.0, 7.0, 8.0,
             ],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut bgr = Image::<f32, 3, _>::from_size_val(image.size(), 0.0, CpuAllocator)?;
+        let mut bgr = Image::<f32, 3>::from_size_val(image.size(), 0.0, host_alloc())?;
 
         super::bgr_from_rgb(&image, &mut bgr)?;
 
         #[rustfmt::skip]
-        let expected: Image<f32, 3, _> = Image::new(
+        let expected: Image<f32, 3> = Image::new(
             ImageSize {
                 width: 1,
                 height: 3,
@@ -534,7 +492,7 @@ mod tests {
                 5.0, 4.0, 3.0,
                 8.0, 7.0, 6.0,
             ],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         assert_eq!(bgr.as_slice(), expected.as_slice());
@@ -560,8 +518,8 @@ mod tests {
             height: 1025,
         };
         let npix = 1024 * 1025;
-        let src = Image::<u8, 3, _>::new(size, ramp_u8(npix * 3), CpuAllocator)?;
-        let mut dst = Image::<u8, 3, _>::from_size_val(size, 0, CpuAllocator)?;
+        let src = Image::<u8, 3>::new(size, ramp_u8(npix * 3), host_alloc())?;
+        let mut dst = Image::<u8, 3>::from_size_val(size, 0, host_alloc())?;
         super::bgr_from_rgb(&src, &mut dst)?;
         let s = src.as_slice();
         let d = dst.as_slice();
@@ -582,8 +540,8 @@ mod tests {
             height: 1025,
         };
         let npix = 1024 * 1025;
-        let src = Image::<u8, 3, _>::new(size, ramp_u8(npix * 3), CpuAllocator)?;
-        let mut dst = Image::<u8, 4, _>::from_size_val(size, 0, CpuAllocator)?;
+        let src = Image::<u8, 3>::new(size, ramp_u8(npix * 3), host_alloc())?;
+        let mut dst = Image::<u8, 4>::from_size_val(size, 0, host_alloc())?;
         super::rgba_from_rgb(&src, &mut dst)?;
         let s = src.as_slice();
         let d = dst.as_slice();
@@ -602,8 +560,8 @@ mod tests {
             width: 7,
             height: 3,
         };
-        let src = Image::<u8, 3, _>::new(size, ramp_u8(7 * 3 * 3), CpuAllocator)?;
-        let mut dst = Image::<u8, 3, _>::from_size_val(size, 0, CpuAllocator)?;
+        let src = Image::<u8, 3>::new(size, ramp_u8(7 * 3 * 3), host_alloc())?;
+        let mut dst = Image::<u8, 3>::from_size_val(size, 0, host_alloc())?;
         super::bgr_from_rgb(&src, &mut dst)?;
 
         let s = src.as_slice();
@@ -621,9 +579,9 @@ mod tests {
             width: 7,
             height: 3,
         };
-        let src = Image::<u8, 3, _>::new(size, ramp_u8(7 * 3 * 3), CpuAllocator)?;
-        let mut bgr = Image::<u8, 3, _>::from_size_val(size, 0, CpuAllocator)?;
-        let mut back = Image::<u8, 3, _>::from_size_val(size, 0, CpuAllocator)?;
+        let src = Image::<u8, 3>::new(size, ramp_u8(7 * 3 * 3), host_alloc())?;
+        let mut bgr = Image::<u8, 3>::from_size_val(size, 0, host_alloc())?;
+        let mut back = Image::<u8, 3>::from_size_val(size, 0, host_alloc())?;
         super::bgr_from_rgb(&src, &mut bgr)?;
         super::bgr_from_rgb(&bgr, &mut back)?;
         assert_eq!(src.as_slice(), back.as_slice());
@@ -636,9 +594,9 @@ mod tests {
             width: 7,
             height: 3,
         };
-        let src = Image::<f32, 3, _>::new(size, ramp_f32(7 * 3 * 3), CpuAllocator)?;
-        let mut bgr = Image::<f32, 3, _>::from_size_val(size, 0.0, CpuAllocator)?;
-        let mut back = Image::<f32, 3, _>::from_size_val(size, 0.0, CpuAllocator)?;
+        let src = Image::<f32, 3>::new(size, ramp_f32(7 * 3 * 3), host_alloc())?;
+        let mut bgr = Image::<f32, 3>::from_size_val(size, 0.0, host_alloc())?;
+        let mut back = Image::<f32, 3>::from_size_val(size, 0.0, host_alloc())?;
         super::bgr_from_rgb(&src, &mut bgr)?;
         super::bgr_from_rgb(&bgr, &mut back)?;
         assert_eq!(src.as_slice(), back.as_slice());
@@ -651,8 +609,8 @@ mod tests {
             width: 7,
             height: 3,
         };
-        let src = Image::<u8, 3, _>::new(size, ramp_u8(7 * 3 * 3), CpuAllocator)?;
-        let mut dst = Image::<u8, 4, _>::from_size_val(size, 0, CpuAllocator)?;
+        let src = Image::<u8, 3>::new(size, ramp_u8(7 * 3 * 3), host_alloc())?;
+        let mut dst = Image::<u8, 4>::from_size_val(size, 0, host_alloc())?;
         super::rgba_from_rgb(&src, &mut dst)?;
 
         let s = src.as_slice();
@@ -667,15 +625,15 @@ mod tests {
 
     #[test]
     fn rgba_from_rgb_u8_known_value() -> Result<(), ImageError> {
-        let src = Image::<u8, 3, _>::new(
+        let src = Image::<u8, 3>::new(
             ImageSize {
                 width: 2,
                 height: 1,
             },
             vec![1, 2, 3, 4, 5, 6],
-            CpuAllocator,
+            host_alloc(),
         )?;
-        let mut dst = Image::<u8, 4, _>::from_size_val(src.size(), 0, CpuAllocator)?;
+        let mut dst = Image::<u8, 4>::from_size_val(src.size(), 0, host_alloc())?;
         super::rgba_from_rgb(&src, &mut dst)?;
         assert_eq!(dst.as_slice(), &[1, 2, 3, 255, 4, 5, 6, 255]);
         Ok(())
@@ -687,8 +645,8 @@ mod tests {
             width: 7,
             height: 3,
         };
-        let src = Image::<f32, 3, _>::new(size, ramp_f32(7 * 3 * 3), CpuAllocator)?;
-        let mut dst = Image::<f32, 4, _>::from_size_val(size, 0.0, CpuAllocator)?;
+        let src = Image::<f32, 3>::new(size, ramp_f32(7 * 3 * 3), host_alloc())?;
+        let mut dst = Image::<f32, 4>::from_size_val(size, 0.0, host_alloc())?;
         super::rgba_from_rgb(&src, &mut dst)?;
 
         let s = src.as_slice();
@@ -707,8 +665,8 @@ mod tests {
             width: 7,
             height: 3,
         };
-        let src = Image::<u8, 3, _>::new(size, ramp_u8(7 * 3 * 3), CpuAllocator)?;
-        let mut dst = Image::<u8, 4, _>::from_size_val(size, 0, CpuAllocator)?;
+        let src = Image::<u8, 3>::new(size, ramp_u8(7 * 3 * 3), host_alloc())?;
+        let mut dst = Image::<u8, 4>::from_size_val(size, 0, host_alloc())?;
         super::bgra_from_rgb(&src, &mut dst)?;
 
         let s = src.as_slice();
@@ -723,15 +681,15 @@ mod tests {
 
     #[test]
     fn bgra_from_rgb_u8_known_value() -> Result<(), ImageError> {
-        let src = Image::<u8, 3, _>::new(
+        let src = Image::<u8, 3>::new(
             ImageSize {
                 width: 2,
                 height: 1,
             },
             vec![1, 2, 3, 4, 5, 6],
-            CpuAllocator,
+            host_alloc(),
         )?;
-        let mut dst = Image::<u8, 4, _>::from_size_val(src.size(), 0, CpuAllocator)?;
+        let mut dst = Image::<u8, 4>::from_size_val(src.size(), 0, host_alloc())?;
         super::bgra_from_rgb(&src, &mut dst)?;
         assert_eq!(dst.as_slice(), &[3, 2, 1, 255, 6, 5, 4, 255]);
         Ok(())
@@ -743,8 +701,8 @@ mod tests {
             width: 7,
             height: 3,
         };
-        let src = Image::<f32, 3, _>::new(size, ramp_f32(7 * 3 * 3), CpuAllocator)?;
-        let mut dst = Image::<f32, 4, _>::from_size_val(size, 0.0, CpuAllocator)?;
+        let src = Image::<f32, 3>::new(size, ramp_f32(7 * 3 * 3), host_alloc())?;
+        let mut dst = Image::<f32, 4>::from_size_val(size, 0.0, host_alloc())?;
         super::bgra_from_rgb(&src, &mut dst)?;
 
         let s = src.as_slice();

--- a/crates/kornia-imgproc/src/color/rgb/mod.rs
+++ b/crates/kornia-imgproc/src/color/rgb/mod.rs
@@ -110,7 +110,6 @@ impl ChannelOps for f64 {
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::color::rgb_from_rgba;
 ///
 /// let src = Image::<u8, 4>::new(ImageSize { width: 3, height: 2 }, vec![
@@ -120,9 +119,9 @@ impl ChannelOps for f64 {
 ///     9, 10, 11, 255, // (1, 0)
 ///     12, 13, 14, 255, // (1, 1)
 ///     15, 16, 17, 255, // (1, 2)
-/// ], host_alloc()).unwrap();
+/// ]).unwrap();
 ///
-/// let mut dst = Image::<u8, 3>::new(ImageSize { width: 3, height: 2 }, vec![0; 18], host_alloc()).unwrap();
+/// let mut dst = Image::<u8, 3>::new(ImageSize { width: 3, height: 2 }, vec![0; 18]).unwrap();
 ///
 /// rgb_from_rgba(&src, &mut dst, None).unwrap();
 /// ```
@@ -171,7 +170,6 @@ pub fn rgb_from_rgba(
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::color::rgb_from_bgra;
 ///
 /// let src = Image::<u8, 4>::new(ImageSize { width: 3, height: 2 }, vec![
@@ -181,9 +179,9 @@ pub fn rgb_from_rgba(
 ///     9, 10, 11, 255, // (1, 0)
 ///     12, 13, 14, 255, // (1, 1)
 ///     15, 16, 17, 255, // (1, 2)
-/// ], host_alloc()).unwrap();
+/// ]).unwrap();
 ///
-/// let mut dst = Image::<u8, 3>::from_size_val(src.size(), 0, host_alloc()).unwrap();
+/// let mut dst = Image::<u8, 3>::from_size_val(src.size(), 0).unwrap();
 ///
 /// rgb_from_bgra(&src, &mut dst, None).unwrap();
 /// ```
@@ -260,15 +258,13 @@ where
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::color::rgba_from_rgb;
 ///
 /// let src = Image::<u8, 3>::new(
 ///     ImageSize { width: 2, height: 1 },
 ///     vec![1, 2, 3, 4, 5, 6],
-///     host_alloc(),
 /// ).unwrap();
-/// let mut dst = Image::<u8, 4>::from_size_val(src.size(), 0, host_alloc()).unwrap();
+/// let mut dst = Image::<u8, 4>::from_size_val(src.size(), 0).unwrap();
 /// rgba_from_rgb(&src, &mut dst).unwrap();
 /// ```
 pub fn rgba_from_rgb<T>(src: &Image<T, 3>, dst: &mut Image<T, 4>) -> Result<(), ImageError>
@@ -295,15 +291,13 @@ where
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::color::bgra_from_rgb;
 ///
 /// let src = Image::<u8, 3>::new(
 ///     ImageSize { width: 2, height: 1 },
 ///     vec![1, 2, 3, 4, 5, 6],
-///     host_alloc(),
 /// ).unwrap();
-/// let mut dst = Image::<u8, 4>::from_size_val(src.size(), 0, host_alloc()).unwrap();
+/// let mut dst = Image::<u8, 4>::from_size_val(src.size(), 0).unwrap();
 /// bgra_from_rgb(&src, &mut dst).unwrap();
 /// ```
 pub fn bgra_from_rgb<T>(src: &Image<T, 3>, dst: &mut Image<T, 4>) -> Result<(), ImageError>
@@ -325,7 +319,6 @@ fn alpha_blend(r: u8, g: u8, b: u8, a: u8, bg: &[u8; 3], rgb: &mut [u8]) {
 mod tests {
     use super::*;
     use kornia_image::ImageSize;
-    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_rgb_from_rgba() -> Result<(), ImageError> {
@@ -343,10 +336,9 @@ mod tests {
                 12, 13, 14, 255, // (1, 1)
                 15, 16, 17, 255, // (1, 2)
             ],
-            host_alloc(),
         )?;
 
-        let mut dst = Image::<u8, 3>::from_size_val(src.size(), 0, host_alloc())?;
+        let mut dst = Image::<u8, 3>::from_size_val(src.size(), 0)?;
 
         let expected = Image::<u8, 3>::new(
             ImageSize {
@@ -361,7 +353,6 @@ mod tests {
                 12, 13, 14, // (1, 1)
                 15, 16, 17, // (1, 2)
             ],
-            host_alloc(),
         )?;
 
         rgb_from_rgba(&src, &mut dst, None)?;
@@ -380,10 +371,9 @@ mod tests {
                 height: 1,
             },
             vec![255, 0, 0, 128],
-            host_alloc(),
         )?;
 
-        let mut dst = Image::<u8, 3>::from_size_val(src.size(), 0, host_alloc())?;
+        let mut dst = Image::<u8, 3>::from_size_val(src.size(), 0)?;
 
         let expected = Image::<u8, 3>::new(
             ImageSize {
@@ -391,7 +381,6 @@ mod tests {
                 height: 1,
             },
             vec![178, 50, 50],
-            host_alloc(),
         )?;
 
         rgb_from_rgba(&src, &mut dst, Some([100, 100, 100]))?;
@@ -410,10 +399,9 @@ mod tests {
                 height: 1,
             },
             vec![0, 0, 255, 128],
-            host_alloc(),
         )?;
 
-        let mut dst = Image::<u8, 3>::from_size_val(src.size(), 0, host_alloc())?;
+        let mut dst = Image::<u8, 3>::from_size_val(src.size(), 0)?;
 
         let expected = Image::<u8, 3>::new(
             ImageSize {
@@ -421,7 +409,6 @@ mod tests {
                 height: 1,
             },
             vec![255, 0, 0],
-            host_alloc(),
         )?;
 
         rgb_from_bgra(&src, &mut dst, None)?;
@@ -440,10 +427,9 @@ mod tests {
                 height: 1,
             },
             vec![0, 0, 255, 128],
-            host_alloc(),
         )?;
 
-        let mut dst = Image::<u8, 3>::from_size_val(src.size(), 0, host_alloc())?;
+        let mut dst = Image::<u8, 3>::from_size_val(src.size(), 0)?;
 
         let expected = Image::<u8, 3>::new(
             ImageSize {
@@ -451,7 +437,6 @@ mod tests {
                 height: 1,
             },
             vec![178, 50, 50],
-            host_alloc(),
         )?;
 
         rgb_from_bgra(&src, &mut dst, Some([100, 100, 100]))?;
@@ -474,10 +459,9 @@ mod tests {
                 3.0, 4.0, 5.0,
                 6.0, 7.0, 8.0,
             ],
-            host_alloc(),
         )?;
 
-        let mut bgr = Image::<f32, 3>::from_size_val(image.size(), 0.0, host_alloc())?;
+        let mut bgr = Image::<f32, 3>::from_size_val(image.size(), 0.0)?;
 
         super::bgr_from_rgb(&image, &mut bgr)?;
 
@@ -492,7 +476,6 @@ mod tests {
                 5.0, 4.0, 3.0,
                 8.0, 7.0, 6.0,
             ],
-            host_alloc(),
         )?;
 
         assert_eq!(bgr.as_slice(), expected.as_slice());
@@ -518,8 +501,8 @@ mod tests {
             height: 1025,
         };
         let npix = 1024 * 1025;
-        let src = Image::<u8, 3>::new(size, ramp_u8(npix * 3), host_alloc())?;
-        let mut dst = Image::<u8, 3>::from_size_val(size, 0, host_alloc())?;
+        let src = Image::<u8, 3>::new(size, ramp_u8(npix * 3))?;
+        let mut dst = Image::<u8, 3>::from_size_val(size, 0)?;
         super::bgr_from_rgb(&src, &mut dst)?;
         let s = src.as_slice();
         let d = dst.as_slice();
@@ -540,8 +523,8 @@ mod tests {
             height: 1025,
         };
         let npix = 1024 * 1025;
-        let src = Image::<u8, 3>::new(size, ramp_u8(npix * 3), host_alloc())?;
-        let mut dst = Image::<u8, 4>::from_size_val(size, 0, host_alloc())?;
+        let src = Image::<u8, 3>::new(size, ramp_u8(npix * 3))?;
+        let mut dst = Image::<u8, 4>::from_size_val(size, 0)?;
         super::rgba_from_rgb(&src, &mut dst)?;
         let s = src.as_slice();
         let d = dst.as_slice();
@@ -560,8 +543,8 @@ mod tests {
             width: 7,
             height: 3,
         };
-        let src = Image::<u8, 3>::new(size, ramp_u8(7 * 3 * 3), host_alloc())?;
-        let mut dst = Image::<u8, 3>::from_size_val(size, 0, host_alloc())?;
+        let src = Image::<u8, 3>::new(size, ramp_u8(7 * 3 * 3))?;
+        let mut dst = Image::<u8, 3>::from_size_val(size, 0)?;
         super::bgr_from_rgb(&src, &mut dst)?;
 
         let s = src.as_slice();
@@ -579,9 +562,9 @@ mod tests {
             width: 7,
             height: 3,
         };
-        let src = Image::<u8, 3>::new(size, ramp_u8(7 * 3 * 3), host_alloc())?;
-        let mut bgr = Image::<u8, 3>::from_size_val(size, 0, host_alloc())?;
-        let mut back = Image::<u8, 3>::from_size_val(size, 0, host_alloc())?;
+        let src = Image::<u8, 3>::new(size, ramp_u8(7 * 3 * 3))?;
+        let mut bgr = Image::<u8, 3>::from_size_val(size, 0)?;
+        let mut back = Image::<u8, 3>::from_size_val(size, 0)?;
         super::bgr_from_rgb(&src, &mut bgr)?;
         super::bgr_from_rgb(&bgr, &mut back)?;
         assert_eq!(src.as_slice(), back.as_slice());
@@ -594,9 +577,9 @@ mod tests {
             width: 7,
             height: 3,
         };
-        let src = Image::<f32, 3>::new(size, ramp_f32(7 * 3 * 3), host_alloc())?;
-        let mut bgr = Image::<f32, 3>::from_size_val(size, 0.0, host_alloc())?;
-        let mut back = Image::<f32, 3>::from_size_val(size, 0.0, host_alloc())?;
+        let src = Image::<f32, 3>::new(size, ramp_f32(7 * 3 * 3))?;
+        let mut bgr = Image::<f32, 3>::from_size_val(size, 0.0)?;
+        let mut back = Image::<f32, 3>::from_size_val(size, 0.0)?;
         super::bgr_from_rgb(&src, &mut bgr)?;
         super::bgr_from_rgb(&bgr, &mut back)?;
         assert_eq!(src.as_slice(), back.as_slice());
@@ -609,8 +592,8 @@ mod tests {
             width: 7,
             height: 3,
         };
-        let src = Image::<u8, 3>::new(size, ramp_u8(7 * 3 * 3), host_alloc())?;
-        let mut dst = Image::<u8, 4>::from_size_val(size, 0, host_alloc())?;
+        let src = Image::<u8, 3>::new(size, ramp_u8(7 * 3 * 3))?;
+        let mut dst = Image::<u8, 4>::from_size_val(size, 0)?;
         super::rgba_from_rgb(&src, &mut dst)?;
 
         let s = src.as_slice();
@@ -631,9 +614,8 @@ mod tests {
                 height: 1,
             },
             vec![1, 2, 3, 4, 5, 6],
-            host_alloc(),
         )?;
-        let mut dst = Image::<u8, 4>::from_size_val(src.size(), 0, host_alloc())?;
+        let mut dst = Image::<u8, 4>::from_size_val(src.size(), 0)?;
         super::rgba_from_rgb(&src, &mut dst)?;
         assert_eq!(dst.as_slice(), &[1, 2, 3, 255, 4, 5, 6, 255]);
         Ok(())
@@ -645,8 +627,8 @@ mod tests {
             width: 7,
             height: 3,
         };
-        let src = Image::<f32, 3>::new(size, ramp_f32(7 * 3 * 3), host_alloc())?;
-        let mut dst = Image::<f32, 4>::from_size_val(size, 0.0, host_alloc())?;
+        let src = Image::<f32, 3>::new(size, ramp_f32(7 * 3 * 3))?;
+        let mut dst = Image::<f32, 4>::from_size_val(size, 0.0)?;
         super::rgba_from_rgb(&src, &mut dst)?;
 
         let s = src.as_slice();
@@ -665,8 +647,8 @@ mod tests {
             width: 7,
             height: 3,
         };
-        let src = Image::<u8, 3>::new(size, ramp_u8(7 * 3 * 3), host_alloc())?;
-        let mut dst = Image::<u8, 4>::from_size_val(size, 0, host_alloc())?;
+        let src = Image::<u8, 3>::new(size, ramp_u8(7 * 3 * 3))?;
+        let mut dst = Image::<u8, 4>::from_size_val(size, 0)?;
         super::bgra_from_rgb(&src, &mut dst)?;
 
         let s = src.as_slice();
@@ -687,9 +669,8 @@ mod tests {
                 height: 1,
             },
             vec![1, 2, 3, 4, 5, 6],
-            host_alloc(),
         )?;
-        let mut dst = Image::<u8, 4>::from_size_val(src.size(), 0, host_alloc())?;
+        let mut dst = Image::<u8, 4>::from_size_val(src.size(), 0)?;
         super::bgra_from_rgb(&src, &mut dst)?;
         assert_eq!(dst.as_slice(), &[3, 2, 1, 255, 6, 5, 4, 255]);
         Ok(())
@@ -701,8 +682,8 @@ mod tests {
             width: 7,
             height: 3,
         };
-        let src = Image::<f32, 3>::new(size, ramp_f32(7 * 3 * 3), host_alloc())?;
-        let mut dst = Image::<f32, 4>::from_size_val(size, 0.0, host_alloc())?;
+        let src = Image::<f32, 3>::new(size, ramp_f32(7 * 3 * 3))?;
+        let mut dst = Image::<f32, 4>::from_size_val(size, 0.0)?;
         super::bgra_from_rgb(&src, &mut dst)?;
 
         let s = src.as_slice();

--- a/crates/kornia-imgproc/src/color/sepia.rs
+++ b/crates/kornia-imgproc/src/color/sepia.rs
@@ -163,7 +163,6 @@ fn sepia_u8_neon(src: &[u8], dst: &mut [u8], npixels: usize) {
 mod tests {
     use super::*;
     use kornia_image::ImageSize;
-    use kornia_tensor::host_alloc;
 
     #[test]
     fn sepia_u8_known_value() {
@@ -177,10 +176,9 @@ mod tests {
                 height: 1,
             },
             255,
-            host_alloc(),
         )
         .unwrap();
-        let mut dst = Image::<u8, 3>::from_size_val(src.size(), 0, host_alloc()).unwrap();
+        let mut dst = Image::<u8, 3>::from_size_val(src.size(), 0).unwrap();
         sepia_from_rgb_u8(&src, &mut dst).unwrap();
         assert_eq!(dst.as_slice(), &[255, 255, 240]);
     }
@@ -196,10 +194,9 @@ mod tests {
                 height: 1,
             },
             data.clone(),
-            host_alloc(),
         )
         .unwrap();
-        let mut got = Image::<u8, 3>::from_size_val(src.size(), 0, host_alloc()).unwrap();
+        let mut got = Image::<u8, 3>::from_size_val(src.size(), 0).unwrap();
         sepia_from_rgb_u8(&src, &mut got).unwrap();
         let mut oracle = vec![0u8; n * 3];
         sepia_u8_scalar(&data, &mut oracle, n);
@@ -214,10 +211,9 @@ mod tests {
                 height: 1,
             },
             vec![100.0, 150.0, 200.0],
-            host_alloc(),
         )
         .unwrap();
-        let mut dst = Image::<f32, 3>::from_size_val(src.size(), 0.0, host_alloc()).unwrap();
+        let mut dst = Image::<f32, 3>::from_size_val(src.size(), 0.0).unwrap();
         sepia_from_rgb_f32(&src, &mut dst).unwrap();
         let exp_r = 0.393 * 100.0 + 0.769 * 150.0 + 0.189 * 200.0;
         let exp_g = 0.349 * 100.0 + 0.686 * 150.0 + 0.168 * 200.0;

--- a/crates/kornia-imgproc/src/color/sepia.rs
+++ b/crates/kornia-imgproc/src/color/sepia.rs
@@ -9,7 +9,7 @@
 //! The f32 path reuses the shared [`matrix3_affine_f32`] kernel; the u8 path uses
 //! a NEON widening multiply-accumulate in Q8 fixed point with a scalar oracle.
 
-use kornia_image::{allocator::ImageAllocator, Image, ImageError};
+use kornia_image::{Image, ImageError};
 
 use super::kernel_common::check_size;
 use super::matrix::matrix3_affine_f32;
@@ -25,10 +25,7 @@ const SEPIA_M: [f32; 9] = [
 ///
 /// # Errors
 /// Returns [`ImageError::InvalidImageSize`] if `src` and `dst` differ in size.
-pub fn sepia_from_rgb_f32<A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<f32, 3, A1>,
-    dst: &mut Image<f32, 3, A2>,
-) -> Result<(), ImageError> {
+pub fn sepia_from_rgb_f32(src: &Image<f32, 3>, dst: &mut Image<f32, 3>) -> Result<(), ImageError> {
     check_size(src, dst)?;
     matrix3_affine_f32(
         src.as_slice(),
@@ -44,10 +41,7 @@ pub fn sepia_from_rgb_f32<A1: ImageAllocator, A2: ImageAllocator>(
 ///
 /// # Errors
 /// Returns [`ImageError::InvalidImageSize`] if `src` and `dst` differ in size.
-pub fn sepia_from_rgb_u8<A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<u8, 3, A1>,
-    dst: &mut Image<u8, 3, A2>,
-) -> Result<(), ImageError> {
+pub fn sepia_from_rgb_u8(src: &Image<u8, 3>, dst: &mut Image<u8, 3>) -> Result<(), ImageError> {
     check_size(src, dst)?;
     let n = src.rows() * src.cols();
     super::kernel_common::par_strip_dispatch(
@@ -118,15 +112,17 @@ fn sepia_u8_neon(src: &[u8], dst: &mut [u8], npixels: usize) {
             cg: u16,
             cb: u16,
         ) -> uint16x8_t {
-            // u32 accumulate to avoid overflow (max ~ 255*(101+197+48)=88230 > u16).
-            let mut lo = vmull_n_u16(vget_low_u16(r), cr);
-            lo = vmlal_n_u16(lo, vget_low_u16(g), cg);
-            lo = vmlal_n_u16(lo, vget_low_u16(b), cb);
-            let mut hi = vmull_n_u16(vget_high_u16(r), cr);
-            hi = vmlal_n_u16(hi, vget_high_u16(g), cg);
-            hi = vmlal_n_u16(hi, vget_high_u16(b), cb);
-            // (acc + 128) >> 8, rounding narrowing shift to u16.
-            vcombine_u16(vrshrn_n_u32::<8>(lo), vrshrn_n_u32::<8>(hi))
+            unsafe {
+                // u32 accumulate to avoid overflow (max ~ 255*(101+197+48)=88230 > u16).
+                let mut lo = vmull_n_u16(vget_low_u16(r), cr);
+                lo = vmlal_n_u16(lo, vget_low_u16(g), cg);
+                lo = vmlal_n_u16(lo, vget_low_u16(b), cb);
+                let mut hi = vmull_n_u16(vget_high_u16(r), cr);
+                hi = vmlal_n_u16(hi, vget_high_u16(g), cg);
+                hi = vmlal_n_u16(hi, vget_high_u16(b), cb);
+                // (acc + 128) >> 8, rounding narrowing shift to u16.
+                vcombine_u16(vrshrn_n_u32::<8>(lo), vrshrn_n_u32::<8>(hi))
+            }
         }
 
         let bulk = npixels & !15;
@@ -167,7 +163,7 @@ fn sepia_u8_neon(src: &[u8], dst: &mut [u8], npixels: usize) {
 mod tests {
     use super::*;
     use kornia_image::ImageSize;
-    use kornia_tensor::CpuAllocator;
+    use kornia_tensor::host_alloc;
 
     #[test]
     fn sepia_u8_known_value() {
@@ -175,16 +171,16 @@ mod tests {
         // R' = round(255*(101+197+48)/256) = round(255*346/256)=round(344.6)=345 -> 255
         // G' = 255*(89+176+43)/256 = 255*308/256 = 306.8 -> 255
         // B' = 255*(70+137+34)/256 = 255*241/256 = 240.04 -> 240
-        let src = Image::<u8, 3, _>::from_size_val(
+        let src = Image::<u8, 3>::from_size_val(
             ImageSize {
                 width: 1,
                 height: 1,
             },
             255,
-            CpuAllocator,
+            host_alloc(),
         )
         .unwrap();
-        let mut dst = Image::<u8, 3, _>::from_size_val(src.size(), 0, CpuAllocator).unwrap();
+        let mut dst = Image::<u8, 3>::from_size_val(src.size(), 0, host_alloc()).unwrap();
         sepia_from_rgb_u8(&src, &mut dst).unwrap();
         assert_eq!(dst.as_slice(), &[255, 255, 240]);
     }
@@ -194,16 +190,16 @@ mod tests {
         // 37 px (16-wide block + tail) of varied values.
         let n = 37;
         let data: Vec<u8> = (0..n * 3).map(|i| ((i * 53 + 7) % 256) as u8).collect();
-        let src = Image::<u8, 3, _>::new(
+        let src = Image::<u8, 3>::new(
             ImageSize {
                 width: n,
                 height: 1,
             },
             data.clone(),
-            CpuAllocator,
+            host_alloc(),
         )
         .unwrap();
-        let mut got = Image::<u8, 3, _>::from_size_val(src.size(), 0, CpuAllocator).unwrap();
+        let mut got = Image::<u8, 3>::from_size_val(src.size(), 0, host_alloc()).unwrap();
         sepia_from_rgb_u8(&src, &mut got).unwrap();
         let mut oracle = vec![0u8; n * 3];
         sepia_u8_scalar(&data, &mut oracle, n);
@@ -212,16 +208,16 @@ mod tests {
 
     #[test]
     fn sepia_f32_known_value() {
-        let src = Image::<f32, 3, _>::new(
+        let src = Image::<f32, 3>::new(
             ImageSize {
                 width: 1,
                 height: 1,
             },
             vec![100.0, 150.0, 200.0],
-            CpuAllocator,
+            host_alloc(),
         )
         .unwrap();
-        let mut dst = Image::<f32, 3, _>::from_size_val(src.size(), 0.0, CpuAllocator).unwrap();
+        let mut dst = Image::<f32, 3>::from_size_val(src.size(), 0.0, host_alloc()).unwrap();
         sepia_from_rgb_f32(&src, &mut dst).unwrap();
         let exp_r = 0.393 * 100.0 + 0.769 * 150.0 + 0.189 * 200.0;
         let exp_g = 0.349 * 100.0 + 0.686 * 150.0 + 0.168 * 200.0;

--- a/crates/kornia-imgproc/src/color/yuv/kernels.rs
+++ b/crates/kornia-imgproc/src/color/yuv/kernels.rs
@@ -217,15 +217,17 @@ fn ycc_from_rgb_u8_neon(src: &[u8], dst: &mut [u8], npixels: usize, order: Chrom
 #[cfg(target_arch = "aarch64")]
 #[inline]
 unsafe fn store_ycc(dp: *mut u8, si: usize, y: u8, cr: u8, cb: u8, order: ChromaOrder) {
-    *dp.add(si) = y;
-    match order {
-        ChromaOrder::YCrCb => {
-            *dp.add(si + 1) = cr;
-            *dp.add(si + 2) = cb;
-        }
-        ChromaOrder::YuvCbCr => {
-            *dp.add(si + 1) = cb;
-            *dp.add(si + 2) = cr;
+    unsafe {
+        *dp.add(si) = y;
+        match order {
+            ChromaOrder::YCrCb => {
+                *dp.add(si + 1) = cr;
+                *dp.add(si + 2) = cb;
+            }
+            ChromaOrder::YuvCbCr => {
+                *dp.add(si + 1) = cb;
+                *dp.add(si + 2) = cr;
+            }
         }
     }
 }
@@ -468,15 +470,17 @@ fn ycc_from_rgb_f32_neon(src: &[f32], dst: &mut [f32], npixels: usize, order: Ch
 #[cfg(target_arch = "aarch64")]
 #[inline]
 unsafe fn store_ycc_f32(dp: *mut f32, si: usize, y: f32, cr: f32, cb: f32, order: ChromaOrder) {
-    *dp.add(si) = y;
-    match order {
-        ChromaOrder::YCrCb => {
-            *dp.add(si + 1) = cr;
-            *dp.add(si + 2) = cb;
-        }
-        ChromaOrder::YuvCbCr => {
-            *dp.add(si + 1) = cb;
-            *dp.add(si + 2) = cr;
+    unsafe {
+        *dp.add(si) = y;
+        match order {
+            ChromaOrder::YCrCb => {
+                *dp.add(si + 1) = cr;
+                *dp.add(si + 2) = cb;
+            }
+            ChromaOrder::YuvCbCr => {
+                *dp.add(si + 1) = cb;
+                *dp.add(si + 2) = cr;
+            }
         }
     }
 }
@@ -779,7 +783,7 @@ fn rgb_from_packed422_row_neon(src: &[u8], dst: &mut [u8], width: usize, fmt: Pa
                 )
             };
 
-            // combine yy + chroma contribution, >>shift, saturating narrow to u8x8
+            // combine yy + chroma contribution>>shift, saturating narrow to u8x8
             let finish = |yy: (int32x4_t, int32x4_t), c: (int32x4_t, int32x4_t)| -> uint8x8_t {
                 let lo = vshrq_n_s32::<ITUR_SHIFT>(vaddq_s32(yy.0, c.0));
                 let hi = vshrq_n_s32::<ITUR_SHIFT>(vaddq_s32(yy.1, c.1));
@@ -990,110 +994,112 @@ unsafe fn rgb_from_planar420_block_neon(
     cy: usize,
     fmt: Planar420,
 ) {
-    use std::arch::aarch64::*;
-    let ytp = y_top.as_ptr();
-    let ybp = y_bot.as_ptr();
-    let dtp = d_top.as_mut_ptr();
-    let dbp = d_bot.as_mut_ptr();
+    unsafe {
+        use std::arch::aarch64::*;
+        let ytp = y_top.as_ptr();
+        let ybp = y_bot.as_ptr();
+        let dtp = d_top.as_mut_ptr();
+        let dbp = d_bot.as_mut_ptr();
 
-    // Load 16 (U,V) chroma samples starting at column `cx` per layout.
-    let load_uv = |cx: usize| -> (uint8x16_t, uint8x16_t) {
-        match fmt {
-            Planar420::Nv12 => {
-                let q = vld2q_u8(c0.as_ptr().add(cy * cw * 2 + cx * 2));
-                (q.0, q.1)
+        // Load 16 (U,V) chroma samples starting at column `cx` per layout.
+        let load_uv = |cx: usize| -> (uint8x16_t, uint8x16_t) {
+            match fmt {
+                Planar420::Nv12 => {
+                    let q = vld2q_u8(c0.as_ptr().add(cy * cw * 2 + cx * 2));
+                    (q.0, q.1)
+                }
+                Planar420::Nv21 => {
+                    let q = vld2q_u8(c0.as_ptr().add(cy * cw * 2 + cx * 2));
+                    (q.1, q.0)
+                }
+                Planar420::I420 => (
+                    vld1q_u8(c0.as_ptr().add(cy * cw + cx)),
+                    vld1q_u8(c1.as_ptr().add(cy * cw + cx)),
+                ),
+                Planar420::Yv12 => (
+                    vld1q_u8(c1.as_ptr().add(cy * cw + cx)),
+                    vld1q_u8(c0.as_ptr().add(cy * cw + cx)),
+                ),
             }
-            Planar420::Nv21 => {
-                let q = vld2q_u8(c0.as_ptr().add(cy * cw * 2 + cx * 2));
-                (q.1, q.0)
+        };
+
+        // Chroma RGB contribution for a centred u8x8 (U,V) → [(r_lo,r_hi),(g..),(b..)] s32 pairs.
+        let chroma_rgb = |u8x8: uint8x8_t, v8x8: uint8x8_t| -> [(int32x4_t, int32x4_t); 3] {
+            let uc = vsubq_s16(vreinterpretq_s16_u16(vmovl_u8(u8x8)), vdupq_n_s16(128));
+            let vc = vsubq_s16(vreinterpretq_s16_u16(vmovl_u8(v8x8)), vdupq_n_s16(128));
+            let (ul, uh) = (vmovl_s16(vget_low_s16(uc)), vmovl_s16(vget_high_s16(uc)));
+            let (vl, vh) = (vmovl_s16(vget_low_s16(vc)), vmovl_s16(vget_high_s16(vc)));
+            let half = vdupq_n_s32(ITUR_HALF);
+            let r = (vmlaq_n_s32(half, vl, CVR), vmlaq_n_s32(half, vh, CVR));
+            let g = (
+                vmlaq_n_s32(vmlaq_n_s32(half, ul, CUG), vl, CVG),
+                vmlaq_n_s32(vmlaq_n_s32(half, uh, CUG), vh, CVG),
+            );
+            let b = (vmlaq_n_s32(half, ul, CUB), vmlaq_n_s32(half, uh, CUB));
+            [r, g, b]
+        };
+        let yy_pair = |y8: uint8x8_t| -> (int32x4_t, int32x4_t) {
+            let y16 = vreinterpretq_s16_u16(vmovl_u8(vqsub_u8(y8, vdup_n_u8(16))));
+            (
+                vmulq_n_s32(vmovl_s16(vget_low_s16(y16)), CY),
+                vmulq_n_s32(vmovl_s16(vget_high_s16(y16)), CY),
+            )
+        };
+        let finish = |yy: (int32x4_t, int32x4_t), c: (int32x4_t, int32x4_t)| -> uint8x8_t {
+            let lo = vshrq_n_s32::<ITUR_SHIFT>(vaddq_s32(yy.0, c.0));
+            let hi = vshrq_n_s32::<ITUR_SHIFT>(vaddq_s32(yy.1, c.1));
+            vqmovun_s16(vcombine_s16(vqmovn_s32(lo), vqmovn_s32(hi)))
+        };
+        // Decode a 16-px luma run (`yp`+col) with chroma groups for px 0..8 (clo) / 8..16 (chi).
+        let decode16_store = |yp: *const u8,
+                              dp: *mut u8,
+                              col: usize,
+                              clo: &[(int32x4_t, int32x4_t); 3],
+                              chi: &[(int32x4_t, int32x4_t); 3]| {
+            let y = vld1q_u8(yp.add(col));
+            let yl = yy_pair(vget_low_u8(y));
+            let yh = yy_pair(vget_high_u8(y));
+            let r = vcombine_u8(finish(yl, clo[0]), finish(yh, chi[0]));
+            let g = vcombine_u8(finish(yl, clo[1]), finish(yh, chi[1]));
+            let b = vcombine_u8(finish(yl, clo[2]), finish(yh, chi[2]));
+            vst3q_u8(dp.add(col * 3), uint8x16x3_t(r, g, b));
+        };
+
+        let bulk = cw & !15;
+        let mut cx = 0usize;
+        while cx < bulk {
+            let (u, v) = load_uv(cx);
+            // ×2 horizontal upsample: lane i → luma cols 2i, 2i+1.
+            let uz = vzipq_u8(u, u);
+            let vz = vzipq_u8(v, v);
+            let g0 = chroma_rgb(vget_low_u8(uz.0), vget_low_u8(vz.0)); // cols 0..8
+            let g1 = chroma_rgb(vget_high_u8(uz.0), vget_high_u8(vz.0)); // cols 8..16
+            let g2 = chroma_rgb(vget_low_u8(uz.1), vget_low_u8(vz.1)); // cols 16..24
+            let g3 = chroma_rgb(vget_high_u8(uz.1), vget_high_u8(vz.1)); // cols 24..32
+            let col = cx * 2;
+            decode16_store(ytp, dtp, col, &g0, &g1);
+            decode16_store(ytp, dtp, col + 16, &g2, &g3);
+            decode16_store(ybp, dbp, col, &g0, &g1);
+            decode16_store(ybp, dbp, col + 16, &g2, &g3);
+            cx += 16;
+        }
+        // scalar tail (cw % 16)
+        while cx < cw {
+            let (u, v) = chroma_at(c0, c1, cw, cy, cx, fmt);
+            let x = cx * 2;
+            for dx in 0..2 {
+                let dt = (x + dx) * 3;
+                let (r, g, b) = decode_px(yy_term(*ytp.add(x + dx) as i32), u, v);
+                *dtp.add(dt) = r;
+                *dtp.add(dt + 1) = g;
+                *dtp.add(dt + 2) = b;
+                let (r2, g2, b2) = decode_px(yy_term(*ybp.add(x + dx) as i32), u, v);
+                *dbp.add(dt) = r2;
+                *dbp.add(dt + 1) = g2;
+                *dbp.add(dt + 2) = b2;
             }
-            Planar420::I420 => (
-                vld1q_u8(c0.as_ptr().add(cy * cw + cx)),
-                vld1q_u8(c1.as_ptr().add(cy * cw + cx)),
-            ),
-            Planar420::Yv12 => (
-                vld1q_u8(c1.as_ptr().add(cy * cw + cx)),
-                vld1q_u8(c0.as_ptr().add(cy * cw + cx)),
-            ),
+            cx += 1;
         }
-    };
-
-    // Chroma RGB contribution for a centred u8x8 (U,V) → [(r_lo,r_hi),(g..),(b..)] s32 pairs.
-    let chroma_rgb = |u8x8: uint8x8_t, v8x8: uint8x8_t| -> [(int32x4_t, int32x4_t); 3] {
-        let uc = vsubq_s16(vreinterpretq_s16_u16(vmovl_u8(u8x8)), vdupq_n_s16(128));
-        let vc = vsubq_s16(vreinterpretq_s16_u16(vmovl_u8(v8x8)), vdupq_n_s16(128));
-        let (ul, uh) = (vmovl_s16(vget_low_s16(uc)), vmovl_s16(vget_high_s16(uc)));
-        let (vl, vh) = (vmovl_s16(vget_low_s16(vc)), vmovl_s16(vget_high_s16(vc)));
-        let half = vdupq_n_s32(ITUR_HALF);
-        let r = (vmlaq_n_s32(half, vl, CVR), vmlaq_n_s32(half, vh, CVR));
-        let g = (
-            vmlaq_n_s32(vmlaq_n_s32(half, ul, CUG), vl, CVG),
-            vmlaq_n_s32(vmlaq_n_s32(half, uh, CUG), vh, CVG),
-        );
-        let b = (vmlaq_n_s32(half, ul, CUB), vmlaq_n_s32(half, uh, CUB));
-        [r, g, b]
-    };
-    let yy_pair = |y8: uint8x8_t| -> (int32x4_t, int32x4_t) {
-        let y16 = vreinterpretq_s16_u16(vmovl_u8(vqsub_u8(y8, vdup_n_u8(16))));
-        (
-            vmulq_n_s32(vmovl_s16(vget_low_s16(y16)), CY),
-            vmulq_n_s32(vmovl_s16(vget_high_s16(y16)), CY),
-        )
-    };
-    let finish = |yy: (int32x4_t, int32x4_t), c: (int32x4_t, int32x4_t)| -> uint8x8_t {
-        let lo = vshrq_n_s32::<ITUR_SHIFT>(vaddq_s32(yy.0, c.0));
-        let hi = vshrq_n_s32::<ITUR_SHIFT>(vaddq_s32(yy.1, c.1));
-        vqmovun_s16(vcombine_s16(vqmovn_s32(lo), vqmovn_s32(hi)))
-    };
-    // Decode a 16-px luma run (`yp`+col) with chroma groups for px 0..8 (clo) / 8..16 (chi).
-    let decode16_store = |yp: *const u8,
-                          dp: *mut u8,
-                          col: usize,
-                          clo: &[(int32x4_t, int32x4_t); 3],
-                          chi: &[(int32x4_t, int32x4_t); 3]| {
-        let y = vld1q_u8(yp.add(col));
-        let yl = yy_pair(vget_low_u8(y));
-        let yh = yy_pair(vget_high_u8(y));
-        let r = vcombine_u8(finish(yl, clo[0]), finish(yh, chi[0]));
-        let g = vcombine_u8(finish(yl, clo[1]), finish(yh, chi[1]));
-        let b = vcombine_u8(finish(yl, clo[2]), finish(yh, chi[2]));
-        vst3q_u8(dp.add(col * 3), uint8x16x3_t(r, g, b));
-    };
-
-    let bulk = cw & !15;
-    let mut cx = 0usize;
-    while cx < bulk {
-        let (u, v) = load_uv(cx);
-        // ×2 horizontal upsample: lane i → luma cols 2i, 2i+1.
-        let uz = vzipq_u8(u, u);
-        let vz = vzipq_u8(v, v);
-        let g0 = chroma_rgb(vget_low_u8(uz.0), vget_low_u8(vz.0)); // cols 0..8
-        let g1 = chroma_rgb(vget_high_u8(uz.0), vget_high_u8(vz.0)); // cols 8..16
-        let g2 = chroma_rgb(vget_low_u8(uz.1), vget_low_u8(vz.1)); // cols 16..24
-        let g3 = chroma_rgb(vget_high_u8(uz.1), vget_high_u8(vz.1)); // cols 24..32
-        let col = cx * 2;
-        decode16_store(ytp, dtp, col, &g0, &g1);
-        decode16_store(ytp, dtp, col + 16, &g2, &g3);
-        decode16_store(ybp, dbp, col, &g0, &g1);
-        decode16_store(ybp, dbp, col + 16, &g2, &g3);
-        cx += 16;
-    }
-    // scalar tail (cw % 16)
-    while cx < cw {
-        let (u, v) = chroma_at(c0, c1, cw, cy, cx, fmt);
-        let x = cx * 2;
-        for dx in 0..2 {
-            let dt = (x + dx) * 3;
-            let (r, g, b) = decode_px(yy_term(*ytp.add(x + dx) as i32), u, v);
-            *dtp.add(dt) = r;
-            *dtp.add(dt + 1) = g;
-            *dtp.add(dt + 2) = b;
-            let (r2, g2, b2) = decode_px(yy_term(*ybp.add(x + dx) as i32), u, v);
-            *dbp.add(dt) = r2;
-            *dbp.add(dt + 1) = g2;
-            *dbp.add(dt + 2) = b2;
-        }
-        cx += 1;
     }
 }
 
@@ -1233,50 +1239,52 @@ fn yuyv_from_rgb_row_scalar(src: &[u8], dst: &mut [u8], width: usize) {
 #[cfg(target_arch = "aarch64")]
 #[target_feature(enable = "neon")]
 unsafe fn yuyv_from_rgb_row_neon(src: &[u8], dst: &mut [u8], width: usize) {
-    use std::arch::aarch64::*;
-    let bulk = width & !15;
-    let mut x = 0;
-    while x < bulk {
-        let rgb = vld3q_u8(src.as_ptr().add(x * 3));
-        // Luma for 16 px.
-        let yacc = |r: uint8x8_t, g: uint8x8_t, b: uint8x8_t| -> uint8x8_t {
-            let mut a = vmull_u8(r, vdup_n_u8(YR as u8));
-            a = vmlal_u8(a, g, vdup_n_u8(YG as u8));
-            a = vmlal_u8(a, b, vdup_n_u8(YB as u8));
-            vqadd_u8(vrshrn_n_u16::<8>(a), vdup_n_u8(16))
-        };
-        let y16 = vcombine_u8(
-            yacc(vget_low_u8(rgb.0), vget_low_u8(rgb.1), vget_low_u8(rgb.2)),
-            yacc(
-                vget_high_u8(rgb.0),
-                vget_high_u8(rgb.1),
-                vget_high_u8(rgb.2),
-            ),
-        );
-        // Per-pair rounded chroma averages (8 pairs).
-        let ravg = vrshrn_n_u16::<1>(vpaddlq_u8(rgb.0));
-        let gavg = vrshrn_n_u16::<1>(vpaddlq_u8(rgb.1));
-        let bavg = vrshrn_n_u16::<1>(vpaddlq_u8(rgb.2));
-        let r16 = vreinterpretq_s16_u16(vmovl_u8(ravg));
-        let g16 = vreinterpretq_s16_u16(vmovl_u8(gavg));
-        let b16 = vreinterpretq_s16_u16(vmovl_u8(bavg));
-        let chroma = |cr: i16, cg: i16, cb: i16| -> uint8x8_t {
-            let mut a = vmulq_s16(r16, vdupq_n_s16(cr));
-            a = vmlaq_s16(a, g16, vdupq_n_s16(cg));
-            a = vmlaq_s16(a, b16, vdupq_n_s16(cb));
-            // (a + 128) >> 8 (rounded, signed) + 128, saturate to u8.
-            vqmovun_s16(vaddq_s16(vrshrq_n_s16::<8>(a), vdupq_n_s16(128)))
-        };
-        let u8v = chroma(UR as i16, UG as i16, UB as i16);
-        let v8v = chroma(VR as i16, VG as i16, VB as i16);
-        // chroma stream [U0,V0,U1,V1,…]; vst2 zips it against luma → Y0 U Y1 V.
-        let uv = vzip_u8(u8v, v8v);
-        let c16 = vcombine_u8(uv.0, uv.1);
-        vst2q_u8(dst.as_mut_ptr().add(x * 2), uint8x16x2_t(y16, c16));
-        x += 16;
-    }
-    if bulk < width {
-        yuyv_from_rgb_row_scalar(&src[bulk * 3..], &mut dst[bulk * 2..], width - bulk);
+    unsafe {
+        use std::arch::aarch64::*;
+        let bulk = width & !15;
+        let mut x = 0;
+        while x < bulk {
+            let rgb = vld3q_u8(src.as_ptr().add(x * 3));
+            // Luma for 16 px.
+            let yacc = |r: uint8x8_t, g: uint8x8_t, b: uint8x8_t| -> uint8x8_t {
+                let mut a = vmull_u8(r, vdup_n_u8(YR as u8));
+                a = vmlal_u8(a, g, vdup_n_u8(YG as u8));
+                a = vmlal_u8(a, b, vdup_n_u8(YB as u8));
+                vqadd_u8(vrshrn_n_u16::<8>(a), vdup_n_u8(16))
+            };
+            let y16 = vcombine_u8(
+                yacc(vget_low_u8(rgb.0), vget_low_u8(rgb.1), vget_low_u8(rgb.2)),
+                yacc(
+                    vget_high_u8(rgb.0),
+                    vget_high_u8(rgb.1),
+                    vget_high_u8(rgb.2),
+                ),
+            );
+            // Per-pair rounded chroma averages (8 pairs).
+            let ravg = vrshrn_n_u16::<1>(vpaddlq_u8(rgb.0));
+            let gavg = vrshrn_n_u16::<1>(vpaddlq_u8(rgb.1));
+            let bavg = vrshrn_n_u16::<1>(vpaddlq_u8(rgb.2));
+            let r16 = vreinterpretq_s16_u16(vmovl_u8(ravg));
+            let g16 = vreinterpretq_s16_u16(vmovl_u8(gavg));
+            let b16 = vreinterpretq_s16_u16(vmovl_u8(bavg));
+            let chroma = |cr: i16, cg: i16, cb: i16| -> uint8x8_t {
+                let mut a = vmulq_s16(r16, vdupq_n_s16(cr));
+                a = vmlaq_s16(a, g16, vdupq_n_s16(cg));
+                a = vmlaq_s16(a, b16, vdupq_n_s16(cb));
+                // (a + 128) >> 8 (rounded, signed) + 128, saturate to u8.
+                vqmovun_s16(vaddq_s16(vrshrq_n_s16::<8>(a), vdupq_n_s16(128)))
+            };
+            let u8v = chroma(UR as i16, UG as i16, UB as i16);
+            let v8v = chroma(VR as i16, VG as i16, VB as i16);
+            // chroma stream [U0,V0,U1,V1,…]; vst2 zips it against luma → Y0 U Y1 V.
+            let uv = vzip_u8(u8v, v8v);
+            let c16 = vcombine_u8(uv.0, uv.1);
+            vst2q_u8(dst.as_mut_ptr().add(x * 2), uint8x16x2_t(y16, c16));
+            x += 16;
+        }
+        if bulk < width {
+            yuyv_from_rgb_row_scalar(&src[bulk * 3..], &mut dst[bulk * 2..], width - bulk);
+        }
     }
 }
 
@@ -1484,53 +1492,55 @@ fn encode_uv_row_scalar(top: &[u8], bot: &[u8], uv: &mut [u8], width: usize) {
 #[cfg(target_arch = "aarch64")]
 #[target_feature(enable = "neon")]
 unsafe fn encode_uv_row_neon(top: &[u8], bot: &[u8], uv: &mut [u8], width: usize) {
-    use std::arch::aarch64::*;
-    let cw = width / 2;
-    let mut cx = 0;
-    while cx + 16 <= cw {
-        let sp = cx * 2 * 3; // byte offset of src px 2*cx
-        let t0 = vld3q_u8(top.as_ptr().add(sp));
-        let t1 = vld3q_u8(top.as_ptr().add(sp + 48));
-        let b0 = vld3q_u8(bot.as_ptr().add(sp));
-        let b1 = vld3q_u8(bot.as_ptr().add(sp + 48));
-        // 2×2 block average for one channel across the two 16-px chunks → u8x16.
-        let avg = |tc0, tc1, bc0, bc1| -> uint8x16_t {
-            let blk0 = vaddq_u16(vpaddlq_u8(tc0), vpaddlq_u8(bc0));
-            let blk1 = vaddq_u16(vpaddlq_u8(tc1), vpaddlq_u8(bc1));
-            vcombine_u8(vrshrn_n_u16::<2>(blk0), vrshrn_n_u16::<2>(blk1))
-        };
-        let ravg = avg(t0.0, t1.0, b0.0, b1.0);
-        let gavg = avg(t0.1, t1.1, b0.1, b1.1);
-        let bavg = avg(t0.2, t1.2, b0.2, b1.2);
-        let chroma = |cr: i16, cg: i16, cb: i16| -> uint8x16_t {
-            let half = |r: uint8x8_t, g: uint8x8_t, b: uint8x8_t| -> uint8x8_t {
-                let r = vreinterpretq_s16_u16(vmovl_u8(r));
-                let g = vreinterpretq_s16_u16(vmovl_u8(g));
-                let b = vreinterpretq_s16_u16(vmovl_u8(b));
-                let mut a = vmulq_s16(r, vdupq_n_s16(cr));
-                a = vmlaq_s16(a, g, vdupq_n_s16(cg));
-                a = vmlaq_s16(a, b, vdupq_n_s16(cb));
-                vqmovun_s16(vaddq_s16(vrshrq_n_s16::<8>(a), vdupq_n_s16(128)))
+    unsafe {
+        use std::arch::aarch64::*;
+        let cw = width / 2;
+        let mut cx = 0;
+        while cx + 16 <= cw {
+            let sp = cx * 2 * 3; // byte offset of src px 2*cx
+            let t0 = vld3q_u8(top.as_ptr().add(sp));
+            let t1 = vld3q_u8(top.as_ptr().add(sp + 48));
+            let b0 = vld3q_u8(bot.as_ptr().add(sp));
+            let b1 = vld3q_u8(bot.as_ptr().add(sp + 48));
+            // 2×2 block average for one channel across the two 16-px chunks → u8x16.
+            let avg = |tc0, tc1, bc0, bc1| -> uint8x16_t {
+                let blk0 = vaddq_u16(vpaddlq_u8(tc0), vpaddlq_u8(bc0));
+                let blk1 = vaddq_u16(vpaddlq_u8(tc1), vpaddlq_u8(bc1));
+                vcombine_u8(vrshrn_n_u16::<2>(blk0), vrshrn_n_u16::<2>(blk1))
             };
-            vcombine_u8(
-                half(vget_low_u8(ravg), vget_low_u8(gavg), vget_low_u8(bavg)),
-                half(vget_high_u8(ravg), vget_high_u8(gavg), vget_high_u8(bavg)),
-            )
-        };
-        let u16v = chroma(UR as i16, UG as i16, UB as i16);
-        let v16v = chroma(VR as i16, VG as i16, VB as i16);
-        let uvz = vzipq_u8(u16v, v16v);
-        vst1q_u8(uv.as_mut_ptr().add(cx * 2), uvz.0);
-        vst1q_u8(uv.as_mut_ptr().add(cx * 2 + 16), uvz.1);
-        cx += 16;
-    }
-    if cx < cw {
-        encode_uv_row_scalar(
-            &top[cx * 2 * 3..],
-            &bot[cx * 2 * 3..],
-            &mut uv[cx * 2..],
-            (cw - cx) * 2,
-        );
+            let ravg = avg(t0.0, t1.0, b0.0, b1.0);
+            let gavg = avg(t0.1, t1.1, b0.1, b1.1);
+            let bavg = avg(t0.2, t1.2, b0.2, b1.2);
+            let chroma = |cr: i16, cg: i16, cb: i16| -> uint8x16_t {
+                let half = |r: uint8x8_t, g: uint8x8_t, b: uint8x8_t| -> uint8x8_t {
+                    let r = vreinterpretq_s16_u16(vmovl_u8(r));
+                    let g = vreinterpretq_s16_u16(vmovl_u8(g));
+                    let b = vreinterpretq_s16_u16(vmovl_u8(b));
+                    let mut a = vmulq_s16(r, vdupq_n_s16(cr));
+                    a = vmlaq_s16(a, g, vdupq_n_s16(cg));
+                    a = vmlaq_s16(a, b, vdupq_n_s16(cb));
+                    vqmovun_s16(vaddq_s16(vrshrq_n_s16::<8>(a), vdupq_n_s16(128)))
+                };
+                vcombine_u8(
+                    half(vget_low_u8(ravg), vget_low_u8(gavg), vget_low_u8(bavg)),
+                    half(vget_high_u8(ravg), vget_high_u8(gavg), vget_high_u8(bavg)),
+                )
+            };
+            let u16v = chroma(UR as i16, UG as i16, UB as i16);
+            let v16v = chroma(VR as i16, VG as i16, VB as i16);
+            let uvz = vzipq_u8(u16v, v16v);
+            vst1q_u8(uv.as_mut_ptr().add(cx * 2), uvz.0);
+            vst1q_u8(uv.as_mut_ptr().add(cx * 2 + 16), uvz.1);
+            cx += 16;
+        }
+        if cx < cw {
+            encode_uv_row_scalar(
+                &top[cx * 2 * 3..],
+                &bot[cx * 2 * 3..],
+                &mut uv[cx * 2..],
+                (cw - cx) * 2,
+            );
+        }
     }
 }
 
@@ -1633,33 +1643,35 @@ unsafe fn encode_uv_row_avx2(top: &[u8], bot: &[u8], uv: &mut [u8], width: usize
 #[cfg(target_arch = "aarch64")]
 #[target_feature(enable = "neon")]
 unsafe fn encode_y_row_neon(src: &[u8], dst: &mut [u8], width: usize) {
-    use std::arch::aarch64::*;
-    let bulk = width & !15;
-    let mut x = 0;
-    while x < bulk {
-        let rgb = vld3q_u8(src.as_ptr().add(x * 3));
-        // Widen each channel to two u16x8 halves and accumulate Y in u16 (Q8 coeffs
-        // fit: 66+129+25 = 220 < 256, so 220*255 = 56100 < 65535).
-        let acc = |r: uint8x8_t, g: uint8x8_t, b: uint8x8_t| -> uint8x8_t {
-            let mut a = vmull_u8(r, vdup_n_u8(YR as u8));
-            a = vmlal_u8(a, g, vdup_n_u8(YG as u8));
-            a = vmlal_u8(a, b, vdup_n_u8(YB as u8));
-            // (a + 128) >> 8, then +16, saturating to u8.
-            let y = vrshrn_n_u16::<8>(a); // rounded narrow ≈ (a+128)>>8
-            vqadd_u8(y, vdup_n_u8(16))
-        };
-        let lo = acc(vget_low_u8(rgb.0), vget_low_u8(rgb.1), vget_low_u8(rgb.2));
-        let hi = acc(
-            vget_high_u8(rgb.0),
-            vget_high_u8(rgb.1),
-            vget_high_u8(rgb.2),
-        );
-        vst1q_u8(dst.as_mut_ptr().add(x), vcombine_u8(lo, hi));
-        x += 16;
-    }
-    for (x, d) in dst.iter_mut().enumerate().skip(bulk) {
-        let s = x * 3;
-        *d = encode_y(src[s] as i32, src[s + 1] as i32, src[s + 2] as i32);
+    unsafe {
+        use std::arch::aarch64::*;
+        let bulk = width & !15;
+        let mut x = 0;
+        while x < bulk {
+            let rgb = vld3q_u8(src.as_ptr().add(x * 3));
+            // Widen each channel to two u16x8 halves and accumulate Y in u16 (Q8 coeffs
+            // fit: 66+129+25 = 220 < 256, so 220*255 = 56100 < 65535).
+            let acc = |r: uint8x8_t, g: uint8x8_t, b: uint8x8_t| -> uint8x8_t {
+                let mut a = vmull_u8(r, vdup_n_u8(YR as u8));
+                a = vmlal_u8(a, g, vdup_n_u8(YG as u8));
+                a = vmlal_u8(a, b, vdup_n_u8(YB as u8));
+                // (a + 128) >> 8, then +16, saturating to u8.
+                let y = vrshrn_n_u16::<8>(a); // rounded narrow ≈ (a+128)>>8
+                vqadd_u8(y, vdup_n_u8(16))
+            };
+            let lo = acc(vget_low_u8(rgb.0), vget_low_u8(rgb.1), vget_low_u8(rgb.2));
+            let hi = acc(
+                vget_high_u8(rgb.0),
+                vget_high_u8(rgb.1),
+                vget_high_u8(rgb.2),
+            );
+            vst1q_u8(dst.as_mut_ptr().add(x), vcombine_u8(lo, hi));
+            x += 16;
+        }
+        for (x, d) in dst.iter_mut().enumerate().skip(bulk) {
+            let s = x * 3;
+            *d = encode_y(src[s] as i32, src[s + 1] as i32, src[s + 2] as i32);
+        }
     }
 }
 

--- a/crates/kornia-imgproc/src/color/yuv/mod.rs
+++ b/crates/kornia-imgproc/src/color/yuv/mod.rs
@@ -1,4 +1,4 @@
-use kornia_image::{allocator::ImageAllocator, Image, ImageError};
+use kornia_image::{Image, ImageError};
 use rayon::prelude::*;
 
 mod kernels;
@@ -16,24 +16,24 @@ use crate::color::kernel_common::{check_size, sealed};
 /// and YUV (`[Y,Cb,Cr]`) via the `order` argument. Sealed.
 pub trait YuvFamily: sealed::Sealed + Sized {
     #[doc(hidden)]
-    fn ycc_from_rgb_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<Self, 3, A1>,
-        dst: &mut Image<Self, 3, A2>,
+    fn ycc_from_rgb_impl(
+        src: &Image<Self, 3>,
+        dst: &mut Image<Self, 3>,
         order: ChromaOrder,
     ) -> Result<(), ImageError>;
 
     #[doc(hidden)]
-    fn rgb_from_ycc_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<Self, 3, A1>,
-        dst: &mut Image<Self, 3, A2>,
+    fn rgb_from_ycc_impl(
+        src: &Image<Self, 3>,
+        dst: &mut Image<Self, 3>,
         order: ChromaOrder,
     ) -> Result<(), ImageError>;
 }
 
 impl YuvFamily for u8 {
-    fn ycc_from_rgb_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<u8, 3, A1>,
-        dst: &mut Image<u8, 3, A2>,
+    fn ycc_from_rgb_impl(
+        src: &Image<u8, 3>,
+        dst: &mut Image<u8, 3>,
         order: ChromaOrder,
     ) -> Result<(), ImageError> {
         check_size(src, dst)?;
@@ -45,9 +45,9 @@ impl YuvFamily for u8 {
         );
         Ok(())
     }
-    fn rgb_from_ycc_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<u8, 3, A1>,
-        dst: &mut Image<u8, 3, A2>,
+    fn rgb_from_ycc_impl(
+        src: &Image<u8, 3>,
+        dst: &mut Image<u8, 3>,
         order: ChromaOrder,
     ) -> Result<(), ImageError> {
         check_size(src, dst)?;
@@ -62,9 +62,9 @@ impl YuvFamily for u8 {
 }
 
 impl YuvFamily for f32 {
-    fn ycc_from_rgb_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<f32, 3, A1>,
-        dst: &mut Image<f32, 3, A2>,
+    fn ycc_from_rgb_impl(
+        src: &Image<f32, 3>,
+        dst: &mut Image<f32, 3>,
         order: ChromaOrder,
     ) -> Result<(), ImageError> {
         check_size(src, dst)?;
@@ -76,9 +76,9 @@ impl YuvFamily for f32 {
         );
         Ok(())
     }
-    fn rgb_from_ycc_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<f32, 3, A1>,
-        dst: &mut Image<f32, 3, A2>,
+    fn rgb_from_ycc_impl(
+        src: &Image<f32, 3>,
+        dst: &mut Image<f32, 3>,
         order: ChromaOrder,
     ) -> Result<(), ImageError> {
         check_size(src, dst)?;
@@ -93,9 +93,9 @@ impl YuvFamily for f32 {
 }
 
 impl YuvFamily for f64 {
-    fn ycc_from_rgb_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<f64, 3, A1>,
-        dst: &mut Image<f64, 3, A2>,
+    fn ycc_from_rgb_impl(
+        src: &Image<f64, 3>,
+        dst: &mut Image<f64, 3>,
         order: ChromaOrder,
     ) -> Result<(), ImageError> {
         check_size(src, dst)?;
@@ -119,9 +119,9 @@ impl YuvFamily for f64 {
         });
         Ok(())
     }
-    fn rgb_from_ycc_impl<A1: ImageAllocator, A2: ImageAllocator>(
-        src: &Image<f64, 3, A1>,
-        dst: &mut Image<f64, 3, A2>,
+    fn rgb_from_ycc_impl(
+        src: &Image<f64, 3>,
+        dst: &mut Image<f64, 3>,
         order: ChromaOrder,
     ) -> Result<(), ImageError> {
         check_size(src, dst)?;
@@ -147,28 +147,18 @@ impl YuvFamily for f64 {
 ///
 /// Dispatches at compile time on pixel type `T`: `u8` (Q14 fixed-point), `f32` (`[0,1]`),
 /// `f64` (scalar). For `u8`/`f32` the aarch64 path is NEON.
-pub fn ycbcr_from_rgb<T, A1, A2>(
-    src: &Image<T, 3, A1>,
-    dst: &mut Image<T, 3, A2>,
-) -> Result<(), ImageError>
+pub fn ycbcr_from_rgb<T>(src: &Image<T, 3>, dst: &mut Image<T, 3>) -> Result<(), ImageError>
 where
     T: YuvFamily,
-    A1: ImageAllocator,
-    A2: ImageAllocator,
 {
     T::ycc_from_rgb_impl(src, dst, ChromaOrder::YCrCb)
 }
 
 /// Convert a YCbCr image (`[Y, Cr, Cb]`, full range) back to RGB. Inverse of
 /// [`ycbcr_from_rgb`].
-pub fn rgb_from_ycbcr<T, A1, A2>(
-    src: &Image<T, 3, A1>,
-    dst: &mut Image<T, 3, A2>,
-) -> Result<(), ImageError>
+pub fn rgb_from_ycbcr<T>(src: &Image<T, 3>, dst: &mut Image<T, 3>) -> Result<(), ImageError>
 where
     T: YuvFamily,
-    A1: ImageAllocator,
-    A2: ImageAllocator,
 {
     T::rgb_from_ycc_impl(src, dst, ChromaOrder::YCrCb)
 }
@@ -176,28 +166,18 @@ where
 /// Convert an RGB image to planar YUV, channel order `[Y, U=Cb, V=Cr]`, full range.
 ///
 /// Same math as [`ycbcr_from_rgb`] with the two chroma channels swapped in storage.
-pub fn yuv_from_rgb<T, A1, A2>(
-    src: &Image<T, 3, A1>,
-    dst: &mut Image<T, 3, A2>,
-) -> Result<(), ImageError>
+pub fn yuv_from_rgb<T>(src: &Image<T, 3>, dst: &mut Image<T, 3>) -> Result<(), ImageError>
 where
     T: YuvFamily,
-    A1: ImageAllocator,
-    A2: ImageAllocator,
 {
     T::ycc_from_rgb_impl(src, dst, ChromaOrder::YuvCbCr)
 }
 
 /// Convert a planar YUV image (`[Y, U=Cb, V=Cr]`, full range) back to RGB. Inverse of
 /// [`yuv_from_rgb`].
-pub fn rgb_from_yuv<T, A1, A2>(
-    src: &Image<T, 3, A1>,
-    dst: &mut Image<T, 3, A2>,
-) -> Result<(), ImageError>
+pub fn rgb_from_yuv<T>(src: &Image<T, 3>, dst: &mut Image<T, 3>) -> Result<(), ImageError>
 where
     T: YuvFamily,
-    A1: ImageAllocator,
-    A2: ImageAllocator,
 {
     T::rgb_from_ycc_impl(src, dst, ChromaOrder::YuvCbCr)
 }
@@ -205,8 +185,8 @@ where
 // ===== Family B: video decode (BT.601 limited range) ================================
 
 #[inline]
-fn check_dst_size<A: ImageAllocator>(
-    dst: &Image<u8, 3, A>,
+fn check_dst_size(
+    dst: &Image<u8, 3>,
     width: usize,
     height: usize,
     src_len: usize,
@@ -224,12 +204,9 @@ fn check_dst_size<A: ImageAllocator>(
 }
 
 macro_rules! impl_packed422 {
-    ($fn_name:ident, $variant:ident, $doc:expr) => {
+    ($fn_name:ident, $variant:ident, $doc:expr_2021) => {
         #[doc = $doc]
-        pub fn $fn_name<A: ImageAllocator>(
-            src: &[u8],
-            dst: &mut Image<u8, 3, A>,
-        ) -> Result<(), ImageError> {
+        pub fn $fn_name(src: &[u8], dst: &mut Image<u8, 3>) -> Result<(), ImageError> {
             let (w, h) = (dst.width(), dst.height());
             check_dst_size(dst, w, h, src.len(), w * h * 2)?;
             kernels::rgb_from_packed422(src, dst.as_slice_mut(), w, h, Packed422::$variant);
@@ -255,10 +232,7 @@ impl_packed422!(
 );
 
 /// Decode a planar 4:2:0 NV12 (Y plane + interleaved `UV`) buffer to RGB (BT.601 limited).
-pub fn rgb_from_nv12<A: ImageAllocator>(
-    src: &[u8],
-    dst: &mut Image<u8, 3, A>,
-) -> Result<(), ImageError> {
+pub fn rgb_from_nv12(src: &[u8], dst: &mut Image<u8, 3>) -> Result<(), ImageError> {
     let (w, h) = (dst.width(), dst.height());
     check_dst_size(dst, w, h, src.len(), w * h * 3 / 2)?;
     let (y, uv) = src.split_at(w * h);
@@ -267,10 +241,7 @@ pub fn rgb_from_nv12<A: ImageAllocator>(
 }
 
 /// Decode a planar 4:2:0 NV21 (Y plane + interleaved `VU`) buffer to RGB (BT.601 limited).
-pub fn rgb_from_nv21<A: ImageAllocator>(
-    src: &[u8],
-    dst: &mut Image<u8, 3, A>,
-) -> Result<(), ImageError> {
+pub fn rgb_from_nv21(src: &[u8], dst: &mut Image<u8, 3>) -> Result<(), ImageError> {
     let (w, h) = (dst.width(), dst.height());
     check_dst_size(dst, w, h, src.len(), w * h * 3 / 2)?;
     let (y, uv) = src.split_at(w * h);
@@ -279,10 +250,7 @@ pub fn rgb_from_nv21<A: ImageAllocator>(
 }
 
 /// Decode a planar 4:2:0 I420 (Y, then U plane, then V plane) buffer to RGB (BT.601 limited).
-pub fn rgb_from_i420<A: ImageAllocator>(
-    src: &[u8],
-    dst: &mut Image<u8, 3, A>,
-) -> Result<(), ImageError> {
+pub fn rgb_from_i420(src: &[u8], dst: &mut Image<u8, 3>) -> Result<(), ImageError> {
     let (w, h) = (dst.width(), dst.height());
     check_dst_size(dst, w, h, src.len(), w * h * 3 / 2)?;
     let n = w * h;
@@ -293,10 +261,7 @@ pub fn rgb_from_i420<A: ImageAllocator>(
 }
 
 /// Decode a planar 4:2:0 YV12 (Y, then V plane, then U plane) buffer to RGB (BT.601 limited).
-pub fn rgb_from_yv12<A: ImageAllocator>(
-    src: &[u8],
-    dst: &mut Image<u8, 3, A>,
-) -> Result<(), ImageError> {
+pub fn rgb_from_yv12(src: &[u8], dst: &mut Image<u8, 3>) -> Result<(), ImageError> {
     let (w, h) = (dst.width(), dst.height());
     check_dst_size(dst, w, h, src.len(), w * h * 3 / 2)?;
     let n = w * h;
@@ -312,10 +277,7 @@ pub fn rgb_from_yv12<A: ImageAllocator>(
 /// `dst` must be exactly `width*height*2` bytes and `width` must be even. Luma is
 /// per-pixel; the shared chroma of each horizontal pixel pair is their rounded
 /// average. Inverse of [`rgb_from_yuyv`] (round-trips to within subsampling error).
-pub fn yuyv_from_rgb<A: ImageAllocator>(
-    src: &Image<u8, 3, A>,
-    dst: &mut [u8],
-) -> Result<(), ImageError> {
+pub fn yuyv_from_rgb(src: &Image<u8, 3>, dst: &mut [u8]) -> Result<(), ImageError> {
     let (w, h) = (src.width(), src.height());
     if w % 2 != 0 || dst.len() != w * h * 2 {
         return Err(ImageError::InvalidImageSize(dst.len(), w, h, w * h * 2));
@@ -330,10 +292,7 @@ pub fn yuyv_from_rgb<A: ImageAllocator>(
 /// `dst` must be exactly `width*height*3/2` bytes and both dimensions must be even.
 /// Each chroma pair is the rounded average of its 2×2 luma block. Inverse of
 /// [`rgb_from_nv12`].
-pub fn nv12_from_rgb<A: ImageAllocator>(
-    src: &Image<u8, 3, A>,
-    dst: &mut [u8],
-) -> Result<(), ImageError> {
+pub fn nv12_from_rgb(src: &Image<u8, 3>, dst: &mut [u8]) -> Result<(), ImageError> {
     let (w, h) = (src.width(), src.height());
     if w % 2 != 0 || h % 2 != 0 || dst.len() != w * h * 3 / 2 {
         return Err(ImageError::InvalidImageSize(dst.len(), w, h, w * h * 3 / 2));
@@ -379,9 +338,9 @@ pub enum YuvToRgbMode {
 /// # Returns
 ///
 /// The RGB image in HxWx3 format.
-pub fn convert_yuyv_to_rgb_u8<A: ImageAllocator>(
+pub fn convert_yuyv_to_rgb_u8(
     src: &[u8],
-    dst: &mut Image<u8, 3, A>,
+    dst: &mut Image<u8, 3>,
     mode: YuvToRgbMode,
 ) -> Result<(), ImageError> {
     // the yuyv image is 2 bytes per pixel, so we need to divide by 2

--- a/crates/kornia-imgproc/src/contours.rs
+++ b/crates/kornia-imgproc/src/contours.rs
@@ -10,7 +10,7 @@
 //! The [`FindContoursExecutor`] reuses internal buffers across multiple calls,
 //! making it suitable for processing video streams with minimal allocation overhead.
 
-use kornia_image::{allocator::ImageAllocator, Image};
+use kornia_image::Image;
 use rayon::prelude::*;
 use std::ops::Range;
 
@@ -172,13 +172,14 @@ impl WorkBuffers {
 /// # Example
 ///
 /// ```rust
-/// # use kornia_image::{Image, ImageSize, allocator::CpuAllocator};
+/// # use kornia_image::{Image, ImageSize};
 /// # use kornia_imgproc::contours::{FindContoursExecutor, RetrievalMode, ContourApproximationMode};
+/// # use kornia_tensor::host_alloc;
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut executor = FindContoursExecutor::new();
 /// # let size = ImageSize { width: 10, height: 10 };
-/// # let img = Image::<u8, 1, _>::from_size_val(size, 0, CpuAllocator)?;
-/// # let img2 = Image::<u8, 1, _>::from_size_val(size, 0, CpuAllocator)?;
+/// # let img = Image::<u8, 1>::from_size_val(size, 0, host_alloc())?;
+/// # let img2 = Image::<u8, 1>::from_size_val(size, 0, host_alloc())?;
 ///
 /// // Process multiple images with reused buffers
 /// let result1 = executor.find_contours(&img, RetrievalMode::List, ContourApproximationMode::Simple)?;
@@ -215,9 +216,9 @@ impl FindContoursExecutor {
     ///
     /// Returns [`ContoursError::NbdOverflow`] if the image contains more than `i16::MAX`
     /// distinct borders.
-    pub fn find_contours<A: ImageAllocator>(
+    pub fn find_contours(
         &mut self,
-        src: &Image<u8, 1, A>,
+        src: &Image<u8, 1>,
         mode: RetrievalMode,
         method: ContourApproximationMode,
     ) -> Result<ContoursResult, ContoursError> {
@@ -236,9 +237,9 @@ impl FindContoursExecutor {
     /// Note: `RetrievalMode` filtering (CCOMP/Tree-style hierarchy reshaping) is
     /// not applied here — only `External` and `List` modes return their natural
     /// arena layout. For `Ccomp`/`Tree` use `find_contours` (which post-processes).
-    pub fn find_contours_view<A: ImageAllocator>(
+    pub fn find_contours_view(
         &mut self,
-        src: &Image<u8, 1, A>,
+        src: &Image<u8, 1>,
         mode: RetrievalMode,
         method: ContourApproximationMode,
     ) -> Result<ContoursView<'_>, ContoursError> {
@@ -251,9 +252,9 @@ impl FindContoursExecutor {
         })
     }
 
-    fn execute<A: ImageAllocator>(
+    fn execute(
         &mut self,
-        src: &Image<u8, 1, A>,
+        src: &Image<u8, 1>,
         mode: RetrievalMode,
         method: ContourApproximationMode,
     ) -> Result<ContoursResult, ContoursError> {
@@ -279,9 +280,9 @@ impl FindContoursExecutor {
 
     /// The actual Suzuki/Abe scan. Fills `self.buffers` but does not allocate
     /// per-contour owned vectors. Returns `Ok(())` on success.
-    fn execute_scan<A: ImageAllocator>(
+    fn execute_scan(
         &mut self,
-        src: &Image<u8, 1, A>,
+        src: &Image<u8, 1>,
         mode: RetrievalMode,
         method: ContourApproximationMode,
     ) -> Result<(), ContoursError> {
@@ -912,18 +913,19 @@ const _: () = {
 /// # Example
 ///
 /// ```rust
-/// # use kornia_image::{Image, ImageSize, allocator::CpuAllocator};
+/// # use kornia_image::{Image, ImageSize};
 /// # use kornia_imgproc::contours::{find_contours, RetrievalMode, ContourApproximationMode};
+/// # use kornia_tensor::host_alloc;
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// # let size = ImageSize { width: 10, height: 10 };
-/// # let img = Image::<u8, 1, _>::from_size_val(size, 0, CpuAllocator)?;
+/// # let img = Image::<u8, 1>::from_size_val(size, 0, host_alloc())?;
 /// let result = find_contours(&img, RetrievalMode::External, ContourApproximationMode::Simple)?;
 /// println!("Found {} contours", result.contours.len());
 /// # Ok(())
 /// # }
 /// ```
-pub fn find_contours<A: ImageAllocator>(
-    src: &Image<u8, 1, A>,
+pub fn find_contours(
+    src: &Image<u8, 1>,
     mode: RetrievalMode,
     method: ContourApproximationMode,
 ) -> Result<ContoursResult, ContoursError> {
@@ -933,15 +935,11 @@ pub fn find_contours<A: ImageAllocator>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kornia_image::allocator::CpuAllocator;
+    use kornia_tensor::host_alloc;
     use kornia_tensor::{Tensor3, TensorError};
 
-    fn make_img(
-        w: usize,
-        h: usize,
-        data: Vec<u8>,
-    ) -> Result<Image<u8, 1, CpuAllocator>, TensorError> {
-        let tensor = Tensor3::from_shape_vec([h, w, 1], data, CpuAllocator)?;
+    fn make_img(w: usize, h: usize, data: Vec<u8>) -> Result<Image<u8, 1>, TensorError> {
+        let tensor = Tensor3::from_shape_vec([h, w, 1], data, host_alloc())?;
         Ok(Image(tensor))
     }
 

--- a/crates/kornia-imgproc/src/contours.rs
+++ b/crates/kornia-imgproc/src/contours.rs
@@ -174,12 +174,11 @@ impl WorkBuffers {
 /// ```rust
 /// # use kornia_image::{Image, ImageSize};
 /// # use kornia_imgproc::contours::{FindContoursExecutor, RetrievalMode, ContourApproximationMode};
-/// # use kornia_tensor::host_alloc;
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut executor = FindContoursExecutor::new();
 /// # let size = ImageSize { width: 10, height: 10 };
-/// # let img = Image::<u8, 1>::from_size_val(size, 0, host_alloc())?;
-/// # let img2 = Image::<u8, 1>::from_size_val(size, 0, host_alloc())?;
+/// # let img = Image::<u8, 1>::from_size_val(size, 0)?;
+/// # let img2 = Image::<u8, 1>::from_size_val(size, 0)?;
 ///
 /// // Process multiple images with reused buffers
 /// let result1 = executor.find_contours(&img, RetrievalMode::List, ContourApproximationMode::Simple)?;
@@ -915,10 +914,9 @@ const _: () = {
 /// ```rust
 /// # use kornia_image::{Image, ImageSize};
 /// # use kornia_imgproc::contours::{find_contours, RetrievalMode, ContourApproximationMode};
-/// # use kornia_tensor::host_alloc;
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// # let size = ImageSize { width: 10, height: 10 };
-/// # let img = Image::<u8, 1>::from_size_val(size, 0, host_alloc())?;
+/// # let img = Image::<u8, 1>::from_size_val(size, 0)?;
 /// let result = find_contours(&img, RetrievalMode::External, ContourApproximationMode::Simple)?;
 /// println!("Found {} contours", result.contours.len());
 /// # Ok(())
@@ -935,11 +933,11 @@ pub fn find_contours(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kornia_tensor::host_alloc;
+
     use kornia_tensor::{Tensor3, TensorError};
 
     fn make_img(w: usize, h: usize, data: Vec<u8>) -> Result<Image<u8, 1>, TensorError> {
-        let tensor = Tensor3::from_shape_vec([h, w, 1], data, host_alloc())?;
+        let tensor = Tensor3::from_shape_vec([h, w, 1], data)?;
         Ok(Image(tensor))
     }
 

--- a/crates/kornia-imgproc/src/core.rs
+++ b/crates/kornia-imgproc/src/core.rs
@@ -1,5 +1,5 @@
 // reference: https://www.strchr.com/standard_deviation_in_one_pass
-use kornia_image::{allocator::ImageAllocator, Image, ImageError};
+use kornia_image::{Image, ImageError};
 use rayon::{
     iter::{IndexedParallelIterator, ParallelIterator},
     slice::{ParallelSlice, ParallelSliceMut},
@@ -24,16 +24,16 @@ use rayon::{
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::core::std_mean;
 ///
-/// let image = Image::<u8, 3, _>::new(
+/// let image = Image::<u8, 3>::new(
 ///    ImageSize {
 ///      width: 2,
 ///      height: 2,
 ///  },
 /// vec![0, 1, 2, 253, 254, 255, 128, 129, 130, 64, 65, 66],
-/// CpuAllocator
+/// host_alloc()
 /// ).unwrap();
 ///
 /// let (std, mean) = std_mean(&image);
@@ -41,7 +41,7 @@ use rayon::{
 /// assert_eq!(std, [93.5183805462862, 93.5183805462862, 93.5183805462862]);
 /// assert_eq!(mean, [111.25, 112.25, 113.25]);
 /// ```
-pub fn std_mean<A: ImageAllocator>(image: &Image<u8, 3, A>) -> ([f64; 3], [f64; 3]) {
+pub fn std_mean(image: &Image<u8, 3>) -> ([f64; 3], [f64; 3]) {
     let (sum, sq_sum) = image.as_slice().chunks_exact(3).fold(
         ([0f64; 3], [0f64; 3]),
         |(mut sum, mut sq_sum), pixel| {
@@ -88,28 +88,28 @@ pub fn std_mean<A: ImageAllocator>(image: &Image<u8, 3, A>) -> ([f64; 3], [f64; 
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::core::bitwise_and;
 ///
-/// let image = Image::<u8, 3, _>::new(
+/// let image = Image::<u8, 3>::new(
 ///    ImageSize {
 ///        width: 2,
 ///        height: 2,
 ///    },
 ///    vec![0, 1, 2, 253, 254, 255, 128, 129, 130, 64, 65, 66],
-///    CpuAllocator
+///    host_alloc()
 /// ).unwrap();
 ///
-/// let mask = Image::<u8, 1, _>::new(
+/// let mask = Image::<u8, 1>::new(
 ///    ImageSize {
 ///        width: 2,
 ///        height: 2,
 ///    },
 ///    vec![255, 0, 255, 0],
-///    CpuAllocator
+///    host_alloc()
 /// ).unwrap();
 ///
-/// let mut output = Image::<u8, 3, _>::from_size_val(image.size(), 0, CpuAllocator).unwrap();
+/// let mut output = Image::<u8, 3>::from_size_val(image.size(), 0, host_alloc()).unwrap();
 ///
 /// bitwise_and(&image, &image, &mut output, &mask).unwrap();
 ///
@@ -118,17 +118,11 @@ pub fn std_mean<A: ImageAllocator>(image: &Image<u8, 3, A>) -> ([f64; 3], [f64; 
 ///
 /// assert_eq!(output.as_slice(), &vec![0, 1, 2, 0, 0, 0, 128, 129, 130, 0, 0, 0]);
 /// ```
-pub fn bitwise_and<
-    const C: usize,
-    A1: ImageAllocator,
-    A2: ImageAllocator,
-    A3: ImageAllocator,
-    A4: ImageAllocator,
->(
-    src1: &Image<u8, C, A1>,
-    src2: &Image<u8, C, A2>,
-    dst: &mut Image<u8, C, A3>,
-    mask: &Image<u8, 1, A4>,
+pub fn bitwise_and<const C: usize>(
+    src1: &Image<u8, C>,
+    src2: &Image<u8, C>,
+    dst: &mut Image<u8, C>,
+    mask: &Image<u8, 1>,
 ) -> Result<(), ImageError> {
     if src1.size() != src2.size() {
         return Err(ImageError::InvalidImageSize(
@@ -194,41 +188,41 @@ pub fn bitwise_and<
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::core::hconcat;
 ///
-/// let image1 = Image::<u8, 3, _>::new(
+/// let image1 = Image::<u8, 3>::new(
 ///     ImageSize {
 ///         width: 2,
 ///         height: 2,
 ///     },
 ///     vec![0, 1, 2, 253, 254, 255, 128, 129, 130, 64, 65, 66],
-///     CpuAllocator
+///     host_alloc()
 /// ).unwrap();
 ///
-/// let image2 = Image::<u8, 3, _>::new(
+/// let image2 = Image::<u8, 3>::new(
 ///     ImageSize {
 ///         width: 2,
 ///         height: 2,
 ///     },
 ///     vec![128, 129, 130, 64, 65, 66, 253, 254, 255, 0, 1, 2],
-///     CpuAllocator
+///     host_alloc()
 /// ).unwrap();
 ///
-/// let mut output = Image::<u8, 3, _>::from_size_val(
+/// let mut output = Image::<u8, 3>::from_size_val(
 ///     ImageSize {
 ///         width: 4,
 ///         height: 2,
 ///     },
 ///     0,
-///     CpuAllocator
+///     host_alloc()
 /// ).unwrap();
 ///
 /// hconcat(vec![&image1, &image2], &mut output).unwrap();
 /// ```
-pub fn hconcat<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: Vec<&Image<u8, C, A1>>,
-    dst: &mut Image<u8, C, A2>,
+pub fn hconcat<const C: usize>(
+    src: Vec<&Image<u8, C>>,
+    dst: &mut Image<u8, C>,
 ) -> Result<(), ImageError> {
     // check that all images have the same height
     let mut count_cols = 0;
@@ -280,17 +274,17 @@ pub fn hconcat<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::CpuAllocator;
+    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_std_mean() -> Result<(), ImageError> {
-        let image = Image::<u8, 3, _>::new(
+        let image = Image::<u8, 3>::new(
             ImageSize {
                 width: 2,
                 height: 2,
             },
             vec![0, 1, 2, 253, 254, 255, 128, 129, 130, 64, 65, 66],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let std_expected = [93.5183805462862, 93.5183805462862, 93.5183805462862];
@@ -304,25 +298,25 @@ mod tests {
 
     #[test]
     fn test_bitwise_and() -> Result<(), ImageError> {
-        let image = Image::<u8, 3, _>::new(
+        let image = Image::<u8, 3>::new(
             ImageSize {
                 width: 2,
                 height: 2,
             },
             vec![0, 1, 2, 253, 254, 255, 128, 129, 130, 64, 65, 66],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mask = Image::<u8, 1, _>::new(
+        let mask = Image::<u8, 1>::new(
             ImageSize {
                 width: 2,
                 height: 2,
             },
             vec![255, 0, 255, 0],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut output = Image::<u8, 3, _>::from_size_val(image.size(), 0, CpuAllocator)?;
+        let mut output = Image::<u8, 3>::from_size_val(image.size(), 0, host_alloc())?;
 
         super::bitwise_and(&image, &image, &mut output, &mask)?;
 
@@ -340,7 +334,7 @@ mod tests {
     #[test]
     fn test_hconcat() -> Result<(), ImageError> {
         #[rustfmt::skip]
-        let image1 = Image::<u8, 3, _>::new(
+        let image1 = Image::<u8, 3>::new(
             ImageSize {
                 width: 2,
                 height: 2,
@@ -351,11 +345,11 @@ mod tests {
                 128, 129, 130,
                 64, 65, 66,
             ],
-            CpuAllocator
+            host_alloc()
         )?;
 
         #[rustfmt::skip]
-        let image2 = Image::<u8, 3, _>::new(
+        let image2 = Image::<u8, 3>::new(
             ImageSize {
                 width: 2,
                 height: 2,
@@ -366,7 +360,7 @@ mod tests {
                 253, 254, 255,
                 0, 1, 2,
             ],
-            CpuAllocator
+            host_alloc()
         )?;
 
         #[rustfmt::skip]
@@ -377,13 +371,13 @@ mod tests {
             253, 254, 255, 0, 1, 2,
         ];
 
-        let mut output = Image::<u8, 3, _>::from_size_val(
+        let mut output = Image::<u8, 3>::from_size_val(
             ImageSize {
                 width: 4,
                 height: 2,
             },
             0,
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         super::hconcat(vec![&image1, &image2], &mut output)?;

--- a/crates/kornia-imgproc/src/core.rs
+++ b/crates/kornia-imgproc/src/core.rs
@@ -24,7 +24,6 @@ use rayon::{
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::core::std_mean;
 ///
 /// let image = Image::<u8, 3>::new(
@@ -33,7 +32,6 @@ use rayon::{
 ///      height: 2,
 ///  },
 /// vec![0, 1, 2, 253, 254, 255, 128, 129, 130, 64, 65, 66],
-/// host_alloc()
 /// ).unwrap();
 ///
 /// let (std, mean) = std_mean(&image);
@@ -88,7 +86,6 @@ pub fn std_mean(image: &Image<u8, 3>) -> ([f64; 3], [f64; 3]) {
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::core::bitwise_and;
 ///
 /// let image = Image::<u8, 3>::new(
@@ -97,7 +94,6 @@ pub fn std_mean(image: &Image<u8, 3>) -> ([f64; 3], [f64; 3]) {
 ///        height: 2,
 ///    },
 ///    vec![0, 1, 2, 253, 254, 255, 128, 129, 130, 64, 65, 66],
-///    host_alloc()
 /// ).unwrap();
 ///
 /// let mask = Image::<u8, 1>::new(
@@ -106,10 +102,9 @@ pub fn std_mean(image: &Image<u8, 3>) -> ([f64; 3], [f64; 3]) {
 ///        height: 2,
 ///    },
 ///    vec![255, 0, 255, 0],
-///    host_alloc()
 /// ).unwrap();
 ///
-/// let mut output = Image::<u8, 3>::from_size_val(image.size(), 0, host_alloc()).unwrap();
+/// let mut output = Image::<u8, 3>::from_size_val(image.size(), 0).unwrap();
 ///
 /// bitwise_and(&image, &image, &mut output, &mask).unwrap();
 ///
@@ -188,7 +183,6 @@ pub fn bitwise_and<const C: usize>(
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::core::hconcat;
 ///
 /// let image1 = Image::<u8, 3>::new(
@@ -197,7 +191,6 @@ pub fn bitwise_and<const C: usize>(
 ///         height: 2,
 ///     },
 ///     vec![0, 1, 2, 253, 254, 255, 128, 129, 130, 64, 65, 66],
-///     host_alloc()
 /// ).unwrap();
 ///
 /// let image2 = Image::<u8, 3>::new(
@@ -206,7 +199,6 @@ pub fn bitwise_and<const C: usize>(
 ///         height: 2,
 ///     },
 ///     vec![128, 129, 130, 64, 65, 66, 253, 254, 255, 0, 1, 2],
-///     host_alloc()
 /// ).unwrap();
 ///
 /// let mut output = Image::<u8, 3>::from_size_val(
@@ -215,7 +207,6 @@ pub fn bitwise_and<const C: usize>(
 ///         height: 2,
 ///     },
 ///     0,
-///     host_alloc()
 /// ).unwrap();
 ///
 /// hconcat(vec![&image1, &image2], &mut output).unwrap();
@@ -274,7 +265,6 @@ pub fn hconcat<const C: usize>(
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_std_mean() -> Result<(), ImageError> {
@@ -284,7 +274,6 @@ mod tests {
                 height: 2,
             },
             vec![0, 1, 2, 253, 254, 255, 128, 129, 130, 64, 65, 66],
-            host_alloc(),
         )?;
 
         let std_expected = [93.5183805462862, 93.5183805462862, 93.5183805462862];
@@ -304,7 +293,6 @@ mod tests {
                 height: 2,
             },
             vec![0, 1, 2, 253, 254, 255, 128, 129, 130, 64, 65, 66],
-            host_alloc(),
         )?;
 
         let mask = Image::<u8, 1>::new(
@@ -313,10 +301,9 @@ mod tests {
                 height: 2,
             },
             vec![255, 0, 255, 0],
-            host_alloc(),
         )?;
 
-        let mut output = Image::<u8, 3>::from_size_val(image.size(), 0, host_alloc())?;
+        let mut output = Image::<u8, 3>::from_size_val(image.size(), 0)?;
 
         super::bitwise_and(&image, &image, &mut output, &mask)?;
 
@@ -344,8 +331,7 @@ mod tests {
                 253, 254, 255,
                 128, 129, 130,
                 64, 65, 66,
-            ],
-            host_alloc()
+            ]
         )?;
 
         #[rustfmt::skip]
@@ -359,8 +345,7 @@ mod tests {
                 64, 65, 66,
                 253, 254, 255,
                 0, 1, 2,
-            ],
-            host_alloc()
+            ]
         )?;
 
         #[rustfmt::skip]
@@ -377,7 +362,6 @@ mod tests {
                 height: 2,
             },
             0,
-            host_alloc(),
         )?;
 
         super::hconcat(vec![&image1, &image2], &mut output)?;

--- a/crates/kornia-imgproc/src/crop.rs
+++ b/crates/kornia-imgproc/src/crop.rs
@@ -1,4 +1,4 @@
-use kornia_image::{allocator::ImageAllocator, Image, ImageError};
+use kornia_image::{Image, ImageError};
 use rayon::{
     iter::{IndexedParallelIterator, ParallelIterator},
     slice::ParallelSliceMut,
@@ -19,40 +19,42 @@ use rayon::{
 #[target_feature(enable = "neon")]
 #[inline]
 unsafe fn copy_row_neon(src: *const u8, dst: *mut u8, n: usize) {
-    use std::arch::aarch64::{vld1q_u8, vst1q_u8};
-    use std::arch::asm;
+    unsafe {
+        use std::arch::aarch64::{vld1q_u8, vst1q_u8};
+        use std::arch::asm;
 
-    // Prefetch ~2KB ahead of the current row to hide L2 fetch latency on the
-    // next iteration (rows are spaced by src stride bytes; prefetcher won't
-    // see the pattern across rows, so we hint manually).
-    asm!(
-        "prfm pldl1strm, [{0}, #2048]",
-        in(reg) src,
-        options(nostack, preserves_flags, readonly)
-    );
+        // Prefetch ~2KB ahead of the current row to hide L2 fetch latency on the
+        // next iteration (rows are spaced by src stride bytes; prefetcher won't
+        // see the pattern across rows, so we hint manually).
+        asm!(
+            "prfm pldl1strm, [{0}, #2048]",
+            in(reg) src,
+            options(nostack, preserves_flags, readonly)
+        );
 
-    let mut i: usize = 0;
-    // Main 32-byte loop: two 128-bit loads/stores per iter.
-    while i + 32 <= n {
-        let s0 = src.add(i);
-        let s1 = src.add(i + 16);
-        let d0 = dst.add(i);
-        let d1 = dst.add(i + 16);
-        let v0 = vld1q_u8(s0);
-        let v1 = vld1q_u8(s1);
-        vst1q_u8(d0, v0);
-        vst1q_u8(d1, v1);
-        i += 32;
-    }
-    // 16-byte remainder.
-    if i + 16 <= n {
-        let v = vld1q_u8(src.add(i));
-        vst1q_u8(dst.add(i), v);
-        i += 16;
-    }
-    // Byte tail.
-    if i < n {
-        std::ptr::copy_nonoverlapping(src.add(i), dst.add(i), n - i);
+        let mut i: usize = 0;
+        // Main 32-byte loop: two 128-bit loads/stores per iter.
+        while i + 32 <= n {
+            let s0 = src.add(i);
+            let s1 = src.add(i + 16);
+            let d0 = dst.add(i);
+            let d1 = dst.add(i + 16);
+            let v0 = vld1q_u8(s0);
+            let v1 = vld1q_u8(s1);
+            vst1q_u8(d0, v0);
+            vst1q_u8(d1, v1);
+            i += 32;
+        }
+        // 16-byte remainder.
+        if i + 16 <= n {
+            let v = vld1q_u8(src.add(i));
+            vst1q_u8(dst.add(i), v);
+            i += 16;
+        }
+        // Byte tail.
+        if i < n {
+            std::ptr::copy_nonoverlapping(src.add(i), dst.add(i), n - i);
+        }
     }
 }
 
@@ -167,25 +169,25 @@ fn copy_row<T: Copy>(src_row: &[T], dst_row: &mut [T]) {
 ///
 /// ```rust
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::crop::crop_image;
 ///
-/// let image = Image::<_, 1, _>::new(ImageSize { width: 4, height: 4 }, vec![
+/// let image = Image::<_, 1>::new(ImageSize { width: 4, height: 4 }, vec![
 ///     0u8, 1, 2, 3,
 ///     4u8, 5, 6, 7,
 ///     8u8, 9, 10, 11,
 ///     12u8, 13, 14, 15
-/// ], CpuAllocator).unwrap();
+/// ], host_alloc()).unwrap();
 ///
-/// let mut cropped = Image::<_, 1, _>::from_size_val(ImageSize { width: 2, height: 2 }, 0u8, CpuAllocator).unwrap();
+/// let mut cropped = Image::<_, 1>::from_size_val(ImageSize { width: 2, height: 2 }, 0u8, host_alloc()).unwrap();
 ///
 /// crop_image(&image, &mut cropped, 1, 1).unwrap();
 ///
 /// assert_eq!(cropped.as_slice(), &[5u8, 6, 9, 10]);
 /// ```
-pub fn crop_image<T, const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<T, C, A1>,
-    dst: &mut Image<T, C, A2>,
+pub fn crop_image<T, const C: usize>(
+    src: &Image<T, C>,
+    dst: &mut Image<T, C>,
     x: usize,
     y: usize,
 ) -> Result<(), ImageError>
@@ -240,7 +242,7 @@ where
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::CpuAllocator;
+    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_crop() -> Result<(), ImageError> {
@@ -250,14 +252,14 @@ mod tests {
         };
 
         #[rustfmt::skip]
-        let image = Image::<_, 3, _>::new(
+        let image = Image::<_, 3>::new(
             image_size,
             vec![
                 0u8, 1, 2, 3, 4, 5,
                 6u8, 7, 8, 9, 10, 11,
                 12u8, 13, 14, 15, 16, 17,
             ],
-            CpuAllocator
+            host_alloc()
         )?;
 
         let data_expected = vec![9u8, 10, 11, 15, 16, 17];
@@ -267,7 +269,7 @@ mod tests {
             height: 2,
         };
 
-        let mut cropped = Image::<_, 3, _>::from_size_val(crop_size, 0u8, CpuAllocator)?;
+        let mut cropped = Image::<_, 3>::from_size_val(crop_size, 0u8, host_alloc())?;
 
         super::crop_image(&image, &mut cropped, 1, 1)?;
 
@@ -291,8 +293,8 @@ mod tests {
             70u8, 80, 90, 100, 110, 120,
         ];
 
-        let image = Image::<_, 2, _>::new(image_size, data.clone(), CpuAllocator)?;
-        let mut dst = Image::<_, 2, _>::from_size_val(image_size, 0u8, CpuAllocator)?;
+        let image = Image::<_, 2>::new(image_size, data.clone(), host_alloc())?;
+        let mut dst = Image::<_, 2>::from_size_val(image_size, 0u8, host_alloc())?;
 
         super::crop_image(&image, &mut dst, 0, 0)?;
 
@@ -310,7 +312,7 @@ mod tests {
         };
 
         #[rustfmt::skip]
-        let image = Image::<_, 1, _>::new(
+        let image = Image::<_, 1>::new(
             image_size,
             vec![
                  0u8,  1,  2,  3,
@@ -318,14 +320,14 @@ mod tests {
                  8u8,  9, 10, 11,
                 12u8, 13, 14, 15,
             ],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let crop_size = ImageSize {
             width: 1,
             height: 1,
         };
-        let mut dst = Image::<_, 1, _>::from_size_val(crop_size, 0u8, CpuAllocator)?;
+        let mut dst = Image::<_, 1>::from_size_val(crop_size, 0u8, host_alloc())?;
 
         // Pixel at column 2, row 3 is value 14.
         super::crop_image(&image, &mut dst, 2, 3)?;
@@ -345,25 +347,25 @@ mod tests {
         for (i, v) in src_data.iter_mut().enumerate() {
             *v = (i & 0xFF) as u8;
         }
-        let src = Image::<_, 3, _>::new(
+        let src = Image::<_, 3>::new(
             ImageSize {
                 width: src_w,
                 height: src_h,
             },
             src_data.clone(),
-            CpuAllocator,
+            host_alloc(),
         )?;
         let crop_w = 224;
         let crop_h = 224;
         let x0 = 848;
         let y0 = 428;
-        let mut dst = Image::<_, 3, _>::from_size_val(
+        let mut dst = Image::<_, 3>::from_size_val(
             ImageSize {
                 width: crop_w,
                 height: crop_h,
             },
             0u8,
-            CpuAllocator,
+            host_alloc(),
         )?;
         super::crop_image(&src, &mut dst, x0, y0)?;
 
@@ -381,22 +383,22 @@ mod tests {
     #[test]
     fn test_crop_oob_returns_err() {
         // crop region extends beyond source width: x=2, dst.cols=3, x+dst.cols=5 > src.cols=4
-        let src = Image::<u8, 1, _>::from_size_val(
+        let src = Image::<u8, 1>::from_size_val(
             ImageSize {
                 width: 4,
                 height: 4,
             },
             0u8,
-            CpuAllocator,
+            host_alloc(),
         )
         .unwrap();
-        let mut dst = Image::<u8, 1, _>::from_size_val(
+        let mut dst = Image::<u8, 1>::from_size_val(
             ImageSize {
                 width: 3,
                 height: 3,
             },
             0u8,
-            CpuAllocator,
+            host_alloc(),
         )
         .unwrap();
         let result = super::crop_image(&src, &mut dst, 2, 0);
@@ -413,26 +415,26 @@ mod tests {
         for (i, v) in src_data.iter_mut().enumerate() {
             *v = ((i * 7) & 0xFF) as u8;
         }
-        let src = Image::<_, 3, _>::new(
+        let src = Image::<_, 3>::new(
             ImageSize {
                 width: src_w,
                 height: src_h,
             },
             src_data.clone(),
-            CpuAllocator,
+            host_alloc(),
         )?;
         // 43 columns * 3 chans = 129 bytes row (hits main + 16-byte tail + 1-byte tail).
         let crop_w = 43;
         let crop_h = 4;
         let x0 = 5;
         let y0 = 2;
-        let mut dst = Image::<_, 3, _>::from_size_val(
+        let mut dst = Image::<_, 3>::from_size_val(
             ImageSize {
                 width: crop_w,
                 height: crop_h,
             },
             0u8,
-            CpuAllocator,
+            host_alloc(),
         )?;
         super::crop_image(&src, &mut dst, x0, y0)?;
         let dst_slice = dst.as_slice();

--- a/crates/kornia-imgproc/src/crop.rs
+++ b/crates/kornia-imgproc/src/crop.rs
@@ -169,7 +169,6 @@ fn copy_row<T: Copy>(src_row: &[T], dst_row: &mut [T]) {
 ///
 /// ```rust
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::crop::crop_image;
 ///
 /// let image = Image::<_, 1>::new(ImageSize { width: 4, height: 4 }, vec![
@@ -177,9 +176,9 @@ fn copy_row<T: Copy>(src_row: &[T], dst_row: &mut [T]) {
 ///     4u8, 5, 6, 7,
 ///     8u8, 9, 10, 11,
 ///     12u8, 13, 14, 15
-/// ], host_alloc()).unwrap();
+/// ]).unwrap();
 ///
-/// let mut cropped = Image::<_, 1>::from_size_val(ImageSize { width: 2, height: 2 }, 0u8, host_alloc()).unwrap();
+/// let mut cropped = Image::<_, 1>::from_size_val(ImageSize { width: 2, height: 2 }, 0u8).unwrap();
 ///
 /// crop_image(&image, &mut cropped, 1, 1).unwrap();
 ///
@@ -242,7 +241,6 @@ where
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_crop() -> Result<(), ImageError> {
@@ -258,8 +256,7 @@ mod tests {
                 0u8, 1, 2, 3, 4, 5,
                 6u8, 7, 8, 9, 10, 11,
                 12u8, 13, 14, 15, 16, 17,
-            ],
-            host_alloc()
+            ]
         )?;
 
         let data_expected = vec![9u8, 10, 11, 15, 16, 17];
@@ -269,7 +266,7 @@ mod tests {
             height: 2,
         };
 
-        let mut cropped = Image::<_, 3>::from_size_val(crop_size, 0u8, host_alloc())?;
+        let mut cropped = Image::<_, 3>::from_size_val(crop_size, 0u8)?;
 
         super::crop_image(&image, &mut cropped, 1, 1)?;
 
@@ -293,8 +290,8 @@ mod tests {
             70u8, 80, 90, 100, 110, 120,
         ];
 
-        let image = Image::<_, 2>::new(image_size, data.clone(), host_alloc())?;
-        let mut dst = Image::<_, 2>::from_size_val(image_size, 0u8, host_alloc())?;
+        let image = Image::<_, 2>::new(image_size, data.clone())?;
+        let mut dst = Image::<_, 2>::from_size_val(image_size, 0u8)?;
 
         super::crop_image(&image, &mut dst, 0, 0)?;
 
@@ -320,14 +317,13 @@ mod tests {
                  8u8,  9, 10, 11,
                 12u8, 13, 14, 15,
             ],
-            host_alloc(),
         )?;
 
         let crop_size = ImageSize {
             width: 1,
             height: 1,
         };
-        let mut dst = Image::<_, 1>::from_size_val(crop_size, 0u8, host_alloc())?;
+        let mut dst = Image::<_, 1>::from_size_val(crop_size, 0u8)?;
 
         // Pixel at column 2, row 3 is value 14.
         super::crop_image(&image, &mut dst, 2, 3)?;
@@ -353,7 +349,6 @@ mod tests {
                 height: src_h,
             },
             src_data.clone(),
-            host_alloc(),
         )?;
         let crop_w = 224;
         let crop_h = 224;
@@ -365,7 +360,6 @@ mod tests {
                 height: crop_h,
             },
             0u8,
-            host_alloc(),
         )?;
         super::crop_image(&src, &mut dst, x0, y0)?;
 
@@ -389,7 +383,6 @@ mod tests {
                 height: 4,
             },
             0u8,
-            host_alloc(),
         )
         .unwrap();
         let mut dst = Image::<u8, 1>::from_size_val(
@@ -398,7 +391,6 @@ mod tests {
                 height: 3,
             },
             0u8,
-            host_alloc(),
         )
         .unwrap();
         let result = super::crop_image(&src, &mut dst, 2, 0);
@@ -421,7 +413,6 @@ mod tests {
                 height: src_h,
             },
             src_data.clone(),
-            host_alloc(),
         )?;
         // 43 columns * 3 chans = 129 bytes row (hits main + 16-byte tail + 1-byte tail).
         let crop_w = 43;
@@ -434,7 +425,6 @@ mod tests {
                 height: crop_h,
             },
             0u8,
-            host_alloc(),
         )?;
         super::crop_image(&src, &mut dst, x0, y0)?;
         let dst_slice = dst.as_slice();

--- a/crates/kornia-imgproc/src/distance_transform.rs
+++ b/crates/kornia-imgproc/src/distance_transform.rs
@@ -1,5 +1,4 @@
 use kornia_image::{Image, ImageError, ImageSize};
-use kornia_tensor::host_alloc;
 use rayon::prelude::*;
 
 const INF: f32 = 1e20;
@@ -31,7 +30,7 @@ pub fn distance_transform_vanilla(image: &Image<f32, 1>) -> Result<Image<f32, 1>
         }
     }
 
-    Image::new(image.size(), output, host_alloc())
+    Image::new(image.size(), output)
 }
 
 /// Executor for computing the Euclidean Distance Transform.
@@ -105,7 +104,7 @@ impl DistanceTransformExecutor {
         let mut final_data = vec![0.0f32; num_pixels];
         transpose_map(&self.scratch, &mut final_data, height, width, |x| x.sqrt());
 
-        Image::new(ImageSize { width, height }, final_data, host_alloc())
+        Image::new(ImageSize { width, height }, final_data)
     }
 }
 
@@ -172,7 +171,6 @@ where
 mod tests {
     use super::*;
     use kornia_image::{Image, ImageSize};
-    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_accuracy_vs_vanilla() -> Result<(), ImageError> {
@@ -183,7 +181,7 @@ mod tests {
         data[102] = 1.0;
         data[300] = 1.0;
 
-        let image = Image::<f32, 1>::new(ImageSize { width, height }, data, host_alloc())?;
+        let image = Image::<f32, 1>::new(ImageSize { width, height }, data)?;
         let expected = distance_transform_vanilla(&image)?;
 
         let mut executor = DistanceTransformExecutor::new();
@@ -206,7 +204,6 @@ mod tests {
             vec![
                 0.0f32, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0,
             ],
-            host_alloc(),
         )?;
 
         let mut executor = DistanceTransformExecutor::new();

--- a/crates/kornia-imgproc/src/distance_transform.rs
+++ b/crates/kornia-imgproc/src/distance_transform.rs
@@ -1,5 +1,5 @@
-use kornia_image::allocator::{CpuAllocator, ImageAllocator};
 use kornia_image::{Image, ImageError, ImageSize};
+use kornia_tensor::host_alloc;
 use rayon::prelude::*;
 
 const INF: f32 = 1e20;
@@ -9,12 +9,7 @@ pub(crate) fn euclidean_distance(x1: Vec<f32>, x2: Vec<f32>) -> f32 {
 }
 
 /// NOTE: only for testing, extremely slow
-pub fn distance_transform_vanilla<A>(
-    image: &Image<f32, 1, A>,
-) -> Result<Image<f32, 1, CpuAllocator>, ImageError>
-where
-    A: ImageAllocator,
-{
+pub fn distance_transform_vanilla(image: &Image<f32, 1>) -> Result<Image<f32, 1>, ImageError> {
     let mut output = vec![0.0f32; image.width() * image.height()];
     let slice = image.as_slice();
 
@@ -36,7 +31,7 @@ where
         }
     }
 
-    Image::new(image.size(), output, CpuAllocator)
+    Image::new(image.size(), output, host_alloc())
 }
 
 /// Executor for computing the Euclidean Distance Transform.
@@ -63,13 +58,7 @@ impl DistanceTransformExecutor {
     }
 
     /// Computes the Euclidean Distance Transform of a binary image.
-    pub fn execute<A>(
-        &mut self,
-        image: &Image<f32, 1, A>,
-    ) -> Result<Image<f32, 1, CpuAllocator>, ImageError>
-    where
-        A: ImageAllocator,
-    {
+    pub fn execute(&mut self, image: &Image<f32, 1>) -> Result<Image<f32, 1>, ImageError> {
         let width = image.width();
         let height = image.height();
         let num_pixels = width * height;
@@ -116,7 +105,7 @@ impl DistanceTransformExecutor {
         let mut final_data = vec![0.0f32; num_pixels];
         transpose_map(&self.scratch, &mut final_data, height, width, |x| x.sqrt());
 
-        Image::new(ImageSize { width, height }, final_data, CpuAllocator)
+        Image::new(ImageSize { width, height }, final_data, host_alloc())
     }
 }
 
@@ -182,8 +171,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kornia_image::allocator::CpuAllocator;
     use kornia_image::{Image, ImageSize};
+    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_accuracy_vs_vanilla() -> Result<(), ImageError> {
@@ -194,7 +183,7 @@ mod tests {
         data[102] = 1.0;
         data[300] = 1.0;
 
-        let image = Image::<f32, 1, _>::new(ImageSize { width, height }, data, CpuAllocator)?;
+        let image = Image::<f32, 1>::new(ImageSize { width, height }, data, host_alloc())?;
         let expected = distance_transform_vanilla(&image)?;
 
         let mut executor = DistanceTransformExecutor::new();
@@ -209,7 +198,7 @@ mod tests {
 
     #[test]
     fn distance_transform_smoke() -> Result<(), ImageError> {
-        let image = Image::<f32, 1, _>::new(
+        let image = Image::<f32, 1>::new(
             ImageSize {
                 width: 3,
                 height: 4,
@@ -217,7 +206,7 @@ mod tests {
             vec![
                 0.0f32, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0,
             ],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let mut executor = DistanceTransformExecutor::new();

--- a/crates/kornia-imgproc/src/draw.rs
+++ b/crates/kornia-imgproc/src/draw.rs
@@ -1,4 +1,4 @@
-use kornia_image::{allocator::ImageAllocator, Image};
+use kornia_image::Image;
 
 /// Draws a line on an image inplace.
 ///
@@ -12,8 +12,8 @@ use kornia_image::{allocator::ImageAllocator, Image};
 /// * `p1` - The end point of the line as a tuple of (x, y).
 /// * `color` - The color of the line as an array of `C` elements.
 /// * `thickness` - The thickness of the line.
-pub fn draw_line<const C: usize, A: ImageAllocator>(
-    img: &mut Image<u8, C, A>,
+pub fn draw_line<const C: usize>(
+    img: &mut Image<u8, C>,
     p0: (i64, i64),
     p1: (i64, i64),
     color: [u8; C],
@@ -105,8 +105,8 @@ pub fn draw_line<const C: usize, A: ImageAllocator>(
 /// * `color` - The color of the polygon lines as an array of `C` elements.
 /// * `thickness` - The thickness of the polygon lines.
 ///
-pub fn draw_polygon<const C: usize, A: ImageAllocator>(
-    img: &mut Image<u8, C, A>,
+pub fn draw_polygon<const C: usize>(
+    img: &mut Image<u8, C>,
     points: &[(i64, i64)],
     color: [u8; C],
     thickness: usize,
@@ -137,8 +137,8 @@ pub fn draw_polygon<const C: usize, A: ImageAllocator>(
 /// * `line_color` - The color of the pen used to draw the polygon.
 /// * `thickness` - The thickness of the polygon lines.
 ///
-pub fn draw_filled_polygon<const C: usize, A: ImageAllocator>(
-    img: &mut Image<u8, C, A>,
+pub fn draw_filled_polygon<const C: usize>(
+    img: &mut Image<u8, C>,
     points: &[(i64, i64)],
     fill_color: [u8; C],
     line_color: [u8; C],
@@ -209,7 +209,7 @@ pub fn draw_filled_polygon<const C: usize, A: ImageAllocator>(
 mod tests {
     use super::{draw_filled_polygon, draw_line, draw_polygon};
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::CpuAllocator;
+    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_draw_line() -> Result<(), ImageError> {
@@ -219,7 +219,7 @@ mod tests {
                 height: 5,
             },
             vec![0; 25],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         draw_line(&mut img, (0, 0), (4, 4), [255], 1);
@@ -246,7 +246,7 @@ mod tests {
                 height: 5,
             },
             vec![0; 25],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let points: [(i64, i64); 3] = [(0, 0), (0, 3), (4, 0)];
@@ -274,7 +274,7 @@ mod tests {
                 height: 5,
             },
             vec![0; 25],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let points: [(i64, i64); 3] = [(0, 0), (0, 3), (4, 0)];
@@ -302,7 +302,7 @@ mod tests {
                 height: 5,
             },
             vec![0; 25],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let points: [(i64, i64); 3] = [(0, 0), (3, 0), (4, 0)];
@@ -324,7 +324,7 @@ mod tests {
 
     #[test]
     fn test_line_strict_endpoint_boundary() {
-        let mut img = Image::<u8, 1, _>::from_size_val([10, 10].into(), 0, CpuAllocator).unwrap();
+        let mut img = Image::<u8, 1>::from_size_val([10, 10].into(), 0, host_alloc()).unwrap();
 
         // Draw horizontal line (2,5) -> (7,5), thickness 5
         draw_line(&mut img, (2, 5), (7, 5), [255], 5);
@@ -339,7 +339,7 @@ mod tests {
 
     #[test]
     fn test_line_perpendicular_precision() {
-        let mut img = Image::<u8, 1, _>::from_size_val([20, 20].into(), 0, CpuAllocator).unwrap();
+        let mut img = Image::<u8, 1>::from_size_val([20, 20].into(), 0, host_alloc()).unwrap();
 
         // Draw horizontal line at y=10 with thickness 4. Should occupy y=[8..11].
         draw_line(&mut img, (5, 10), (15, 10), [255], 4);
@@ -354,7 +354,7 @@ mod tests {
 
     #[test]
     fn test_diagonal_flat_cap() {
-        let mut img = Image::<u8, 1, _>::from_size_val([20, 20].into(), 0, CpuAllocator).unwrap();
+        let mut img = Image::<u8, 1>::from_size_val([20, 20].into(), 0, host_alloc()).unwrap();
 
         // Diagonal line (0,0) -> (10,10), thickness 6
         draw_line(&mut img, (0, 0), (10, 10), [255], 6);

--- a/crates/kornia-imgproc/src/draw.rs
+++ b/crates/kornia-imgproc/src/draw.rs
@@ -209,7 +209,6 @@ pub fn draw_filled_polygon<const C: usize>(
 mod tests {
     use super::{draw_filled_polygon, draw_line, draw_polygon};
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_draw_line() -> Result<(), ImageError> {
@@ -219,7 +218,6 @@ mod tests {
                 height: 5,
             },
             vec![0; 25],
-            host_alloc(),
         )?;
 
         draw_line(&mut img, (0, 0), (4, 4), [255], 1);
@@ -246,7 +244,6 @@ mod tests {
                 height: 5,
             },
             vec![0; 25],
-            host_alloc(),
         )?;
 
         let points: [(i64, i64); 3] = [(0, 0), (0, 3), (4, 0)];
@@ -274,7 +271,6 @@ mod tests {
                 height: 5,
             },
             vec![0; 25],
-            host_alloc(),
         )?;
 
         let points: [(i64, i64); 3] = [(0, 0), (0, 3), (4, 0)];
@@ -302,7 +298,6 @@ mod tests {
                 height: 5,
             },
             vec![0; 25],
-            host_alloc(),
         )?;
 
         let points: [(i64, i64); 3] = [(0, 0), (3, 0), (4, 0)];
@@ -324,7 +319,7 @@ mod tests {
 
     #[test]
     fn test_line_strict_endpoint_boundary() {
-        let mut img = Image::<u8, 1>::from_size_val([10, 10].into(), 0, host_alloc()).unwrap();
+        let mut img = Image::<u8, 1>::from_size_val([10, 10].into(), 0).unwrap();
 
         // Draw horizontal line (2,5) -> (7,5), thickness 5
         draw_line(&mut img, (2, 5), (7, 5), [255], 5);
@@ -339,7 +334,7 @@ mod tests {
 
     #[test]
     fn test_line_perpendicular_precision() {
-        let mut img = Image::<u8, 1>::from_size_val([20, 20].into(), 0, host_alloc()).unwrap();
+        let mut img = Image::<u8, 1>::from_size_val([20, 20].into(), 0).unwrap();
 
         // Draw horizontal line at y=10 with thickness 4. Should occupy y=[8..11].
         draw_line(&mut img, (5, 10), (15, 10), [255], 4);
@@ -354,7 +349,7 @@ mod tests {
 
     #[test]
     fn test_diagonal_flat_cap() {
-        let mut img = Image::<u8, 1>::from_size_val([20, 20].into(), 0, host_alloc()).unwrap();
+        let mut img = Image::<u8, 1>::from_size_val([20, 20].into(), 0).unwrap();
 
         // Diagonal line (0,0) -> (10,10), thickness 6
         draw_line(&mut img, (0, 0), (10, 10), [255], 6);

--- a/crates/kornia-imgproc/src/enhance.rs
+++ b/crates/kornia-imgproc/src/enhance.rs
@@ -1,4 +1,4 @@
-use kornia_image::{allocator::ImageAllocator, Image, ImageError};
+use kornia_image::{Image, ImageError};
 use num_traits::Float;
 
 use crate::parallel;
@@ -24,13 +24,13 @@ use crate::parallel;
 ///
 /// Returns an error if the sizes of `src1` and `src2` do not match.
 /// Returns an error if the size of `dst` does not match the size of `src1` or `src2`.
-pub fn add_weighted<T, const C: usize, A1: ImageAllocator, A2: ImageAllocator, A3: ImageAllocator>(
-    src1: &Image<T, C, A1>,
+pub fn add_weighted<T, const C: usize>(
+    src1: &Image<T, C>,
     alpha: T,
-    src2: &Image<T, C, A2>,
+    src2: &Image<T, C>,
     beta: T,
     gamma: T,
-    dst: &mut Image<T, C, A3>,
+    dst: &mut Image<T, C>,
 ) -> Result<(), ImageError>
 where
     T: num_traits::Float + num_traits::FromPrimitive + std::fmt::Debug + Send + Sync + Copy,
@@ -81,9 +81,9 @@ where
 /// # Errors
 ///
 /// Returns an [ImageError::InvalidImageSize] if the sizes of `src` and `dst` do not match.
-pub fn adjust_brightness<T, const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<T, C, A1>,
-    dst: &mut Image<T, C, A2>,
+pub fn adjust_brightness<T, const C: usize>(
+    src: &Image<T, C>,
+    dst: &mut Image<T, C>,
     factor: T,
     clip_output: bool,
 ) -> Result<(), ImageError>
@@ -117,34 +117,35 @@ where
 
 #[cfg(test)]
 mod tests {
-    use kornia_image::{allocator::CpuAllocator, Image, ImageError, ImageSize};
-    type TestImage = Image<f32, 1, CpuAllocator>;
+    use kornia_image::{Image, ImageError, ImageSize};
+    use kornia_tensor::host_alloc;
+    type TestImage = Image<f32, 1>;
     #[test]
     fn test_add_weighted() -> Result<(), ImageError> {
         let src1_data = vec![1.0f32, 2.0, 3.0, 4.0];
-        let src1 = Image::<f32, 1, _>::new(
+        let src1 = Image::<f32, 1>::new(
             ImageSize {
                 width: 2,
                 height: 2,
             },
             src1_data,
-            CpuAllocator,
+            host_alloc(),
         )?;
         let src2_data = vec![4.0f32, 5.0, 6.0, 7.0];
-        let src2 = Image::<f32, 1, _>::new(
+        let src2 = Image::<f32, 1>::new(
             ImageSize {
                 width: 2,
                 height: 2,
             },
             src2_data,
-            CpuAllocator,
+            host_alloc(),
         )?;
         let alpha = 2.0f32;
         let beta = 2.0f32;
         let gamma = 1.0f32;
         let expected = [11.0, 15.0, 19.0, 23.0];
 
-        let mut weighted = Image::<f32, 1, _>::from_size_val(src1.size(), 0.0, CpuAllocator)?;
+        let mut weighted = Image::<f32, 1>::from_size_val(src1.size(), 0.0, host_alloc())?;
 
         super::add_weighted(&src1, alpha, &src2, beta, gamma, &mut weighted)?;
 
@@ -162,15 +163,15 @@ mod tests {
     // Helper function to create a base image for tests
     fn create_test_image() -> Result<(TestImage, TestImage), ImageError> {
         let src_data = vec![0.5f32, 0.5];
-        let src = Image::<f32, 1, _>::new(
+        let src = Image::<f32, 1>::new(
             ImageSize {
                 width: 2,
                 height: 1,
             },
             src_data,
-            CpuAllocator,
+            host_alloc(),
         )?;
-        let dst = Image::<f32, 1, _>::from_size_val(src.size(), 0.0, CpuAllocator)?;
+        let dst = Image::<f32, 1>::from_size_val(src.size(), 0.0, host_alloc())?;
         Ok((src, dst))
     }
 

--- a/crates/kornia-imgproc/src/enhance.rs
+++ b/crates/kornia-imgproc/src/enhance.rs
@@ -118,7 +118,6 @@ where
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::host_alloc;
     type TestImage = Image<f32, 1>;
     #[test]
     fn test_add_weighted() -> Result<(), ImageError> {
@@ -129,7 +128,6 @@ mod tests {
                 height: 2,
             },
             src1_data,
-            host_alloc(),
         )?;
         let src2_data = vec![4.0f32, 5.0, 6.0, 7.0];
         let src2 = Image::<f32, 1>::new(
@@ -138,14 +136,13 @@ mod tests {
                 height: 2,
             },
             src2_data,
-            host_alloc(),
         )?;
         let alpha = 2.0f32;
         let beta = 2.0f32;
         let gamma = 1.0f32;
         let expected = [11.0, 15.0, 19.0, 23.0];
 
-        let mut weighted = Image::<f32, 1>::from_size_val(src1.size(), 0.0, host_alloc())?;
+        let mut weighted = Image::<f32, 1>::from_size_val(src1.size(), 0.0)?;
 
         super::add_weighted(&src1, alpha, &src2, beta, gamma, &mut weighted)?;
 
@@ -169,9 +166,8 @@ mod tests {
                 height: 1,
             },
             src_data,
-            host_alloc(),
         )?;
-        let dst = Image::<f32, 1>::from_size_val(src.size(), 0.0, host_alloc())?;
+        let dst = Image::<f32, 1>::from_size_val(src.size(), 0.0)?;
         Ok((src, dst))
     }
 

--- a/crates/kornia-imgproc/src/features/cells.rs
+++ b/crates/kornia-imgproc/src/features/cells.rs
@@ -15,7 +15,7 @@
 //!
 //! Returns are all named structs ([`FastCorner`], [`CellKeypoint`],
 //! [`PyramidKeypoint`]) so adding fields later is non-breaking.
-use kornia_image::{allocator::ImageAllocator, Image};
+use kornia_image::Image;
 use rayon::prelude::*;
 
 use super::fast::fast_detect_rows_u8_serial;
@@ -138,8 +138,8 @@ impl Default for CellDetectConfig {
 /// This is **Layer 1** of the layered API: it produces a flat list of
 /// corners inside the rect, with no cell bookkeeping or NMS. For the usual
 /// ORB-SLAM / Basalt cell loop, prefer [`fast_detect_cells_u8`].
-pub fn fast_detect_rect_u8<A: ImageAllocator>(
-    image: &Image<u8, 1, A>,
+pub fn fast_detect_rect_u8(
+    image: &Image<u8, 1>,
     rect: Rect,
     threshold: f32,
     arc_length: usize,
@@ -199,8 +199,8 @@ fn grid_dims(image_w: usize, image_h: usize, cell_size: usize) -> (usize, usize)
 /// points without rebuilding the image.
 ///
 /// Cells are processed in parallel via rayon.
-pub fn fast_detect_cells_u8<A: ImageAllocator + Sync>(
-    image: &Image<u8, 1, A>,
+pub fn fast_detect_cells_u8(
+    image: &Image<u8, 1>,
     cfg: &CellDetectConfig,
     occupancy: Option<&[bool]>,
 ) -> Vec<CellKeypoint> {
@@ -282,8 +282,8 @@ pub fn fast_detect_cells_u8<A: ImageAllocator + Sync>(
 /// Rescale uses the exact width/height ratio `levels[0].size / levels[i].size`
 /// rather than assuming a fixed factor (1.2×, 2×, …), so ORB-SLAM's 1.2×
 /// chain and Basalt's 2× chain both work without special-casing.
-pub fn fast_detect_pyramid_u8<A: ImageAllocator + Sync>(
-    levels: &[&Image<u8, 1, A>],
+pub fn fast_detect_pyramid_u8(
+    levels: &[&Image<u8, 1>],
     cfg: &CellDetectConfig,
 ) -> Vec<PyramidKeypoint> {
     if levels.is_empty() {
@@ -315,7 +315,7 @@ pub fn fast_detect_pyramid_u8<A: ImageAllocator + Sync>(
 mod tests {
     use super::*;
     use kornia_image::ImageSize;
-    use kornia_tensor::CpuAllocator;
+    use kornia_tensor::host_alloc;
 
     /// Black background with 5×5 bright squares placed on a regular grid.
     /// Each square has 4 strong FAST corners (center pixel bright, most of the
@@ -323,7 +323,7 @@ mod tests {
     /// fires reliably at every grid position — unlike an axis-aligned
     /// checkerboard, whose T-junctions only produce runs of ~5 same-sign
     /// pixels, below the FAST-9 threshold.
-    fn dot_image(w: usize, h: usize, spacing: usize) -> Image<u8, 1, CpuAllocator> {
+    fn dot_image(w: usize, h: usize, spacing: usize) -> Image<u8, 1> {
         let size = ImageSize {
             width: w,
             height: h,
@@ -342,7 +342,7 @@ mod tests {
             }
             cy += spacing;
         }
-        Image::from_size_slice(size, &buf, CpuAllocator).unwrap()
+        Image::from_size_slice(size, &buf, host_alloc()).unwrap()
     }
 
     #[test]

--- a/crates/kornia-imgproc/src/features/cells.rs
+++ b/crates/kornia-imgproc/src/features/cells.rs
@@ -315,7 +315,6 @@ pub fn fast_detect_pyramid_u8(
 mod tests {
     use super::*;
     use kornia_image::ImageSize;
-    use kornia_tensor::host_alloc;
 
     /// Black background with 5×5 bright squares placed on a regular grid.
     /// Each square has 4 strong FAST corners (center pixel bright, most of the
@@ -342,7 +341,7 @@ mod tests {
             }
             cy += spacing;
         }
-        Image::from_size_slice(size, &buf, host_alloc()).unwrap()
+        Image::from_size_slice(size, &buf).unwrap()
     }
 
     #[test]

--- a/crates/kornia-imgproc/src/features/fast.rs
+++ b/crates/kornia-imgproc/src/features/fast.rs
@@ -1,7 +1,6 @@
 use std::ops::ControlFlow;
 
 use kornia_image::{Image, ImageError, ImageSize};
-use kornia_tensor::host_alloc;
 use rayon::prelude::*;
 
 #[derive(Clone, Copy, PartialEq)]
@@ -48,8 +47,8 @@ impl FastDetector {
             threshold,
             min_distance,
             arc_length,
-            corner_response: Image::from_size_val(image_size, 0.0, host_alloc())?,
-            mask: Image::from_size_val(image_size, false, host_alloc())?,
+            corner_response: Image::from_size_val(image_size, 0.0)?,
+            mask: Image::from_size_val(image_size, false)?,
             taken: vec![false; image_size.height * image_size.width],
         })
     }
@@ -1186,17 +1185,16 @@ mod tests {
     use super::*;
     use kornia_image::Image;
     use kornia_io::jpeg::read_image_jpeg_rgb8;
-    use kornia_tensor::host_alloc;
     use std::collections::HashSet;
 
     #[test]
     fn test_fast_feature_detector() -> Result<(), Box<dyn std::error::Error>> {
         #[rustfmt::skip]
         let img = read_image_jpeg_rgb8("../../tests/data/dog.jpeg")?;
-        let mut gray_img = Image::from_size_val(img.size(), 0, host_alloc())?;
+        let mut gray_img = Image::from_size_val(img.size(), 0)?;
         gray_from_rgb_u8(&img, &mut gray_img)?;
 
-        let mut gray_imgf32 = Image::from_size_val(img.size(), 0.0, host_alloc())?;
+        let mut gray_imgf32 = Image::from_size_val(img.size(), 0.0)?;
         gray_img
             .as_slice()
             .iter()
@@ -1252,7 +1250,7 @@ mod tests {
             *p = ((((x / 5) + (y / 5)) & 1) as u8 * 140)
                 .wrapping_add(((x.wrapping_mul(37)).wrapping_add(y.wrapping_mul(13)) as u8) / 4);
         }
-        let img = Image::<u8, 1>::new(sz, data, host_alloc())?;
+        let img = Image::<u8, 1>::new(sz, data)?;
 
         let mut det_neon = FastDetector::new(sz, 20.0 / 255.0, 9, 1)?;
         det_neon.compute_corner_response_u8(&img);

--- a/crates/kornia-imgproc/src/features/fast.rs
+++ b/crates/kornia-imgproc/src/features/fast.rs
@@ -1,7 +1,7 @@
 use std::ops::ControlFlow;
 
-use kornia_image::{allocator::ImageAllocator, Image, ImageError, ImageSize};
-use kornia_tensor::CpuAllocator;
+use kornia_image::{Image, ImageError, ImageSize};
+use kornia_tensor::host_alloc;
 use rayon::prelude::*;
 
 #[derive(Clone, Copy, PartialEq)]
@@ -20,8 +20,8 @@ pub struct FastDetector {
     pub min_distance: usize,
     /// The minimum arc length for a sequence of contiguous pixels to be considered a corner.
     pub arc_length: usize,
-    corner_response: Image<f32, 1, CpuAllocator>,
-    mask: Image<bool, 1, CpuAllocator>,
+    corner_response: Image<f32, 1>,
+    mask: Image<bool, 1>,
     taken: Vec<bool>,
 }
 
@@ -48,8 +48,8 @@ impl FastDetector {
             threshold,
             min_distance,
             arc_length,
-            corner_response: Image::from_size_val(image_size, 0.0, CpuAllocator)?,
-            mask: Image::from_size_val(image_size, false, CpuAllocator)?,
+            corner_response: Image::from_size_val(image_size, 0.0, host_alloc())?,
+            mask: Image::from_size_val(image_size, false, host_alloc())?,
             taken: vec![false; image_size.height * image_size.width],
         })
     }
@@ -62,7 +62,7 @@ impl FastDetector {
     /// Access the precomputed corner response image (populated by
     /// `compute_corner_response` / `compute_corner_response_u8`). Useful for
     /// callers that want to read per-pixel FAST score without re-running NMS.
-    pub fn corner_response_image(&self) -> &Image<f32, 1, CpuAllocator> {
+    pub fn corner_response_image(&self) -> &Image<f32, 1> {
         &self.corner_response
     }
 
@@ -74,11 +74,7 @@ impl FastDetector {
     ///
     /// The internal `corner_response` image is NOT populated. Callers that
     /// need the dense response image must still use `compute_corner_response_u8`.
-    pub fn detect_direct_u8<A: ImageAllocator>(
-        &self,
-        src: &Image<u8, 1, A>,
-        border: usize,
-    ) -> Vec<([usize; 2], f32)> {
+    pub fn detect_direct_u8(&self, src: &Image<u8, 1>, border: usize) -> Vec<([usize; 2], f32)> {
         let height = src.height();
         let margin = border.max(3);
         fast_detect_rows_u8(
@@ -99,10 +95,7 @@ impl FastDetector {
     /// # Returns
     ///
     /// Returns a reference to the image containing the corner response.
-    pub fn compute_corner_response<A: ImageAllocator>(
-        &mut self,
-        src: &Image<f32, 1, A>,
-    ) -> &Image<f32, 1, CpuAllocator> {
+    pub fn compute_corner_response(&mut self, src: &Image<f32, 1>) -> &Image<f32, 1> {
         let src_slice = src.as_slice();
 
         let width = src.width();
@@ -187,10 +180,7 @@ impl FastDetector {
     /// Reads pixels directly from a u8 source, avoiding a full image u8→f32 pass.
     /// Threshold is interpreted as a 0..1 fraction and rounded to the nearest u8.
     /// The output response image remains f32 so downstream NMS ranking is unchanged.
-    pub fn compute_corner_response_u8<A: ImageAllocator>(
-        &mut self,
-        src: &Image<u8, 1, A>,
-    ) -> &Image<f32, 1, CpuAllocator> {
+    pub fn compute_corner_response_u8(&mut self, src: &Image<u8, 1>) -> &Image<f32, 1> {
         let src_slice = src.as_slice();
         let width = src.width();
         let height = src.height();
@@ -460,8 +450,8 @@ pub fn suppress_direct_standalone(
 /// Runs the row loop in **parallel** (per-row rayon tasks). Do not call from
 /// within another `par_iter` — use [`fast_detect_rows_u8_serial`] instead to
 /// avoid nested-parallelism scheduler thrash on rayon's global pool.
-pub fn fast_detect_rows_u8<A: ImageAllocator>(
-    src: &Image<u8, 1, A>,
+pub fn fast_detect_rows_u8(
+    src: &Image<u8, 1>,
     threshold: f32,
     arc_length: usize,
     border: usize,
@@ -473,8 +463,8 @@ pub fn fast_detect_rows_u8<A: ImageAllocator>(
 /// Serial variant of [`fast_detect_rows_u8`]. Use this from inside an outer
 /// `par_iter` so the row loop runs on the caller's rayon worker rather than
 /// re-entering the global pool.
-pub fn fast_detect_rows_u8_serial<A: ImageAllocator>(
-    src: &Image<u8, 1, A>,
+pub fn fast_detect_rows_u8_serial(
+    src: &Image<u8, 1>,
     threshold: f32,
     arc_length: usize,
     border: usize,
@@ -483,8 +473,8 @@ pub fn fast_detect_rows_u8_serial<A: ImageAllocator>(
     fast_detect_rows_u8_impl(src, threshold, arc_length, border, rows, false)
 }
 
-fn fast_detect_rows_u8_impl<A: ImageAllocator>(
-    src: &Image<u8, 1, A>,
+fn fast_detect_rows_u8_impl(
+    src: &Image<u8, 1>,
     threshold: f32,
     arc_length: usize,
     border: usize,
@@ -750,79 +740,81 @@ unsafe fn fast_block_neon_16(
     n: u8,
     out_ptr: *mut u16,
 ) -> u16 {
-    use std::arch::aarch64::*;
+    unsafe {
+        use std::arch::aarch64::*;
 
-    let base = src_slice.as_ptr().add(center_ix);
-    let centers = vld1q_u8(base);
-    let threshold_v = vdupq_n_u8(threshold_u8);
-    let upper = vqaddq_u8(centers, threshold_v);
-    let lower = vqsubq_u8(centers, threshold_v);
+        let base = src_slice.as_ptr().add(center_ix);
+        let centers = vld1q_u8(base);
+        let threshold_v = vdupq_n_u8(threshold_u8);
+        let upper = vqaddq_u8(centers, threshold_v);
+        let lower = vqsubq_u8(centers, threshold_v);
 
-    // Block-level cardinal early-reject: if no lane has ≥3 cardinals outside
-    // the band, the whole 16-lane block is flat — write zeros and return.
-    let c0 = vld1q_u8(base.offset(ring[0]));
-    let c4 = vld1q_u8(base.offset(ring[4]));
-    let c8 = vld1q_u8(base.offset(ring[8]));
-    let c12 = vld1q_u8(base.offset(ring[12]));
+        // Block-level cardinal early-reject: if no lane has ≥3 cardinals outside
+        // the band, the whole 16-lane block is flat — write zeros and return.
+        let c0 = vld1q_u8(base.offset(ring[0]));
+        let c4 = vld1q_u8(base.offset(ring[4]));
+        let c8 = vld1q_u8(base.offset(ring[8]));
+        let c12 = vld1q_u8(base.offset(ring[12]));
 
-    let b0 = vshrq_n_u8::<7>(vcgtq_u8(c0, upper));
-    let b4 = vshrq_n_u8::<7>(vcgtq_u8(c4, upper));
-    let b8 = vshrq_n_u8::<7>(vcgtq_u8(c8, upper));
-    let b12 = vshrq_n_u8::<7>(vcgtq_u8(c12, upper));
-    let b_count = vaddq_u8(vaddq_u8(b0, b4), vaddq_u8(b8, b12));
+        let b0 = vshrq_n_u8::<7>(vcgtq_u8(c0, upper));
+        let b4 = vshrq_n_u8::<7>(vcgtq_u8(c4, upper));
+        let b8 = vshrq_n_u8::<7>(vcgtq_u8(c8, upper));
+        let b12 = vshrq_n_u8::<7>(vcgtq_u8(c12, upper));
+        let b_count = vaddq_u8(vaddq_u8(b0, b4), vaddq_u8(b8, b12));
 
-    let d0 = vshrq_n_u8::<7>(vcltq_u8(c0, lower));
-    let d4 = vshrq_n_u8::<7>(vcltq_u8(c4, lower));
-    let d8 = vshrq_n_u8::<7>(vcltq_u8(c8, lower));
-    let d12 = vshrq_n_u8::<7>(vcltq_u8(c12, lower));
-    let d_count = vaddq_u8(vaddq_u8(d0, d4), vaddq_u8(d8, d12));
+        let d0 = vshrq_n_u8::<7>(vcltq_u8(c0, lower));
+        let d4 = vshrq_n_u8::<7>(vcltq_u8(c4, lower));
+        let d8 = vshrq_n_u8::<7>(vcltq_u8(c8, lower));
+        let d12 = vshrq_n_u8::<7>(vcltq_u8(c12, lower));
+        let d_count = vaddq_u8(vaddq_u8(d0, d4), vaddq_u8(d8, d12));
 
-    // ⌊n/4⌋ is the minimum number of cardinals on a 16-ring arc of length n.
-    let min_card_v = vdupq_n_u8(n / 4);
-    let any_pass = vorrq_u8(vcgeq_u8(b_count, min_card_v), vcgeq_u8(d_count, min_card_v));
+        // ⌊n/4⌋ is the minimum number of cardinals on a 16-ring arc of length n.
+        let min_card_v = vdupq_n_u8(n / 4);
+        let any_pass = vorrq_u8(vcgeq_u8(b_count, min_card_v), vcgeq_u8(d_count, min_card_v));
 
-    if vmaxvq_u8(any_pass) == 0 {
-        // All 16 lanes fail cardinal check → mask = 0. Scores irrelevant,
-        // caller won't read them.
-        return 0;
+        if vmaxvq_u8(any_pass) == 0 {
+            // All 16 lanes fail cardinal check → mask = 0. Scores irrelevant,
+            // caller won't read them.
+            return 0;
+        }
+
+        // Reference FAST-9 `cornerScore`: max over 16 arc-starts of (min over
+        // 9-arc) of saturating diff, on both dark and bright sides. Replaces an
+        // earlier Σ|ring−center| proxy score, which was a poor NMS ordering even
+        // though it agreed on the pass/fail decision.
+        //
+        // `cornerScore ≥ threshold ⇔ FAST-9 arc test passes at threshold`, so we
+        // can drop the separate chain-counter pass and derive the mask from
+        // `score > threshold_u8` directly. `n` is unused on this NEON path —
+        // only FAST-9 is used by ORB; other `n` fall through to scalar in the
+        // tail loop.
+        let mut ring_vals = [vdupq_n_u8(0); 16];
+        for k in 0..16 {
+            ring_vals[k] = vld1q_u8(base.offset(ring[k]));
+        }
+        let _ = (upper, lower, n); // values used only on the scalar tail path
+        let score_u8 = corner_score_9_neon(centers, &ring_vals);
+        let pass = vcgtq_u8(score_u8, threshold_v);
+        // Widen u8 → u16 to preserve the existing `*mut u16` out buffer
+        // (scalar fallback writes score as f32 = u16/255 at the caller).
+        let score_lo = vmovl_u8(vget_low_u8(score_u8));
+        let score_hi = vmovl_u8(vget_high_u8(score_u8));
+
+        // Extract a 16-bit pass-mask from `pass` (uint8x16_t with 0x00 or 0xFF per
+        // byte). Multiply each byte by its bit-weight (1,2,4,...,128) and sum the
+        // low/high halves with vaddv_u8 — each half produces an 8-bit byte, which
+        // concatenate to the full 16-bit mask.
+        let weights = vld1q_u8(BIT_WEIGHTS.as_ptr());
+        let masked = vandq_u8(pass, weights);
+        let lo_mask = vaddv_u8(vget_low_u8(masked)) as u16;
+        let hi_mask = vaddv_u8(vget_high_u8(masked)) as u16;
+        let mask = (hi_mask << 8) | lo_mask;
+
+        vst1q_u16(out_ptr, score_lo);
+        vst1q_u16(out_ptr.add(8), score_hi);
+
+        mask
     }
-
-    // Reference FAST-9 `cornerScore`: max over 16 arc-starts of (min over
-    // 9-arc) of saturating diff, on both dark and bright sides. Replaces an
-    // earlier Σ|ring−center| proxy score, which was a poor NMS ordering even
-    // though it agreed on the pass/fail decision.
-    //
-    // `cornerScore ≥ threshold ⇔ FAST-9 arc test passes at threshold`, so we
-    // can drop the separate chain-counter pass and derive the mask from
-    // `score > threshold_u8` directly. `n` is unused on this NEON path —
-    // only FAST-9 is used by ORB; other `n` fall through to scalar in the
-    // tail loop.
-    let mut ring_vals = [vdupq_n_u8(0); 16];
-    for k in 0..16 {
-        ring_vals[k] = vld1q_u8(base.offset(ring[k]));
-    }
-    let _ = (upper, lower, n); // values used only on the scalar tail path
-    let score_u8 = corner_score_9_neon(centers, &ring_vals);
-    let pass = vcgtq_u8(score_u8, threshold_v);
-    // Widen u8 → u16 to preserve the existing `*mut u16` out buffer
-    // (scalar fallback writes score as f32 = u16/255 at the caller).
-    let score_lo = vmovl_u8(vget_low_u8(score_u8));
-    let score_hi = vmovl_u8(vget_high_u8(score_u8));
-
-    // Extract a 16-bit pass-mask from `pass` (uint8x16_t with 0x00 or 0xFF per
-    // byte). Multiply each byte by its bit-weight (1,2,4,...,128) and sum the
-    // low/high halves with vaddv_u8 — each half produces an 8-bit byte, which
-    // concatenate to the full 16-bit mask.
-    let weights = vld1q_u8(BIT_WEIGHTS.as_ptr());
-    let masked = vandq_u8(pass, weights);
-    let lo_mask = vaddv_u8(vget_low_u8(masked)) as u16;
-    let hi_mask = vaddv_u8(vget_high_u8(masked)) as u16;
-    let mask = (hi_mask << 8) | lo_mask;
-
-    vst1q_u16(out_ptr, score_lo);
-    vst1q_u16(out_ptr.add(8), score_hi);
-
-    mask
 }
 
 #[cfg(target_arch = "aarch64")]
@@ -895,32 +887,34 @@ unsafe fn corner_score_9_neon(
     centers: std::arch::aarch64::uint8x16_t,
     ring_vals: &[std::arch::aarch64::uint8x16_t; 16],
 ) -> std::arch::aarch64::uint8x16_t {
-    use std::arch::aarch64::*;
-    let mut dark = [vdupq_n_u8(0); 16];
-    let mut bright = [vdupq_n_u8(0); 16];
-    for k in 0..16 {
-        dark[k] = vqsubq_u8(centers, ring_vals[k]);
-        bright[k] = vqsubq_u8(ring_vals[k], centers);
-    }
-    let mut dark_score = vdupq_n_u8(0);
-    let mut bright_score = vdupq_n_u8(0);
-    let mut k = 0;
-    while k < 16 {
-        let mut core_d = dark[(k + 1) & 15];
-        let mut core_b = bright[(k + 1) & 15];
-        for i in 2..=8 {
-            core_d = vminq_u8(core_d, dark[(k + i) & 15]);
-            core_b = vminq_u8(core_b, bright[(k + i) & 15]);
+    unsafe {
+        use std::arch::aarch64::*;
+        let mut dark = [vdupq_n_u8(0); 16];
+        let mut bright = [vdupq_n_u8(0); 16];
+        for k in 0..16 {
+            dark[k] = vqsubq_u8(centers, ring_vals[k]);
+            bright[k] = vqsubq_u8(ring_vals[k], centers);
         }
-        let arc_k_d = vminq_u8(core_d, dark[k & 15]);
-        let arc_k1_d = vminq_u8(core_d, dark[(k + 9) & 15]);
-        dark_score = vmaxq_u8(dark_score, vmaxq_u8(arc_k_d, arc_k1_d));
-        let arc_k_b = vminq_u8(core_b, bright[k & 15]);
-        let arc_k1_b = vminq_u8(core_b, bright[(k + 9) & 15]);
-        bright_score = vmaxq_u8(bright_score, vmaxq_u8(arc_k_b, arc_k1_b));
-        k += 2;
+        let mut dark_score = vdupq_n_u8(0);
+        let mut bright_score = vdupq_n_u8(0);
+        let mut k = 0;
+        while k < 16 {
+            let mut core_d = dark[(k + 1) & 15];
+            let mut core_b = bright[(k + 1) & 15];
+            for i in 2..=8 {
+                core_d = vminq_u8(core_d, dark[(k + i) & 15]);
+                core_b = vminq_u8(core_b, bright[(k + i) & 15]);
+            }
+            let arc_k_d = vminq_u8(core_d, dark[k & 15]);
+            let arc_k1_d = vminq_u8(core_d, dark[(k + 9) & 15]);
+            dark_score = vmaxq_u8(dark_score, vmaxq_u8(arc_k_d, arc_k1_d));
+            let arc_k_b = vminq_u8(core_b, bright[k & 15]);
+            let arc_k1_b = vminq_u8(core_b, bright[(k + 9) & 15]);
+            bright_score = vmaxq_u8(bright_score, vmaxq_u8(arc_k_b, arc_k1_b));
+            k += 2;
+        }
+        vmaxq_u8(dark_score, bright_score)
     }
-    vmaxq_u8(dark_score, bright_score)
 }
 
 /// 16-lane parallel FAST-9 cornerScore on x86_64 AVX2. Direct mirror of
@@ -1082,11 +1076,7 @@ fn corner_fast_response(
     0.0
 }
 
-fn get_peak_mask<A: ImageAllocator>(
-    src: &Image<f32, 1, A>,
-    mask: &mut Image<bool, 1, A>,
-    threshold: f32,
-) {
+fn get_peak_mask(src: &Image<f32, 1>, mask: &mut Image<bool, 1>, threshold: f32) {
     let src_slice = src.as_slice();
     let mask_slice = mask.as_slice_mut();
 
@@ -1096,7 +1086,7 @@ fn get_peak_mask<A: ImageAllocator>(
         .for_each(|(src, mask)| *mask = *src > threshold);
 }
 
-fn exclude_border<A: ImageAllocator>(label: &mut Image<bool, 1, A>, border_width: usize) {
+fn exclude_border(label: &mut Image<bool, 1>, border_width: usize) {
     let label_size = label.size();
     let label_slice = label.as_slice_mut();
 
@@ -1115,9 +1105,9 @@ fn exclude_border<A: ImageAllocator>(label: &mut Image<bool, 1, A>, border_width
     });
 }
 
-fn get_high_intensity_peaks<A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<f32, 1, A1>,
-    mask: &Image<bool, 1, A2>,
+fn get_high_intensity_peaks(
+    src: &Image<f32, 1>,
+    mask: &Image<bool, 1>,
     min_distance: usize,
     taken: &mut [bool],
     max_peaks: usize,
@@ -1196,17 +1186,17 @@ mod tests {
     use super::*;
     use kornia_image::Image;
     use kornia_io::jpeg::read_image_jpeg_rgb8;
-    use kornia_tensor::CpuAllocator;
+    use kornia_tensor::host_alloc;
     use std::collections::HashSet;
 
     #[test]
     fn test_fast_feature_detector() -> Result<(), Box<dyn std::error::Error>> {
         #[rustfmt::skip]
         let img = read_image_jpeg_rgb8("../../tests/data/dog.jpeg")?;
-        let mut gray_img = Image::from_size_val(img.size(), 0, CpuAllocator)?;
+        let mut gray_img = Image::from_size_val(img.size(), 0, host_alloc())?;
         gray_from_rgb_u8(&img, &mut gray_img)?;
 
-        let mut gray_imgf32 = Image::from_size_val(img.size(), 0.0, CpuAllocator)?;
+        let mut gray_imgf32 = Image::from_size_val(img.size(), 0.0, host_alloc())?;
         gray_img
             .as_slice()
             .iter()
@@ -1262,7 +1252,7 @@ mod tests {
             *p = ((((x / 5) + (y / 5)) & 1) as u8 * 140)
                 .wrapping_add(((x.wrapping_mul(37)).wrapping_add(y.wrapping_mul(13)) as u8) / 4);
         }
-        let img = Image::<u8, 1, _>::new(sz, data, CpuAllocator)?;
+        let img = Image::<u8, 1>::new(sz, data, host_alloc())?;
 
         let mut det_neon = FastDetector::new(sz, 20.0 / 255.0, 9, 1)?;
         det_neon.compute_corner_response_u8(&img);

--- a/crates/kornia-imgproc/src/features/orb/extractor.rs
+++ b/crates/kornia-imgproc/src/features/orb/extractor.rs
@@ -1,5 +1,5 @@
-use kornia_image::{allocator::ImageAllocator, Image, ImageError, ImageSize};
-use kornia_tensor::CpuAllocator;
+use kornia_image::{Image, ImageError, ImageSize};
+use kornia_tensor::host_alloc;
 use rayon::prelude::*;
 
 use crate::{
@@ -197,11 +197,8 @@ impl OrbDetector {
         features_per_level
     }
 
-    fn build_pyramid<A: ImageAllocator>(
-        &self,
-        img: &Image<f32, 1, A>,
-    ) -> Result<Vec<Image<f32, 1, CpuAllocator>>, ImageError> {
-        let img = Image::from_size_slice(img.size(), img.as_slice(), CpuAllocator)?;
+    fn build_pyramid(&self, img: &Image<f32, 1>) -> Result<Vec<Image<f32, 1>>, ImageError> {
+        let img = Image::from_size_slice(img.size(), img.as_slice(), host_alloc())?;
 
         let base = img.size();
         let mut pyramid = Vec::with_capacity(self.n_scales);
@@ -222,9 +219,9 @@ impl OrbDetector {
     }
 
     #[allow(clippy::type_complexity)]
-    fn detect_octave<A: ImageAllocator>(
+    fn detect_octave(
         &self,
-        octave_image: &Image<f32, 1, A>,
+        octave_image: &Image<f32, 1>,
     ) -> Result<(Vec<[usize; 2]>, Vec<f32>, Vec<f32>), ImageError> {
         // Two-tier FAST detection: first try with higher threshold, then lower if needed.
         // This matches ORB-SLAM3's approach of using iniThFAST then falling back to minThFAST.
@@ -278,7 +275,7 @@ impl OrbDetector {
             .filter_map(|((_, &ori), &m)| if m { Some(ori) } else { None })
             .collect();
 
-        let mut response = Image::from_size_val(octave_image.size(), 0f32, CpuAllocator)?;
+        let mut response = Image::from_size_val(octave_image.size(), 0f32, host_alloc())?;
         let mut harris_response = HarrisResponse::new(octave_image.size()).with_k(self.harris_k);
         harris_response.compute(octave_image, &mut response)?;
 
@@ -299,9 +296,9 @@ impl OrbDetector {
     /// Returns `(keypoints, scales, orientations, responses)` where each vector
     /// has the same length and keypoints are in `(row, col)` coordinates.
     #[allow(clippy::type_complexity)]
-    pub fn detect<A: ImageAllocator>(
+    pub fn detect(
         &self,
-        src: &Image<f32, 1, A>,
+        src: &Image<f32, 1>,
     ) -> Result<(Vec<(f32, f32)>, Vec<f32>, Vec<f32>, Vec<f32>), ImageError> {
         let pyramid = self.build_pyramid(src)?;
         let features_per_level = self.features_per_level();
@@ -357,9 +354,9 @@ impl OrbDetector {
         ))
     }
 
-    fn extract_octave<A: ImageAllocator>(
+    fn extract_octave(
         &self,
-        octave_image: &Image<f32, 1, A>,
+        octave_image: &Image<f32, 1>,
         keypoints: &[(i32, i32)],
         orientations: &[f32],
     ) -> Result<(Vec<[u8; 32]>, Vec<bool>), ImageError> {
@@ -380,7 +377,7 @@ impl OrbDetector {
 
         // Apply Gaussian blur before computing descriptors (matches ORB-SLAM3).
         // ORB-SLAM3 uses 7x7 kernel with sigma=2.
-        let mut blurred = Image::from_size_val(octave_image.size(), 0.0f32, CpuAllocator)?;
+        let mut blurred = Image::from_size_val(octave_image.size(), 0.0f32, host_alloc())?;
         gaussian_blur(octave_image, &mut blurred, (7, 7), (2.0, 2.0))?;
 
         let descriptors = orb_loop(&blurred, &filtered_keypoints, &filtered_orientations);
@@ -392,9 +389,9 @@ impl OrbDetector {
     ///
     /// Returns `(descriptors, mask)` where `mask[i]` indicates whether descriptor `i`
     /// was successfully computed (keypoints too close to the image border are skipped).
-    pub fn extract<A: ImageAllocator>(
+    pub fn extract(
         &self,
-        src: &Image<f32, 1, A>,
+        src: &Image<f32, 1>,
         keypoints: &[(f32, f32)],
         scales: &[f32],
         orientations: &[f32],
@@ -444,7 +441,7 @@ impl OrbDetector {
     fn detect_octave_u8(
         &self,
         octave: usize,
-        octave_image: &Image<u8, 1, CpuAllocator>,
+        octave_image: &Image<u8, 1>,
         features_per_level: &[usize],
         trace: bool,
     ) -> Result<(Vec<(f32, f32)>, Vec<f32>, Vec<f32>, Vec<f32>), ImageError> {
@@ -604,18 +601,17 @@ impl OrbDetector {
     /// chain with the full detect+extract work per octave — pyramid images
     /// are consumed by the spawned tasks and aren't returned.
     #[allow(clippy::type_complexity)]
-    fn build_pyramid_and_process_u8<A: ImageAllocator>(
+    fn build_pyramid_and_process_u8(
         &self,
-        img: &Image<u8, 1, A>,
+        img: &Image<u8, 1>,
     ) -> Result<Vec<(Vec<[f32; 2]>, Vec<f32>, Vec<[u8; 32]>, Vec<u8>)>, ImageError> {
         use std::sync::{Arc, OnceLock};
 
         let trace = std::env::var("KORNIA_ORB_TRACE").is_ok();
         let features_per_level = self.features_per_level();
 
-        let level0 = Image::from_size_slice(img.size(), img.as_slice(), CpuAllocator)?;
-        let mut pyramid_arcs: Vec<Arc<Image<u8, 1, CpuAllocator>>> =
-            Vec::with_capacity(self.n_scales);
+        let level0 = Image::from_size_slice(img.size(), img.as_slice(), host_alloc())?;
+        let mut pyramid_arcs: Vec<Arc<Image<u8, 1>>> = Vec::with_capacity(self.n_scales);
         pyramid_arcs.push(Arc::new(level0));
 
         // OnceLock (not Mutex) — each slot is written by exactly one spawn and
@@ -680,9 +676,9 @@ impl OrbDetector {
         Ok(per_octave)
     }
 
-    fn extract_octave_u8<A: ImageAllocator>(
+    fn extract_octave_u8(
         &self,
-        octave_image: &Image<u8, 1, A>,
+        octave_image: &Image<u8, 1>,
         keypoints: &[(i32, i32)],
         orientations: &[f32],
     ) -> Result<(Vec<[u8; 32]>, Vec<bool>), ImageError> {
@@ -701,7 +697,7 @@ impl OrbDetector {
         // Pre-BRIEF blur via the Q8+Q8 u8 NEON path: ≤1 LSB off a float
         // reference, which is well under the bit-flip threshold that would
         // drift the 256-bit Hamming distance.
-        let mut blurred = Image::from_size_val(octave_image.size(), 0u8, CpuAllocator)?;
+        let mut blurred = Image::from_size_val(octave_image.size(), 0u8, host_alloc())?;
         gaussian_blur_u8(octave_image, &mut blurred, (7, 7), (2.0, 2.0))?;
 
         let descriptors = orb_loop_u8(&blurred, &filtered_keypoints, &filtered_orientations);
@@ -718,7 +714,7 @@ impl OrbDetector {
     fn process_octave_u8(
         &self,
         octave: usize,
-        octave_image: &Image<u8, 1, CpuAllocator>,
+        octave_image: &Image<u8, 1>,
         features_per_level: &[usize],
         trace: bool,
     ) -> Result<(Vec<[f32; 2]>, Vec<f32>, Vec<[u8; 32]>, Vec<u8>), ImageError> {
@@ -765,10 +761,7 @@ impl OrbDetector {
     /// u8-native pipeline: the image stays u8 through pyramid build, FAST
     /// detection, Harris scoring, orientation, and BRIEF. Takes u8 pixels
     /// in and returns packed 32-byte descriptors out.
-    pub fn detect_and_extract_u8<A: ImageAllocator>(
-        &self,
-        src: &Image<u8, 1, A>,
-    ) -> Result<OrbFeatures, ImageError> {
+    pub fn detect_and_extract_u8(&self, src: &Image<u8, 1>) -> Result<OrbFeatures, ImageError> {
         let trace = std::env::var("KORNIA_ORB_TRACE").is_ok();
         let t0 = std::time::Instant::now();
         let per_octave = self.build_pyramid_and_process_u8(src)?;
@@ -807,10 +800,7 @@ impl OrbDetector {
     /// Equivalent to calling [`detect`](Self::detect) then [`extract`](Self::extract),
     /// but filters out border keypoints and returns an [`OrbFeatures`] with matching
     /// `keypoints_xy`, `orientations`, and `descriptors` vectors.
-    pub fn detect_and_extract<A: ImageAllocator>(
-        &self,
-        src: &Image<f32, 1, A>,
-    ) -> Result<OrbFeatures, ImageError> {
+    pub fn detect_and_extract(&self, src: &Image<f32, 1>) -> Result<OrbFeatures, ImageError> {
         let (kps_rc, scales, orientations, _responses) = self.detect(src)?;
         let (descriptors, mask) = self.extract(src, &kps_rc, &scales, &orientations)?;
 
@@ -869,32 +859,29 @@ fn pyramid_size_at_level(base: ImageSize, downscale: f32, level: usize) -> Image
     }
 }
 
-fn pyramid_reduce_u8<A: ImageAllocator>(
-    img: &Image<u8, 1, A>,
-    target: ImageSize,
-) -> Result<Image<u8, 1, CpuAllocator>, ImageError> {
+fn pyramid_reduce_u8(img: &Image<u8, 1>, target: ImageSize) -> Result<Image<u8, 1>, ImageError> {
     // For downscale=1.2 the theoretical anti-alias sigma is 2*1.2/6 = 0.4 —
     // a 3-tap filter with weights ≈ [0.25, 0.50, 0.25]. The bilinear resize
     // kernel itself already provides equivalent low-pass over a 1.2× factor
     // on near-natural images, so the separate blur pass is skipped.
-    let mut resized = Image::from_size_val(target, 0u8, CpuAllocator)?;
+    let mut resized = Image::from_size_val(target, 0u8, host_alloc())?;
     resize_fast_u8(img, &mut resized, InterpolationMode::Bilinear)?;
     Ok(resized)
 }
 
-fn pyramid_reduce<A: ImageAllocator>(
-    img: &Image<f32, 1, A>,
+fn pyramid_reduce(
+    img: &Image<f32, 1>,
     target: ImageSize,
     downscale: f32,
-) -> Result<Image<f32, 1, CpuAllocator>, ImageError> {
+) -> Result<Image<f32, 1>, ImageError> {
     // ORB-SLAM3 builds pyramid by resizing the previous level with bilinear interpolation.
     // We apply a small Gaussian blur to reduce aliasing.
     let sigma = 2.0 * downscale / 6.0;
 
-    let mut smoothed = Image::from_size_val(img.size(), 0.0, CpuAllocator)?;
+    let mut smoothed = Image::from_size_val(img.size(), 0.0, host_alloc())?;
     gaussian_blur(img, &mut smoothed, (0, 0), (sigma, 0.0))?;
 
-    let mut resized = Image::from_size_val(target, 0.0, CpuAllocator)?;
+    let mut resized = Image::from_size_val(target, 0.0, host_alloc())?;
     resize_native(
         &smoothed,
         &mut resized,
@@ -922,7 +909,7 @@ fn mask_border_keypoints(size: ImageSize, keypoints: &[[usize; 2]], distance: i3
         .collect()
 }
 
-fn octave_bounds<A: ImageAllocator>(image: &Image<f32, 1, A>) -> (i32, i32, i32, i32) {
+fn octave_bounds(image: &Image<f32, 1>) -> (i32, i32, i32, i32) {
     const EDGE_THRESHOLD: i32 = 19;
     let min_x = EDGE_THRESHOLD - 3;
     let min_y = EDGE_THRESHOLD - 3;
@@ -1159,12 +1146,7 @@ fn mask_border_keypoints_i32(
 /// 72 u8 reads per call for the same pixels. Bit-exact with the old path because
 /// the Sobel expression and accumulation order are unchanged; only the source
 /// of the pixel values (register cache vs re-read) differs.
-fn harris_response_at_u8<A: ImageAllocator>(
-    src: &Image<u8, 1, A>,
-    r0: usize,
-    c0: usize,
-    k: f32,
-) -> f32 {
+fn harris_response_at_u8(src: &Image<u8, 1>, r0: usize, c0: usize, k: f32) -> f32 {
     let cols = src.cols();
     let src_data = src.as_slice();
     let base = (r0 - 2) * cols + (c0 - 2);
@@ -1251,54 +1233,56 @@ const DC_HIGH: [i16; 16] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
 #[cfg(target_arch = "aarch64")]
 #[target_feature(enable = "neon")]
 unsafe fn orientation_kp_neon(src_slice: &[u8], r0: usize, c0: usize, cols: usize) -> f32 {
-    use std::arch::aarch64::*;
+    unsafe {
+        use std::arch::aarch64::*;
 
-    let dc_low_0 = vld1q_s16(DC_LOW.as_ptr());
-    let dc_low_1 = vld1q_s16(DC_LOW.as_ptr().add(8));
-    let dc_high_0 = vld1q_s16(DC_HIGH.as_ptr());
-    let dc_high_1 = vld1q_s16(DC_HIGH.as_ptr().add(8));
+        let dc_low_0 = vld1q_s16(DC_LOW.as_ptr());
+        let dc_low_1 = vld1q_s16(DC_LOW.as_ptr().add(8));
+        let dc_high_0 = vld1q_s16(DC_HIGH.as_ptr());
+        let dc_high_1 = vld1q_s16(DC_HIGH.as_ptr().add(8));
 
-    let mut m01_acc: i32 = 0;
-    let mut m10_sum = vdupq_n_s32(0);
+        let mut m01_acc: i32 = 0;
+        let mut m10_sum = vdupq_n_s32(0);
 
-    let base = src_slice.as_ptr();
-    for dr in -15i32..=15 {
-        let row_ptr = base.add(((r0 as isize + dr as isize) * cols as isize) as usize);
-        let mask_row = DISK_MASKS[(dr + 15) as usize].as_ptr();
-        let mask_low = vld1q_u8(mask_row);
-        let mask_high = vld1q_u8(mask_row.add(16));
+        let base = src_slice.as_ptr();
+        for dr in -15i32..=15 {
+            let row_ptr = base.add(((r0 as isize + dr as isize) * cols as isize) as usize);
+            let mask_row = DISK_MASKS[(dr + 15) as usize].as_ptr();
+            let mask_low = vld1q_u8(mask_row);
+            let mask_high = vld1q_u8(mask_row.add(16));
 
-        // Two 16-byte loads centered at c0. Low: dc ∈ [-16, -1]. High: dc ∈ [0, 15].
-        let px_low = vandq_u8(vld1q_u8(row_ptr.offset(c0 as isize - 16)), mask_low);
-        let px_high = vandq_u8(vld1q_u8(row_ptr.add(c0)), mask_high);
+            // Two 16-byte loads centered at c0. Low: dc ∈ [-16, -1]. High: dc ∈ [0, 15].
+            let px_low = vandq_u8(vld1q_u8(row_ptr.offset(c0 as isize - 16)), mask_low);
+            let px_high = vandq_u8(vld1q_u8(row_ptr.add(c0)), mask_high);
 
-        // m01 row sum: masked bytes widened-and-added across all lanes.
-        let row_sum = (vaddlvq_u8(px_low) + vaddlvq_u8(px_high)) as i32;
-        m01_acc += row_sum * dr;
+            // m01 row sum: masked bytes widened-and-added across all lanes.
+            let row_sum = (vaddlvq_u8(px_low) + vaddlvq_u8(px_high)) as i32;
+            m01_acc += row_sum * dr;
 
-        // m10: Σ px * dc. Widen u8 → u16, reinterpret as s16 (safe: values ≤ 255
-        // fit in i16's positive range), multiply by dc using vmull_s16 to
-        // produce i32 partial products, accumulate.
-        let px_low_u16_0 = vreinterpretq_s16_u16(vmovl_u8(vget_low_u8(px_low)));
-        let px_low_u16_1 = vreinterpretq_s16_u16(vmovl_u8(vget_high_u8(px_low)));
-        let px_high_u16_0 = vreinterpretq_s16_u16(vmovl_u8(vget_low_u8(px_high)));
-        let px_high_u16_1 = vreinterpretq_s16_u16(vmovl_u8(vget_high_u8(px_high)));
+            // m10: Σ px * dc. Widen u8 → u16, reinterpret as s16 (safe: values ≤ 255
+            // fit in i16's positive range), multiply by dc using vmull_s16 to
+            // produce i32 partial products, accumulate.
+            let px_low_u16_0 = vreinterpretq_s16_u16(vmovl_u8(vget_low_u8(px_low)));
+            let px_low_u16_1 = vreinterpretq_s16_u16(vmovl_u8(vget_high_u8(px_low)));
+            let px_high_u16_0 = vreinterpretq_s16_u16(vmovl_u8(vget_low_u8(px_high)));
+            let px_high_u16_1 = vreinterpretq_s16_u16(vmovl_u8(vget_high_u8(px_high)));
 
-        let p0 = vmull_s16(vget_low_s16(px_low_u16_0), vget_low_s16(dc_low_0));
-        let p1 = vmull_high_s16(px_low_u16_0, dc_low_0);
-        let p2 = vmull_s16(vget_low_s16(px_low_u16_1), vget_low_s16(dc_low_1));
-        let p3 = vmull_high_s16(px_low_u16_1, dc_low_1);
-        let p4 = vmull_s16(vget_low_s16(px_high_u16_0), vget_low_s16(dc_high_0));
-        let p5 = vmull_high_s16(px_high_u16_0, dc_high_0);
-        let p6 = vmull_s16(vget_low_s16(px_high_u16_1), vget_low_s16(dc_high_1));
-        let p7 = vmull_high_s16(px_high_u16_1, dc_high_1);
+            let p0 = vmull_s16(vget_low_s16(px_low_u16_0), vget_low_s16(dc_low_0));
+            let p1 = vmull_high_s16(px_low_u16_0, dc_low_0);
+            let p2 = vmull_s16(vget_low_s16(px_low_u16_1), vget_low_s16(dc_low_1));
+            let p3 = vmull_high_s16(px_low_u16_1, dc_low_1);
+            let p4 = vmull_s16(vget_low_s16(px_high_u16_0), vget_low_s16(dc_high_0));
+            let p5 = vmull_high_s16(px_high_u16_0, dc_high_0);
+            let p6 = vmull_s16(vget_low_s16(px_high_u16_1), vget_low_s16(dc_high_1));
+            let p7 = vmull_high_s16(px_high_u16_1, dc_high_1);
 
-        m10_sum = vaddq_s32(m10_sum, vaddq_s32(vaddq_s32(p0, p1), vaddq_s32(p2, p3)));
-        m10_sum = vaddq_s32(m10_sum, vaddq_s32(vaddq_s32(p4, p5), vaddq_s32(p6, p7)));
+            m10_sum = vaddq_s32(m10_sum, vaddq_s32(vaddq_s32(p0, p1), vaddq_s32(p2, p3)));
+            m10_sum = vaddq_s32(m10_sum, vaddq_s32(vaddq_s32(p4, p5), vaddq_s32(p6, p7)));
+        }
+
+        let m10 = vaddvq_s32(m10_sum);
+        (m01_acc as f32).atan2(m10 as f32)
     }
-
-    let m10 = vaddvq_s32(m10_sum);
-    (m01_acc as f32).atan2(m10 as f32)
 }
 
 /// AVX2 mirror of [`orientation_kp_neon`]. Same disk-masked moment scan,
@@ -1368,10 +1352,7 @@ unsafe fn orientation_kp_avx2(src_slice: &[u8], r0: usize, c0: usize, cols: usiz
     (m01_acc as f32).atan2(m10 as f32)
 }
 
-fn corner_orientations_u8<A: ImageAllocator>(
-    src: &Image<u8, 1, A>,
-    corners: &[[usize; 2]],
-) -> Vec<f32> {
+fn corner_orientations_u8(src: &Image<u8, 1>, corners: &[[usize; 2]]) -> Vec<f32> {
     // Caller must have already filtered keypoints by border distance ≥ 15.
     const HALF: i32 = 15;
 
@@ -1432,10 +1413,7 @@ fn corner_orientations_u8<A: ImageAllocator>(
         .collect()
 }
 
-fn corner_orientations<A: ImageAllocator>(
-    src: &Image<f32, 1, A>,
-    corners: &[[usize; 2]],
-) -> Vec<f32> {
+fn corner_orientations(src: &Image<f32, 1>, corners: &[[usize; 2]]) -> Vec<f32> {
     const M_SIZE: usize = 31; // NOTE: This must be uneven
     let src_slice = src.as_slice();
 
@@ -1479,11 +1457,7 @@ fn corner_orientations<A: ImageAllocator>(
     orientations
 }
 
-fn orb_loop_u8<A: ImageAllocator>(
-    src: &Image<u8, 1, A>,
-    keypoints: &[(i32, i32)],
-    orientation: &[f32],
-) -> Vec<[u8; 32]> {
+fn orb_loop_u8(src: &Image<u8, 1>, keypoints: &[(i32, i32)], orientation: &[f32]) -> Vec<[u8; 32]> {
     let cols = src.cols();
     let src_data = src.as_slice();
 
@@ -1657,11 +1631,7 @@ fn compute_brief_descriptor_scalar(
 
 /// Compute ORB descriptors packed into 32 bytes (256 bits) per keypoint —
 /// the standard ORB-SLAM3 descriptor format.
-fn orb_loop<A: ImageAllocator>(
-    src: &Image<f32, 1, A>,
-    keypoints: &[(i32, i32)],
-    orientation: &[f32],
-) -> Vec<[u8; 32]> {
+fn orb_loop(src: &Image<f32, 1>, keypoints: &[(i32, i32)], orientation: &[f32]) -> Vec<[u8; 32]> {
     let n_keypoints = keypoints.len();
     let height = src.height() as i32;
     let width = src.width() as i32;
@@ -1722,10 +1692,10 @@ fn orb_loop<A: ImageAllocator>(
 mod tests {
     use super::*;
     use kornia_image::Image;
-    use kornia_tensor::CpuAllocator;
+    use kornia_tensor::host_alloc;
 
-    fn make_gradient_x(size: usize) -> Image<f32, 1, CpuAllocator> {
-        let mut img = Image::from_size_val([size, size].into(), 0.0, CpuAllocator).unwrap();
+    fn make_gradient_x(size: usize) -> Image<f32, 1> {
+        let mut img = Image::from_size_val([size, size].into(), 0.0, host_alloc()).unwrap();
         let width = img.width();
         let height = img.height();
         let denom = (width.saturating_sub(1)).max(1) as f32;
@@ -1739,8 +1709,8 @@ mod tests {
         img
     }
 
-    fn make_gradient_y(size: usize) -> Image<f32, 1, CpuAllocator> {
-        let mut img = Image::from_size_val([size, size].into(), 0.0, CpuAllocator).unwrap();
+    fn make_gradient_y(size: usize) -> Image<f32, 1> {
+        let mut img = Image::from_size_val([size, size].into(), 0.0, host_alloc()).unwrap();
         let width = img.width();
         let height = img.height();
         let denom = (height.saturating_sub(1)).max(1) as f32;
@@ -1788,7 +1758,7 @@ mod tests {
                 .wrapping_add(1442695040888963407);
             *px = (s >> 32) as u8;
         }
-        let img = Image::<u8, 1, _>::from_size_slice([w, h].into(), &data, CpuAllocator).unwrap();
+        let img = Image::<u8, 1>::from_size_slice([w, h].into(), &data, host_alloc()).unwrap();
 
         let corners: Vec<[usize; 2]> = (0..50)
             .map(|i| {
@@ -1798,11 +1768,14 @@ mod tests {
             })
             .collect();
 
-        std::env::set_var("KORNIA_ORB_ORI_NEON", "1");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("KORNIA_ORB_ORI_NEON", "1") };
         let neon = corner_orientations_u8(&img, &corners);
-        std::env::set_var("KORNIA_ORB_ORI_NEON", "0");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("KORNIA_ORB_ORI_NEON", "0") };
         let scalar = corner_orientations_u8(&img, &corners);
-        std::env::remove_var("KORNIA_ORB_ORI_NEON");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::remove_var("KORNIA_ORB_ORI_NEON") };
 
         for (i, (n, s)) in neon.iter().zip(scalar.iter()).enumerate() {
             // atan2 of identical integer moments is bit-identical.

--- a/crates/kornia-imgproc/src/features/orb/extractor.rs
+++ b/crates/kornia-imgproc/src/features/orb/extractor.rs
@@ -1,5 +1,4 @@
 use kornia_image::{Image, ImageError, ImageSize};
-use kornia_tensor::host_alloc;
 use rayon::prelude::*;
 
 use crate::{
@@ -198,7 +197,7 @@ impl OrbDetector {
     }
 
     fn build_pyramid(&self, img: &Image<f32, 1>) -> Result<Vec<Image<f32, 1>>, ImageError> {
-        let img = Image::from_size_slice(img.size(), img.as_slice(), host_alloc())?;
+        let img = Image::from_size_slice(img.size(), img.as_slice())?;
 
         let base = img.size();
         let mut pyramid = Vec::with_capacity(self.n_scales);
@@ -275,7 +274,7 @@ impl OrbDetector {
             .filter_map(|((_, &ori), &m)| if m { Some(ori) } else { None })
             .collect();
 
-        let mut response = Image::from_size_val(octave_image.size(), 0f32, host_alloc())?;
+        let mut response = Image::from_size_val(octave_image.size(), 0f32)?;
         let mut harris_response = HarrisResponse::new(octave_image.size()).with_k(self.harris_k);
         harris_response.compute(octave_image, &mut response)?;
 
@@ -377,7 +376,7 @@ impl OrbDetector {
 
         // Apply Gaussian blur before computing descriptors (matches ORB-SLAM3).
         // ORB-SLAM3 uses 7x7 kernel with sigma=2.
-        let mut blurred = Image::from_size_val(octave_image.size(), 0.0f32, host_alloc())?;
+        let mut blurred = Image::from_size_val(octave_image.size(), 0.0f32)?;
         gaussian_blur(octave_image, &mut blurred, (7, 7), (2.0, 2.0))?;
 
         let descriptors = orb_loop(&blurred, &filtered_keypoints, &filtered_orientations);
@@ -610,7 +609,7 @@ impl OrbDetector {
         let trace = std::env::var("KORNIA_ORB_TRACE").is_ok();
         let features_per_level = self.features_per_level();
 
-        let level0 = Image::from_size_slice(img.size(), img.as_slice(), host_alloc())?;
+        let level0 = Image::from_size_slice(img.size(), img.as_slice())?;
         let mut pyramid_arcs: Vec<Arc<Image<u8, 1>>> = Vec::with_capacity(self.n_scales);
         pyramid_arcs.push(Arc::new(level0));
 
@@ -697,7 +696,7 @@ impl OrbDetector {
         // Pre-BRIEF blur via the Q8+Q8 u8 NEON path: ≤1 LSB off a float
         // reference, which is well under the bit-flip threshold that would
         // drift the 256-bit Hamming distance.
-        let mut blurred = Image::from_size_val(octave_image.size(), 0u8, host_alloc())?;
+        let mut blurred = Image::from_size_val(octave_image.size(), 0u8)?;
         gaussian_blur_u8(octave_image, &mut blurred, (7, 7), (2.0, 2.0))?;
 
         let descriptors = orb_loop_u8(&blurred, &filtered_keypoints, &filtered_orientations);
@@ -864,7 +863,7 @@ fn pyramid_reduce_u8(img: &Image<u8, 1>, target: ImageSize) -> Result<Image<u8, 
     // a 3-tap filter with weights ≈ [0.25, 0.50, 0.25]. The bilinear resize
     // kernel itself already provides equivalent low-pass over a 1.2× factor
     // on near-natural images, so the separate blur pass is skipped.
-    let mut resized = Image::from_size_val(target, 0u8, host_alloc())?;
+    let mut resized = Image::from_size_val(target, 0u8)?;
     resize_fast_u8(img, &mut resized, InterpolationMode::Bilinear)?;
     Ok(resized)
 }
@@ -878,10 +877,10 @@ fn pyramid_reduce(
     // We apply a small Gaussian blur to reduce aliasing.
     let sigma = 2.0 * downscale / 6.0;
 
-    let mut smoothed = Image::from_size_val(img.size(), 0.0, host_alloc())?;
+    let mut smoothed = Image::from_size_val(img.size(), 0.0)?;
     gaussian_blur(img, &mut smoothed, (0, 0), (sigma, 0.0))?;
 
-    let mut resized = Image::from_size_val(target, 0.0, host_alloc())?;
+    let mut resized = Image::from_size_val(target, 0.0)?;
     resize_native(
         &smoothed,
         &mut resized,
@@ -1692,10 +1691,9 @@ fn orb_loop(src: &Image<f32, 1>, keypoints: &[(i32, i32)], orientation: &[f32]) 
 mod tests {
     use super::*;
     use kornia_image::Image;
-    use kornia_tensor::host_alloc;
 
     fn make_gradient_x(size: usize) -> Image<f32, 1> {
-        let mut img = Image::from_size_val([size, size].into(), 0.0, host_alloc()).unwrap();
+        let mut img = Image::from_size_val([size, size].into(), 0.0).unwrap();
         let width = img.width();
         let height = img.height();
         let denom = (width.saturating_sub(1)).max(1) as f32;
@@ -1710,7 +1708,7 @@ mod tests {
     }
 
     fn make_gradient_y(size: usize) -> Image<f32, 1> {
-        let mut img = Image::from_size_val([size, size].into(), 0.0, host_alloc()).unwrap();
+        let mut img = Image::from_size_val([size, size].into(), 0.0).unwrap();
         let width = img.width();
         let height = img.height();
         let denom = (height.saturating_sub(1)).max(1) as f32;
@@ -1758,7 +1756,7 @@ mod tests {
                 .wrapping_add(1442695040888963407);
             *px = (s >> 32) as u8;
         }
-        let img = Image::<u8, 1>::from_size_slice([w, h].into(), &data, host_alloc()).unwrap();
+        let img = Image::<u8, 1>::from_size_slice([w, h].into(), &data).unwrap();
 
         let corners: Vec<[usize; 2]> = (0..50)
             .map(|i| {

--- a/crates/kornia-imgproc/src/features/orb/mod.rs
+++ b/crates/kornia-imgproc/src/features/orb/mod.rs
@@ -9,7 +9,6 @@ pub use matcher::{match_orb_descriptors, OrbMatchConfig};
 mod opencv_tests {
     use super::*;
     use kornia_image::Image;
-    use kornia_tensor::host_alloc;
     use opencv::{
         core::{no_array, Mat, Vector},
         features2d::{ORB_ScoreType, ORB},
@@ -18,7 +17,7 @@ mod opencv_tests {
     };
 
     fn u8_to_f32_image(src: &Image<u8, 1>) -> Image<f32, 1> {
-        let mut dst = Image::from_size_val(src.size(), 0.0, host_alloc()).unwrap();
+        let mut dst = Image::from_size_val(src.size(), 0.0).unwrap();
         src.as_slice()
             .iter()
             .zip(dst.as_slice_mut())
@@ -42,7 +41,7 @@ mod opencv_tests {
     #[test]
     fn test_orb_compare_with_opencv() -> Result<(), Box<dyn std::error::Error>> {
         let img_rgb = kornia_io::jpeg::read_image_jpeg_rgb8("../../tests/data/dog.jpeg")?;
-        let mut img_gray = Image::from_size_val(img_rgb.size(), 0u8, host_alloc())?;
+        let mut img_gray = Image::from_size_val(img_rgb.size(), 0u8)?;
         crate::color::gray_from_rgb_u8(&img_rgb, &mut img_gray)?;
         let img_f32 = u8_to_f32_image(&img_gray);
 

--- a/crates/kornia-imgproc/src/features/orb/mod.rs
+++ b/crates/kornia-imgproc/src/features/orb/mod.rs
@@ -9,7 +9,7 @@ pub use matcher::{match_orb_descriptors, OrbMatchConfig};
 mod opencv_tests {
     use super::*;
     use kornia_image::Image;
-    use kornia_tensor::CpuAllocator;
+    use kornia_tensor::host_alloc;
     use opencv::{
         core::{no_array, Mat, Vector},
         features2d::{ORB_ScoreType, ORB},
@@ -17,8 +17,8 @@ mod opencv_tests {
         prelude::*,
     };
 
-    fn u8_to_f32_image(src: &Image<u8, 1, CpuAllocator>) -> Image<f32, 1, CpuAllocator> {
-        let mut dst = Image::from_size_val(src.size(), 0.0, CpuAllocator).unwrap();
+    fn u8_to_f32_image(src: &Image<u8, 1>) -> Image<f32, 1> {
+        let mut dst = Image::from_size_val(src.size(), 0.0, host_alloc()).unwrap();
         src.as_slice()
             .iter()
             .zip(dst.as_slice_mut())
@@ -42,7 +42,7 @@ mod opencv_tests {
     #[test]
     fn test_orb_compare_with_opencv() -> Result<(), Box<dyn std::error::Error>> {
         let img_rgb = kornia_io::jpeg::read_image_jpeg_rgb8("../../tests/data/dog.jpeg")?;
-        let mut img_gray = Image::from_size_val(img_rgb.size(), 0u8, CpuAllocator)?;
+        let mut img_gray = Image::from_size_val(img_rgb.size(), 0u8, host_alloc())?;
         crate::color::gray_from_rgb_u8(&img_rgb, &mut img_gray)?;
         let img_f32 = u8_to_f32_image(&img_gray);
 

--- a/crates/kornia-imgproc/src/features/responses.rs
+++ b/crates/kornia-imgproc/src/features/responses.rs
@@ -2,7 +2,6 @@ use crate::filter::{gaussian_blur, kernels::sobel_kernel_1d, separable_filter};
 use crate::morphology::{dilate, Kernel, KernelShape};
 use crate::padding::PaddingMode;
 use kornia_image::{Image, ImageError, ImageSize};
-use kornia_tensor::host_alloc;
 use rayon::prelude::*;
 
 /// Method to calculate gradient for feature response
@@ -536,7 +535,7 @@ pub fn dog_response(
     let ks2 = _get_kernel_size(sigma2);
 
     gaussian_blur(src, dst, (ks2, ks2), (sigma2, sigma2))?;
-    let mut gauss1 = Image::from_size_val(src.size(), 0.0, host_alloc())?;
+    let mut gauss1 = Image::from_size_val(src.size(), 0.0)?;
     gaussian_blur(src, &mut gauss1, (ks1, ks1), (sigma1, sigma1))?;
 
     let dst_data = dst.as_slice_mut();
@@ -578,7 +577,7 @@ pub fn non_max_suppression(
 
     let size = src.size();
 
-    let mut src_u32: Image<u32, 1> = Image::from_size_val(size, 0u32, host_alloc())?;
+    let mut src_u32: Image<u32, 1> = Image::from_size_val(size, 0u32)?;
     src_u32
         .as_slice_mut()
         .par_iter_mut()
@@ -588,7 +587,7 @@ pub fn non_max_suppression(
             *out_bits = v.to_bits();
         });
 
-    let mut dilated_u32: Image<u32, 1> = Image::from_size_val(size, 0u32, host_alloc())?;
+    let mut dilated_u32: Image<u32, 1> = Image::from_size_val(size, 0u32)?;
     let kernel = Kernel::new(KernelShape::Box { size: 3 });
     dilate(
         &src_u32,
@@ -668,8 +667,8 @@ pub fn gftt_response(
     let rows = src.rows();
     let cols = src.cols();
 
-    let mut dx = Image::from_size_val(image_size, 0.0f32, host_alloc())?;
-    let mut dy = Image::from_size_val(image_size, 0.0f32, host_alloc())?;
+    let mut dx = Image::from_size_val(image_size, 0.0f32)?;
+    let mut dy = Image::from_size_val(image_size, 0.0f32)?;
 
     let (kernel_deriv, kernel_smooth) = sobel_kernel_1d(sobel_size)?;
 
@@ -686,9 +685,9 @@ pub fn gftt_response(
     separable_filter(src, &mut dy, &kernel_smooth_norm, &kernel_deriv_norm)?;
 
     // compute structure tensor components
-    let mut m11: Image<f32, 1> = Image::from_size_val(image_size, 0.0f32, host_alloc())?;
-    let mut m22: Image<f32, 1> = Image::from_size_val(image_size, 0.0f32, host_alloc())?;
-    let mut m12: Image<f32, 1> = Image::from_size_val(image_size, 0.0f32, host_alloc())?;
+    let mut m11: Image<f32, 1> = Image::from_size_val(image_size, 0.0f32)?;
+    let mut m22: Image<f32, 1> = Image::from_size_val(image_size, 0.0f32)?;
+    let mut m12: Image<f32, 1> = Image::from_size_val(image_size, 0.0f32)?;
 
     let dx_slice = dx.as_slice();
     let dy_slice = dy.as_slice();
@@ -711,9 +710,9 @@ pub fn gftt_response(
         });
 
     // smoothing structure tensor
-    let mut m11_smooth = Image::from_size_val(image_size, 0.0f32, host_alloc())?;
-    let mut m22_smooth = Image::from_size_val(image_size, 0.0f32, host_alloc())?;
-    let mut m12_smooth = Image::from_size_val(image_size, 0.0f32, host_alloc())?;
+    let mut m11_smooth = Image::from_size_val(image_size, 0.0f32)?;
+    let mut m22_smooth = Image::from_size_val(image_size, 0.0f32)?;
+    let mut m12_smooth = Image::from_size_val(image_size, 0.0f32)?;
 
     let box_kernel = vec![1.0; window_size];
     separable_filter(&m11, &mut m11_smooth, &box_kernel, &box_kernel)?;
@@ -750,7 +749,7 @@ pub fn gftt_response(
 
     // conditionally apply non-maximum suppression using morphological dilation
     if apply_nms {
-        let mut tmp = Image::from_size_val(image_size, 0.0f32, host_alloc())?;
+        let mut tmp = Image::from_size_val(image_size, 0.0f32)?;
         non_max_suppression(dst, &mut tmp, 1e-6)?;
         dst.as_slice_mut().copy_from_slice(tmp.as_slice());
     }
@@ -773,11 +772,10 @@ mod tests {
                 0.0, 1.0, 0.0, 1.0, 0.0,
                 0.0, 1.0, 1.0, 1.0, 0.0,
                 0.0, 0.0, 0.0, 0.0, 0.0,
-            ],
-            host_alloc()
+            ]
         )?;
 
-        let mut dst = Image::from_size_val([5, 5].into(), 0.0, host_alloc())?;
+        let mut dst = Image::from_size_val([5, 5].into(), 0.0)?;
         hessian_response(&src, &mut dst)?;
 
         #[rustfmt::skip]
@@ -809,11 +807,10 @@ mod tests {
                 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0,
                 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
                 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-            ],
-            host_alloc()
+            ]
         )?;
 
-        let mut dst = Image::from_size_val([9, 9].into(), 0.0, host_alloc())?;
+        let mut dst = Image::from_size_val([9, 9].into(), 0.0)?;
         HarrisResponse::new(dst.size()).compute(&src, &mut dst)?;
 
         #[rustfmt::skip]
@@ -849,11 +846,10 @@ mod tests {
                 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0,
                 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
                 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-            ],
-            host_alloc()
+            ]
         )?;
 
-        let mut dst = Image::from_size_val(src.size(), 0.0, host_alloc())?;
+        let mut dst = Image::from_size_val(src.size(), 0.0)?;
         HarrisResponse::new(src.size())
             .with_k(0.01)
             .compute(&src, &mut dst)?;
@@ -892,11 +888,10 @@ mod tests {
                 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0,
                 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
                 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-            ],
-            host_alloc()
+            ]
         )?;
 
-        let mut dst = Image::from_size_val([9, 9].into(), 0.0, host_alloc())?;
+        let mut dst = Image::from_size_val([9, 9].into(), 0.0)?;
         HarrisResponse::new(dst.size())
             .with_k(0.01)
             .compute(&src, &mut dst)?;
@@ -928,11 +923,10 @@ mod tests {
                 0.0, 1.0, 1.0, 1.0, 0.0,
                 0.0, 1.0, 1.0, 1.0, 0.0,
                 0.0, 0.0, 0.0, 0.0, 0.0,
-            ],
-            host_alloc()
+            ]
         )?;
 
-        let mut dst = Image::from_size_val([5, 5].into(), 0.0, host_alloc())?;
+        let mut dst = Image::from_size_val([5, 5].into(), 0.0)?;
 
         let sigma1 = 0.5;
         let sigma2 = 1.0;
@@ -971,11 +965,10 @@ mod tests {
                 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0,
                 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
                 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-            ],
-            host_alloc()
+            ]
         )?;
 
-        let mut dst = Image::from_size_val([9, 9].into(), 0.0, host_alloc())?;
+        let mut dst = Image::from_size_val([9, 9].into(), 0.0)?;
         gftt_response(&src, &mut dst, 3, 5, false)?;
 
         #[rustfmt::skip]
@@ -1006,10 +999,9 @@ mod tests {
                 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
                 0.0,
             ],
-            host_alloc(),
         )?;
 
-        let mut dst = Image::from_size_val([9, 9].into(), 0.0, host_alloc())?;
+        let mut dst = Image::from_size_val([9, 9].into(), 0.0)?;
         gftt_response(&src, &mut dst, 3, 5, true)?;
 
         let data = dst.as_slice();

--- a/crates/kornia-imgproc/src/features/responses.rs
+++ b/crates/kornia-imgproc/src/features/responses.rs
@@ -1,8 +1,8 @@
 use crate::filter::{gaussian_blur, kernels::sobel_kernel_1d, separable_filter};
 use crate::morphology::{dilate, Kernel, KernelShape};
 use crate::padding::PaddingMode;
-use kornia_image::{allocator::ImageAllocator, Image, ImageError, ImageSize};
-use kornia_tensor::CpuAllocator;
+use kornia_image::{Image, ImageError, ImageSize};
+use kornia_tensor::host_alloc;
 use rayon::prelude::*;
 
 /// Method to calculate gradient for feature response
@@ -41,10 +41,7 @@ fn _get_kernel_size(sigma: f32) -> usize {
 /// Args:
 ///     src: The source image with shape (H, W).
 ///     dst: The destination image with shape (H, W).
-pub fn hessian_response<A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<f32, 1, A1>,
-    dst: &mut Image<f32, 1, A2>,
-) -> Result<(), ImageError> {
+pub fn hessian_response(src: &Image<f32, 1>, dst: &mut Image<f32, 1>) -> Result<(), ImageError> {
     if src.size() != dst.size() {
         return Err(ImageError::InvalidImageSize(
             src.cols(),
@@ -154,10 +151,10 @@ impl HarrisResponse {
     /// scaling (det and k·trace² scale identically), so the output is magnitude-
     /// scaled relative to the f32 path but preserves peak ranking. Output remains
     /// f32 so that downstream octree ranking is unchanged.
-    pub fn compute_u8<A1: ImageAllocator, A2: ImageAllocator>(
+    pub fn compute_u8(
         &mut self,
-        src: &Image<u8, 1, A1>,
-        dst: &mut Image<f32, 1, A2>,
+        src: &Image<u8, 1>,
+        dst: &mut Image<f32, 1>,
     ) -> Result<(), ImageError> {
         if src.size() != self.image_size {
             return Err(ImageError::InvalidImageSize(
@@ -334,10 +331,10 @@ impl HarrisResponse {
     /// Args:
     ///     src: The source image with shape (H, W).
     ///     dst: The destination image with shape (H, W).
-    pub fn compute<A1: ImageAllocator, A2: ImageAllocator>(
+    pub fn compute(
         &mut self,
-        src: &Image<f32, 1, A1>,
-        dst: &mut Image<f32, 1, A2>,
+        src: &Image<f32, 1>,
+        dst: &mut Image<f32, 1>,
     ) -> Result<(), ImageError> {
         if src.size() != self.image_size {
             return Err(ImageError::InvalidImageSize(
@@ -520,9 +517,9 @@ impl HarrisResponse {
 ///     dst: The destination image with shape (H, W).
 ///     sigma1: The sigma of the first Gaussian kernel.
 ///     sigma2: The sigma of the second Gaussian kernel.
-pub fn dog_response<A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<f32, 1, A1>,
-    dst: &mut Image<f32, 1, A2>,
+pub fn dog_response(
+    src: &Image<f32, 1>,
+    dst: &mut Image<f32, 1>,
     sigma1: f32,
     sigma2: f32,
 ) -> Result<(), ImageError> {
@@ -539,7 +536,7 @@ pub fn dog_response<A1: ImageAllocator, A2: ImageAllocator>(
     let ks2 = _get_kernel_size(sigma2);
 
     gaussian_blur(src, dst, (ks2, ks2), (sigma2, sigma2))?;
-    let mut gauss1 = Image::from_size_val(src.size(), 0.0, CpuAllocator)?;
+    let mut gauss1 = Image::from_size_val(src.size(), 0.0, host_alloc())?;
     gaussian_blur(src, &mut gauss1, (ks1, ks1), (sigma1, sigma1))?;
 
     let dst_data = dst.as_slice_mut();
@@ -565,9 +562,9 @@ pub fn dog_response<A1: ImageAllocator, A2: ImageAllocator>(
 /// * `dst` - The destination image with shape (H, W).
 /// * `eps` - Small tolerance for floating-point comparisons
 ///   (e.g. `1e-6`) to avoid numerical instability.
-pub fn non_max_suppression<A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<f32, 1, A1>,
-    dst: &mut Image<f32, 1, A2>,
+pub fn non_max_suppression(
+    src: &Image<f32, 1>,
+    dst: &mut Image<f32, 1>,
     eps: f32,
 ) -> Result<(), ImageError> {
     if src.size() != dst.size() {
@@ -581,7 +578,7 @@ pub fn non_max_suppression<A1: ImageAllocator, A2: ImageAllocator>(
 
     let size = src.size();
 
-    let mut src_u32: Image<u32, 1, _> = Image::from_size_val(size, 0u32, CpuAllocator)?;
+    let mut src_u32: Image<u32, 1> = Image::from_size_val(size, 0u32, host_alloc())?;
     src_u32
         .as_slice_mut()
         .par_iter_mut()
@@ -591,7 +588,7 @@ pub fn non_max_suppression<A1: ImageAllocator, A2: ImageAllocator>(
             *out_bits = v.to_bits();
         });
 
-    let mut dilated_u32: Image<u32, 1, _> = Image::from_size_val(size, 0u32, CpuAllocator)?;
+    let mut dilated_u32: Image<u32, 1> = Image::from_size_val(size, 0u32, host_alloc())?;
     let kernel = Kernel::new(KernelShape::Box { size: 3 });
     dilate(
         &src_u32,
@@ -651,9 +648,9 @@ pub fn non_max_suppression<A1: ImageAllocator, A2: ImageAllocator>(
 /// # Notes
 ///
 /// - No thresholding is performed inside this function.
-pub fn gftt_response<A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<f32, 1, A1>,
-    dst: &mut Image<f32, 1, A2>,
+pub fn gftt_response(
+    src: &Image<f32, 1>,
+    dst: &mut Image<f32, 1>,
     sobel_size: usize,
     window_size: usize,
     apply_nms: bool,
@@ -671,8 +668,8 @@ pub fn gftt_response<A1: ImageAllocator, A2: ImageAllocator>(
     let rows = src.rows();
     let cols = src.cols();
 
-    let mut dx = Image::from_size_val(image_size, 0.0f32, CpuAllocator)?;
-    let mut dy = Image::from_size_val(image_size, 0.0f32, CpuAllocator)?;
+    let mut dx = Image::from_size_val(image_size, 0.0f32, host_alloc())?;
+    let mut dy = Image::from_size_val(image_size, 0.0f32, host_alloc())?;
 
     let (kernel_deriv, kernel_smooth) = sobel_kernel_1d(sobel_size)?;
 
@@ -689,12 +686,9 @@ pub fn gftt_response<A1: ImageAllocator, A2: ImageAllocator>(
     separable_filter(src, &mut dy, &kernel_smooth_norm, &kernel_deriv_norm)?;
 
     // compute structure tensor components
-    let mut m11: Image<f32, 1, CpuAllocator> =
-        Image::from_size_val(image_size, 0.0f32, CpuAllocator)?;
-    let mut m22: Image<f32, 1, CpuAllocator> =
-        Image::from_size_val(image_size, 0.0f32, CpuAllocator)?;
-    let mut m12: Image<f32, 1, CpuAllocator> =
-        Image::from_size_val(image_size, 0.0f32, CpuAllocator)?;
+    let mut m11: Image<f32, 1> = Image::from_size_val(image_size, 0.0f32, host_alloc())?;
+    let mut m22: Image<f32, 1> = Image::from_size_val(image_size, 0.0f32, host_alloc())?;
+    let mut m12: Image<f32, 1> = Image::from_size_val(image_size, 0.0f32, host_alloc())?;
 
     let dx_slice = dx.as_slice();
     let dy_slice = dy.as_slice();
@@ -717,9 +711,9 @@ pub fn gftt_response<A1: ImageAllocator, A2: ImageAllocator>(
         });
 
     // smoothing structure tensor
-    let mut m11_smooth = Image::from_size_val(image_size, 0.0f32, CpuAllocator)?;
-    let mut m22_smooth = Image::from_size_val(image_size, 0.0f32, CpuAllocator)?;
-    let mut m12_smooth = Image::from_size_val(image_size, 0.0f32, CpuAllocator)?;
+    let mut m11_smooth = Image::from_size_val(image_size, 0.0f32, host_alloc())?;
+    let mut m22_smooth = Image::from_size_val(image_size, 0.0f32, host_alloc())?;
+    let mut m12_smooth = Image::from_size_val(image_size, 0.0f32, host_alloc())?;
 
     let box_kernel = vec![1.0; window_size];
     separable_filter(&m11, &mut m11_smooth, &box_kernel, &box_kernel)?;
@@ -756,7 +750,7 @@ pub fn gftt_response<A1: ImageAllocator, A2: ImageAllocator>(
 
     // conditionally apply non-maximum suppression using morphological dilation
     if apply_nms {
-        let mut tmp = Image::from_size_val(image_size, 0.0f32, CpuAllocator)?;
+        let mut tmp = Image::from_size_val(image_size, 0.0f32, host_alloc())?;
         non_max_suppression(dst, &mut tmp, 1e-6)?;
         dst.as_slice_mut().copy_from_slice(tmp.as_slice());
     }
@@ -780,10 +774,10 @@ mod tests {
                 0.0, 1.0, 1.0, 1.0, 0.0,
                 0.0, 0.0, 0.0, 0.0, 0.0,
             ],
-            CpuAllocator
+            host_alloc()
         )?;
 
-        let mut dst = Image::from_size_val([5, 5].into(), 0.0, CpuAllocator)?;
+        let mut dst = Image::from_size_val([5, 5].into(), 0.0, host_alloc())?;
         hessian_response(&src, &mut dst)?;
 
         #[rustfmt::skip]
@@ -816,10 +810,10 @@ mod tests {
                 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
                 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
             ],
-            CpuAllocator
+            host_alloc()
         )?;
 
-        let mut dst = Image::from_size_val([9, 9].into(), 0.0, CpuAllocator)?;
+        let mut dst = Image::from_size_val([9, 9].into(), 0.0, host_alloc())?;
         HarrisResponse::new(dst.size()).compute(&src, &mut dst)?;
 
         #[rustfmt::skip]
@@ -856,10 +850,10 @@ mod tests {
                 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
                 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
             ],
-            CpuAllocator
+            host_alloc()
         )?;
 
-        let mut dst = Image::from_size_val(src.size(), 0.0, CpuAllocator)?;
+        let mut dst = Image::from_size_val(src.size(), 0.0, host_alloc())?;
         HarrisResponse::new(src.size())
             .with_k(0.01)
             .compute(&src, &mut dst)?;
@@ -899,10 +893,10 @@ mod tests {
                 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
                 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
             ],
-            CpuAllocator
+            host_alloc()
         )?;
 
-        let mut dst = Image::from_size_val([9, 9].into(), 0.0, CpuAllocator)?;
+        let mut dst = Image::from_size_val([9, 9].into(), 0.0, host_alloc())?;
         HarrisResponse::new(dst.size())
             .with_k(0.01)
             .compute(&src, &mut dst)?;
@@ -935,10 +929,10 @@ mod tests {
                 0.0, 1.0, 1.0, 1.0, 0.0,
                 0.0, 0.0, 0.0, 0.0, 0.0,
             ],
-            CpuAllocator
+            host_alloc()
         )?;
 
-        let mut dst = Image::from_size_val([5, 5].into(), 0.0, CpuAllocator)?;
+        let mut dst = Image::from_size_val([5, 5].into(), 0.0, host_alloc())?;
 
         let sigma1 = 0.5;
         let sigma2 = 1.0;
@@ -978,10 +972,10 @@ mod tests {
                 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
                 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
             ],
-            CpuAllocator
+            host_alloc()
         )?;
 
-        let mut dst = Image::from_size_val([9, 9].into(), 0.0, CpuAllocator)?;
+        let mut dst = Image::from_size_val([9, 9].into(), 0.0, host_alloc())?;
         gftt_response(&src, &mut dst, 3, 5, false)?;
 
         #[rustfmt::skip]
@@ -1012,10 +1006,10 @@ mod tests {
                 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
                 0.0,
             ],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut dst = Image::from_size_val([9, 9].into(), 0.0, CpuAllocator)?;
+        let mut dst = Image::from_size_val([9, 9].into(), 0.0, host_alloc())?;
         gftt_response(&src, &mut dst, 3, 5, true)?;
 
         let data = dst.as_slice();

--- a/crates/kornia-imgproc/src/filter/ops.rs
+++ b/crates/kornia-imgproc/src/filter/ops.rs
@@ -1,5 +1,5 @@
-use kornia_image::{allocator::ImageAllocator, Image, ImageError, ImageSize};
-use kornia_tensor::CpuAllocator;
+use kornia_image::{Image, ImageError, ImageSize};
+use kornia_tensor::host_alloc;
 use rayon::{
     iter::{IndexedParallelIterator, ParallelIterator},
     slice::ParallelSliceMut,
@@ -16,9 +16,9 @@ use super::{fast_horizontal_filter, kernels, separable_filter};
 /// * `kernel_size` - The size of the kernel (kernel_x, kernel_y).
 ///
 /// PRECONDITION: `src` and `dst` must have the same shape.
-pub fn box_blur<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<f32, C, A1>,
-    dst: &mut Image<f32, C, A2>,
+pub fn box_blur<const C: usize>(
+    src: &Image<f32, C>,
+    dst: &mut Image<f32, C>,
     kernel_size: (usize, usize),
 ) -> Result<(), ImageError> {
     let kernel_x = kernels::box_blur_kernel_1d(kernel_size.0);
@@ -33,9 +33,9 @@ pub fn box_blur<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
 /// kernel summing to 256, reusing the same striped ring-buffer path as
 /// [`gaussian_blur_u8`]. The k=5 case hits the 32-u8/iter vmull/vmlal V-pass
 /// unroll.
-pub fn box_blur_u8<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<u8, C, A1>,
-    dst: &mut Image<u8, C, A2>,
+pub fn box_blur_u8<const C: usize>(
+    src: &Image<u8, C>,
+    dst: &mut Image<u8, C>,
     kernel_size: (usize, usize),
 ) -> Result<(), ImageError> {
     if src.size() != dst.size() {
@@ -87,9 +87,9 @@ pub fn box_blur_u8<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
 ///
 /// PRECONDITION: `src` and `dst` must have the same shape.
 /// NOTE: This function uses a constant border type.
-pub fn gaussian_blur<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<f32, C, A1>,
-    dst: &mut Image<f32, C, A2>,
+pub fn gaussian_blur<const C: usize>(
+    src: &Image<f32, C>,
+    dst: &mut Image<f32, C>,
     kernel_size: (usize, usize),
     sigma: (f32, f32),
 ) -> Result<(), ImageError> {
@@ -142,19 +142,19 @@ pub fn gaussian_blur<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
 /// * `kernel_size` - The size of the kernel (kernel_x, kernel_y).
 ///
 /// PRECONDITION: `src` and `dst` must have the same shape.
-pub fn sobel<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<f32, C, A1>,
-    dst: &mut Image<f32, C, A2>,
+pub fn sobel<const C: usize>(
+    src: &Image<f32, C>,
+    dst: &mut Image<f32, C>,
     kernel_size: usize,
 ) -> Result<(), ImageError> {
     // get the sobel kernels
     let (kernel_x, kernel_y) = kernels::sobel_kernel_1d(kernel_size)?;
 
     // apply the sobel filter using separable filter
-    let mut gx = Image::<f32, C, _>::from_size_val(src.size(), 0.0, CpuAllocator)?;
+    let mut gx = Image::<f32, C>::from_size_val(src.size(), 0.0, host_alloc())?;
     separable_filter(src, &mut gx, &kernel_x, &kernel_y)?;
 
-    let mut gy = Image::<f32, C, _>::from_size_val(src.size(), 0.0, CpuAllocator)?;
+    let mut gy = Image::<f32, C>::from_size_val(src.size(), 0.0, host_alloc())?;
     separable_filter(src, &mut gy, &kernel_y, &kernel_x)?;
 
     // compute the magnitude in parallel by rows
@@ -178,17 +178,17 @@ pub fn sobel<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
 /// * `kernel_size` - The size of the kernel (kernel_x, kernel_y).
 ///
 /// PRECONDITION: `src` and `dst` must have the same shape.
-pub fn scharr<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<f32, C, A1>,
-    dst: &mut Image<f32, C, A2>,
+pub fn scharr<const C: usize>(
+    src: &Image<f32, C>,
+    dst: &mut Image<f32, C>,
     kernel_size: usize,
 ) -> Result<(), ImageError> {
     let (kernel_x, kernel_y) = kernels::scharr_kernel_1d(kernel_size)?;
 
-    let mut gx = Image::<f32, C, _>::from_size_val(src.size(), 0.0, CpuAllocator)?;
+    let mut gx = Image::<f32, C>::from_size_val(src.size(), 0.0, host_alloc())?;
     separable_filter(src, &mut gx, &kernel_x, &kernel_y)?;
 
-    let mut gy = Image::<f32, C, _>::from_size_val(src.size(), 0.0, CpuAllocator)?;
+    let mut gy = Image::<f32, C>::from_size_val(src.size(), 0.0, host_alloc())?;
     separable_filter(src, &mut gy, &kernel_y, &kernel_x)?;
 
     dst.as_slice_mut()
@@ -212,9 +212,9 @@ pub fn scharr<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
 /// * `sigma` - The sigma of the gaussian kernel, xy-ordered.
 ///
 /// PRECONDITION: `src` and `dst` must have the same shape.
-pub fn box_blur_fast<const C: usize, A: ImageAllocator>(
-    src: &Image<f32, C, A>,
-    dst: &mut Image<f32, C, A>,
+pub fn box_blur_fast<const C: usize>(
+    src: &Image<f32, C>,
+    dst: &mut Image<f32, C>,
     sigma: (f32, f32),
 ) -> Result<(), ImageError> {
     let half_kernel_x_sizes = kernels::box_blur_fast_kernels_1d(sigma.0, 3);
@@ -226,7 +226,7 @@ pub fn box_blur_fast<const C: usize, A: ImageAllocator>(
     };
 
     let mut input_img = src;
-    let mut transposed = Image::<f32, C, _>::from_size_val(transposed_size, 0.0, CpuAllocator)?;
+    let mut transposed = Image::<f32, C>::from_size_val(transposed_size, 0.0, host_alloc())?;
 
     for (half_kernel_x_size, half_kernel_y_size) in
         half_kernel_x_sizes.iter().zip(half_kernel_y_sizes.iter())
@@ -247,15 +247,10 @@ pub fn box_blur_fast<const C: usize, A: ImageAllocator>(
 /// * `src` - The source image with shape (H, W, C).
 /// * `dx` - The destination image for x-derivative with shape (H, W, C).
 /// * `dy` - The destination image for y-derivative with shape (H, W, C).
-pub fn spatial_gradient_float<
-    const C: usize,
-    A1: ImageAllocator,
-    A2: ImageAllocator,
-    A3: ImageAllocator,
->(
-    src: &Image<f32, C, A1>,
-    dx: &mut Image<f32, C, A2>,
-    dy: &mut Image<f32, C, A3>,
+pub fn spatial_gradient_float<const C: usize>(
+    src: &Image<f32, C>,
+    dx: &mut Image<f32, C>,
+    dy: &mut Image<f32, C>,
 ) -> Result<(), ImageError> {
     if src.size() != dx.size() {
         return Err(ImageError::InvalidImageSize(
@@ -320,15 +315,10 @@ pub fn spatial_gradient_float<
 /// * `src` - The source image with shape (H, W, C).
 /// * `dx` - The destination image for x-derivative with shape (H, W, C).
 /// * `dy` - The destination image for y-derivative with shape (H, W, C).
-pub fn spatial_gradient_float_parallel_row<
-    const C: usize,
-    A1: ImageAllocator,
-    A2: ImageAllocator,
-    A3: ImageAllocator,
->(
-    src: &Image<f32, C, A1>,
-    dx: &mut Image<f32, C, A2>,
-    dy: &mut Image<f32, C, A3>,
+pub fn spatial_gradient_float_parallel_row<const C: usize>(
+    src: &Image<f32, C>,
+    dx: &mut Image<f32, C>,
+    dy: &mut Image<f32, C>,
 ) -> Result<(), ImageError> {
     if src.size() != dx.size() {
         return Err(ImageError::InvalidImageSize(
@@ -414,15 +404,10 @@ pub fn spatial_gradient_float_parallel_row<
 /// * `src` - The source image with shape (H, W, C).
 /// * `dx` - The destination image for x-derivative with shape (H, W, C).
 /// * `dy` - The destination image for y-derivative with shape (H, W, C).
-pub fn spatial_gradient_float_parallel<
-    const C: usize,
-    A1: ImageAllocator,
-    A2: ImageAllocator,
-    A3: ImageAllocator,
->(
-    src: &Image<f32, C, A1>,
-    dx: &mut Image<f32, C, A2>,
-    dy: &mut Image<f32, C, A3>,
+pub fn spatial_gradient_float_parallel<const C: usize>(
+    src: &Image<f32, C>,
+    dx: &mut Image<f32, C>,
+    dy: &mut Image<f32, C>,
 ) -> Result<(), ImageError> {
     if src.size() != dx.size() {
         return Err(ImageError::InvalidImageSize(
@@ -486,15 +471,10 @@ pub fn spatial_gradient_float_parallel<
 /// * `src` - The source image with shape (H, W, C).
 /// * `dx` - The destination image for x-derivative with shape (H, W, C).
 /// * `dy` - The destination image for y-derivative with shape (H, W, C).
-pub fn scharr_spatial_gradient_float<
-    const C: usize,
-    A1: ImageAllocator,
-    A2: ImageAllocator,
-    A3: ImageAllocator,
->(
-    src: &Image<f32, C, A1>,
-    dx: &mut Image<f32, C, A2>,
-    dy: &mut Image<f32, C, A3>,
+pub fn scharr_spatial_gradient_float<const C: usize>(
+    src: &Image<f32, C>,
+    dx: &mut Image<f32, C>,
+    dy: &mut Image<f32, C>,
 ) -> Result<(), ImageError> {
     if src.size() != dx.size() {
         return Err(ImageError::InvalidImageSize(
@@ -619,9 +599,9 @@ fn resolve_gaussian_params(
 ///   If zero, it is computed from `sigma`.
 /// * `sigma` - Gaussian sigma (sigma_x, sigma_y). If zero, it is computed
 ///   from `kernel_size`.
-pub fn gaussian_blur_u8<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<u8, C, A1>,
-    dst: &mut Image<u8, C, A2>,
+pub fn gaussian_blur_u8<const C: usize>(
+    src: &Image<u8, C>,
+    dst: &mut Image<u8, C>,
     kernel_size: (usize, usize),
     sigma: (f32, f32),
 ) -> Result<(), ImageError> {
@@ -1973,14 +1953,17 @@ mod tests {
         let mut sym = vec![0u8; rows * cols];
         gaussian_blur_7x7_sym_u8::<1>(&src, &mut sym, rows, cols, &ikx, &iky);
 
-        let mut gen = vec![0u8; rows * cols];
-        separable_blur_u8_striped(&src, &mut gen, rows, cols, 1, &ikx, 3, &iky, 3);
+        let mut r#gen = vec![0u8; rows * cols];
+        separable_blur_u8_striped(&src, &mut r#gen, rows, cols, 1, &ikx, 3, &iky, 3);
 
         // Symmetric path computes pair sums before multiplying; general path
         // accumulates one tap at a time. The final Q8+Q8 result is identical
         // because addition is associative in u16 and neither path overflows
         // (kernel sums to 256, inputs ≤ 255, so pre-shift acc ≤ 256·255 < 2^16).
-        assert_eq!(sym, gen, "7x7 symmetric path must match general Q8+Q8 path");
+        assert_eq!(
+            sym, r#gen,
+            "7x7 symmetric path must match general Q8+Q8 path"
+        );
     }
 
     /// Verify that gaussian_blur_u8 with k=5 produces the same result as the
@@ -1995,33 +1978,33 @@ mod tests {
         for (i, v) in src_data.iter_mut().enumerate() {
             *v = ((i.wrapping_mul(2654435761)) >> 24) as u8;
         }
-        let src_img = Image::<u8, 1, _>::new(
+        let src_img = Image::<u8, 1>::new(
             ImageSize {
                 width: cols,
                 height: rows,
             },
             src_data.clone(),
-            CpuAllocator,
+            host_alloc(),
         )?;
-        let mut dst_5x5 = Image::<u8, 1, _>::from_size_val(
+        let mut dst_5x5 = Image::<u8, 1>::from_size_val(
             ImageSize {
                 width: cols,
                 height: rows,
             },
             0u8,
-            CpuAllocator,
+            host_alloc(),
         )?;
         gaussian_blur_u8(&src_img, &mut dst_5x5, (5, 5), (1.0, 1.0))?;
 
         // General path reference (same as what gaussian_blur_u8 falls through to now).
         let ikx = quantize_kernel_256(&kernels::gaussian_kernel_1d(5, 1.0));
         let iky = ikx.clone();
-        let mut gen = vec![0u8; n];
-        separable_blur_u8_striped(&src_data, &mut gen, rows, cols, 1, &ikx, 2, &iky, 2);
+        let mut r#gen = vec![0u8; n];
+        separable_blur_u8_striped(&src_data, &mut r#gen, rows, cols, 1, &ikx, 2, &iky, 2);
 
         assert_eq!(
             dst_5x5.as_slice(),
-            gen.as_slice(),
+            r#gen.as_slice(),
             "5x5 gaussian_blur_u8 must match general separable path"
         );
         Ok(())
@@ -2054,15 +2037,15 @@ mod tests {
             let sx = 0.85f32; // natural sigma for [1,2,1]/4
             let ikx = quantize_kernel_256(&kernels::gaussian_kernel_1d(3, sx));
             let iky = ikx.clone();
-            let mut gen = vec![0u8; n];
-            separable_blur_u8_striped(&src, &mut gen, rows, cols, channels, &ikx, 1, &iky, 1);
+            let mut r#gen = vec![0u8; n];
+            separable_blur_u8_striped(&src, &mut r#gen, rows, cols, channels, &ikx, 1, &iky, 1);
 
             // The halving-add vrhadd path computes (a+2b+c+3)/4 (rounded up);
             // the Q8 path computes (a+2b+c+2)/4 with different rounding.
             // Allow ≤2 LSB difference on any pixel.
             let max_diff = binom
                 .iter()
-                .zip(gen.iter())
+                .zip(r#gen.iter())
                 .map(|(&a, &b)| (a as i16 - b as i16).unsigned_abs())
                 .max()
                 .unwrap_or(0);
@@ -2081,21 +2064,21 @@ mod tests {
         let rows = 5usize;
         let cols = 1usize;
         let src_data: Vec<u8> = (0..rows).map(|i| (i * 50) as u8).collect();
-        let src = Image::<u8, 1, _>::new(
+        let src = Image::<u8, 1>::new(
             ImageSize {
                 width: cols,
                 height: rows,
             },
             src_data,
-            CpuAllocator,
+            host_alloc(),
         )?;
-        let mut dst = Image::<u8, 1, _>::from_size_val(
+        let mut dst = Image::<u8, 1>::from_size_val(
             ImageSize {
                 width: cols,
                 height: rows,
             },
             0u8,
-            CpuAllocator,
+            host_alloc(),
         )?;
         // Must not panic.
         gaussian_blur_u8(&src, &mut dst, (3, 3), (1.0, 1.0))?;
@@ -2109,21 +2092,21 @@ mod tests {
         let rows = 1usize;
         let cols = 5usize;
         let src_data: Vec<u8> = (0..cols).map(|i| (i * 50) as u8).collect();
-        let src = Image::<u8, 1, _>::new(
+        let src = Image::<u8, 1>::new(
             ImageSize {
                 width: cols,
                 height: rows,
             },
             src_data,
-            CpuAllocator,
+            host_alloc(),
         )?;
-        let mut dst = Image::<u8, 1, _>::from_size_val(
+        let mut dst = Image::<u8, 1>::from_size_val(
             ImageSize {
                 width: cols,
                 height: rows,
             },
             0u8,
-            CpuAllocator,
+            host_alloc(),
         )?;
         // Must not panic.
         gaussian_blur_u8(&src, &mut dst, (3, 3), (1.0, 1.0))?;
@@ -2137,8 +2120,8 @@ mod tests {
             height: 5,
         };
 
-        let img = Image::new(size, (0..25).map(|x| x as f32).collect(), CpuAllocator)?;
-        let mut dst = Image::<_, 1, _>::from_size_val(size, 0.0, CpuAllocator)?;
+        let img = Image::new(size, (0..25).map(|x| x as f32).collect(), host_alloc())?;
+        let mut dst = Image::<_, 1>::from_size_val(size, 0.0, host_alloc())?;
 
         box_blur_fast(&img, &mut dst, (0.5, 0.5))?;
 
@@ -2164,9 +2147,9 @@ mod tests {
             height: 5,
         };
 
-        let img = Image::new(size, (0..25).map(|x| x as f32).collect(), CpuAllocator)?;
+        let img = Image::new(size, (0..25).map(|x| x as f32).collect(), host_alloc())?;
 
-        let mut dst = Image::<_, 1, _>::from_size_val(size, 0.0, CpuAllocator)?;
+        let mut dst = Image::<_, 1>::from_size_val(size, 0.0, host_alloc())?;
 
         gaussian_blur(&img, &mut dst, (3, 3), (0.5, 0.5))?;
 
@@ -2191,9 +2174,9 @@ mod tests {
             height: 5,
         };
 
-        let img = Image::new(size, (0..25).map(|x| x as f32).collect(), CpuAllocator)?;
+        let img = Image::new(size, (0..25).map(|x| x as f32).collect(), host_alloc())?;
 
-        let mut dst = Image::<_, 1, _>::from_size_val(size, 0.0, CpuAllocator)?;
+        let mut dst = Image::<_, 1>::from_size_val(size, 0.0, host_alloc())?;
 
         gaussian_blur(&img, &mut dst, (0, 0), (0.5, 0.5))?;
 
@@ -2217,9 +2200,9 @@ mod tests {
             height: 5,
         };
 
-        let img = Image::new(size, (0..25).map(|x| x as f32).collect(), CpuAllocator)?;
+        let img = Image::new(size, (0..25).map(|x| x as f32).collect(), host_alloc())?;
 
-        let mut dst = Image::<_, 1, _>::from_size_val(size, 0.0, CpuAllocator)?;
+        let mut dst = Image::<_, 1>::from_size_val(size, 0.0, host_alloc())?;
 
         gaussian_blur(&img, &mut dst, (3, 3), (0.0, 0.0))?;
 
@@ -2239,11 +2222,8 @@ mod tests {
     #[test]
     fn test_spatial_gradient() -> Result<(), ImageError> {
         // First, define a type alias for the function signature
-        type FilterFunction = fn(
-            &Image<f32, 2, CpuAllocator>,
-            &mut Image<f32, 2, CpuAllocator>,
-            &mut Image<f32, 2, CpuAllocator>,
-        ) -> Result<(), ImageError>;
+        type FilterFunction =
+            fn(&Image<f32, 2>, &mut Image<f32, 2>, &mut Image<f32, 2>) -> Result<(), ImageError>;
 
         // Then, define a type for the test tuple
         type TestCase = (FilterFunction, &'static str);
@@ -2266,14 +2246,14 @@ mod tests {
             height: 5,
         };
 
-        let img = Image::<f32, 2, _>::new(
+        let img = Image::<f32, 2>::new(
             size,
             (0..25).flat_map(|x| [x as f32, x as f32 + 25.0]).collect(),
-            CpuAllocator,
+            host_alloc(),
         )?;
         for (test_fn, fn_name) in TEST_FUNCTIONS {
-            let mut dx = Image::<_, 2, _>::from_size_val(size, 0.0, CpuAllocator)?;
-            let mut dy = Image::<_, 2, _>::from_size_val(size, 0.0, CpuAllocator)?;
+            let mut dx = Image::<_, 2>::from_size_val(size, 0.0, host_alloc())?;
+            let mut dy = Image::<_, 2>::from_size_val(size, 0.0, host_alloc())?;
 
             test_fn(&img, &mut dx, &mut dy)?;
 
@@ -2340,14 +2320,14 @@ mod tests {
             height: 5,
         };
 
-        let img = Image::<f32, 2, _>::new(
+        let img = Image::<f32, 2>::new(
             size,
             (0..25).flat_map(|x| [x as f32, x as f32 + 25.0]).collect(),
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut dx = Image::<_, 2, _>::from_size_val(size, 0.0, CpuAllocator)?;
-        let mut dy = Image::<_, 2, _>::from_size_val(size, 0.0, CpuAllocator)?;
+        let mut dx = Image::<_, 2>::from_size_val(size, 0.0, host_alloc())?;
+        let mut dy = Image::<_, 2>::from_size_val(size, 0.0, host_alloc())?;
 
         scharr_spatial_gradient_float(&img, &mut dx, &mut dy)?;
 

--- a/crates/kornia-imgproc/src/filter/ops.rs
+++ b/crates/kornia-imgproc/src/filter/ops.rs
@@ -1,5 +1,4 @@
 use kornia_image::{Image, ImageError, ImageSize};
-use kornia_tensor::host_alloc;
 use rayon::{
     iter::{IndexedParallelIterator, ParallelIterator},
     slice::ParallelSliceMut,
@@ -151,10 +150,10 @@ pub fn sobel<const C: usize>(
     let (kernel_x, kernel_y) = kernels::sobel_kernel_1d(kernel_size)?;
 
     // apply the sobel filter using separable filter
-    let mut gx = Image::<f32, C>::from_size_val(src.size(), 0.0, host_alloc())?;
+    let mut gx = Image::<f32, C>::from_size_val(src.size(), 0.0)?;
     separable_filter(src, &mut gx, &kernel_x, &kernel_y)?;
 
-    let mut gy = Image::<f32, C>::from_size_val(src.size(), 0.0, host_alloc())?;
+    let mut gy = Image::<f32, C>::from_size_val(src.size(), 0.0)?;
     separable_filter(src, &mut gy, &kernel_y, &kernel_x)?;
 
     // compute the magnitude in parallel by rows
@@ -185,10 +184,10 @@ pub fn scharr<const C: usize>(
 ) -> Result<(), ImageError> {
     let (kernel_x, kernel_y) = kernels::scharr_kernel_1d(kernel_size)?;
 
-    let mut gx = Image::<f32, C>::from_size_val(src.size(), 0.0, host_alloc())?;
+    let mut gx = Image::<f32, C>::from_size_val(src.size(), 0.0)?;
     separable_filter(src, &mut gx, &kernel_x, &kernel_y)?;
 
-    let mut gy = Image::<f32, C>::from_size_val(src.size(), 0.0, host_alloc())?;
+    let mut gy = Image::<f32, C>::from_size_val(src.size(), 0.0)?;
     separable_filter(src, &mut gy, &kernel_y, &kernel_x)?;
 
     dst.as_slice_mut()
@@ -226,7 +225,7 @@ pub fn box_blur_fast<const C: usize>(
     };
 
     let mut input_img = src;
-    let mut transposed = Image::<f32, C>::from_size_val(transposed_size, 0.0, host_alloc())?;
+    let mut transposed = Image::<f32, C>::from_size_val(transposed_size, 0.0)?;
 
     for (half_kernel_x_size, half_kernel_y_size) in
         half_kernel_x_sizes.iter().zip(half_kernel_y_sizes.iter())
@@ -1984,7 +1983,6 @@ mod tests {
                 height: rows,
             },
             src_data.clone(),
-            host_alloc(),
         )?;
         let mut dst_5x5 = Image::<u8, 1>::from_size_val(
             ImageSize {
@@ -1992,7 +1990,6 @@ mod tests {
                 height: rows,
             },
             0u8,
-            host_alloc(),
         )?;
         gaussian_blur_u8(&src_img, &mut dst_5x5, (5, 5), (1.0, 1.0))?;
 
@@ -2070,7 +2067,6 @@ mod tests {
                 height: rows,
             },
             src_data,
-            host_alloc(),
         )?;
         let mut dst = Image::<u8, 1>::from_size_val(
             ImageSize {
@@ -2078,7 +2074,6 @@ mod tests {
                 height: rows,
             },
             0u8,
-            host_alloc(),
         )?;
         // Must not panic.
         gaussian_blur_u8(&src, &mut dst, (3, 3), (1.0, 1.0))?;
@@ -2098,7 +2093,6 @@ mod tests {
                 height: rows,
             },
             src_data,
-            host_alloc(),
         )?;
         let mut dst = Image::<u8, 1>::from_size_val(
             ImageSize {
@@ -2106,7 +2100,6 @@ mod tests {
                 height: rows,
             },
             0u8,
-            host_alloc(),
         )?;
         // Must not panic.
         gaussian_blur_u8(&src, &mut dst, (3, 3), (1.0, 1.0))?;
@@ -2120,8 +2113,8 @@ mod tests {
             height: 5,
         };
 
-        let img = Image::new(size, (0..25).map(|x| x as f32).collect(), host_alloc())?;
-        let mut dst = Image::<_, 1>::from_size_val(size, 0.0, host_alloc())?;
+        let img = Image::new(size, (0..25).map(|x| x as f32).collect())?;
+        let mut dst = Image::<_, 1>::from_size_val(size, 0.0)?;
 
         box_blur_fast(&img, &mut dst, (0.5, 0.5))?;
 
@@ -2147,9 +2140,9 @@ mod tests {
             height: 5,
         };
 
-        let img = Image::new(size, (0..25).map(|x| x as f32).collect(), host_alloc())?;
+        let img = Image::new(size, (0..25).map(|x| x as f32).collect())?;
 
-        let mut dst = Image::<_, 1>::from_size_val(size, 0.0, host_alloc())?;
+        let mut dst = Image::<_, 1>::from_size_val(size, 0.0)?;
 
         gaussian_blur(&img, &mut dst, (3, 3), (0.5, 0.5))?;
 
@@ -2174,9 +2167,9 @@ mod tests {
             height: 5,
         };
 
-        let img = Image::new(size, (0..25).map(|x| x as f32).collect(), host_alloc())?;
+        let img = Image::new(size, (0..25).map(|x| x as f32).collect())?;
 
-        let mut dst = Image::<_, 1>::from_size_val(size, 0.0, host_alloc())?;
+        let mut dst = Image::<_, 1>::from_size_val(size, 0.0)?;
 
         gaussian_blur(&img, &mut dst, (0, 0), (0.5, 0.5))?;
 
@@ -2200,9 +2193,9 @@ mod tests {
             height: 5,
         };
 
-        let img = Image::new(size, (0..25).map(|x| x as f32).collect(), host_alloc())?;
+        let img = Image::new(size, (0..25).map(|x| x as f32).collect())?;
 
-        let mut dst = Image::<_, 1>::from_size_val(size, 0.0, host_alloc())?;
+        let mut dst = Image::<_, 1>::from_size_val(size, 0.0)?;
 
         gaussian_blur(&img, &mut dst, (3, 3), (0.0, 0.0))?;
 
@@ -2249,11 +2242,10 @@ mod tests {
         let img = Image::<f32, 2>::new(
             size,
             (0..25).flat_map(|x| [x as f32, x as f32 + 25.0]).collect(),
-            host_alloc(),
         )?;
         for (test_fn, fn_name) in TEST_FUNCTIONS {
-            let mut dx = Image::<_, 2>::from_size_val(size, 0.0, host_alloc())?;
-            let mut dy = Image::<_, 2>::from_size_val(size, 0.0, host_alloc())?;
+            let mut dx = Image::<_, 2>::from_size_val(size, 0.0)?;
+            let mut dy = Image::<_, 2>::from_size_val(size, 0.0)?;
 
             test_fn(&img, &mut dx, &mut dy)?;
 
@@ -2323,11 +2315,10 @@ mod tests {
         let img = Image::<f32, 2>::new(
             size,
             (0..25).flat_map(|x| [x as f32, x as f32 + 25.0]).collect(),
-            host_alloc(),
         )?;
 
-        let mut dx = Image::<_, 2>::from_size_val(size, 0.0, host_alloc())?;
-        let mut dy = Image::<_, 2>::from_size_val(size, 0.0, host_alloc())?;
+        let mut dx = Image::<_, 2>::from_size_val(size, 0.0)?;
+        let mut dy = Image::<_, 2>::from_size_val(size, 0.0)?;
 
         scharr_spatial_gradient_float(&img, &mut dx, &mut dy)?;
 

--- a/crates/kornia-imgproc/src/filter/separable_filter.rs
+++ b/crates/kornia-imgproc/src/filter/separable_filter.rs
@@ -260,7 +260,6 @@ pub(crate) fn fast_horizontal_filter<const C: usize>(
 mod tests {
     use super::*;
     use kornia_image::ImageSize;
-    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_separable_filter_f32() -> Result<(), ImageError> {
@@ -278,11 +277,10 @@ mod tests {
                 0.0, 0.0, 1.0, 0.0, 0.0,
                 0.0, 0.0, 0.0, 0.0, 0.0,
                 0.0, 0.0, 0.0, 0.0, 0.0,
-            ],
-            host_alloc()
+            ]
         )?;
 
-        let mut dst = Image::<_, 1>::from_size_val(img.size(), 0f32, host_alloc())?;
+        let mut dst = Image::<_, 1>::from_size_val(img.size(), 0f32)?;
         let kernel_x = vec![1.0, 1.0, 1.0];
         let kernel_y = vec![1.0, 1.0, 1.0];
         separable_filter(&img, &mut dst, &kernel_x, &kernel_y)?;
@@ -321,11 +319,10 @@ mod tests {
                 0, 0, 255, 0, 0,
                 0, 0, 0, 0, 0,
                 0, 0, 0, 0, 0,
-            ],
-            host_alloc()
+            ]
         )?;
 
-        let mut dst = Image::<u8, 1>::from_size_val(img.size(), 0, host_alloc())?;
+        let mut dst = Image::<u8, 1>::from_size_val(img.size(), 0)?;
         let kernel_x = vec![1.0, 1.0, 1.0];
         let kernel_y = vec![1.0, 1.0, 1.0];
         separable_filter(&img, &mut dst, &kernel_x, &kernel_y)?;
@@ -354,10 +351,10 @@ mod tests {
         let kernel_x = vec![1.0, 1.0, 1.0];
         let kernel_y = vec![1.0, 1.0, 1.0];
 
-        let mut img = Image::<u8, 1>::from_size_val(size, 0, host_alloc())?;
+        let mut img = Image::<u8, 1>::from_size_val(size, 0)?;
         img.as_slice_mut()[12] = 255;
 
-        let mut dst = Image::<u8, 1>::from_size_val(size, 0, host_alloc())?;
+        let mut dst = Image::<u8, 1>::from_size_val(size, 0)?;
         separable_filter(&img, &mut dst, &kernel_x, &kernel_y)?;
 
         #[rustfmt::skip]
@@ -388,11 +385,10 @@ mod tests {
                 0.0, 0.0, 9.0, 0.0, 0.0,
                 0.0, 0.0, 0.0, 0.0, 0.0,
                 0.0, 0.0, 0.0, 0.0, 0.0,
-            ],
-            host_alloc()
+            ]
         )?;
 
-        let mut transposed = Image::<_, 1>::from_size_val(size, 0.0, host_alloc())?;
+        let mut transposed = Image::<_, 1>::from_size_val(size, 0.0)?;
 
         fast_horizontal_filter(&img, &mut transposed, 1)?;
 
@@ -408,7 +404,7 @@ mod tests {
             ]
         );
 
-        let mut dst = Image::<_, 1>::from_size_val(size, 0.0, host_alloc())?;
+        let mut dst = Image::<_, 1>::from_size_val(size, 0.0)?;
 
         fast_horizontal_filter(&transposed, &mut dst, 1)?;
 

--- a/crates/kornia-imgproc/src/filter/separable_filter.rs
+++ b/crates/kornia-imgproc/src/filter/separable_filter.rs
@@ -1,4 +1,4 @@
-use kornia_image::{allocator::ImageAllocator, Image, ImageError};
+use kornia_image::{Image, ImageError};
 use num_traits::Zero;
 
 /// Trait for floating point casting
@@ -84,10 +84,10 @@ impl SeparableFilter {
     ///
     /// * `src` - The source image
     /// * `dst` - The destination image (must be same size as source)
-    fn apply<T, const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
+    fn apply<T, const C: usize>(
         &self,
-        src: &Image<T, C, A1>,
-        dst: &mut Image<T, C, A2>,
+        src: &Image<T, C>,
+        dst: &mut Image<T, C>,
     ) -> Result<(), ImageError>
     where
         T: FloatConversion + Clone + Zero,
@@ -163,9 +163,9 @@ impl SeparableFilter {
 /// * `dst` - The destination image with shape (H, W, C).
 /// * `kernel_x` - The horizontal kernel.
 /// * `kernel_y` - The vertical kernel.
-pub fn separable_filter<T, const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<T, C, A1>,
-    dst: &mut Image<T, C, A2>,
+pub fn separable_filter<T, const C: usize>(
+    src: &Image<T, C>,
+    dst: &mut Image<T, C>,
     kernel_x: &[f32],
     kernel_y: &[f32],
 ) -> Result<(), ImageError>
@@ -199,9 +199,9 @@ where
 /// * `src` - The source image with shape (H, W, C).
 /// * `dst` - The destination image with transposed shape (W, H, C).
 /// * `half_kernel_x_size` - Half of the kernel at weight 1. The total size would be 2*this+1
-pub(crate) fn fast_horizontal_filter<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<f32, C, A1>,
-    dst: &mut Image<f32, C, A2>,
+pub(crate) fn fast_horizontal_filter<const C: usize>(
+    src: &Image<f32, C>,
+    dst: &mut Image<f32, C>,
     half_kernel_x_size: usize,
 ) -> Result<(), ImageError> {
     let src_data = src.as_slice();
@@ -260,7 +260,7 @@ pub(crate) fn fast_horizontal_filter<const C: usize, A1: ImageAllocator, A2: Ima
 mod tests {
     use super::*;
     use kornia_image::ImageSize;
-    use kornia_tensor::CpuAllocator;
+    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_separable_filter_f32() -> Result<(), ImageError> {
@@ -279,10 +279,10 @@ mod tests {
                 0.0, 0.0, 0.0, 0.0, 0.0,
                 0.0, 0.0, 0.0, 0.0, 0.0,
             ],
-            CpuAllocator
+            host_alloc()
         )?;
 
-        let mut dst = Image::<_, 1, _>::from_size_val(img.size(), 0f32, CpuAllocator)?;
+        let mut dst = Image::<_, 1>::from_size_val(img.size(), 0f32, host_alloc())?;
         let kernel_x = vec![1.0, 1.0, 1.0];
         let kernel_y = vec![1.0, 1.0, 1.0];
         separable_filter(&img, &mut dst, &kernel_x, &kernel_y)?;
@@ -322,10 +322,10 @@ mod tests {
                 0, 0, 0, 0, 0,
                 0, 0, 0, 0, 0,
             ],
-            CpuAllocator
+            host_alloc()
         )?;
 
-        let mut dst = Image::<u8, 1, _>::from_size_val(img.size(), 0, CpuAllocator)?;
+        let mut dst = Image::<u8, 1>::from_size_val(img.size(), 0, host_alloc())?;
         let kernel_x = vec![1.0, 1.0, 1.0];
         let kernel_y = vec![1.0, 1.0, 1.0];
         separable_filter(&img, &mut dst, &kernel_x, &kernel_y)?;
@@ -354,10 +354,10 @@ mod tests {
         let kernel_x = vec![1.0, 1.0, 1.0];
         let kernel_y = vec![1.0, 1.0, 1.0];
 
-        let mut img = Image::<u8, 1, _>::from_size_val(size, 0, CpuAllocator)?;
+        let mut img = Image::<u8, 1>::from_size_val(size, 0, host_alloc())?;
         img.as_slice_mut()[12] = 255;
 
-        let mut dst = Image::<u8, 1, _>::from_size_val(size, 0, CpuAllocator)?;
+        let mut dst = Image::<u8, 1>::from_size_val(size, 0, host_alloc())?;
         separable_filter(&img, &mut dst, &kernel_x, &kernel_y)?;
 
         #[rustfmt::skip]
@@ -389,10 +389,10 @@ mod tests {
                 0.0, 0.0, 0.0, 0.0, 0.0,
                 0.0, 0.0, 0.0, 0.0, 0.0,
             ],
-            CpuAllocator
+            host_alloc()
         )?;
 
-        let mut transposed = Image::<_, 1, _>::from_size_val(size, 0.0, CpuAllocator)?;
+        let mut transposed = Image::<_, 1>::from_size_val(size, 0.0, host_alloc())?;
 
         fast_horizontal_filter(&img, &mut transposed, 1)?;
 
@@ -408,7 +408,7 @@ mod tests {
             ]
         );
 
-        let mut dst = Image::<_, 1, _>::from_size_val(size, 0.0, CpuAllocator)?;
+        let mut dst = Image::<_, 1>::from_size_val(size, 0.0, host_alloc())?;
 
         fast_horizontal_filter(&transposed, &mut dst, 1)?;
 

--- a/crates/kornia-imgproc/src/flip.rs
+++ b/crates/kornia-imgproc/src/flip.rs
@@ -21,7 +21,6 @@ use rayon::{
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::flip::horizontal_flip;
 ///
 /// let image = Image::<f32, 3>::new(
@@ -30,11 +29,10 @@ use rayon::{
 ///         height: 3,
 ///     },
 ///     vec![0f32; 2 * 3 * 3],
-///     host_alloc()
 /// )
 /// .unwrap();
 ///
-/// let mut flipped = Image::<f32, 3>::from_size_val(image.size(), 0.0, host_alloc()).unwrap();
+/// let mut flipped = Image::<f32, 3>::from_size_val(image.size(), 0.0).unwrap();
 ///
 /// horizontal_flip(&image, &mut flipped).unwrap();
 /// ```
@@ -288,7 +286,6 @@ fn hflip_rgb_u8_neon(src: &[u8], dst: &mut [u8], cols: usize) {
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::flip::vertical_flip;
 ///
 /// let image = Image::<f32, 3>::new(
@@ -297,11 +294,10 @@ fn hflip_rgb_u8_neon(src: &[u8], dst: &mut [u8], cols: usize) {
 ///         height: 3,
 ///     },
 ///     vec![0f32; 2 * 3 * 3],
-///     host_alloc(),
 /// )
 /// .unwrap();
 ///
-/// let mut flipped = Image::<f32, 3>::from_size_val(image.size(), 0.0, host_alloc()).unwrap();
+/// let mut flipped = Image::<f32, 3>::from_size_val(image.size(), 0.0).unwrap();
 ///
 /// vertical_flip(&image, &mut flipped).unwrap();
 ///
@@ -366,7 +362,6 @@ where
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_hflip() -> Result<(), ImageError> {
@@ -379,12 +374,11 @@ mod tests {
             vec![
                 0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
             ],
-            host_alloc(),
         )?;
         let data_expected = vec![
             3u8, 4, 5, 0, 1, 2, 9, 10, 11, 6, 7, 8, 15, 16, 17, 12, 13, 14,
         ];
-        let mut flipped = Image::<_, 3>::from_size_val(image_size, 0u8, host_alloc())?;
+        let mut flipped = Image::<_, 3>::from_size_val(image_size, 0u8)?;
         super::horizontal_flip(&image, &mut flipped)?;
         assert_eq!(flipped.as_slice(), &data_expected);
         Ok(())
@@ -401,12 +395,11 @@ mod tests {
             vec![
                 0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
             ],
-            host_alloc(),
         )?;
         let data_expected = vec![
             12u8, 13, 14, 15, 16, 17, 6, 7, 8, 9, 10, 11, 0, 1, 2, 3, 4, 5,
         ];
-        let mut flipped = Image::<_, 3>::from_size_val(image_size, 0u8, host_alloc())?;
+        let mut flipped = Image::<_, 3>::from_size_val(image_size, 0u8)?;
         super::vertical_flip(&image, &mut flipped)?;
         assert_eq!(flipped.as_slice(), &data_expected);
         Ok(())
@@ -423,8 +416,8 @@ mod tests {
             height: 4,
         };
         let pixels: Vec<u8> = (0..(80 * 4 * 3)).map(|i| (i & 0xff) as u8).collect();
-        let image = Image::<u8, 3>::new(image_size, pixels.clone(), host_alloc())?;
-        let mut flipped = Image::<u8, 3>::from_size_val(image_size, 0u8, host_alloc())?;
+        let image = Image::<u8, 3>::new(image_size, pixels.clone())?;
+        let mut flipped = Image::<u8, 3>::from_size_val(image_size, 0u8)?;
         super::horizontal_flip(&image, &mut flipped)?;
 
         let mut expected = vec![0u8; 80 * 4 * 3];
@@ -447,8 +440,8 @@ mod tests {
             width: 4,
             height: 1,
         };
-        let image = Image::<_, 1>::new(image_size, vec![10u8, 20, 30, 40], host_alloc())?;
-        let mut flipped = Image::<_, 1>::from_size_val(image_size, 0u8, host_alloc())?;
+        let image = Image::<_, 1>::new(image_size, vec![10u8, 20, 30, 40])?;
+        let mut flipped = Image::<_, 1>::from_size_val(image_size, 0u8)?;
         super::horizontal_flip(&image, &mut flipped)?;
         // Columns reversed: [40, 30, 20, 10]
         assert_eq!(flipped.as_slice(), &[40u8, 30, 20, 10]);
@@ -463,8 +456,8 @@ mod tests {
             width: 1,
             height: 4,
         };
-        let image = Image::<_, 1>::new(image_size, vec![10u8, 20, 30, 40], host_alloc())?;
-        let mut flipped = Image::<_, 1>::from_size_val(image_size, 0u8, host_alloc())?;
+        let image = Image::<_, 1>::new(image_size, vec![10u8, 20, 30, 40])?;
+        let mut flipped = Image::<_, 1>::from_size_val(image_size, 0u8)?;
         super::vertical_flip(&image, &mut flipped)?;
         // Rows reversed: [40, 30, 20, 10]
         assert_eq!(flipped.as_slice(), &[40u8, 30, 20, 10]);

--- a/crates/kornia-imgproc/src/flip.rs
+++ b/crates/kornia-imgproc/src/flip.rs
@@ -1,4 +1,4 @@
-use kornia_image::{allocator::ImageAllocator, Image, ImageError};
+use kornia_image::{Image, ImageError};
 use rayon::{
     iter::{IndexedParallelIterator, ParallelIterator},
     slice::{ParallelSlice, ParallelSliceMut},
@@ -21,26 +21,26 @@ use rayon::{
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::flip::horizontal_flip;
 ///
-/// let image = Image::<f32, 3, _>::new(
+/// let image = Image::<f32, 3>::new(
 ///     ImageSize {
 ///         width: 2,
 ///         height: 3,
 ///     },
 ///     vec![0f32; 2 * 3 * 3],
-///     CpuAllocator
+///     host_alloc()
 /// )
 /// .unwrap();
 ///
-/// let mut flipped = Image::<f32, 3, _>::from_size_val(image.size(), 0.0, CpuAllocator).unwrap();
+/// let mut flipped = Image::<f32, 3>::from_size_val(image.size(), 0.0, host_alloc()).unwrap();
 ///
 /// horizontal_flip(&image, &mut flipped).unwrap();
 /// ```
-pub fn horizontal_flip<T, const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<T, C, A1>,
-    dst: &mut Image<T, C, A2>,
+pub fn horizontal_flip<T, const C: usize>(
+    src: &Image<T, C>,
+    dst: &mut Image<T, C>,
 ) -> Result<(), ImageError>
 where
     T: Copy + Send + Sync + 'static,
@@ -288,27 +288,27 @@ fn hflip_rgb_u8_neon(src: &[u8], dst: &mut [u8], cols: usize) {
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::flip::vertical_flip;
 ///
-/// let image = Image::<f32, 3, _>::new(
+/// let image = Image::<f32, 3>::new(
 ///     ImageSize {
 ///         width: 2,
 ///         height: 3,
 ///     },
 ///     vec![0f32; 2 * 3 * 3],
-///     CpuAllocator,
+///     host_alloc(),
 /// )
 /// .unwrap();
 ///
-/// let mut flipped = Image::<f32, 3, _>::from_size_val(image.size(), 0.0, CpuAllocator).unwrap();
+/// let mut flipped = Image::<f32, 3>::from_size_val(image.size(), 0.0, host_alloc()).unwrap();
 ///
 /// vertical_flip(&image, &mut flipped).unwrap();
 ///
 /// ```
-pub fn vertical_flip<T, const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<T, C, A1>,
-    dst: &mut Image<T, C, A2>,
+pub fn vertical_flip<T, const C: usize>(
+    src: &Image<T, C>,
+    dst: &mut Image<T, C>,
 ) -> Result<(), ImageError>
 where
     T: Copy + Send + Sync,
@@ -366,7 +366,7 @@ where
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::CpuAllocator;
+    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_hflip() -> Result<(), ImageError> {
@@ -374,17 +374,17 @@ mod tests {
             width: 2,
             height: 3,
         };
-        let image = Image::<_, 3, _>::new(
+        let image = Image::<_, 3>::new(
             image_size,
             vec![
                 0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
             ],
-            CpuAllocator,
+            host_alloc(),
         )?;
         let data_expected = vec![
             3u8, 4, 5, 0, 1, 2, 9, 10, 11, 6, 7, 8, 15, 16, 17, 12, 13, 14,
         ];
-        let mut flipped = Image::<_, 3, _>::from_size_val(image_size, 0u8, CpuAllocator)?;
+        let mut flipped = Image::<_, 3>::from_size_val(image_size, 0u8, host_alloc())?;
         super::horizontal_flip(&image, &mut flipped)?;
         assert_eq!(flipped.as_slice(), &data_expected);
         Ok(())
@@ -396,17 +396,17 @@ mod tests {
             width: 2,
             height: 3,
         };
-        let image = Image::<_, 3, _>::new(
+        let image = Image::<_, 3>::new(
             image_size,
             vec![
                 0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
             ],
-            CpuAllocator,
+            host_alloc(),
         )?;
         let data_expected = vec![
             12u8, 13, 14, 15, 16, 17, 6, 7, 8, 9, 10, 11, 0, 1, 2, 3, 4, 5,
         ];
-        let mut flipped = Image::<_, 3, _>::from_size_val(image_size, 0u8, CpuAllocator)?;
+        let mut flipped = Image::<_, 3>::from_size_val(image_size, 0u8, host_alloc())?;
         super::vertical_flip(&image, &mut flipped)?;
         assert_eq!(flipped.as_slice(), &data_expected);
         Ok(())
@@ -423,8 +423,8 @@ mod tests {
             height: 4,
         };
         let pixels: Vec<u8> = (0..(80 * 4 * 3)).map(|i| (i & 0xff) as u8).collect();
-        let image = Image::<u8, 3, _>::new(image_size, pixels.clone(), CpuAllocator)?;
-        let mut flipped = Image::<u8, 3, _>::from_size_val(image_size, 0u8, CpuAllocator)?;
+        let image = Image::<u8, 3>::new(image_size, pixels.clone(), host_alloc())?;
+        let mut flipped = Image::<u8, 3>::from_size_val(image_size, 0u8, host_alloc())?;
         super::horizontal_flip(&image, &mut flipped)?;
 
         let mut expected = vec![0u8; 80 * 4 * 3];
@@ -447,8 +447,8 @@ mod tests {
             width: 4,
             height: 1,
         };
-        let image = Image::<_, 1, _>::new(image_size, vec![10u8, 20, 30, 40], CpuAllocator)?;
-        let mut flipped = Image::<_, 1, _>::from_size_val(image_size, 0u8, CpuAllocator)?;
+        let image = Image::<_, 1>::new(image_size, vec![10u8, 20, 30, 40], host_alloc())?;
+        let mut flipped = Image::<_, 1>::from_size_val(image_size, 0u8, host_alloc())?;
         super::horizontal_flip(&image, &mut flipped)?;
         // Columns reversed: [40, 30, 20, 10]
         assert_eq!(flipped.as_slice(), &[40u8, 30, 20, 10]);
@@ -463,8 +463,8 @@ mod tests {
             width: 1,
             height: 4,
         };
-        let image = Image::<_, 1, _>::new(image_size, vec![10u8, 20, 30, 40], CpuAllocator)?;
-        let mut flipped = Image::<_, 1, _>::from_size_val(image_size, 0u8, CpuAllocator)?;
+        let image = Image::<_, 1>::new(image_size, vec![10u8, 20, 30, 40], host_alloc())?;
+        let mut flipped = Image::<_, 1>::from_size_val(image_size, 0u8, host_alloc())?;
         super::vertical_flip(&image, &mut flipped)?;
         // Rows reversed: [40, 30, 20, 10]
         assert_eq!(flipped.as_slice(), &[40u8, 30, 20, 10]);

--- a/crates/kornia-imgproc/src/histogram.rs
+++ b/crates/kornia-imgproc/src/histogram.rs
@@ -1,4 +1,4 @@
-use kornia_image::{allocator::ImageAllocator, Image, ImageError};
+use kornia_image::{Image, ImageError};
 use rayon::prelude::*;
 
 /// Compute the pixel intensity histogram of an image.
@@ -23,16 +23,16 @@ use rayon::prelude::*;
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::histogram::compute_histogram;
 ///
-/// let image = Image::<u8, 1, _>::new(
+/// let image = Image::<u8, 1>::new(
 ///   ImageSize {
 ///     width: 3,
 ///     height: 3,
 ///   },
 ///   vec![0, 2, 4, 128, 130, 132, 254, 255, 255],
-///   CpuAllocator
+///   host_alloc()
 /// ).unwrap();
 ///
 /// let mut histogram = vec![0; 3];
@@ -40,8 +40,8 @@ use rayon::prelude::*;
 /// compute_histogram(&image, &mut histogram, 3).unwrap();
 /// assert_eq!(histogram, vec![3, 3, 3]);
 /// ```
-pub fn compute_histogram<A: ImageAllocator>(
-    src: &Image<u8, 1, A>,
+pub fn compute_histogram(
+    src: &Image<u8, 1>,
     hist: &mut [usize],
     num_bins: usize,
 ) -> Result<(), ImageError> {
@@ -93,7 +93,7 @@ pub fn compute_histogram<A: ImageAllocator>(
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::CpuAllocator;
+    use kornia_tensor::host_alloc;
     #[test]
     fn test_compute_histogram() -> Result<(), ImageError> {
         let image = Image::new(
@@ -102,7 +102,7 @@ mod tests {
                 height: 3,
             },
             vec![0, 2, 4, 128, 130, 132, 254, 255, 255],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let mut histogram = vec![0; 3];

--- a/crates/kornia-imgproc/src/histogram.rs
+++ b/crates/kornia-imgproc/src/histogram.rs
@@ -23,7 +23,6 @@ use rayon::prelude::*;
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::histogram::compute_histogram;
 ///
 /// let image = Image::<u8, 1>::new(
@@ -32,7 +31,6 @@ use rayon::prelude::*;
 ///     height: 3,
 ///   },
 ///   vec![0, 2, 4, 128, 130, 132, 254, 255, 255],
-///   host_alloc()
 /// ).unwrap();
 ///
 /// let mut histogram = vec![0; 3];
@@ -93,7 +91,7 @@ pub fn compute_histogram(
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::host_alloc;
+
     #[test]
     fn test_compute_histogram() -> Result<(), ImageError> {
         let image = Image::new(
@@ -102,7 +100,6 @@ mod tests {
                 height: 3,
             },
             vec![0, 2, 4, 128, 130, 132, 254, 255, 255],
-            host_alloc(),
         )?;
 
         let mut histogram = vec![0; 3];

--- a/crates/kornia-imgproc/src/interpolation/bilinear.rs
+++ b/crates/kornia-imgproc/src/interpolation/bilinear.rs
@@ -1,4 +1,4 @@
-use kornia_image::{allocator::ImageAllocator, Image};
+use kornia_image::Image;
 
 /// Kernel for bilinear interpolation
 ///
@@ -13,8 +13,8 @@ use kornia_image::{allocator::ImageAllocator, Image};
 ///
 /// The interpolated pixel value.
 // TODO: add support for other data types. Maybe use a trait? or template?
-pub(crate) fn bilinear_interpolation<const C: usize, A: ImageAllocator>(
-    image: &Image<f32, C, A>,
+pub(crate) fn bilinear_interpolation<const C: usize>(
+    image: &Image<f32, C>,
     u: f32,
     v: f32,
     c: usize,

--- a/crates/kornia-imgproc/src/interpolation/grid.rs
+++ b/crates/kornia-imgproc/src/interpolation/grid.rs
@@ -1,4 +1,4 @@
-use kornia_tensor::{CpuAllocator, CpuTensor2, TensorError};
+use kornia_tensor::{host_alloc, CpuTensor2, TensorError};
 use num_traits::Float;
 use rayon::iter::ParallelIterator;
 use rayon::{iter::IndexedParallelIterator, slice::ParallelSliceMut};
@@ -42,8 +42,8 @@ where
     T: Float + Send + Sync,
 {
     // allocate the output tensors
-    let mut map_x = CpuTensor2::<T>::zeros([rows, cols], CpuAllocator);
-    let mut map_y = CpuTensor2::<T>::zeros([rows, cols], CpuAllocator);
+    let mut map_x = CpuTensor2::<T>::zeros([rows, cols], host_alloc());
+    let mut map_y = CpuTensor2::<T>::zeros([rows, cols], host_alloc());
 
     // fill the output tensors
     let chunk_elems = ROWS_PER_TASK * cols;

--- a/crates/kornia-imgproc/src/interpolation/grid.rs
+++ b/crates/kornia-imgproc/src/interpolation/grid.rs
@@ -1,4 +1,4 @@
-use kornia_tensor::{host_alloc, CpuTensor2, TensorError};
+use kornia_tensor::{CpuTensor2, TensorError};
 use num_traits::Float;
 use rayon::iter::ParallelIterator;
 use rayon::{iter::IndexedParallelIterator, slice::ParallelSliceMut};
@@ -42,8 +42,8 @@ where
     T: Float + Send + Sync,
 {
     // allocate the output tensors
-    let mut map_x = CpuTensor2::<T>::zeros([rows, cols], host_alloc());
-    let mut map_y = CpuTensor2::<T>::zeros([rows, cols], host_alloc());
+    let mut map_x = CpuTensor2::<T>::zeros([rows, cols]);
+    let mut map_y = CpuTensor2::<T>::zeros([rows, cols]);
 
     // fill the output tensors
     let chunk_elems = ROWS_PER_TASK * cols;

--- a/crates/kornia-imgproc/src/interpolation/interpolate.rs
+++ b/crates/kornia-imgproc/src/interpolation/interpolate.rs
@@ -1,6 +1,5 @@
 use super::bilinear::bilinear_interpolation;
 use super::nearest::nearest_neighbor_interpolation;
-use kornia_image::allocator::ImageAllocator;
 use kornia_image::{Image, ImageError};
 
 pub use kornia_image::InterpolationMode;
@@ -28,8 +27,8 @@ pub fn validate_interpolation(interpolation: InterpolationMode) -> Result<(), Im
 ///
 /// # Returns
 /// The interpolated pixel value, or an error if the interpolation mode is unsupported.
-pub fn interpolate_pixel<const C: usize, A: ImageAllocator>(
-    image: &Image<f32, C, A>,
+pub fn interpolate_pixel<const C: usize>(
+    image: &Image<f32, C>,
     u: f32,
     v: f32,
     c: usize,
@@ -40,8 +39,8 @@ pub fn interpolate_pixel<const C: usize, A: ImageAllocator>(
 }
 
 /// Fallible-free internal kernel for fast pixel interpolation (must be validated first)
-pub(crate) fn interpolate_pixel_fast<const C: usize, A: ImageAllocator>(
-    image: &Image<f32, C, A>,
+pub(crate) fn interpolate_pixel_fast<const C: usize>(
+    image: &Image<f32, C>,
     u: f32,
     v: f32,
     c: usize,

--- a/crates/kornia-imgproc/src/interpolation/nearest.rs
+++ b/crates/kornia-imgproc/src/interpolation/nearest.rs
@@ -1,4 +1,4 @@
-use kornia_image::{allocator::ImageAllocator, Image};
+use kornia_image::Image;
 
 /// Kernel for nearest neighbor interpolation
 ///
@@ -12,8 +12,8 @@ use kornia_image::{allocator::ImageAllocator, Image};
 /// # Returns
 ///
 /// The interpolated pixel value.
-pub(crate) fn nearest_neighbor_interpolation<const C: usize, A: ImageAllocator>(
-    image: &Image<f32, C, A>,
+pub(crate) fn nearest_neighbor_interpolation<const C: usize>(
+    image: &Image<f32, C>,
     u: f32,
     v: f32,
     c: usize,

--- a/crates/kornia-imgproc/src/interpolation/remap.rs
+++ b/crates/kornia-imgproc/src/interpolation/remap.rs
@@ -2,8 +2,8 @@ use crate::parallel;
 
 use super::interpolate::{interpolate_pixel_fast, validate_interpolation};
 use super::InterpolationMode;
-use kornia_image::{allocator::ImageAllocator, Image, ImageError};
-use kornia_tensor::{CpuAllocator, Tensor2};
+use kornia_image::{Image, ImageError};
+use kornia_tensor::Tensor2;
 
 /// Apply generic geometric transformation to an image.
 ///
@@ -19,11 +19,11 @@ use kornia_tensor::{CpuAllocator, Tensor2};
 ///
 /// * The mapx and mapy must have the same size.
 /// * The output image must have the same size as the mapx and mapy.
-pub fn remap<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<f32, C, A1>,
-    dst: &mut Image<f32, C, A2>,
-    map_x: &Tensor2<f32, CpuAllocator>,
-    map_y: &Tensor2<f32, CpuAllocator>,
+pub fn remap<const C: usize>(
+    src: &Image<f32, C>,
+    dst: &mut Image<f32, C>,
+    map_x: &Tensor2<f32>,
+    map_y: &Tensor2<f32>,
     interpolation: InterpolationMode,
 ) -> Result<(), ImageError> {
     if map_x.shape != map_y.shape {
@@ -60,27 +60,27 @@ pub fn remap<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::{CpuAllocator, Tensor2};
+    use kornia_tensor::{host_alloc, Tensor2};
 
     #[test]
     fn remap_unsupported_interpolation() -> Result<(), ImageError> {
-        let image = Image::<_, 1, _>::new(
+        let image = Image::<_, 1>::new(
             ImageSize {
                 width: 2,
                 height: 2,
             },
             vec![0f32; 4],
-            CpuAllocator,
+            host_alloc(),
         )?;
-        let map_x = Tensor2::from_shape_vec([2, 2], vec![0.0, 1.0, 0.0, 1.0], CpuAllocator)?;
-        let map_y = Tensor2::from_shape_vec([2, 2], vec![0.0, 0.0, 1.0, 1.0], CpuAllocator)?;
-        let mut dst = Image::<_, 1, _>::from_size_val(
+        let map_x = Tensor2::from_shape_vec([2, 2], vec![0.0, 1.0, 0.0, 1.0], host_alloc())?;
+        let map_y = Tensor2::from_shape_vec([2, 2], vec![0.0, 0.0, 1.0, 1.0], host_alloc())?;
+        let mut dst = Image::<_, 1>::from_size_val(
             ImageSize {
                 width: 2,
                 height: 2,
             },
             0.0,
-            CpuAllocator,
+            host_alloc(),
         )?;
         let err = super::remap(
             &image,
@@ -95,31 +95,31 @@ mod tests {
 
     #[test]
     fn remap_smoke() -> Result<(), ImageError> {
-        let image = Image::<_, 1, _>::new(
+        let image = Image::<_, 1>::new(
             ImageSize {
                 width: 3,
                 height: 3,
             },
             vec![0f32, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let new_size = [2, 2];
 
-        let map_x = Tensor2::from_shape_vec(new_size, vec![0.0, 2.0, 0.0, 2.0], CpuAllocator)?;
-        let map_y = Tensor2::from_shape_vec(new_size, vec![0.0, 0.0, 2.0, 2.0], CpuAllocator)?;
+        let map_x = Tensor2::from_shape_vec(new_size, vec![0.0, 2.0, 0.0, 2.0], host_alloc())?;
+        let map_y = Tensor2::from_shape_vec(new_size, vec![0.0, 0.0, 2.0, 2.0], host_alloc())?;
 
-        let expected = Image::<_, 1, _>::new(
+        let expected = Image::<_, 1>::new(
             ImageSize {
                 width: 2,
                 height: 2,
             },
             vec![0.0, 2.0, 6.0, 8.0],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let mut image_transformed =
-            Image::<_, 1, _>::from_size_val(new_size.into(), 0.0, CpuAllocator)?;
+            Image::<_, 1>::from_size_val(new_size.into(), 0.0, host_alloc())?;
 
         super::remap(
             &image,

--- a/crates/kornia-imgproc/src/interpolation/remap.rs
+++ b/crates/kornia-imgproc/src/interpolation/remap.rs
@@ -60,7 +60,7 @@ pub fn remap<const C: usize>(
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::{host_alloc, Tensor2};
+    use kornia_tensor::Tensor2;
 
     #[test]
     fn remap_unsupported_interpolation() -> Result<(), ImageError> {
@@ -70,17 +70,15 @@ mod tests {
                 height: 2,
             },
             vec![0f32; 4],
-            host_alloc(),
         )?;
-        let map_x = Tensor2::from_shape_vec([2, 2], vec![0.0, 1.0, 0.0, 1.0], host_alloc())?;
-        let map_y = Tensor2::from_shape_vec([2, 2], vec![0.0, 0.0, 1.0, 1.0], host_alloc())?;
+        let map_x = Tensor2::from_shape_vec([2, 2], vec![0.0, 1.0, 0.0, 1.0])?;
+        let map_y = Tensor2::from_shape_vec([2, 2], vec![0.0, 0.0, 1.0, 1.0])?;
         let mut dst = Image::<_, 1>::from_size_val(
             ImageSize {
                 width: 2,
                 height: 2,
             },
             0.0,
-            host_alloc(),
         )?;
         let err = super::remap(
             &image,
@@ -101,13 +99,12 @@ mod tests {
                 height: 3,
             },
             vec![0f32, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
-            host_alloc(),
         )?;
 
         let new_size = [2, 2];
 
-        let map_x = Tensor2::from_shape_vec(new_size, vec![0.0, 2.0, 0.0, 2.0], host_alloc())?;
-        let map_y = Tensor2::from_shape_vec(new_size, vec![0.0, 0.0, 2.0, 2.0], host_alloc())?;
+        let map_x = Tensor2::from_shape_vec(new_size, vec![0.0, 2.0, 0.0, 2.0])?;
+        let map_y = Tensor2::from_shape_vec(new_size, vec![0.0, 0.0, 2.0, 2.0])?;
 
         let expected = Image::<_, 1>::new(
             ImageSize {
@@ -115,11 +112,9 @@ mod tests {
                 height: 2,
             },
             vec![0.0, 2.0, 6.0, 8.0],
-            host_alloc(),
         )?;
 
-        let mut image_transformed =
-            Image::<_, 1>::from_size_val(new_size.into(), 0.0, host_alloc())?;
+        let mut image_transformed = Image::<_, 1>::from_size_val(new_size.into(), 0.0)?;
 
         super::remap(
             &image,

--- a/crates/kornia-imgproc/src/metrics/huber.rs
+++ b/crates/kornia-imgproc/src/metrics/huber.rs
@@ -24,7 +24,6 @@ use kornia_image::{Image, ImageError};
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 ///
 /// let image1 = Image::<f32, 1>::new(
 ///    ImageSize {
@@ -32,7 +31,6 @@ use kornia_image::{Image, ImageError};
 ///      height: 3,
 /// },
 /// vec![0f32, 1f32, 2f32, 3f32, 4f32, 5f32],
-/// host_alloc()
 /// )
 /// .unwrap();
 ///
@@ -42,7 +40,6 @@ use kornia_image::{Image, ImageError};
 ///   height: 3,
 /// },
 /// vec![5f32, 4f32, 3f32, 2f32, 1f32, 0f32],
-/// host_alloc()
 /// )
 /// .unwrap();
 ///
@@ -91,7 +88,6 @@ pub fn huber<const C: usize>(
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_huber() -> Result<(), ImageError> {
@@ -101,7 +97,6 @@ mod tests {
                 height: 3,
             },
             vec![0f32, 1f32, 2f32, 3f32, 4f32, 5f32],
-            host_alloc(),
         )?;
 
         let image2 = Image::<_, 1>::new(
@@ -110,7 +105,6 @@ mod tests {
                 height: 3,
             },
             vec![5f32, 4f32, 3f32, 2f32, 1f32, 0f32],
-            host_alloc(),
         )?;
 
         let huber = super::huber(&image1, &image2, 1.0)?;

--- a/crates/kornia-imgproc/src/metrics/huber.rs
+++ b/crates/kornia-imgproc/src/metrics/huber.rs
@@ -1,4 +1,4 @@
-use kornia_image::{allocator::ImageAllocator, Image, ImageError};
+use kornia_image::{Image, ImageError};
 
 /// Compute the Huber loss between two images.
 ///
@@ -24,25 +24,25 @@ use kornia_image::{allocator::ImageAllocator, Image, ImageError};
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 ///
-/// let image1 = Image::<f32, 1, _>::new(
+/// let image1 = Image::<f32, 1>::new(
 ///    ImageSize {
 ///       width: 2,
 ///      height: 3,
 /// },
 /// vec![0f32, 1f32, 2f32, 3f32, 4f32, 5f32],
-/// CpuAllocator
+/// host_alloc()
 /// )
 /// .unwrap();
 ///
-/// let image2 = Image::<f32, 1, _>::new(
+/// let image2 = Image::<f32, 1>::new(
 ///   ImageSize {
 ///     width: 2,
 ///   height: 3,
 /// },
 /// vec![5f32, 4f32, 3f32, 2f32, 1f32, 0f32],
-/// CpuAllocator
+/// host_alloc()
 /// )
 /// .unwrap();
 ///
@@ -57,9 +57,9 @@ use kornia_image::{allocator::ImageAllocator, Image, ImageError};
 /// # References
 ///
 /// [Wikipedia - Huber loss](https://en.wikipedia.org/wiki/Huber_loss)
-pub fn huber<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    image1: &Image<f32, C, A1>,
-    image2: &Image<f32, C, A2>,
+pub fn huber<const C: usize>(
+    image1: &Image<f32, C>,
+    image2: &Image<f32, C>,
     delta: f32,
 ) -> Result<f32, ImageError> {
     if image1.size() != image2.size() {
@@ -91,26 +91,26 @@ pub fn huber<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::CpuAllocator;
+    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_huber() -> Result<(), ImageError> {
-        let image1 = Image::<_, 1, _>::new(
+        let image1 = Image::<_, 1>::new(
             ImageSize {
                 width: 2,
                 height: 3,
             },
             vec![0f32, 1f32, 2f32, 3f32, 4f32, 5f32],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let image2 = Image::<_, 1, _>::new(
+        let image2 = Image::<_, 1>::new(
             ImageSize {
                 width: 2,
                 height: 3,
             },
             vec![5f32, 4f32, 3f32, 2f32, 1f32, 0f32],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let huber = super::huber(&image1, &image2, 1.0)?;

--- a/crates/kornia-imgproc/src/metrics/l1.rs
+++ b/crates/kornia-imgproc/src/metrics/l1.rs
@@ -1,4 +1,4 @@
-use kornia_image::{allocator::ImageAllocator, Image, ImageError};
+use kornia_image::{Image, ImageError};
 
 /// Compute the L1 loss between two images.
 ///
@@ -23,26 +23,26 @@ use kornia_image::{allocator::ImageAllocator, Image, ImageError};
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::metrics::l1_loss;
 ///
-/// let image1 = Image::<f32, 1, _>::new(
+/// let image1 = Image::<f32, 1>::new(
 ///   ImageSize {
 ///    width: 2,
 ///    height: 3,
 ///   },
 ///   vec![0f32, 1f32, 2f32, 3f32, 4f32, 5f32],
-///   CpuAllocator
+///   host_alloc()
 /// )
 /// .unwrap();
 ///
-/// let image2 = Image::<f32, 1, _>::new(
+/// let image2 = Image::<f32, 1>::new(
 ///   ImageSize {
 ///     width: 2,
 ///     height: 3,
 ///   },
 ///   vec![5f32, 4f32, 3f32, 2f32, 1f32, 0f32],
-///   CpuAllocator
+///   host_alloc()
 /// )
 /// .unwrap();
 ///
@@ -57,9 +57,9 @@ use kornia_image::{allocator::ImageAllocator, Image, ImageError};
 /// # References
 ///
 /// [Wikipedia - L1 loss](https://en.wikipedia.org/wiki/Huber_loss)
-pub fn l1_loss<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    image1: &Image<f32, C, A1>,
-    image2: &Image<f32, C, A2>,
+pub fn l1_loss<const C: usize>(
+    image1: &Image<f32, C>,
+    image2: &Image<f32, C>,
 ) -> Result<f32, ImageError> {
     if image1.size() != image2.size() {
         return Err(ImageError::InvalidImageSize(
@@ -82,26 +82,26 @@ pub fn l1_loss<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::CpuAllocator;
+    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_l1_loss() -> Result<(), ImageError> {
-        let image1 = Image::<_, 1, _>::new(
+        let image1 = Image::<_, 1>::new(
             ImageSize {
                 width: 2,
                 height: 3,
             },
             vec![0f32, 1f32, 2f32, 3f32, 4f32, 5f32],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let image2 = Image::<_, 1, _>::new(
+        let image2 = Image::<_, 1>::new(
             ImageSize {
                 width: 2,
                 height: 3,
             },
             vec![5f32, 4f32, 3f32, 2f32, 1f32, 0f32],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let l1_loss = crate::metrics::l1_loss(&image1, &image2)?;

--- a/crates/kornia-imgproc/src/metrics/l1.rs
+++ b/crates/kornia-imgproc/src/metrics/l1.rs
@@ -23,7 +23,6 @@ use kornia_image::{Image, ImageError};
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::metrics::l1_loss;
 ///
 /// let image1 = Image::<f32, 1>::new(
@@ -32,7 +31,6 @@ use kornia_image::{Image, ImageError};
 ///    height: 3,
 ///   },
 ///   vec![0f32, 1f32, 2f32, 3f32, 4f32, 5f32],
-///   host_alloc()
 /// )
 /// .unwrap();
 ///
@@ -42,7 +40,6 @@ use kornia_image::{Image, ImageError};
 ///     height: 3,
 ///   },
 ///   vec![5f32, 4f32, 3f32, 2f32, 1f32, 0f32],
-///   host_alloc()
 /// )
 /// .unwrap();
 ///
@@ -82,7 +79,6 @@ pub fn l1_loss<const C: usize>(
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_l1_loss() -> Result<(), ImageError> {
@@ -92,7 +88,6 @@ mod tests {
                 height: 3,
             },
             vec![0f32, 1f32, 2f32, 3f32, 4f32, 5f32],
-            host_alloc(),
         )?;
 
         let image2 = Image::<_, 1>::new(
@@ -101,7 +96,6 @@ mod tests {
                 height: 3,
             },
             vec![5f32, 4f32, 3f32, 2f32, 1f32, 0f32],
-            host_alloc(),
         )?;
 
         let l1_loss = crate::metrics::l1_loss(&image1, &image2)?;

--- a/crates/kornia-imgproc/src/metrics/mse.rs
+++ b/crates/kornia-imgproc/src/metrics/mse.rs
@@ -1,4 +1,4 @@
-use kornia_image::{allocator::ImageAllocator, Image, ImageError};
+use kornia_image::{Image, ImageError};
 
 /// Compute the mean squared error (MSE) between two images.
 ///
@@ -21,26 +21,26 @@ use kornia_image::{allocator::ImageAllocator, Image, ImageError};
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::metrics::mse;
 ///
-/// let image1 = Image::<f32, 1, _>::new(
+/// let image1 = Image::<f32, 1>::new(
 ///    ImageSize {
 ///      width: 2,
 ///      height: 3,
 ///    },
 ///    vec![0f32, 1f32, 2f32, 3f32, 4f32, 5f32],
-///    CpuAllocator
+///    host_alloc()
 /// )
 /// .unwrap();
 ///
-/// let image2 = Image::<f32, 1, _>::new(
+/// let image2 = Image::<f32, 1>::new(
 ///    ImageSize {
 ///      width: 2,
 ///      height: 3,
 ///    },
 ///    vec![0f32, 1f32, 2f32, 3f32, 4f32, 5f32],
-///    CpuAllocator
+///    host_alloc()
 /// )
 /// .unwrap();
 ///
@@ -51,9 +51,9 @@ use kornia_image::{allocator::ImageAllocator, Image, ImageError};
 /// # Panics
 ///
 /// Panics if the two images have different shapes.
-pub fn mse<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    image1: &Image<f32, C, A1>,
-    image2: &Image<f32, C, A2>,
+pub fn mse<const C: usize>(
+    image1: &Image<f32, C>,
+    image2: &Image<f32, C>,
 ) -> Result<f32, ImageError> {
     if image1.size() != image2.size() {
         return Err(ImageError::InvalidImageSize(
@@ -95,26 +95,26 @@ pub fn mse<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
 /// # Example
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::metrics::psnr;
 ///
-/// let image1 = Image::<f32, 3, _>::new(
+/// let image1 = Image::<f32, 3>::new(
 ///   ImageSize {
 ///     width: 1,
 ///     height: 2,
 ///   },
 ///   vec![0f32, 1f32, 2f32, 3f32, 4f32, 5f32],
-///   CpuAllocator
+///   host_alloc()
 /// )
 /// .unwrap();
 ///
-/// let image2 = Image::<f32, 3, _>::new(
+/// let image2 = Image::<f32, 3>::new(
 ///   ImageSize {
 ///     width: 1,
 ///     height: 2,
 ///   },
 ///   vec![1f32, 3f32, 2f32, 4f32, 5f32, 6f32],
-///   CpuAllocator
+///   host_alloc()
 /// )
 /// .unwrap();
 ///
@@ -134,9 +134,9 @@ pub fn mse<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
 /// The PSNR is used to measure the quality of a reconstructed image. The higher the PSNR, the better the quality of the reconstructed image.
 /// The PSNR is widely used in image and video compression.
 /// Underneath, the PSNR is based on the mean squared error [mse].
-pub fn psnr<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    image1: &Image<f32, C, A1>,
-    image2: &Image<f32, C, A2>,
+pub fn psnr<const C: usize>(
+    image1: &Image<f32, C>,
+    image2: &Image<f32, C>,
     max_value: f32,
 ) -> Result<f32, ImageError> {
     if image1.size() != image2.size() {
@@ -160,25 +160,25 @@ pub fn psnr<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::CpuAllocator;
+    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_equal() -> Result<(), ImageError> {
-        let image1 = Image::<_, 1, _>::new(
+        let image1 = Image::<_, 1>::new(
             ImageSize {
                 width: 2,
                 height: 3,
             },
             vec![0f32, 1f32, 2f32, 3f32, 4f32, 5f32],
-            CpuAllocator,
+            host_alloc(),
         )?;
-        let image2 = Image::<_, 1, _>::new(
+        let image2 = Image::<_, 1>::new(
             ImageSize {
                 width: 2,
                 height: 3,
             },
             vec![0f32, 1f32, 2f32, 3f32, 4f32, 5f32],
-            CpuAllocator,
+            host_alloc(),
         )?;
         let mse = crate::metrics::mse(&image1, &image2)?;
         assert_eq!(mse, 0f32);
@@ -188,21 +188,21 @@ mod tests {
 
     #[test]
     fn test_not_equal() -> Result<(), ImageError> {
-        let image1 = Image::<_, 1, _>::new(
+        let image1 = Image::<_, 1>::new(
             ImageSize {
                 width: 2,
                 height: 2,
             },
             vec![0f32, 1f32, 2f32, 3f32],
-            CpuAllocator,
+            host_alloc(),
         )?;
-        let image2 = Image::<_, 1, _>::new(
+        let image2 = Image::<_, 1>::new(
             ImageSize {
                 width: 2,
                 height: 2,
             },
             vec![0f32, 3f32, 2f32, 3f32],
-            CpuAllocator,
+            host_alloc(),
         )?;
         let mse = crate::metrics::mse(&image1, &image2)?;
         assert_eq!(mse, 1.0);
@@ -212,21 +212,21 @@ mod tests {
 
     #[test]
     fn test_psnr() -> Result<(), ImageError> {
-        let image1 = Image::<_, 3, _>::new(
+        let image1 = Image::<_, 3>::new(
             ImageSize {
                 width: 1,
                 height: 2,
             },
             vec![0f32, 1f32, 2f32, 3f32, 4f32, 5f32],
-            CpuAllocator,
+            host_alloc(),
         )?;
-        let image2 = Image::<_, 3, _>::new(
+        let image2 = Image::<_, 3>::new(
             ImageSize {
                 width: 1,
                 height: 2,
             },
             vec![1f32, 3f32, 2f32, 4f32, 5f32, 6f32],
-            CpuAllocator,
+            host_alloc(),
         )?;
         let psnr = crate::metrics::psnr(&image1, &image2, 1.0)?;
         assert_eq!(psnr, 320.15698);

--- a/crates/kornia-imgproc/src/metrics/mse.rs
+++ b/crates/kornia-imgproc/src/metrics/mse.rs
@@ -21,7 +21,6 @@ use kornia_image::{Image, ImageError};
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::metrics::mse;
 ///
 /// let image1 = Image::<f32, 1>::new(
@@ -30,7 +29,6 @@ use kornia_image::{Image, ImageError};
 ///      height: 3,
 ///    },
 ///    vec![0f32, 1f32, 2f32, 3f32, 4f32, 5f32],
-///    host_alloc()
 /// )
 /// .unwrap();
 ///
@@ -40,7 +38,6 @@ use kornia_image::{Image, ImageError};
 ///      height: 3,
 ///    },
 ///    vec![0f32, 1f32, 2f32, 3f32, 4f32, 5f32],
-///    host_alloc()
 /// )
 /// .unwrap();
 ///
@@ -95,7 +92,6 @@ pub fn mse<const C: usize>(
 /// # Example
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::metrics::psnr;
 ///
 /// let image1 = Image::<f32, 3>::new(
@@ -104,7 +100,6 @@ pub fn mse<const C: usize>(
 ///     height: 2,
 ///   },
 ///   vec![0f32, 1f32, 2f32, 3f32, 4f32, 5f32],
-///   host_alloc()
 /// )
 /// .unwrap();
 ///
@@ -114,7 +109,6 @@ pub fn mse<const C: usize>(
 ///     height: 2,
 ///   },
 ///   vec![1f32, 3f32, 2f32, 4f32, 5f32, 6f32],
-///   host_alloc()
 /// )
 /// .unwrap();
 ///
@@ -160,7 +154,6 @@ pub fn psnr<const C: usize>(
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_equal() -> Result<(), ImageError> {
@@ -170,7 +163,6 @@ mod tests {
                 height: 3,
             },
             vec![0f32, 1f32, 2f32, 3f32, 4f32, 5f32],
-            host_alloc(),
         )?;
         let image2 = Image::<_, 1>::new(
             ImageSize {
@@ -178,7 +170,6 @@ mod tests {
                 height: 3,
             },
             vec![0f32, 1f32, 2f32, 3f32, 4f32, 5f32],
-            host_alloc(),
         )?;
         let mse = crate::metrics::mse(&image1, &image2)?;
         assert_eq!(mse, 0f32);
@@ -194,7 +185,6 @@ mod tests {
                 height: 2,
             },
             vec![0f32, 1f32, 2f32, 3f32],
-            host_alloc(),
         )?;
         let image2 = Image::<_, 1>::new(
             ImageSize {
@@ -202,7 +192,6 @@ mod tests {
                 height: 2,
             },
             vec![0f32, 3f32, 2f32, 3f32],
-            host_alloc(),
         )?;
         let mse = crate::metrics::mse(&image1, &image2)?;
         assert_eq!(mse, 1.0);
@@ -218,7 +207,6 @@ mod tests {
                 height: 2,
             },
             vec![0f32, 1f32, 2f32, 3f32, 4f32, 5f32],
-            host_alloc(),
         )?;
         let image2 = Image::<_, 3>::new(
             ImageSize {
@@ -226,7 +214,6 @@ mod tests {
                 height: 2,
             },
             vec![1f32, 3f32, 2f32, 4f32, 5f32, 6f32],
-            host_alloc(),
         )?;
         let psnr = crate::metrics::psnr(&image1, &image2, 1.0)?;
         assert_eq!(psnr, 320.15698);

--- a/crates/kornia-imgproc/src/morphology/ops.rs
+++ b/crates/kornia-imgproc/src/morphology/ops.rs
@@ -1,7 +1,7 @@
 use super::kernels::Kernel;
 use crate::padding::{spatial_padding, Padding2D, PaddingMode};
-use kornia_image::{allocator::ImageAllocator, Image, ImageError, ImageSize};
-use kornia_tensor::CpuAllocator;
+use kornia_image::{Image, ImageError, ImageSize};
+use kornia_tensor::host_alloc;
 use rayon::prelude::*;
 
 /// Dilate an image using a [`Kernel`].
@@ -20,14 +20,9 @@ use rayon::prelude::*;
 /// # Returns
 ///
 /// Ok(()) on success, or [`ImageError`] if shapes don't match.
-pub fn dilate<
-    T: Copy + Default + Send + Sync + Ord,
-    const C: usize,
-    A1: ImageAllocator,
-    A2: ImageAllocator,
->(
-    src: &Image<T, C, A1>,
-    dst: &mut Image<T, C, A2>,
+pub fn dilate<T: Copy + Default + Send + Sync + Ord, const C: usize>(
+    src: &Image<T, C>,
+    dst: &mut Image<T, C>,
     kernel: &Kernel,
     padding_mode: PaddingMode,
     constant_value: [T; C],
@@ -53,7 +48,7 @@ pub fn dilate<
         height: height + 2 * pad_h,
     };
     let padded_buffer = vec![T::default(); padded_size.width * padded_size.height * C];
-    let mut padded = Image::new(padded_size, padded_buffer, CpuAllocator)?;
+    let mut padded = Image::new(padded_size, padded_buffer, host_alloc())?;
 
     let padding = Padding2D {
         top: pad_h,
@@ -112,14 +107,9 @@ pub fn dilate<
 /// # Returns
 ///
 /// Ok(()) on success, or [`ImageError`] if shapes don't match.
-pub fn erode<
-    T: Copy + Default + Send + Sync + Ord,
-    const C: usize,
-    A1: ImageAllocator,
-    A2: ImageAllocator,
->(
-    src: &Image<T, C, A1>,
-    dst: &mut Image<T, C, A2>,
+pub fn erode<T: Copy + Default + Send + Sync + Ord, const C: usize>(
+    src: &Image<T, C>,
+    dst: &mut Image<T, C>,
     kernel: &Kernel,
     padding_mode: PaddingMode,
     constant_value: [T; C],
@@ -145,7 +135,7 @@ pub fn erode<
         height: height + 2 * pad_h,
     };
     let padded_buffer = vec![T::default(); padded_size.width * padded_size.height * C];
-    let mut padded = Image::new(padded_size, padded_buffer, CpuAllocator)?;
+    let mut padded = Image::new(padded_size, padded_buffer, host_alloc())?;
 
     let padding = Padding2D {
         top: pad_h,
@@ -206,19 +196,14 @@ pub fn erode<
 /// # Returns
 ///
 /// Ok(()) on success, or [`ImageError`] if shapes don't match.
-pub fn open<
-    T: Copy + Default + Send + Sync + Ord,
-    const C: usize,
-    A1: ImageAllocator,
-    A2: ImageAllocator,
->(
-    src: &Image<T, C, A1>,
-    dst: &mut Image<T, C, A2>,
+pub fn open<T: Copy + Default + Send + Sync + Ord, const C: usize>(
+    src: &Image<T, C>,
+    dst: &mut Image<T, C>,
     kernel: &Kernel,
     padding_mode: PaddingMode,
     constant_value: [T; C],
 ) -> Result<(), ImageError> {
-    let mut temp_img = Image::from_size_val(src.size(), T::default(), CpuAllocator)?;
+    let mut temp_img = Image::from_size_val(src.size(), T::default(), host_alloc())?;
     erode(src, &mut temp_img, kernel, padding_mode, constant_value)?;
     dilate(&temp_img, dst, kernel, padding_mode, constant_value)?;
     Ok(())
@@ -239,19 +224,14 @@ pub fn open<
 /// # Returns
 ///
 /// Ok(()) on success, or [`ImageError`] if shapes don't match.
-pub fn close<
-    T: Copy + Default + Send + Sync + Ord,
-    const C: usize,
-    A1: ImageAllocator,
-    A2: ImageAllocator,
->(
-    src: &Image<T, C, A1>,
-    dst: &mut Image<T, C, A2>,
+pub fn close<T: Copy + Default + Send + Sync + Ord, const C: usize>(
+    src: &Image<T, C>,
+    dst: &mut Image<T, C>,
     kernel: &Kernel,
     padding_mode: PaddingMode,
     constant_value: [T; C],
 ) -> Result<(), ImageError> {
-    let mut temp_img = Image::from_size_val(src.size(), T::default(), CpuAllocator)?;
+    let mut temp_img = Image::from_size_val(src.size(), T::default(), host_alloc())?;
     dilate(src, &mut temp_img, kernel, padding_mode, constant_value)?;
     erode(&temp_img, dst, kernel, padding_mode, constant_value)?;
     Ok(())
@@ -312,8 +292,8 @@ mod tests {
             height: 3,
         };
         let data = vec![0u8, 0, 0, 0, 255, 0, 0, 0, 0];
-        let src = Image::new(size, data, CpuAllocator)?;
-        let mut dst = Image::new(size, vec![0u8; 9], CpuAllocator)?;
+        let src = Image::new(size, data, host_alloc())?;
+        let mut dst = Image::new(size, vec![0u8; 9], host_alloc())?;
 
         let kernel = Kernel::new(KernelShape::Box { size: 3 });
         dilate(&src, &mut dst, &kernel, PaddingMode::Constant, [0])?;
@@ -332,8 +312,8 @@ mod tests {
             width: 3,
             height: 3,
         };
-        let src = Image::new(size, vec![255u8; 9], CpuAllocator)?;
-        let mut dst = Image::new(size, vec![0u8; 9], CpuAllocator)?;
+        let src = Image::new(size, vec![255u8; 9], host_alloc())?;
+        let mut dst = Image::new(size, vec![0u8; 9], host_alloc())?;
 
         let kernel = Kernel::new(KernelShape::Box { size: 3 });
         erode(&src, &mut dst, &kernel, PaddingMode::Constant, [0])?;
@@ -356,8 +336,8 @@ mod tests {
         let mut data = vec![0u8; 25];
         data[6] = 255;
 
-        let src = Image::new(size, data, CpuAllocator)?;
-        let mut dst = Image::new(size, vec![0u8; 25], CpuAllocator)?;
+        let src = Image::new(size, data, host_alloc())?;
+        let mut dst = Image::new(size, vec![0u8; 25], host_alloc())?;
 
         let kernel = Kernel::new(KernelShape::Box { size: 3 });
         open(&src, &mut dst, &kernel, PaddingMode::Constant, [0])?;
@@ -384,8 +364,8 @@ mod tests {
         }
         data[12] = 0;
 
-        let src = Image::new(size, data, CpuAllocator)?;
-        let mut dst = Image::new(size, vec![0u8; 25], CpuAllocator)?;
+        let src = Image::new(size, data, host_alloc())?;
+        let mut dst = Image::new(size, vec![0u8; 25], host_alloc())?;
 
         let kernel = Kernel::new(KernelShape::Box { size: 3 });
         close(&src, &mut dst, &kernel, PaddingMode::Constant, [0])?;

--- a/crates/kornia-imgproc/src/morphology/ops.rs
+++ b/crates/kornia-imgproc/src/morphology/ops.rs
@@ -1,7 +1,6 @@
 use super::kernels::Kernel;
 use crate::padding::{spatial_padding, Padding2D, PaddingMode};
 use kornia_image::{Image, ImageError, ImageSize};
-use kornia_tensor::host_alloc;
 use rayon::prelude::*;
 
 /// Dilate an image using a [`Kernel`].
@@ -48,7 +47,7 @@ pub fn dilate<T: Copy + Default + Send + Sync + Ord, const C: usize>(
         height: height + 2 * pad_h,
     };
     let padded_buffer = vec![T::default(); padded_size.width * padded_size.height * C];
-    let mut padded = Image::new(padded_size, padded_buffer, host_alloc())?;
+    let mut padded = Image::new(padded_size, padded_buffer)?;
 
     let padding = Padding2D {
         top: pad_h,
@@ -135,7 +134,7 @@ pub fn erode<T: Copy + Default + Send + Sync + Ord, const C: usize>(
         height: height + 2 * pad_h,
     };
     let padded_buffer = vec![T::default(); padded_size.width * padded_size.height * C];
-    let mut padded = Image::new(padded_size, padded_buffer, host_alloc())?;
+    let mut padded = Image::new(padded_size, padded_buffer)?;
 
     let padding = Padding2D {
         top: pad_h,
@@ -203,7 +202,7 @@ pub fn open<T: Copy + Default + Send + Sync + Ord, const C: usize>(
     padding_mode: PaddingMode,
     constant_value: [T; C],
 ) -> Result<(), ImageError> {
-    let mut temp_img = Image::from_size_val(src.size(), T::default(), host_alloc())?;
+    let mut temp_img = Image::from_size_val(src.size(), T::default())?;
     erode(src, &mut temp_img, kernel, padding_mode, constant_value)?;
     dilate(&temp_img, dst, kernel, padding_mode, constant_value)?;
     Ok(())
@@ -231,7 +230,7 @@ pub fn close<T: Copy + Default + Send + Sync + Ord, const C: usize>(
     padding_mode: PaddingMode,
     constant_value: [T; C],
 ) -> Result<(), ImageError> {
-    let mut temp_img = Image::from_size_val(src.size(), T::default(), host_alloc())?;
+    let mut temp_img = Image::from_size_val(src.size(), T::default())?;
     dilate(src, &mut temp_img, kernel, padding_mode, constant_value)?;
     erode(&temp_img, dst, kernel, padding_mode, constant_value)?;
     Ok(())
@@ -292,8 +291,8 @@ mod tests {
             height: 3,
         };
         let data = vec![0u8, 0, 0, 0, 255, 0, 0, 0, 0];
-        let src = Image::new(size, data, host_alloc())?;
-        let mut dst = Image::new(size, vec![0u8; 9], host_alloc())?;
+        let src = Image::new(size, data)?;
+        let mut dst = Image::new(size, vec![0u8; 9])?;
 
         let kernel = Kernel::new(KernelShape::Box { size: 3 });
         dilate(&src, &mut dst, &kernel, PaddingMode::Constant, [0])?;
@@ -312,8 +311,8 @@ mod tests {
             width: 3,
             height: 3,
         };
-        let src = Image::new(size, vec![255u8; 9], host_alloc())?;
-        let mut dst = Image::new(size, vec![0u8; 9], host_alloc())?;
+        let src = Image::new(size, vec![255u8; 9])?;
+        let mut dst = Image::new(size, vec![0u8; 9])?;
 
         let kernel = Kernel::new(KernelShape::Box { size: 3 });
         erode(&src, &mut dst, &kernel, PaddingMode::Constant, [0])?;
@@ -336,8 +335,8 @@ mod tests {
         let mut data = vec![0u8; 25];
         data[6] = 255;
 
-        let src = Image::new(size, data, host_alloc())?;
-        let mut dst = Image::new(size, vec![0u8; 25], host_alloc())?;
+        let src = Image::new(size, data)?;
+        let mut dst = Image::new(size, vec![0u8; 25])?;
 
         let kernel = Kernel::new(KernelShape::Box { size: 3 });
         open(&src, &mut dst, &kernel, PaddingMode::Constant, [0])?;
@@ -364,8 +363,8 @@ mod tests {
         }
         data[12] = 0;
 
-        let src = Image::new(size, data, host_alloc())?;
-        let mut dst = Image::new(size, vec![0u8; 25], host_alloc())?;
+        let src = Image::new(size, data)?;
+        let mut dst = Image::new(size, vec![0u8; 25])?;
 
         let kernel = Kernel::new(KernelShape::Box { size: 3 });
         close(&src, &mut dst, &kernel, PaddingMode::Constant, [0])?;

--- a/crates/kornia-imgproc/src/normalize.rs
+++ b/crates/kornia-imgproc/src/normalize.rs
@@ -27,7 +27,6 @@ use crate::parallel;
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::normalize::normalize_mean_std;
 ///
 /// let image_data = vec![0f32, 1.0, 0.0, 1.0, 2.0, 3.0, 0.0, 1.0, 0.0, 1.0, 2.0, 3.0];
@@ -37,11 +36,10 @@ use crate::parallel;
 ///     height: 2,
 ///   },
 ///   image_data,
-///   host_alloc()
 /// )
 /// .unwrap();
 ///
-/// let mut image_normalized = Image::<f32, 3>::from_size_val(image.size(), 0.0, host_alloc()).unwrap();
+/// let mut image_normalized = Image::<f32, 3>::from_size_val(image.size(), 0.0).unwrap();
 ///
 /// normalize_mean_std(
 ///     &image,
@@ -106,7 +104,6 @@ where
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::normalize::find_min_max;
 ///
 /// let image_data = vec![0u8, 1, 0, 1, 2, 3, 0, 1, 0, 1, 2, 3];
@@ -116,7 +113,6 @@ where
 ///     height: 2,
 ///   },
 ///   image_data,
-///   host_alloc()
 /// )
 /// .unwrap();
 ///
@@ -172,7 +168,6 @@ where
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::normalize::normalize_min_max;
 ///
 /// let image_data = vec![0.0f32, 1.0, 0.0, 1.0, 2.0, 3.0, 0.0, 1.0, 0.0, 1.0, 2.0, 3.0];
@@ -182,11 +177,10 @@ where
 ///     height: 2,
 ///   },
 ///   image_data,
-///   host_alloc()
 /// )
 /// .unwrap();
 ///
-/// let mut image_normalized = Image::<f32, 3>::from_size_val(image.size(), 0.0, host_alloc()).unwrap();
+/// let mut image_normalized = Image::<f32, 3>::from_size_val(image.size(), 0.0).unwrap();
 ///
 /// normalize_min_max(&image, &mut image_normalized, 0.0, 1.0).unwrap();
 ///
@@ -428,7 +422,6 @@ fn normalize_rgb_u8_scalar(
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::host_alloc;
 
     #[test]
     fn normalize_mean_std() -> Result<(), ImageError> {
@@ -446,13 +439,12 @@ mod tests {
                 height: 2,
             },
             image_data,
-            host_alloc(),
         )?;
 
         let mean = [0.5, 1.0, 0.5];
         let std = [1.0, 1.0, 1.0];
 
-        let mut normalized = Image::<f32, 3>::from_size_val(image.size(), 0.0, host_alloc())?;
+        let mut normalized = Image::<f32, 3>::from_size_val(image.size(), 0.0)?;
 
         super::normalize_mean_std(&image, &mut normalized, &mean, &std)?;
 
@@ -480,7 +472,6 @@ mod tests {
                 height: 2,
             },
             image_data,
-            host_alloc(),
         )?;
 
         let (min, max) = super::find_min_max(&image)?;
@@ -508,10 +499,9 @@ mod tests {
                 height: 2,
             },
             image_data,
-            host_alloc(),
         )?;
 
-        let mut normalized = Image::<f32, 3>::from_size_val(image.size(), 0.0, host_alloc())?;
+        let mut normalized = Image::<f32, 3>::from_size_val(image.size(), 0.0)?;
 
         super::normalize_min_max(&image, &mut normalized, 0.0, 1.0)?;
 

--- a/crates/kornia-imgproc/src/normalize.rs
+++ b/crates/kornia-imgproc/src/normalize.rs
@@ -1,6 +1,6 @@
 use num_traits::Float;
 
-use kornia_image::{allocator::ImageAllocator, Image, ImageError};
+use kornia_image::{Image, ImageError};
 
 use crate::parallel;
 
@@ -27,21 +27,21 @@ use crate::parallel;
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::normalize::normalize_mean_std;
 ///
 /// let image_data = vec![0f32, 1.0, 0.0, 1.0, 2.0, 3.0, 0.0, 1.0, 0.0, 1.0, 2.0, 3.0];
-/// let image = Image::<f32, 3, _>::new(
+/// let image = Image::<f32, 3>::new(
 ///   ImageSize {
 ///     width: 2,
 ///     height: 2,
 ///   },
 ///   image_data,
-///   CpuAllocator
+///   host_alloc()
 /// )
 /// .unwrap();
 ///
-/// let mut image_normalized = Image::<f32, 3, _>::from_size_val(image.size(), 0.0, CpuAllocator).unwrap();
+/// let mut image_normalized = Image::<f32, 3>::from_size_val(image.size(), 0.0, host_alloc()).unwrap();
 ///
 /// normalize_mean_std(
 ///     &image,
@@ -55,9 +55,9 @@ use crate::parallel;
 /// assert_eq!(image_normalized.size().width, 2);
 /// assert_eq!(image_normalized.size().height, 2);
 /// ```
-pub fn normalize_mean_std<T, const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<T, C, A1>,
-    dst: &mut Image<T, C, A2>,
+pub fn normalize_mean_std<T, const C: usize>(
+    src: &Image<T, C>,
+    dst: &mut Image<T, C>,
     mean: &[T; C],
     std: &[T; C],
 ) -> Result<(), ImageError>
@@ -106,17 +106,17 @@ where
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::normalize::find_min_max;
 ///
 /// let image_data = vec![0u8, 1, 0, 1, 2, 3, 0, 1, 0, 1, 2, 3];
-/// let image = Image::<u8, 3, _>::new(
+/// let image = Image::<u8, 3>::new(
 ///   ImageSize {
 ///     width: 2,
 ///     height: 2,
 ///   },
 ///   image_data,
-///   CpuAllocator
+///   host_alloc()
 /// )
 /// .unwrap();
 ///
@@ -124,9 +124,7 @@ where
 /// assert_eq!(min, 0);
 /// assert_eq!(max, 3);
 /// ```
-pub fn find_min_max<T, const C: usize, A: ImageAllocator>(
-    image: &Image<T, C, A>,
-) -> Result<(T, T), ImageError>
+pub fn find_min_max<T, const C: usize>(image: &Image<T, C>) -> Result<(T, T), ImageError>
 where
     T: Clone + Copy + PartialOrd,
 {
@@ -174,21 +172,21 @@ where
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::normalize::normalize_min_max;
 ///
 /// let image_data = vec![0.0f32, 1.0, 0.0, 1.0, 2.0, 3.0, 0.0, 1.0, 0.0, 1.0, 2.0, 3.0];
-/// let image = Image::<f32, 3, _>::new(
+/// let image = Image::<f32, 3>::new(
 ///   ImageSize {
 ///     width: 2,
 ///     height: 2,
 ///   },
 ///   image_data,
-///   CpuAllocator
+///   host_alloc()
 /// )
 /// .unwrap();
 ///
-/// let mut image_normalized = Image::<f32, 3, _>::from_size_val(image.size(), 0.0, CpuAllocator).unwrap();
+/// let mut image_normalized = Image::<f32, 3>::from_size_val(image.size(), 0.0, host_alloc()).unwrap();
 ///
 /// normalize_min_max(&image, &mut image_normalized, 0.0, 1.0).unwrap();
 ///
@@ -196,9 +194,9 @@ where
 /// assert_eq!(image_normalized.size().width, 2);
 /// assert_eq!(image_normalized.size().height, 2);
 /// ```
-pub fn normalize_min_max<T, const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<T, C, A1>,
-    dst: &mut Image<T, C, A2>,
+pub fn normalize_min_max<T, const C: usize>(
+    src: &Image<T, C>,
+    dst: &mut Image<T, C>,
     min: T,
     max: T,
 ) -> Result<(), ImageError>
@@ -281,44 +279,46 @@ unsafe fn normalize_rgb_u8_neon(
     scale: &[f32; 3],
     offset: &[f32; 3],
 ) {
-    use std::arch::aarch64::*;
-    let bulk = npixels & !7; // 8 pixels per iteration
-    let s0 = vdupq_n_f32(scale[0]);
-    let s1 = vdupq_n_f32(scale[1]);
-    let s2 = vdupq_n_f32(scale[2]);
-    let o0 = vdupq_n_f32(offset[0]);
-    let o1 = vdupq_n_f32(offset[1]);
-    let o2 = vdupq_n_f32(offset[2]);
-    let mut i = 0usize;
-    while i < bulk {
-        // Load 8 RGB pixels (24 bytes), deinterleave into R/G/B vectors
-        let rgb = vld3_u8(src.as_ptr().add(i * 3));
-        // Widen u8→u16→u32→f32, then fma: val * scale + offset
-        let r16 = vmovl_u8(rgb.0);
-        let r_lo = vfmaq_f32(o0, vcvtq_f32_u32(vmovl_u16(vget_low_u16(r16))), s0);
-        let r_hi = vfmaq_f32(o0, vcvtq_f32_u32(vmovl_u16(vget_high_u16(r16))), s0);
-        let g16 = vmovl_u8(rgb.1);
-        let g_lo = vfmaq_f32(o1, vcvtq_f32_u32(vmovl_u16(vget_low_u16(g16))), s1);
-        let g_hi = vfmaq_f32(o1, vcvtq_f32_u32(vmovl_u16(vget_high_u16(g16))), s1);
-        let b16 = vmovl_u8(rgb.2);
-        let b_lo = vfmaq_f32(o2, vcvtq_f32_u32(vmovl_u16(vget_low_u16(b16))), s2);
-        let b_hi = vfmaq_f32(o2, vcvtq_f32_u32(vmovl_u16(vget_high_u16(b16))), s2);
-        // Interleave back to [R,G,B, R,G,B, ...] and store
-        vst3q_f32(dst.as_mut_ptr().add(i * 3), float32x4x3_t(r_lo, g_lo, b_lo));
-        vst3q_f32(
-            dst.as_mut_ptr().add((i + 4) * 3),
-            float32x4x3_t(r_hi, g_hi, b_hi),
-        );
-        i += 8;
-    }
-    // Scalar tail
-    for i in bulk..npixels {
-        let base = i * 3;
-        *dst.get_unchecked_mut(base) = *src.get_unchecked(base) as f32 * scale[0] + offset[0];
-        *dst.get_unchecked_mut(base + 1) =
-            *src.get_unchecked(base + 1) as f32 * scale[1] + offset[1];
-        *dst.get_unchecked_mut(base + 2) =
-            *src.get_unchecked(base + 2) as f32 * scale[2] + offset[2];
+    unsafe {
+        use std::arch::aarch64::*;
+        let bulk = npixels & !7; // 8 pixels per iteration
+        let s0 = vdupq_n_f32(scale[0]);
+        let s1 = vdupq_n_f32(scale[1]);
+        let s2 = vdupq_n_f32(scale[2]);
+        let o0 = vdupq_n_f32(offset[0]);
+        let o1 = vdupq_n_f32(offset[1]);
+        let o2 = vdupq_n_f32(offset[2]);
+        let mut i = 0usize;
+        while i < bulk {
+            // Load 8 RGB pixels (24 bytes), deinterleave into R/G/B vectors
+            let rgb = vld3_u8(src.as_ptr().add(i * 3));
+            // Widen u8→u16→u32→f32, then fma: val * scale + offset
+            let r16 = vmovl_u8(rgb.0);
+            let r_lo = vfmaq_f32(o0, vcvtq_f32_u32(vmovl_u16(vget_low_u16(r16))), s0);
+            let r_hi = vfmaq_f32(o0, vcvtq_f32_u32(vmovl_u16(vget_high_u16(r16))), s0);
+            let g16 = vmovl_u8(rgb.1);
+            let g_lo = vfmaq_f32(o1, vcvtq_f32_u32(vmovl_u16(vget_low_u16(g16))), s1);
+            let g_hi = vfmaq_f32(o1, vcvtq_f32_u32(vmovl_u16(vget_high_u16(g16))), s1);
+            let b16 = vmovl_u8(rgb.2);
+            let b_lo = vfmaq_f32(o2, vcvtq_f32_u32(vmovl_u16(vget_low_u16(b16))), s2);
+            let b_hi = vfmaq_f32(o2, vcvtq_f32_u32(vmovl_u16(vget_high_u16(b16))), s2);
+            // Interleave back to [R,G,B, R,G,B, ...] and store
+            vst3q_f32(dst.as_mut_ptr().add(i * 3), float32x4x3_t(r_lo, g_lo, b_lo));
+            vst3q_f32(
+                dst.as_mut_ptr().add((i + 4) * 3),
+                float32x4x3_t(r_hi, g_hi, b_hi),
+            );
+            i += 8;
+        }
+        // Scalar tail
+        for i in bulk..npixels {
+            let base = i * 3;
+            *dst.get_unchecked_mut(base) = *src.get_unchecked(base) as f32 * scale[0] + offset[0];
+            *dst.get_unchecked_mut(base + 1) =
+                *src.get_unchecked(base + 1) as f32 * scale[1] + offset[1];
+            *dst.get_unchecked_mut(base + 2) =
+                *src.get_unchecked(base + 2) as f32 * scale[2] + offset[2];
+        }
     }
 }
 
@@ -428,7 +428,7 @@ fn normalize_rgb_u8_scalar(
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::CpuAllocator;
+    use kornia_tensor::host_alloc;
 
     #[test]
     fn normalize_mean_std() -> Result<(), ImageError> {
@@ -440,19 +440,19 @@ mod tests {
             -0.5f32, 0.0, -0.5, 0.5, 1.0, 2.5, -0.5, 0.0, -0.5, 0.5, 1.0, 2.5,
         ];
 
-        let image = Image::<f32, 3, _>::new(
+        let image = Image::<f32, 3>::new(
             ImageSize {
                 width: 2,
                 height: 2,
             },
             image_data,
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let mean = [0.5, 1.0, 0.5];
         let std = [1.0, 1.0, 1.0];
 
-        let mut normalized = Image::<f32, 3, _>::from_size_val(image.size(), 0.0, CpuAllocator)?;
+        let mut normalized = Image::<f32, 3>::from_size_val(image.size(), 0.0, host_alloc())?;
 
         super::normalize_mean_std(&image, &mut normalized, &mean, &std)?;
 
@@ -474,13 +474,13 @@ mod tests {
     #[test]
     fn find_min_max() -> Result<(), ImageError> {
         let image_data = vec![0u8, 1, 0, 1, 2, 3, 0, 1, 0, 1, 2, 3];
-        let image = Image::<u8, 3, _>::new(
+        let image = Image::<u8, 3>::new(
             ImageSize {
                 width: 2,
                 height: 2,
             },
             image_data,
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let (min, max) = super::find_min_max(&image)?;
@@ -502,16 +502,16 @@ mod tests {
             0.6666667, 1.0,
         ];
 
-        let image = Image::<f32, 3, _>::new(
+        let image = Image::<f32, 3>::new(
             ImageSize {
                 width: 2,
                 height: 2,
             },
             image_data,
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut normalized = Image::<f32, 3, _>::from_size_val(image.size(), 0.0, CpuAllocator)?;
+        let mut normalized = Image::<f32, 3>::from_size_val(image.size(), 0.0, host_alloc())?;
 
         super::normalize_min_max(&image, &mut normalized, 0.0, 1.0)?;
 

--- a/crates/kornia-imgproc/src/optical_flow_pyr_lk.rs
+++ b/crates/kornia-imgproc/src/optical_flow_pyr_lk.rs
@@ -1268,9 +1268,9 @@ pub fn build_lk_precomputed(
         };
 
         let mut prev_down =
-            Image::from_size_val(down_size, 0.0f32, prev_img.storage.alloc().clone())?;
+            Image::from_size_val_in(down_size, 0.0f32, prev_img.storage.alloc().clone())?;
         let mut next_down =
-            Image::from_size_val(down_size, 0.0f32, next_img.storage.alloc().clone())?;
+            Image::from_size_val_in(down_size, 0.0f32, next_img.storage.alloc().clone())?;
 
         pyrdown_f32(prev_src, &mut prev_down)?;
         pyrdown_f32(next_src, &mut next_down)?;
@@ -1282,8 +1282,8 @@ pub fn build_lk_precomputed(
     let mut grad_x_pyr = Vec::with_capacity(max_level + 1);
     let mut grad_y_pyr = Vec::with_capacity(max_level + 1);
     for img in prev_pyr.iter().take(max_level + 1) {
-        let mut ix = Image::from_size_val(img.size(), 0.0f32, prev_img.storage.alloc().clone())?;
-        let mut iy = Image::from_size_val(img.size(), 0.0f32, prev_img.storage.alloc().clone())?;
+        let mut ix = Image::from_size_val_in(img.size(), 0.0f32, prev_img.storage.alloc().clone())?;
+        let mut iy = Image::from_size_val_in(img.size(), 0.0f32, prev_img.storage.alloc().clone())?;
         scharr_spatial_gradient_float(img, &mut ix, &mut iy)?;
         grad_x_pyr.push(ix);
         grad_y_pyr.push(iy);
@@ -1438,7 +1438,6 @@ pub fn calc_optical_flow_pyr_lk_with_precomputed(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kornia_tensor::host_alloc;
 
     fn default_params() -> PyrLKParams {
         PyrLKParams::default()
@@ -1491,10 +1490,8 @@ mod tests {
         // structure-tensor entries are non-trivial.
         let size = 128;
         let img = make_gradient_image(size);
-        let mut ix =
-            Image::<f32, 1>::from_size_val([size, size].into(), 0.0, host_alloc()).unwrap();
-        let mut iy =
-            Image::<f32, 1>::from_size_val([size, size].into(), 0.0, host_alloc()).unwrap();
+        let mut ix = Image::<f32, 1>::from_size_val([size, size].into(), 0.0).unwrap();
+        let mut iy = Image::<f32, 1>::from_size_val([size, size].into(), 0.0).unwrap();
         crate::filter::scharr_spatial_gradient_float(&img, &mut ix, &mut iy).unwrap();
 
         // A few interior centres with non-trivial fractional parts so the
@@ -1644,10 +1641,8 @@ mod tests {
         let size = 128;
         let img = make_gradient_image(size);
         // Build gradient images so all three patches have non-trivial data.
-        let mut ix =
-            Image::<f32, 1>::from_size_val([size, size].into(), 0.0, host_alloc()).unwrap();
-        let mut iy =
-            Image::<f32, 1>::from_size_val([size, size].into(), 0.0, host_alloc()).unwrap();
+        let mut ix = Image::<f32, 1>::from_size_val([size, size].into(), 0.0).unwrap();
+        let mut iy = Image::<f32, 1>::from_size_val([size, size].into(), 0.0).unwrap();
         crate::filter::scharr_spatial_gradient_float(&img, &mut ix, &mut iy).unwrap();
         let cols = img.cols();
 
@@ -1733,8 +1728,7 @@ mod tests {
         let dx = 1.0_f32;
         let dy = 0.5_f32;
         let img1 = make_gradient_image(size);
-        let mut img2 =
-            Image::<f32, 1>::from_size_val([size, size].into(), 0.0, host_alloc()).unwrap();
+        let mut img2 = Image::<f32, 1>::from_size_val([size, size].into(), 0.0).unwrap();
         for y in 0..size {
             for x in 0..size {
                 let sx = (x as f32 - dx).clamp(0.0, size as f32 - 1.0);
@@ -1777,8 +1771,7 @@ mod tests {
         let dy = -0.7;
         let img1 = make_gradient_image(size);
         // Synthesise img2 as img1 shifted by (dx, dy).
-        let mut img2 =
-            Image::<f32, 1>::from_size_val([size, size].into(), 0.0, host_alloc()).unwrap();
+        let mut img2 = Image::<f32, 1>::from_size_val([size, size].into(), 0.0).unwrap();
         for y in 0..size {
             for x in 0..size {
                 let sx = (x as f32 - dx).clamp(0.0, size as f32 - 1.0);
@@ -1804,8 +1797,7 @@ mod tests {
     }
 
     fn make_circle_image(size: usize, cx: f32, cy: f32, r: f32) -> Image<f32, 1> {
-        let mut img =
-            Image::<f32, 1>::from_size_val([size, size].into(), 0.0, host_alloc()).unwrap();
+        let mut img = Image::<f32, 1>::from_size_val([size, size].into(), 0.0).unwrap();
         for y in 0..size {
             for x in 0..size {
                 let dx = x as f32 - cx;
@@ -1819,8 +1811,7 @@ mod tests {
     }
 
     fn make_gradient_image(size: usize) -> Image<f32, 1> {
-        let mut img =
-            Image::<f32, 1>::from_size_val([size, size].into(), 0.0, host_alloc()).unwrap();
+        let mut img = Image::<f32, 1>::from_size_val([size, size].into(), 0.0).unwrap();
         for y in 0..size {
             for x in 0..size {
                 let xf = x as f32;
@@ -1949,7 +1940,7 @@ mod tests {
     #[test]
     fn test_lk_low_texture_rejection() {
         let size = 64;
-        let img1 = Image::<f32, 1>::from_size_val([size, size].into(), 0.5, host_alloc()).unwrap();
+        let img1 = Image::<f32, 1>::from_size_val([size, size].into(), 0.5).unwrap();
         let img2 = img1.clone();
         let pts = vec![[32.0, 32.0]];
         let params = default_params();
@@ -2145,8 +2136,7 @@ mod tests {
         let dx = 3.0;
         let dy = -2.0;
         let img1 = make_gradient_image(size);
-        let mut img2 =
-            Image::<f32, 1>::from_size_val([size, size].into(), 0.0, host_alloc()).unwrap();
+        let mut img2 = Image::<f32, 1>::from_size_val([size, size].into(), 0.0).unwrap();
 
         // Shift image
         for y in 0..size {

--- a/crates/kornia-imgproc/src/optical_flow_pyr_lk.rs
+++ b/crates/kornia-imgproc/src/optical_flow_pyr_lk.rs
@@ -2,7 +2,7 @@
 use crate::filter::scharr_spatial_gradient_float;
 use crate::interpolation::{interpolate_pixel_fast, InterpolationMode};
 use crate::pyramid::pyrdown_f32;
-use kornia_image::{allocator::ImageAllocator, Image, ImageError, ImageSize};
+use kornia_image::{Image, ImageError, ImageSize};
 use rayon::prelude::*;
 use thiserror::Error;
 
@@ -81,15 +81,15 @@ pub struct PyrLKResult {
 
 /// Precomputed data for sparse pyramidal LK tracking.
 #[derive(Clone)]
-pub struct PyrLKPrecomputed<A: ImageAllocator> {
+pub struct PyrLKPrecomputed {
     /// Gaussian pyramid of previous image.
-    pub prev_pyr: Vec<Image<f32, 1, A>>,
+    pub prev_pyr: Vec<Image<f32, 1>>,
     /// Gaussian pyramid of next image.
-    pub next_pyr: Vec<Image<f32, 1, A>>,
+    pub next_pyr: Vec<Image<f32, 1>>,
     /// X gradient pyramid for previous image.
-    pub grad_x_pyr: Vec<Image<f32, 1, A>>,
+    pub grad_x_pyr: Vec<Image<f32, 1>>,
     /// Y gradient pyramid for previous image.
-    pub grad_y_pyr: Vec<Image<f32, 1, A>>,
+    pub grad_y_pyr: Vec<Image<f32, 1>>,
 }
 
 /// Error type for sparse pyramidal Lucas–Kanade optical flow.
@@ -169,7 +169,7 @@ fn mirror_coord(x: f32, max: f32) -> f32 {
 }
 
 #[inline]
-fn sample_at<A: ImageAllocator>(img: &Image<f32, 1, A>, x: f32, y: f32, mode: BorderMode) -> f32 {
+fn sample_at(img: &Image<f32, 1>, x: f32, y: f32, mode: BorderMode) -> f32 {
     let max_x = img.cols() as f32 - 1.0;
     let max_y = img.rows() as f32 - 1.0;
     let (xf, yf) = match mode {
@@ -220,10 +220,10 @@ fn is_interior_for_lk(cx: f32, cy: f32, cols: usize, rows: usize) -> bool {
 /// `calc_optical_flow_pyr_lk_with_precomputed`).
 #[inline(always)]
 #[allow(clippy::too_many_arguments)]
-fn build_three_patches_interior<A: ImageAllocator>(
-    prev: &Image<f32, 1, A>,
-    ix: &Image<f32, 1, A>,
-    iy: &Image<f32, 1, A>,
+fn build_three_patches_interior(
+    prev: &Image<f32, 1>,
+    ix: &Image<f32, 1>,
+    iy: &Image<f32, 1>,
     cx: f32,
     cy: f32,
     prev_out: &mut [f32; 441],
@@ -457,105 +457,109 @@ unsafe fn build_three_patches_interior_neon(
     ix_out: &mut [f32; 441],
     iy_out: &mut [f32; 441],
 ) -> (f32, f32, f32) {
-    use std::arch::aarch64::*;
-    let w00v = vdupq_n_f32(w.w00);
-    let w01v = vdupq_n_f32(w.w01);
-    let w10v = vdupq_n_f32(w.w10);
-    let w11v = vdupq_n_f32(w.w11);
-    let mut a_acc = vdupq_n_f32(0.0);
-    let mut b_acc = vdupq_n_f32(0.0);
-    let mut c_acc = vdupq_n_f32(0.0);
-    let mut a_scalar = 0.0_f32;
-    let mut b_scalar = 0.0_f32;
-    let mut c_scalar = 0.0_f32;
+    unsafe {
+        use std::arch::aarch64::*;
+        let w00v = vdupq_n_f32(w.w00);
+        let w01v = vdupq_n_f32(w.w01);
+        let w10v = vdupq_n_f32(w.w10);
+        let w11v = vdupq_n_f32(w.w11);
+        let mut a_acc = vdupq_n_f32(0.0);
+        let mut b_acc = vdupq_n_f32(0.0);
+        let mut c_acc = vdupq_n_f32(0.0);
+        let mut a_scalar = 0.0_f32;
+        let mut b_scalar = 0.0_f32;
+        let mut c_scalar = 0.0_f32;
 
-    #[inline(always)]
-    unsafe fn bilin4(
-        data: *const f32,
-        base_top: usize,
-        base_bot: usize,
-        w00v: float32x4_t,
-        w01v: float32x4_t,
-        w10v: float32x4_t,
-        w11v: float32x4_t,
-    ) -> float32x4_t {
-        let p00 = vld1q_f32(data.add(base_top));
-        let p01 = vld1q_f32(data.add(base_top + 1));
-        let p10 = vld1q_f32(data.add(base_bot));
-        let p11 = vld1q_f32(data.add(base_bot + 1));
-        let mut v = vmulq_f32(p00, w00v);
-        v = vfmaq_f32(v, p01, w01v);
-        v = vfmaq_f32(v, p10, w10v);
-        v = vfmaq_f32(v, p11, w11v);
-        v
-    }
-
-    let prev_ptr = prev_data.as_ptr();
-    let ix_ptr = ix_data.as_ptr();
-    let iy_ptr = iy_data.as_ptr();
-    let prev_out_ptr = prev_out.as_mut_ptr();
-    let ix_out_ptr = ix_out.as_mut_ptr();
-    let iy_out_ptr = iy_out.as_mut_ptr();
-    let mut idx = 0usize;
-
-    for wy in -10i32..=10 {
-        let iv = (iv_base + wy) as usize;
-        let row_top = iv * cols;
-        let row_bot = row_top + cols;
-        let iu_start = (iu_base - 10) as usize;
-
-        for batch in 0..5usize {
-            let off = batch * 4;
-            let base_top = row_top + iu_start + off;
-            let base_bot = row_bot + iu_start + off;
-
-            let pv = bilin4(prev_ptr, base_top, base_bot, w00v, w01v, w10v, w11v);
-            let xv = bilin4(ix_ptr, base_top, base_bot, w00v, w01v, w10v, w11v);
-            let yv = bilin4(iy_ptr, base_top, base_bot, w00v, w01v, w10v, w11v);
-
-            vst1q_f32(prev_out_ptr.add(idx + off), pv);
-            vst1q_f32(ix_out_ptr.add(idx + off), xv);
-            vst1q_f32(iy_out_ptr.add(idx + off), yv);
-
-            a_acc = vfmaq_f32(a_acc, xv, xv);
-            b_acc = vfmaq_f32(b_acc, xv, yv);
-            c_acc = vfmaq_f32(c_acc, yv, yv);
+        #[inline(always)]
+        unsafe fn bilin4(
+            data: *const f32,
+            base_top: usize,
+            base_bot: usize,
+            w00v: float32x4_t,
+            w01v: float32x4_t,
+            w10v: float32x4_t,
+            w11v: float32x4_t,
+        ) -> float32x4_t {
+            unsafe {
+                let p00 = vld1q_f32(data.add(base_top));
+                let p01 = vld1q_f32(data.add(base_top + 1));
+                let p10 = vld1q_f32(data.add(base_bot));
+                let p11 = vld1q_f32(data.add(base_bot + 1));
+                let mut v = vmulq_f32(p00, w00v);
+                v = vfmaq_f32(v, p01, w01v);
+                v = vfmaq_f32(v, p10, w10v);
+                v = vfmaq_f32(v, p11, w11v);
+                v
+            }
         }
 
-        let iu = iu_start + 20;
-        let p00 = prev_data[row_top + iu];
-        let p01 = prev_data[row_top + iu + 1];
-        let p10 = prev_data[row_bot + iu];
-        let p11 = prev_data[row_bot + iu + 1];
-        let pv = p00 * w.w00 + p01 * w.w01 + p10 * w.w10 + p11 * w.w11;
-        prev_out[idx + 20] = pv;
+        let prev_ptr = prev_data.as_ptr();
+        let ix_ptr = ix_data.as_ptr();
+        let iy_ptr = iy_data.as_ptr();
+        let prev_out_ptr = prev_out.as_mut_ptr();
+        let ix_out_ptr = ix_out.as_mut_ptr();
+        let iy_out_ptr = iy_out.as_mut_ptr();
+        let mut idx = 0usize;
 
-        let x00 = ix_data[row_top + iu];
-        let x01 = ix_data[row_top + iu + 1];
-        let x10 = ix_data[row_bot + iu];
-        let x11 = ix_data[row_bot + iu + 1];
-        let xv = x00 * w.w00 + x01 * w.w01 + x10 * w.w10 + x11 * w.w11;
-        ix_out[idx + 20] = xv;
+        for wy in -10i32..=10 {
+            let iv = (iv_base + wy) as usize;
+            let row_top = iv * cols;
+            let row_bot = row_top + cols;
+            let iu_start = (iu_base - 10) as usize;
 
-        let y00 = iy_data[row_top + iu];
-        let y01 = iy_data[row_top + iu + 1];
-        let y10 = iy_data[row_bot + iu];
-        let y11 = iy_data[row_bot + iu + 1];
-        let yv = y00 * w.w00 + y01 * w.w01 + y10 * w.w10 + y11 * w.w11;
-        iy_out[idx + 20] = yv;
+            for batch in 0..5usize {
+                let off = batch * 4;
+                let base_top = row_top + iu_start + off;
+                let base_bot = row_bot + iu_start + off;
 
-        a_scalar += xv * xv;
-        b_scalar += xv * yv;
-        c_scalar += yv * yv;
+                let pv = bilin4(prev_ptr, base_top, base_bot, w00v, w01v, w10v, w11v);
+                let xv = bilin4(ix_ptr, base_top, base_bot, w00v, w01v, w10v, w11v);
+                let yv = bilin4(iy_ptr, base_top, base_bot, w00v, w01v, w10v, w11v);
 
-        idx += 21;
+                vst1q_f32(prev_out_ptr.add(idx + off), pv);
+                vst1q_f32(ix_out_ptr.add(idx + off), xv);
+                vst1q_f32(iy_out_ptr.add(idx + off), yv);
+
+                a_acc = vfmaq_f32(a_acc, xv, xv);
+                b_acc = vfmaq_f32(b_acc, xv, yv);
+                c_acc = vfmaq_f32(c_acc, yv, yv);
+            }
+
+            let iu = iu_start + 20;
+            let p00 = prev_data[row_top + iu];
+            let p01 = prev_data[row_top + iu + 1];
+            let p10 = prev_data[row_bot + iu];
+            let p11 = prev_data[row_bot + iu + 1];
+            let pv = p00 * w.w00 + p01 * w.w01 + p10 * w.w10 + p11 * w.w11;
+            prev_out[idx + 20] = pv;
+
+            let x00 = ix_data[row_top + iu];
+            let x01 = ix_data[row_top + iu + 1];
+            let x10 = ix_data[row_bot + iu];
+            let x11 = ix_data[row_bot + iu + 1];
+            let xv = x00 * w.w00 + x01 * w.w01 + x10 * w.w10 + x11 * w.w11;
+            ix_out[idx + 20] = xv;
+
+            let y00 = iy_data[row_top + iu];
+            let y01 = iy_data[row_top + iu + 1];
+            let y10 = iy_data[row_bot + iu];
+            let y11 = iy_data[row_bot + iu + 1];
+            let yv = y00 * w.w00 + y01 * w.w01 + y10 * w.w10 + y11 * w.w11;
+            iy_out[idx + 20] = yv;
+
+            a_scalar += xv * xv;
+            b_scalar += xv * yv;
+            c_scalar += yv * yv;
+
+            idx += 21;
+        }
+
+        (
+            vaddvq_f32(a_acc) + a_scalar,
+            vaddvq_f32(b_acc) + b_scalar,
+            vaddvq_f32(c_acc) + c_scalar,
+        )
     }
-
-    (
-        vaddvq_f32(a_acc) + a_scalar,
-        vaddvq_f32(b_acc) + b_scalar,
-        vaddvq_f32(c_acc) + c_scalar,
-    )
 }
 
 /// Fast-path single Gauss-Newton iteration step: samples `next` at
@@ -596,8 +600,8 @@ fn weights_for(cx: f32, cy: f32) -> (i32, i32, BilinearWeights) {
 }
 
 #[inline(always)]
-fn iter_step_interior<A: ImageAllocator>(
-    next: &Image<f32, 1, A>,
+fn iter_step_interior(
+    next: &Image<f32, 1>,
     cx: f32,
     cy: f32,
     prev_patch: &[f32; 441],
@@ -802,70 +806,72 @@ unsafe fn iter_step_interior_neon(
     ix_patch: &[f32; 441],
     iy_patch: &[f32; 441],
 ) -> (f32, f32) {
-    use std::arch::aarch64::*;
-    let w00v = vdupq_n_f32(w.w00);
-    let w01v = vdupq_n_f32(w.w01);
-    let w10v = vdupq_n_f32(w.w10);
-    let w11v = vdupq_n_f32(w.w11);
-    let mut d_acc = vdupq_n_f32(0.0);
-    let mut e_acc = vdupq_n_f32(0.0);
-    let mut d_scalar = 0.0_f32;
-    let mut e_scalar = 0.0_f32;
+    unsafe {
+        use std::arch::aarch64::*;
+        let w00v = vdupq_n_f32(w.w00);
+        let w01v = vdupq_n_f32(w.w01);
+        let w10v = vdupq_n_f32(w.w10);
+        let w11v = vdupq_n_f32(w.w11);
+        let mut d_acc = vdupq_n_f32(0.0);
+        let mut e_acc = vdupq_n_f32(0.0);
+        let mut d_scalar = 0.0_f32;
+        let mut e_scalar = 0.0_f32;
 
-    let next_ptr = next_data.as_ptr();
-    let prev_ptr = prev_patch.as_ptr();
-    let ix_ptr = ix_patch.as_ptr();
-    let iy_ptr = iy_patch.as_ptr();
-    let mut idx = 0usize;
+        let next_ptr = next_data.as_ptr();
+        let prev_ptr = prev_patch.as_ptr();
+        let ix_ptr = ix_patch.as_ptr();
+        let iy_ptr = iy_patch.as_ptr();
+        let mut idx = 0usize;
 
-    for wy in -10i32..=10 {
-        let iv = (iv_base + wy) as usize;
-        let row_top = iv * cols;
-        let row_bot = row_top + cols;
-        let iu_start = (iu_base - 10) as usize;
+        for wy in -10i32..=10 {
+            let iv = (iv_base + wy) as usize;
+            let row_top = iv * cols;
+            let row_bot = row_top + cols;
+            let iu_start = (iu_base - 10) as usize;
 
-        // Five 4-wide batches: pixels [0..4], [4..8], [8..12], [12..16], [16..20].
-        for batch in 0..5usize {
-            let off = batch * 4;
-            let base_top = row_top + iu_start + off;
-            let base_bot = row_bot + iu_start + off;
+            // Five 4-wide batches: pixels [0..4], [4..8], [8..12], [12..16], [16..20].
+            for batch in 0..5usize {
+                let off = batch * 4;
+                let base_top = row_top + iu_start + off;
+                let base_bot = row_bot + iu_start + off;
 
-            let p00 = vld1q_f32(next_ptr.add(base_top));
-            let p01 = vld1q_f32(next_ptr.add(base_top + 1));
-            let p10 = vld1q_f32(next_ptr.add(base_bot));
-            let p11 = vld1q_f32(next_ptr.add(base_bot + 1));
+                let p00 = vld1q_f32(next_ptr.add(base_top));
+                let p01 = vld1q_f32(next_ptr.add(base_top + 1));
+                let p10 = vld1q_f32(next_ptr.add(base_bot));
+                let p11 = vld1q_f32(next_ptr.add(base_bot + 1));
 
-            let mut i1 = vmulq_f32(p00, w00v);
-            i1 = vfmaq_f32(i1, p01, w01v);
-            i1 = vfmaq_f32(i1, p10, w10v);
-            i1 = vfmaq_f32(i1, p11, w11v);
+                let mut i1 = vmulq_f32(p00, w00v);
+                i1 = vfmaq_f32(i1, p01, w01v);
+                i1 = vfmaq_f32(i1, p10, w10v);
+                i1 = vfmaq_f32(i1, p11, w11v);
 
-            let prev_v = vld1q_f32(prev_ptr.add(idx + off));
-            let it = vsubq_f32(i1, prev_v);
+                let prev_v = vld1q_f32(prev_ptr.add(idx + off));
+                let it = vsubq_f32(i1, prev_v);
 
-            let ix_v = vld1q_f32(ix_ptr.add(idx + off));
-            let iy_v = vld1q_f32(iy_ptr.add(idx + off));
+                let ix_v = vld1q_f32(ix_ptr.add(idx + off));
+                let iy_v = vld1q_f32(iy_ptr.add(idx + off));
 
-            // d -= ix*it  ==  fma-subtract: d_acc = d_acc - ix*it.
-            d_acc = vfmsq_f32(d_acc, ix_v, it);
-            e_acc = vfmsq_f32(e_acc, iy_v, it);
+                // d -= ix*it  ==  fma-subtract: d_acc = d_acc - ix*it.
+                d_acc = vfmsq_f32(d_acc, ix_v, it);
+                e_acc = vfmsq_f32(e_acc, iy_v, it);
+            }
+
+            // 1-pixel scalar tail (k = 20).
+            let iu = iu_start + 20;
+            let p00 = next_data[row_top + iu];
+            let p01 = next_data[row_top + iu + 1];
+            let p10 = next_data[row_bot + iu];
+            let p11 = next_data[row_bot + iu + 1];
+            let i1 = p00 * w.w00 + p01 * w.w01 + p10 * w.w10 + p11 * w.w11;
+            let it = i1 - prev_patch[idx + 20];
+            d_scalar -= ix_patch[idx + 20] * it;
+            e_scalar -= iy_patch[idx + 20] * it;
+
+            idx += 21;
         }
 
-        // 1-pixel scalar tail (k = 20).
-        let iu = iu_start + 20;
-        let p00 = next_data[row_top + iu];
-        let p01 = next_data[row_top + iu + 1];
-        let p10 = next_data[row_bot + iu];
-        let p11 = next_data[row_bot + iu + 1];
-        let i1 = p00 * w.w00 + p01 * w.w01 + p10 * w.w10 + p11 * w.w11;
-        let it = i1 - prev_patch[idx + 20];
-        d_scalar -= ix_patch[idx + 20] * it;
-        e_scalar -= iy_patch[idx + 20] * it;
-
-        idx += 21;
+        (vaddvq_f32(d_acc) + d_scalar, vaddvq_f32(e_acc) + e_scalar)
     }
-
-    (vaddvq_f32(d_acc) + d_scalar, vaddvq_f32(e_acc) + e_scalar)
 }
 
 /// Fast-path final error pass: samples `next` and accumulates
@@ -875,12 +881,7 @@ unsafe fn iter_step_interior_neon(
 ///
 /// Caller MUST have established [`is_interior_for_lk`] for `(cx, cy)`.
 #[inline(always)]
-fn error_pass_interior<A: ImageAllocator>(
-    next: &Image<f32, 1, A>,
-    cx: f32,
-    cy: f32,
-    prev_patch: &[f32; 441],
-) -> f32 {
+fn error_pass_interior(next: &Image<f32, 1>, cx: f32, cy: f32, prev_patch: &[f32; 441]) -> f32 {
     let cols = next.cols();
     let next_data = next.as_slice();
     let (iu_base, iv_base, w) = weights_for(cx, cy);
@@ -1015,62 +1016,64 @@ unsafe fn error_pass_interior_neon(
     w: BilinearWeights,
     prev_patch: &[f32; 441],
 ) -> f32 {
-    use std::arch::aarch64::*;
-    let w00v = vdupq_n_f32(w.w00);
-    let w01v = vdupq_n_f32(w.w01);
-    let w10v = vdupq_n_f32(w.w10);
-    let w11v = vdupq_n_f32(w.w11);
-    let mut err_acc = vdupq_n_f32(0.0);
-    let mut err_scalar = 0.0_f32;
+    unsafe {
+        use std::arch::aarch64::*;
+        let w00v = vdupq_n_f32(w.w00);
+        let w01v = vdupq_n_f32(w.w01);
+        let w10v = vdupq_n_f32(w.w10);
+        let w11v = vdupq_n_f32(w.w11);
+        let mut err_acc = vdupq_n_f32(0.0);
+        let mut err_scalar = 0.0_f32;
 
-    let next_ptr = next_data.as_ptr();
-    let prev_ptr = prev_patch.as_ptr();
-    let mut idx = 0usize;
+        let next_ptr = next_data.as_ptr();
+        let prev_ptr = prev_patch.as_ptr();
+        let mut idx = 0usize;
 
-    for wy in -10i32..=10 {
-        let iv = (iv_base + wy) as usize;
-        let row_top = iv * cols;
-        let row_bot = row_top + cols;
-        let iu_start = (iu_base - 10) as usize;
+        for wy in -10i32..=10 {
+            let iv = (iv_base + wy) as usize;
+            let row_top = iv * cols;
+            let row_bot = row_top + cols;
+            let iu_start = (iu_base - 10) as usize;
 
-        for batch in 0..5usize {
-            let off = batch * 4;
-            let base_top = row_top + iu_start + off;
-            let base_bot = row_bot + iu_start + off;
+            for batch in 0..5usize {
+                let off = batch * 4;
+                let base_top = row_top + iu_start + off;
+                let base_bot = row_bot + iu_start + off;
 
-            let p00 = vld1q_f32(next_ptr.add(base_top));
-            let p01 = vld1q_f32(next_ptr.add(base_top + 1));
-            let p10 = vld1q_f32(next_ptr.add(base_bot));
-            let p11 = vld1q_f32(next_ptr.add(base_bot + 1));
+                let p00 = vld1q_f32(next_ptr.add(base_top));
+                let p01 = vld1q_f32(next_ptr.add(base_top + 1));
+                let p10 = vld1q_f32(next_ptr.add(base_bot));
+                let p11 = vld1q_f32(next_ptr.add(base_bot + 1));
 
-            let mut i1 = vmulq_f32(p00, w00v);
-            i1 = vfmaq_f32(i1, p01, w01v);
-            i1 = vfmaq_f32(i1, p10, w10v);
-            i1 = vfmaq_f32(i1, p11, w11v);
+                let mut i1 = vmulq_f32(p00, w00v);
+                i1 = vfmaq_f32(i1, p01, w01v);
+                i1 = vfmaq_f32(i1, p10, w10v);
+                i1 = vfmaq_f32(i1, p11, w11v);
 
-            let prev_v = vld1q_f32(prev_ptr.add(idx + off));
-            let diff = vsubq_f32(i1, prev_v);
-            err_acc = vaddq_f32(err_acc, vabsq_f32(diff));
+                let prev_v = vld1q_f32(prev_ptr.add(idx + off));
+                let diff = vsubq_f32(i1, prev_v);
+                err_acc = vaddq_f32(err_acc, vabsq_f32(diff));
+            }
+
+            let iu = iu_start + 20;
+            let p00 = next_data[row_top + iu];
+            let p01 = next_data[row_top + iu + 1];
+            let p10 = next_data[row_bot + iu];
+            let p11 = next_data[row_bot + iu + 1];
+            let i1 = p00 * w.w00 + p01 * w.w01 + p10 * w.w10 + p11 * w.w11;
+            err_scalar += (i1 - prev_patch[idx + 20]).abs();
+
+            idx += 21;
         }
 
-        let iu = iu_start + 20;
-        let p00 = next_data[row_top + iu];
-        let p01 = next_data[row_top + iu + 1];
-        let p10 = next_data[row_bot + iu];
-        let p11 = next_data[row_bot + iu + 1];
-        let i1 = p00 * w.w00 + p01 * w.w01 + p10 * w.w10 + p11 * w.w11;
-        err_scalar += (i1 - prev_patch[idx + 20]).abs();
-
-        idx += 21;
+        vaddvq_f32(err_acc) + err_scalar
     }
-
-    vaddvq_f32(err_acc) + err_scalar
 }
 
-fn track_feature<A: ImageAllocator>(
+fn track_feature(
     pt: [f32; 2],
     initial_flow: Option<[f32; 2]>,
-    precomputed: &PyrLKPrecomputed<A>,
+    precomputed: &PyrLKPrecomputed,
     params: &PyrLKParams,
 ) -> Option<([f32; 2], f32)> {
     const WIN_SIZE: usize = 21;
@@ -1237,11 +1240,11 @@ fn track_feature<A: ImageAllocator>(
 }
 
 /// Build Gaussian pyramids and gradients required by sparse LK.
-pub fn build_lk_precomputed<A: ImageAllocator>(
-    prev_img: &Image<f32, 1, A>,
-    next_img: &Image<f32, 1, A>,
+pub fn build_lk_precomputed(
+    prev_img: &Image<f32, 1>,
+    next_img: &Image<f32, 1>,
     max_level: usize,
-) -> Result<PyrLKPrecomputed<A>, PyrLKError> {
+) -> Result<PyrLKPrecomputed, PyrLKError> {
     if prev_img.size() != next_img.size() {
         return Err(PyrLKError::ImageSizeMismatch {
             prev_width: prev_img.width(),
@@ -1305,9 +1308,9 @@ pub fn build_lk_precomputed<A: ImageAllocator>(
 ///
 /// # Returns
 /// * `Result<PyrLKResult, PyrLKError>` with next points, status, and error
-pub fn calc_optical_flow_pyr_lk<A: ImageAllocator>(
-    prev_img: &Image<f32, 1, A>,
-    next_img: &Image<f32, 1, A>,
+pub fn calc_optical_flow_pyr_lk(
+    prev_img: &Image<f32, 1>,
+    next_img: &Image<f32, 1>,
     prev_pts: &[[f32; 2]],
     next_pts_in: Option<&[[f32; 2]]>,
     params: &PyrLKParams,
@@ -1339,8 +1342,8 @@ pub fn calc_optical_flow_pyr_lk<A: ImageAllocator>(
 }
 
 /// Compute sparse pyramidal LK flow using precomputed pyramids and gradients.
-pub fn calc_optical_flow_pyr_lk_with_precomputed<A: ImageAllocator>(
-    precomputed: &PyrLKPrecomputed<A>,
+pub fn calc_optical_flow_pyr_lk_with_precomputed(
+    precomputed: &PyrLKPrecomputed,
     prev_pts: &[[f32; 2]],
     next_pts_in: Option<&[[f32; 2]]>,
     params: &PyrLKParams,
@@ -1435,7 +1438,7 @@ pub fn calc_optical_flow_pyr_lk_with_precomputed<A: ImageAllocator>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kornia_image::allocator::CpuAllocator;
+    use kornia_tensor::host_alloc;
 
     fn default_params() -> PyrLKParams {
         PyrLKParams::default()
@@ -1445,9 +1448,9 @@ mod tests {
     /// `sample_at` / BorderMode path. Used as the byte-equality oracle for
     /// the fast-path kernels.
     fn build_three_patches_slow(
-        prev: &Image<f32, 1, CpuAllocator>,
-        ix: &Image<f32, 1, CpuAllocator>,
-        iy: &Image<f32, 1, CpuAllocator>,
+        prev: &Image<f32, 1>,
+        ix: &Image<f32, 1>,
+        iy: &Image<f32, 1>,
         cx: f32,
         cy: f32,
     ) -> (Vec<f32>, Vec<f32>, Vec<f32>, f32, f32, f32) {
@@ -1489,11 +1492,9 @@ mod tests {
         let size = 128;
         let img = make_gradient_image(size);
         let mut ix =
-            Image::<f32, 1, CpuAllocator>::from_size_val([size, size].into(), 0.0, CpuAllocator)
-                .unwrap();
+            Image::<f32, 1>::from_size_val([size, size].into(), 0.0, host_alloc()).unwrap();
         let mut iy =
-            Image::<f32, 1, CpuAllocator>::from_size_val([size, size].into(), 0.0, CpuAllocator)
-                .unwrap();
+            Image::<f32, 1>::from_size_val([size, size].into(), 0.0, host_alloc()).unwrap();
         crate::filter::scharr_spatial_gradient_float(&img, &mut ix, &mut iy).unwrap();
 
         // A few interior centres with non-trivial fractional parts so the
@@ -1644,11 +1645,9 @@ mod tests {
         let img = make_gradient_image(size);
         // Build gradient images so all three patches have non-trivial data.
         let mut ix =
-            Image::<f32, 1, CpuAllocator>::from_size_val([size, size].into(), 0.0, CpuAllocator)
-                .unwrap();
+            Image::<f32, 1>::from_size_val([size, size].into(), 0.0, host_alloc()).unwrap();
         let mut iy =
-            Image::<f32, 1, CpuAllocator>::from_size_val([size, size].into(), 0.0, CpuAllocator)
-                .unwrap();
+            Image::<f32, 1>::from_size_val([size, size].into(), 0.0, host_alloc()).unwrap();
         crate::filter::scharr_spatial_gradient_float(&img, &mut ix, &mut iy).unwrap();
         let cols = img.cols();
 
@@ -1735,8 +1734,7 @@ mod tests {
         let dy = 0.5_f32;
         let img1 = make_gradient_image(size);
         let mut img2 =
-            Image::<f32, 1, CpuAllocator>::from_size_val([size, size].into(), 0.0, CpuAllocator)
-                .unwrap();
+            Image::<f32, 1>::from_size_val([size, size].into(), 0.0, host_alloc()).unwrap();
         for y in 0..size {
             for x in 0..size {
                 let sx = (x as f32 - dx).clamp(0.0, size as f32 - 1.0);
@@ -1780,8 +1778,7 @@ mod tests {
         let img1 = make_gradient_image(size);
         // Synthesise img2 as img1 shifted by (dx, dy).
         let mut img2 =
-            Image::<f32, 1, CpuAllocator>::from_size_val([size, size].into(), 0.0, CpuAllocator)
-                .unwrap();
+            Image::<f32, 1>::from_size_val([size, size].into(), 0.0, host_alloc()).unwrap();
         for y in 0..size {
             for x in 0..size {
                 let sx = (x as f32 - dx).clamp(0.0, size as f32 - 1.0);
@@ -1806,10 +1803,9 @@ mod tests {
         );
     }
 
-    fn make_circle_image(size: usize, cx: f32, cy: f32, r: f32) -> Image<f32, 1, CpuAllocator> {
+    fn make_circle_image(size: usize, cx: f32, cy: f32, r: f32) -> Image<f32, 1> {
         let mut img =
-            Image::<f32, 1, CpuAllocator>::from_size_val([size, size].into(), 0.0, CpuAllocator)
-                .unwrap();
+            Image::<f32, 1>::from_size_val([size, size].into(), 0.0, host_alloc()).unwrap();
         for y in 0..size {
             for x in 0..size {
                 let dx = x as f32 - cx;
@@ -1822,10 +1818,9 @@ mod tests {
         img
     }
 
-    fn make_gradient_image(size: usize) -> Image<f32, 1, CpuAllocator> {
+    fn make_gradient_image(size: usize) -> Image<f32, 1> {
         let mut img =
-            Image::<f32, 1, CpuAllocator>::from_size_val([size, size].into(), 0.0, CpuAllocator)
-                .unwrap();
+            Image::<f32, 1>::from_size_val([size, size].into(), 0.0, host_alloc()).unwrap();
         for y in 0..size {
             for x in 0..size {
                 let xf = x as f32;
@@ -1954,9 +1949,7 @@ mod tests {
     #[test]
     fn test_lk_low_texture_rejection() {
         let size = 64;
-        let img1 =
-            Image::<f32, 1, CpuAllocator>::from_size_val([size, size].into(), 0.5, CpuAllocator)
-                .unwrap();
+        let img1 = Image::<f32, 1>::from_size_val([size, size].into(), 0.5, host_alloc()).unwrap();
         let img2 = img1.clone();
         let pts = vec![[32.0, 32.0]];
         let params = default_params();
@@ -2153,8 +2146,7 @@ mod tests {
         let dy = -2.0;
         let img1 = make_gradient_image(size);
         let mut img2 =
-            Image::<f32, 1, CpuAllocator>::from_size_val([size, size].into(), 0.0, CpuAllocator)
-                .unwrap();
+            Image::<f32, 1>::from_size_val([size, size].into(), 0.0, host_alloc()).unwrap();
 
         // Shift image
         for y in 0..size {

--- a/crates/kornia-imgproc/src/padding.rs
+++ b/crates/kornia-imgproc/src/padding.rs
@@ -1,4 +1,4 @@
-use kornia_image::{allocator::ImageAllocator, Image, ImageError, ImageSize};
+use kornia_image::{Image, ImageError, ImageSize};
 use rayon::prelude::*;
 
 /// A border type for the spatial padding.
@@ -253,21 +253,22 @@ impl Padding2D {
 /// # Example
 ///
 /// ```rust
-/// use kornia_image::{allocator::CpuAllocator, ImageSize, Image};
+/// use kornia_image::{Image, ImageSize};
 /// use kornia_imgproc::padding::{PaddingMode, Padding2D, spatial_padding};
+/// use kornia_tensor::host_alloc;
 ///
 /// // Create a 2x2 RGB image filled with 1s
-/// let src = Image::<u8, 3, _>::new(
+/// let src = Image::<u8, 3>::new(
 ///     ImageSize { width: 2, height: 2 },
 ///     vec![1u8; 2 * 2 * 3],
-///     CpuAllocator,
+///     host_alloc(),
 /// ).unwrap();
 ///
 /// // Create destination image
-/// let mut dst = Image::<u8, 3, _>::new(
+/// let mut dst = Image::<u8, 3>::new(
 ///     ImageSize { width: 4, height: 4 },
 ///     vec![0u8; 4 * 4 * 3],
-///     CpuAllocator,
+///     host_alloc(),
 /// ).unwrap();
 ///
 /// // Apply 1-pixel constant padding with black (0) border
@@ -283,9 +284,9 @@ impl Padding2D {
 /// assert_eq!(dst.size().width, 4);
 /// assert_eq!(dst.size().height, 4);
 /// ```
-pub fn spatial_padding<T, const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<T, C, A1>,
-    dst: &mut Image<T, C, A2>,
+pub fn spatial_padding<T, const C: usize>(
+    src: &Image<T, C>,
+    dst: &mut Image<T, C>,
     padding: Padding2D,
     padding_mode: PaddingMode,
     constant_value: [T; C],
@@ -345,28 +346,29 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kornia_image::{allocator::CpuAllocator, Image, ImageError, ImageSize};
+    use kornia_image::{Image, ImageError, ImageSize};
+    use kornia_tensor::host_alloc;
 
     // helper functions
-    fn make_src_2x2_rgb() -> Result<Image<u8, 3, CpuAllocator>, ImageError> {
+    fn make_src_2x2_rgb() -> Result<Image<u8, 3>, ImageError> {
         Image::new(
             ImageSize {
                 width: 2,
                 height: 2,
             },
             vec![1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4],
-            CpuAllocator,
+            host_alloc(),
         )
     }
 
-    fn make_dst_4x4_rgb() -> Result<Image<u8, 3, CpuAllocator>, ImageError> {
+    fn make_dst_4x4_rgb() -> Result<Image<u8, 3>, ImageError> {
         Image::new(
             ImageSize {
                 width: 4,
                 height: 4,
             },
             vec![0u8; 48],
-            CpuAllocator,
+            host_alloc(),
         )
     }
 
@@ -486,13 +488,13 @@ mod tests {
     #[test]
     fn test_spatial_padding_dst_size_mismatch() -> Result<(), ImageError> {
         let src = make_src_2x2_rgb()?;
-        let mut dst = Image::<u8, 3, _>::new(
+        let mut dst = Image::<u8, 3>::new(
             ImageSize {
                 width: 3,
                 height: 4,
             },
             vec![0u8; 36],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let res = spatial_padding(&src, &mut dst, PAD_1, PaddingMode::Replicate, [0, 0, 0]);
@@ -503,13 +505,13 @@ mod tests {
 
     #[test]
     fn test_spatial_padding_larger_than_image_replicate() -> Result<(), ImageError> {
-        let src = Image::<u8, 3, _>::new(
+        let src = Image::<u8, 3>::new(
             ImageSize {
                 width: 1,
                 height: 1,
             },
             vec![7, 7, 7],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let padding = Padding2D {
@@ -519,13 +521,13 @@ mod tests {
             right: 4,
         };
 
-        let mut dst = Image::<u8, 3, _>::new(
+        let mut dst = Image::<u8, 3>::new(
             ImageSize {
                 width: 9,
                 height: 7,
             },
             vec![0u8; 189],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         spatial_padding(&src, &mut dst, padding, PaddingMode::Replicate, [0, 0, 0])?;
@@ -539,13 +541,13 @@ mod tests {
 
     #[test]
     fn test_spatial_padding_larger_than_image_wrap() -> Result<(), ImageError> {
-        let src = Image::<u8, 3, _>::new(
+        let src = Image::<u8, 3>::new(
             ImageSize {
                 width: 1,
                 height: 1,
             },
             vec![5, 5, 5],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let padding = Padding2D {
@@ -555,13 +557,13 @@ mod tests {
             right: 2,
         };
 
-        let mut dst = Image::<u8, 3, _>::new(
+        let mut dst = Image::<u8, 3>::new(
             ImageSize {
                 width: 5,
                 height: 5,
             },
             vec![0u8; 75],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         spatial_padding(&src, &mut dst, padding, PaddingMode::Wrap, [0, 0, 0])?;

--- a/crates/kornia-imgproc/src/padding.rs
+++ b/crates/kornia-imgproc/src/padding.rs
@@ -255,20 +255,17 @@ impl Padding2D {
 /// ```rust
 /// use kornia_image::{Image, ImageSize};
 /// use kornia_imgproc::padding::{PaddingMode, Padding2D, spatial_padding};
-/// use kornia_tensor::host_alloc;
 ///
 /// // Create a 2x2 RGB image filled with 1s
 /// let src = Image::<u8, 3>::new(
 ///     ImageSize { width: 2, height: 2 },
 ///     vec![1u8; 2 * 2 * 3],
-///     host_alloc(),
 /// ).unwrap();
 ///
 /// // Create destination image
 /// let mut dst = Image::<u8, 3>::new(
 ///     ImageSize { width: 4, height: 4 },
 ///     vec![0u8; 4 * 4 * 3],
-///     host_alloc(),
 /// ).unwrap();
 ///
 /// // Apply 1-pixel constant padding with black (0) border
@@ -347,7 +344,6 @@ where
 mod tests {
     use super::*;
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::host_alloc;
 
     // helper functions
     fn make_src_2x2_rgb() -> Result<Image<u8, 3>, ImageError> {
@@ -357,7 +353,6 @@ mod tests {
                 height: 2,
             },
             vec![1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4],
-            host_alloc(),
         )
     }
 
@@ -368,7 +363,6 @@ mod tests {
                 height: 4,
             },
             vec![0u8; 48],
-            host_alloc(),
         )
     }
 
@@ -494,7 +488,6 @@ mod tests {
                 height: 4,
             },
             vec![0u8; 36],
-            host_alloc(),
         )?;
 
         let res = spatial_padding(&src, &mut dst, PAD_1, PaddingMode::Replicate, [0, 0, 0]);
@@ -511,7 +504,6 @@ mod tests {
                 height: 1,
             },
             vec![7, 7, 7],
-            host_alloc(),
         )?;
 
         let padding = Padding2D {
@@ -527,7 +519,6 @@ mod tests {
                 height: 7,
             },
             vec![0u8; 189],
-            host_alloc(),
         )?;
 
         spatial_padding(&src, &mut dst, padding, PaddingMode::Replicate, [0, 0, 0])?;
@@ -547,7 +538,6 @@ mod tests {
                 height: 1,
             },
             vec![5, 5, 5],
-            host_alloc(),
         )?;
 
         let padding = Padding2D {
@@ -563,7 +553,6 @@ mod tests {
                 height: 5,
             },
             vec![0u8; 75],
-            host_alloc(),
         )?;
 
         spatial_padding(&src, &mut dst, padding, PaddingMode::Wrap, [0, 0, 0])?;

--- a/crates/kornia-imgproc/src/parallel.rs
+++ b/crates/kornia-imgproc/src/parallel.rs
@@ -1,7 +1,7 @@
 use rayon::prelude::*;
 
-use kornia_image::{allocator::ImageAllocator, Image};
-use kornia_tensor::{CpuAllocator, Tensor2};
+use kornia_image::Image;
+use kornia_tensor::Tensor2;
 
 /// Row-group granularity for per-pixel rayon sharding. At 1 row per task,
 /// spawn overhead (~2-5 μs on the 8-core Orin pool) rivals per-row work for
@@ -17,16 +17,9 @@ const ROWS_PER_TASK: usize = 16;
 /// * `src` - The input image.
 /// * `dst` - The output image.
 /// * `f` - The function to apply to each pixel.
-pub fn par_iter_rows<
-    T1,
-    const C1: usize,
-    A1: ImageAllocator,
-    T2,
-    const C2: usize,
-    A2: ImageAllocator,
->(
-    src: &Image<T1, C1, A1>,
-    dst: &mut Image<T2, C2, A2>,
+pub fn par_iter_rows<T1, const C1: usize, T2, const C2: usize>(
+    src: &Image<T1, C1>,
+    dst: &mut Image<T2, C2>,
     f: impl Fn(&[T1], &mut [T2]) + Send + Sync,
 ) where
     T1: Clone + Send + Sync,
@@ -51,16 +44,9 @@ pub fn par_iter_rows<
 }
 
 /// Apply a function to each pixel in the image in parallel with a value.
-pub fn par_iter_rows_val<
-    T1,
-    const C1: usize,
-    A1: ImageAllocator,
-    T2,
-    const C2: usize,
-    A2: ImageAllocator,
->(
-    src: &Image<T1, C1, A1>,
-    dst: &mut Image<T2, C2, A2>,
+pub fn par_iter_rows_val<T1, const C1: usize, T2, const C2: usize>(
+    src: &Image<T1, C1>,
+    dst: &mut Image<T2, C2>,
     f: impl Fn(&T1, &mut T2) + Send + Sync,
 ) where
     T1: Clone + Send + Sync,
@@ -85,20 +71,10 @@ pub fn par_iter_rows_val<
 }
 
 /// Apply a function to each pixel in the image in parallel with two values.
-pub fn par_iter_rows_val_two<
-    T1,
-    const C1: usize,
-    A1: ImageAllocator,
-    T2,
-    const C2: usize,
-    A2: ImageAllocator,
-    T3,
-    const C3: usize,
-    A3: ImageAllocator,
->(
-    src1: &Image<T1, C1, A1>,
-    src2: &Image<T2, C2, A2>,
-    dst: &mut Image<T3, C3, A3>,
+pub fn par_iter_rows_val_two<T1, const C1: usize, T2, const C2: usize, T3, const C3: usize>(
+    src1: &Image<T1, C1>,
+    src2: &Image<T2, C2>,
+    dst: &mut Image<T3, C3>,
     f: impl Fn(&T1, &T2, &mut T3) + Send + Sync,
 ) where
     T1: Clone + Send + Sync,
@@ -125,10 +101,10 @@ pub fn par_iter_rows_val_two<
 }
 
 /// Apply a function to each pixel for grid sampling in parallel.
-pub fn par_iter_rows_resample<const C: usize, A: ImageAllocator>(
-    dst: &mut Image<f32, C, A>,
-    map_x: &Tensor2<f32, CpuAllocator>,
-    map_y: &Tensor2<f32, CpuAllocator>,
+pub fn par_iter_rows_resample<const C: usize>(
+    dst: &mut Image<f32, C>,
+    map_x: &Tensor2<f32>,
+    map_y: &Tensor2<f32>,
     f: impl Fn(&f32, &f32, &mut [f32]) + Send + Sync,
 ) {
     let cols = dst.cols();
@@ -149,8 +125,8 @@ pub fn par_iter_rows_resample<const C: usize, A: ImageAllocator>(
 }
 
 /// Apply a spatial mapping function to each pixel in parallel without pre-allocating coordinate tensors.
-pub fn par_iter_rows_spatial_mapping<const C: usize, A: ImageAllocator>(
-    dst: &mut Image<f32, C, A>,
+pub fn par_iter_rows_spatial_mapping<const C: usize>(
+    dst: &mut Image<f32, C>,
     map_coord: impl Fn(usize, usize) -> (f32, f32) + Send + Sync,
     f: impl Fn(f32, f32, &mut [f32]) + Send + Sync,
 ) {

--- a/crates/kornia-imgproc/src/pyramid.rs
+++ b/crates/kornia-imgproc/src/pyramid.rs
@@ -187,7 +187,6 @@ fn pyrup_vertical_pass_f32<const C: usize>(
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::pyramid::pyrup_f32;
 ///
 /// let image = Image::<f32, 1>::new(
@@ -196,7 +195,6 @@ fn pyrup_vertical_pass_f32<const C: usize>(
 ///         height: 2,
 ///     },
 ///     vec![0.0, 1.0, 2.0, 3.0],
-///     host_alloc()
 /// ).unwrap();
 ///
 /// let mut upsampled = Image::<f32, 1>::from_size_val(
@@ -205,7 +203,6 @@ fn pyrup_vertical_pass_f32<const C: usize>(
 ///         height: 4,
 ///     },
 ///     0.0,
-///     host_alloc()
 /// ).unwrap();
 ///
 /// pyrup_f32(&image, &mut upsampled).unwrap();
@@ -284,7 +281,6 @@ fn reflect_101(mut p: i32, len: i32) -> i32 {
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::pyramid::pyrdown_f32;
 ///
 /// let image = Image::<f32, 3>::new(
@@ -293,7 +289,6 @@ fn reflect_101(mut p: i32, len: i32) -> i32 {
 ///         height: 4,
 ///     },
 ///     (0..48).map(|x| x as f32).collect(),
-///     host_alloc(),
 /// ).unwrap();
 ///
 /// let mut downsampled = Image::<f32, 3>::from_size_val(
@@ -302,7 +297,6 @@ fn reflect_101(mut p: i32, len: i32) -> i32 {
 ///         height: 2,
 ///     },
 ///     0.0,
-///     host_alloc(),
 /// ).unwrap();
 ///
 /// pyrdown_f32(&image, &mut downsampled).unwrap();
@@ -432,7 +426,7 @@ pub fn build_pyramid<const C: usize>(
             height: current_img.rows().div_ceil(2),
         };
         let mut downsampled =
-            Image::from_size_val(new_size, 0.0, current_img.storage.alloc().clone())?;
+            Image::from_size_val_in(new_size, 0.0, current_img.storage.alloc().clone())?;
         pyrdown_f32(current_img, &mut downsampled)?;
         pyramid.push(downsampled);
     }
@@ -820,7 +814,6 @@ pub fn pyrup_u8<const C: usize>(
 mod tests {
     use super::*;
     use kornia_image::{Image, ImageSize};
-    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_build_pyramid_levels_and_sizes_odd_dimensions() {
@@ -829,7 +822,7 @@ mod tests {
             width: 5,
             height: 7,
         };
-        let src: Image<f32, 1> = Image::from_size_val(size, 1.0_f32, host_alloc()).unwrap();
+        let src: Image<f32, 1> = Image::from_size_val(size, 1.0_f32).unwrap();
 
         let max_level = 3;
         let pyramid = build_pyramid(&src, max_level).unwrap();
@@ -864,7 +857,6 @@ mod tests {
                 height: 2,
             },
             vec![0.0, 1.0, 2.0, 3.0],
-            host_alloc(),
         )?;
 
         let mut dst = Image::<f32, 1>::from_size_val(
@@ -873,7 +865,6 @@ mod tests {
                 height: 4,
             },
             0.0,
-            host_alloc(),
         )?;
 
         pyrup_f32(&src, &mut dst)?;
@@ -900,7 +891,6 @@ mod tests {
                 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0,
                 15.0,
             ],
-            host_alloc(),
         )?;
 
         let mut dst = Image::<f32, 1>::from_size_val(
@@ -909,7 +899,6 @@ mod tests {
                 height: 2,
             },
             0.0,
-            host_alloc(),
         )?;
 
         pyrdown_f32(&src, &mut dst)?;
@@ -939,7 +928,6 @@ mod tests {
                 height: 4,
             },
             (0..48).map(|x| x as f32).collect(),
-            host_alloc(),
         )?;
 
         let mut dst = Image::<f32, 3>::from_size_val(
@@ -948,7 +936,6 @@ mod tests {
                 height: 2,
             },
             0.0,
-            host_alloc(),
         )?;
 
         pyrdown_f32(&src, &mut dst)?;
@@ -982,7 +969,6 @@ mod tests {
                 height: 4,
             },
             vec![0.0; 16],
-            host_alloc(),
         )?;
 
         let mut dst = Image::<f32, 1>::from_size_val(
@@ -991,7 +977,6 @@ mod tests {
                 height: 3,
             },
             0.0,
-            host_alloc(),
         )?;
 
         let result = pyrdown_f32(&src, &mut dst);
@@ -1008,7 +993,6 @@ mod tests {
                 height: 7,
             },
             (0..(5 * 7)).map(|x| x as f32).collect(),
-            host_alloc(),
         )?;
 
         let mut dst = Image::<f32, 1>::from_size_val(
@@ -1017,7 +1001,6 @@ mod tests {
                 height: 4,
             },
             0.0,
-            host_alloc(),
         )?;
 
         pyrdown_f32(&src, &mut dst)?;
@@ -1039,7 +1022,6 @@ mod tests {
                 height: 1,
             },
             vec![42.0],
-            host_alloc(),
         )?;
         let mut dst1 = Image::<f32, 1>::from_size_val(
             ImageSize {
@@ -1047,7 +1029,6 @@ mod tests {
                 height: 1,
             },
             0.0,
-            host_alloc(),
         )?;
         pyrdown_f32(&src1, &mut dst1)?;
         assert_eq!(dst1.width(), 1);
@@ -1060,7 +1041,6 @@ mod tests {
                 height: 2,
             },
             vec![1.0, 2.0],
-            host_alloc(),
         )?;
         let mut dst2 = Image::<f32, 1>::from_size_val(
             ImageSize {
@@ -1068,7 +1048,6 @@ mod tests {
                 height: 1,
             },
             0.0,
-            host_alloc(),
         )?;
         pyrdown_f32(&src2, &mut dst2)?;
         assert_eq!(dst2.width(), 1);
@@ -1081,7 +1060,6 @@ mod tests {
                 height: 1,
             },
             vec![1.0, 2.0],
-            host_alloc(),
         )?;
         let mut dst3 = Image::<f32, 1>::from_size_val(
             ImageSize {
@@ -1089,7 +1067,6 @@ mod tests {
                 height: 1,
             },
             0.0,
-            host_alloc(),
         )?;
         pyrdown_f32(&src3, &mut dst3)?;
         assert_eq!(dst3.width(), 1);
@@ -1109,7 +1086,6 @@ mod tests {
                 height: 4,
             },
             vec![large_val; 16],
-            host_alloc(),
         )?;
         let mut dst = Image::<f32, 1>::from_size_val(
             ImageSize {
@@ -1117,7 +1093,6 @@ mod tests {
                 height: 2,
             },
             0.0,
-            host_alloc(),
         )?;
         pyrdown_f32(&src, &mut dst)?;
         for &v in dst.as_slice() {
@@ -1135,7 +1110,6 @@ mod tests {
                 height: 4,
             },
             vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
-            host_alloc(),
         )?;
 
         let mut dst = Image::<u8, 1>::from_size_val(
@@ -1144,7 +1118,6 @@ mod tests {
                 height: 2,
             },
             0,
-            host_alloc(),
         )?;
 
         pyrdown_u8(&src, &mut dst)?;
@@ -1167,7 +1140,6 @@ mod tests {
                 height: 2,
             },
             vec![0, 10, 20, 30],
-            host_alloc(),
         )?;
 
         let mut dst = Image::<u8, 1>::from_size_val(
@@ -1176,7 +1148,6 @@ mod tests {
                 height: 4,
             },
             0,
-            host_alloc(),
         )?;
 
         pyrup_u8(&src, &mut dst)?;
@@ -1195,7 +1166,6 @@ mod tests {
                 height: 2,
             },
             vec![0; 4],
-            host_alloc(),
         )?;
 
         let mut dst = Image::<u8, 1>::from_size_val(
@@ -1204,7 +1174,6 @@ mod tests {
                 height: 4,
             },
             0,
-            host_alloc(),
         )?;
 
         let result = pyrup_u8(&src, &mut dst);
@@ -1221,7 +1190,6 @@ mod tests {
                 height: 1,
             },
             vec![100],
-            host_alloc(),
         )?;
         let mut dst1 = Image::<u8, 1>::from_size_val(
             ImageSize {
@@ -1229,7 +1197,6 @@ mod tests {
                 height: 2,
             },
             0,
-            host_alloc(),
         )?;
 
         pyrup_u8(&src1, &mut dst1)?;
@@ -1252,7 +1219,6 @@ mod tests {
                 height: 16,
             },
             vec![val; 16 * 16],
-            host_alloc(),
         )?;
 
         let mut dst = Image::<u8, 1>::from_size_val(
@@ -1261,7 +1227,6 @@ mod tests {
                 height: 8,
             },
             0,
-            host_alloc(),
         )?;
 
         pyrdown_u8(&src, &mut dst)?;
@@ -1287,7 +1252,6 @@ mod tests {
                 height: 4,
             },
             vec![0; 16],
-            host_alloc(),
         )?;
 
         let mut dst = Image::<u8, 1>::from_size_val(
@@ -1296,7 +1260,6 @@ mod tests {
                 height: 3,
             },
             0,
-            host_alloc(),
         )?;
 
         let result = pyrdown_u8(&src, &mut dst);
@@ -1313,7 +1276,6 @@ mod tests {
                 height: 7,
             },
             (0..(5 * 7)).map(|x| x as u8).collect(),
-            host_alloc(),
         )?;
 
         let mut dst = Image::<u8, 1>::from_size_val(
@@ -1322,7 +1284,6 @@ mod tests {
                 height: 4,
             },
             0,
-            host_alloc(),
         )?;
 
         pyrdown_u8(&src, &mut dst)?;
@@ -1341,7 +1302,6 @@ mod tests {
                 height: 1,
             },
             vec![42],
-            host_alloc(),
         )?;
         let mut dst1 = Image::<u8, 1>::from_size_val(
             ImageSize {
@@ -1349,7 +1309,6 @@ mod tests {
                 height: 1,
             },
             0,
-            host_alloc(),
         )?;
         pyrdown_u8(&src1, &mut dst1)?;
         assert_eq!(dst1.width(), 1);
@@ -1362,7 +1321,6 @@ mod tests {
                 height: 2,
             },
             vec![10, 20],
-            host_alloc(),
         )?;
         let mut dst2 = Image::<u8, 1>::from_size_val(
             ImageSize {
@@ -1370,7 +1328,6 @@ mod tests {
                 height: 1,
             },
             0,
-            host_alloc(),
         )?;
         pyrdown_u8(&src2, &mut dst2)?;
         assert_eq!(dst2.width(), 1);
@@ -1390,7 +1347,6 @@ mod tests {
                 height: 4,
             },
             (0..48).map(|x| x as u8).collect(),
-            host_alloc(),
         )?;
 
         let mut dst = Image::<u8, 3>::from_size_val(
@@ -1399,7 +1355,6 @@ mod tests {
                 height: 2,
             },
             0,
-            host_alloc(),
         )?;
 
         pyrdown_u8(&src, &mut dst)?;
@@ -1442,7 +1397,6 @@ mod tests {
                 70, 80, 90, // (1,0)
                 100, 110, 120, // (1,1)
             ],
-            host_alloc(),
         )?;
 
         let mut dst = Image::<u8, 3>::from_size_val(
@@ -1451,7 +1405,6 @@ mod tests {
                 height: 4,
             },
             0,
-            host_alloc(),
         )?;
 
         pyrup_u8(&src, &mut dst)?;

--- a/crates/kornia-imgproc/src/pyramid.rs
+++ b/crates/kornia-imgproc/src/pyramid.rs
@@ -1,4 +1,4 @@
-use kornia_image::{allocator::ImageAllocator, Image, ImageError, ImageSize};
+use kornia_image::{Image, ImageError, ImageSize};
 use rayon::prelude::*;
 
 // Gaussian kernel weights
@@ -19,13 +19,11 @@ const W_BORDER: f32 = 7.0;
 /// * `src` - The source image.
 /// * `dst` - The destination buffer for the horizontal pass.
 /// * `dst_width` - The width of the destination image.
-fn pyrup_horizontal_pass_f32<const C: usize, A>(
-    src: &Image<f32, C, A>,
+fn pyrup_horizontal_pass_f32<const C: usize>(
+    src: &Image<f32, C>,
     dst: &mut [f32],
     dst_width: usize,
-) where
-    A: ImageAllocator,
-{
+) {
     let src_width = src.width();
     let src_data = src.as_slice();
     let dst_stride = dst_width * C;
@@ -189,37 +187,33 @@ fn pyrup_vertical_pass_f32<const C: usize>(
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::pyramid::pyrup_f32;
 ///
-/// let image = Image::<f32, 1, _>::new(
+/// let image = Image::<f32, 1>::new(
 ///     ImageSize {
 ///         width: 2,
 ///         height: 2,
 ///     },
 ///     vec![0.0, 1.0, 2.0, 3.0],
-///     CpuAllocator
+///     host_alloc()
 /// ).unwrap();
 ///
-/// let mut upsampled = Image::<f32, 1, _>::from_size_val(
+/// let mut upsampled = Image::<f32, 1>::from_size_val(
 ///     ImageSize {
 ///         width: 4,
 ///         height: 4,
 ///     },
 ///     0.0,
-///     CpuAllocator
+///     host_alloc()
 /// ).unwrap();
 ///
 /// pyrup_f32(&image, &mut upsampled).unwrap();
 /// ```
-pub fn pyrup_f32<const C: usize, A1, A2>(
-    src: &Image<f32, C, A1>,
-    dst: &mut Image<f32, C, A2>,
-) -> Result<(), ImageError>
-where
-    A1: ImageAllocator,
-    A2: ImageAllocator,
-{
+pub fn pyrup_f32<const C: usize>(
+    src: &Image<f32, C>,
+    dst: &mut Image<f32, C>,
+) -> Result<(), ImageError> {
     let expected_width = src.width() * 2;
     let expected_height = src.height() * 2;
 
@@ -234,7 +228,7 @@ where
 
     // Intermediate buffer for horizontal pass, pyrup_horizontal writes here
     let mut buffer = vec![0.0f32; dst.width() * src.height() * C];
-    pyrup_horizontal_pass_f32::<C, _>(src, &mut buffer, dst.width());
+    pyrup_horizontal_pass_f32::<C>(src, &mut buffer, dst.width());
 
     // Vertical pass reads from buffer and finally writes to dst
     let dst_width = dst.width();
@@ -290,32 +284,32 @@ fn reflect_101(mut p: i32, len: i32) -> i32 {
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::pyramid::pyrdown_f32;
 ///
-/// let image = Image::<f32, 3, _>::new(
+/// let image = Image::<f32, 3>::new(
 ///     ImageSize {
 ///         width: 4,
 ///         height: 4,
 ///     },
 ///     (0..48).map(|x| x as f32).collect(),
-///     CpuAllocator,
+///     host_alloc(),
 /// ).unwrap();
 ///
-/// let mut downsampled = Image::<f32, 3, _>::from_size_val(
+/// let mut downsampled = Image::<f32, 3>::from_size_val(
 ///     ImageSize {
 ///         width: 2,
 ///         height: 2,
 ///     },
 ///     0.0,
-///     CpuAllocator,
+///     host_alloc(),
 /// ).unwrap();
 ///
 /// pyrdown_f32(&image, &mut downsampled).unwrap();
 /// ```
-pub fn pyrdown_f32<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<f32, C, A1>,
-    dst: &mut Image<f32, C, A2>,
+pub fn pyrdown_f32<const C: usize>(
+    src: &Image<f32, C>,
+    dst: &mut Image<f32, C>,
 ) -> Result<(), ImageError> {
     let expected_width = src.width().div_ceil(2);
     let expected_height = src.height().div_ceil(2);
@@ -424,10 +418,10 @@ pub fn pyrdown_f32<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
 /// * `max_level` - The maximum level of the pyramid (0 means just the original image).
 /// # Returns
 /// A vector of images representing the Gaussian pyramid.
-pub fn build_pyramid<const C: usize, A: ImageAllocator>(
-    src: &Image<f32, C, A>,
+pub fn build_pyramid<const C: usize>(
+    src: &Image<f32, C>,
     max_level: usize,
-) -> Result<Vec<Image<f32, C, A>>, ImageError> {
+) -> Result<Vec<Image<f32, C>>, ImageError> {
     let mut pyramid = Vec::with_capacity(max_level + 1);
     pyramid.push(src.clone());
 
@@ -462,9 +456,9 @@ pub fn build_pyramid<const C: usize, A: ImageAllocator>(
 /// # Returns
 ///
 /// * `Result<(), ImageError>` - Ok if successful, Err otherwise.
-pub fn pyrdown_u8<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<u8, C, A1>,
-    dst: &mut Image<u8, C, A2>,
+pub fn pyrdown_u8<const C: usize>(
+    src: &Image<u8, C>,
+    dst: &mut Image<u8, C>,
 ) -> Result<(), ImageError> {
     let expected_width = src.width().div_ceil(2);
     let expected_height = src.height().div_ceil(2);
@@ -483,7 +477,7 @@ pub fn pyrdown_u8<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
     let mut buffer = vec![0u16; buffer_width * buffer_height * C];
 
     // Horizontal pass: 1D convolution + downsample
-    pyrdown_horizontal_pass_u8::<C, _>(src, &mut buffer, buffer_width);
+    pyrdown_horizontal_pass_u8::<C>(src, &mut buffer, buffer_width);
 
     // Vertical pass
     let dst_width = dst.width();
@@ -498,13 +492,11 @@ pub fn pyrdown_u8<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
     Ok(())
 }
 
-fn pyrdown_horizontal_pass_u8<const C: usize, A>(
-    src: &Image<u8, C, A>,
+fn pyrdown_horizontal_pass_u8<const C: usize>(
+    src: &Image<u8, C>,
     dst: &mut [u16],
     dst_width: usize,
-) where
-    A: ImageAllocator,
-{
+) {
     let src_width = src.width();
     let src_data = src.as_slice();
     let dst_stride = dst_width * C;
@@ -643,13 +635,7 @@ fn pyrdown_vertical_pass_u8<const C: usize>(
         });
 }
 
-fn pyrup_horizontal_pass_u8<const C: usize, A>(
-    src: &Image<u8, C, A>,
-    dst: &mut [u8],
-    dst_width: usize,
-) where
-    A: ImageAllocator,
-{
+fn pyrup_horizontal_pass_u8<const C: usize>(src: &Image<u8, C>, dst: &mut [u8], dst_width: usize) {
     let src_width = src.width();
     let src_data = src.as_slice();
     let dst_stride = dst_width * C;
@@ -797,14 +783,10 @@ fn pyrup_vertical_pass_u8<const C: usize>(
 /// # Returns
 ///
 /// * `Result<(), ImageError>` - Ok if successful, Err otherwise.
-pub fn pyrup_u8<const C: usize, A1, A2>(
-    src: &Image<u8, C, A1>,
-    dst: &mut Image<u8, C, A2>,
-) -> Result<(), ImageError>
-where
-    A1: ImageAllocator,
-    A2: ImageAllocator,
-{
+pub fn pyrup_u8<const C: usize>(
+    src: &Image<u8, C>,
+    dst: &mut Image<u8, C>,
+) -> Result<(), ImageError> {
     let expected_width = src.width() * 2;
     let expected_height = src.height() * 2;
 
@@ -819,7 +801,7 @@ where
 
     // Intermediate buffer for horizontal pass
     let mut buffer = vec![0u8; dst.width() * src.height() * C];
-    pyrup_horizontal_pass_u8::<C, _>(src, &mut buffer, dst.width());
+    pyrup_horizontal_pass_u8::<C>(src, &mut buffer, dst.width());
 
     // Vertical pass
     let dst_width = dst.width();
@@ -837,7 +819,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kornia_image::{allocator::CpuAllocator, Image, ImageSize};
+    use kornia_image::{Image, ImageSize};
+    use kornia_tensor::host_alloc;
 
     #[test]
     fn test_build_pyramid_levels_and_sizes_odd_dimensions() {
@@ -846,8 +829,7 @@ mod tests {
             width: 5,
             height: 7,
         };
-        let src: Image<f32, 1, CpuAllocator> =
-            Image::from_size_val(size, 1.0_f32, CpuAllocator).unwrap();
+        let src: Image<f32, 1> = Image::from_size_val(size, 1.0_f32, host_alloc()).unwrap();
 
         let max_level = 3;
         let pyramid = build_pyramid(&src, max_level).unwrap();
@@ -876,22 +858,22 @@ mod tests {
 
     #[test]
     fn test_pyrup() -> Result<(), ImageError> {
-        let src = Image::<f32, 1, _>::new(
+        let src = Image::<f32, 1>::new(
             ImageSize {
                 width: 2,
                 height: 2,
             },
             vec![0.0, 1.0, 2.0, 3.0],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut dst = Image::<f32, 1, _>::from_size_val(
+        let mut dst = Image::<f32, 1>::from_size_val(
             ImageSize {
                 width: 4,
                 height: 4,
             },
             0.0,
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         pyrup_f32(&src, &mut dst)?;
@@ -909,7 +891,7 @@ mod tests {
     #[test]
     fn test_pyrdown() -> Result<(), ImageError> {
         // NOTE: verified with opencv
-        let src = Image::<f32, 1, _>::new(
+        let src = Image::<f32, 1>::new(
             ImageSize {
                 width: 4,
                 height: 4,
@@ -918,16 +900,16 @@ mod tests {
                 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0,
                 15.0,
             ],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut dst = Image::<f32, 1, _>::from_size_val(
+        let mut dst = Image::<f32, 1>::from_size_val(
             ImageSize {
                 width: 2,
                 height: 2,
             },
             0.0,
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         pyrdown_f32(&src, &mut dst)?;
@@ -951,22 +933,22 @@ mod tests {
     #[test]
     fn test_pyrdown_3c() -> Result<(), ImageError> {
         // NOTE: verified with opencv
-        let src = Image::<f32, 3, _>::new(
+        let src = Image::<f32, 3>::new(
             ImageSize {
                 width: 4,
                 height: 4,
             },
             (0..48).map(|x| x as f32).collect(),
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut dst = Image::<f32, 3, _>::from_size_val(
+        let mut dst = Image::<f32, 3>::from_size_val(
             ImageSize {
                 width: 2,
                 height: 2,
             },
             0.0,
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         pyrdown_f32(&src, &mut dst)?;
@@ -994,22 +976,22 @@ mod tests {
 
     #[test]
     fn test_pyrdown_invalid_size() -> Result<(), ImageError> {
-        let src = Image::<f32, 1, _>::new(
+        let src = Image::<f32, 1>::new(
             ImageSize {
                 width: 4,
                 height: 4,
             },
             vec![0.0; 16],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut dst = Image::<f32, 1, _>::from_size_val(
+        let mut dst = Image::<f32, 1>::from_size_val(
             ImageSize {
                 width: 3,
                 height: 3,
             },
             0.0,
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let result = pyrdown_f32(&src, &mut dst);
@@ -1020,22 +1002,22 @@ mod tests {
 
     #[test]
     fn test_pyrdown_odd_dims() -> Result<(), ImageError> {
-        let src = Image::<f32, 1, _>::new(
+        let src = Image::<f32, 1>::new(
             ImageSize {
                 width: 5,
                 height: 7,
             },
             (0..(5 * 7)).map(|x| x as f32).collect(),
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut dst = Image::<f32, 1, _>::from_size_val(
+        let mut dst = Image::<f32, 1>::from_size_val(
             ImageSize {
                 width: 3,
                 height: 4,
             },
             0.0,
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         pyrdown_f32(&src, &mut dst)?;
@@ -1051,63 +1033,63 @@ mod tests {
 
     #[test]
     fn test_pyrdown_min_sizes() -> Result<(), ImageError> {
-        let src1 = Image::<f32, 1, _>::new(
+        let src1 = Image::<f32, 1>::new(
             ImageSize {
                 width: 1,
                 height: 1,
             },
             vec![42.0],
-            CpuAllocator,
+            host_alloc(),
         )?;
-        let mut dst1 = Image::<f32, 1, _>::from_size_val(
+        let mut dst1 = Image::<f32, 1>::from_size_val(
             ImageSize {
                 width: 1,
                 height: 1,
             },
             0.0,
-            CpuAllocator,
+            host_alloc(),
         )?;
         pyrdown_f32(&src1, &mut dst1)?;
         assert_eq!(dst1.width(), 1);
         assert_eq!(dst1.height(), 1);
         assert!(dst1.as_slice().iter().all(|v| v.is_finite()));
 
-        let src2 = Image::<f32, 1, _>::new(
+        let src2 = Image::<f32, 1>::new(
             ImageSize {
                 width: 1,
                 height: 2,
             },
             vec![1.0, 2.0],
-            CpuAllocator,
+            host_alloc(),
         )?;
-        let mut dst2 = Image::<f32, 1, _>::from_size_val(
+        let mut dst2 = Image::<f32, 1>::from_size_val(
             ImageSize {
                 width: 1,
                 height: 1,
             },
             0.0,
-            CpuAllocator,
+            host_alloc(),
         )?;
         pyrdown_f32(&src2, &mut dst2)?;
         assert_eq!(dst2.width(), 1);
         assert_eq!(dst2.height(), 1);
         assert!(dst2.as_slice().iter().all(|v| v.is_finite()));
 
-        let src3 = Image::<f32, 1, _>::new(
+        let src3 = Image::<f32, 1>::new(
             ImageSize {
                 width: 2,
                 height: 1,
             },
             vec![1.0, 2.0],
-            CpuAllocator,
+            host_alloc(),
         )?;
-        let mut dst3 = Image::<f32, 1, _>::from_size_val(
+        let mut dst3 = Image::<f32, 1>::from_size_val(
             ImageSize {
                 width: 1,
                 height: 1,
             },
             0.0,
-            CpuAllocator,
+            host_alloc(),
         )?;
         pyrdown_f32(&src3, &mut dst3)?;
         assert_eq!(dst3.width(), 1);
@@ -1121,21 +1103,21 @@ mod tests {
     #[test]
     fn test_pyrdown_numeric_extremes() -> Result<(), ImageError> {
         let large_val = 1e9_f32;
-        let src = Image::<f32, 1, _>::new(
+        let src = Image::<f32, 1>::new(
             ImageSize {
                 width: 4,
                 height: 4,
             },
             vec![large_val; 16],
-            CpuAllocator,
+            host_alloc(),
         )?;
-        let mut dst = Image::<f32, 1, _>::from_size_val(
+        let mut dst = Image::<f32, 1>::from_size_val(
             ImageSize {
                 width: 2,
                 height: 2,
             },
             0.0,
-            CpuAllocator,
+            host_alloc(),
         )?;
         pyrdown_f32(&src, &mut dst)?;
         for &v in dst.as_slice() {
@@ -1147,22 +1129,22 @@ mod tests {
     }
     #[test]
     fn test_pyrdown_u8_smoke() -> Result<(), ImageError> {
-        let src = Image::<u8, 1, _>::new(
+        let src = Image::<u8, 1>::new(
             ImageSize {
                 width: 4,
                 height: 4,
             },
             vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut dst = Image::<u8, 1, _>::from_size_val(
+        let mut dst = Image::<u8, 1>::from_size_val(
             ImageSize {
                 width: 2,
                 height: 2,
             },
             0,
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         pyrdown_u8(&src, &mut dst)?;
@@ -1179,22 +1161,22 @@ mod tests {
 
     #[test]
     fn test_pyrup_u8_smoke() -> Result<(), ImageError> {
-        let src = Image::<u8, 1, _>::new(
+        let src = Image::<u8, 1>::new(
             ImageSize {
                 width: 2,
                 height: 2,
             },
             vec![0, 10, 20, 30],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut dst = Image::<u8, 1, _>::from_size_val(
+        let mut dst = Image::<u8, 1>::from_size_val(
             ImageSize {
                 width: 4,
                 height: 4,
             },
             0,
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         pyrup_u8(&src, &mut dst)?;
@@ -1207,22 +1189,22 @@ mod tests {
 
     #[test]
     fn test_pyrup_u8_invalid_size() -> Result<(), ImageError> {
-        let src = Image::<u8, 1, _>::new(
+        let src = Image::<u8, 1>::new(
             ImageSize {
                 width: 2,
                 height: 2,
             },
             vec![0; 4],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut dst = Image::<u8, 1, _>::from_size_val(
+        let mut dst = Image::<u8, 1>::from_size_val(
             ImageSize {
                 width: 3, // Expected 4
                 height: 4,
             },
             0,
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let result = pyrup_u8(&src, &mut dst);
@@ -1233,21 +1215,21 @@ mod tests {
 
     #[test]
     fn test_pyrup_u8_min_sizes() -> Result<(), ImageError> {
-        let src1 = Image::<u8, 1, _>::new(
+        let src1 = Image::<u8, 1>::new(
             ImageSize {
                 width: 1,
                 height: 1,
             },
             vec![100],
-            CpuAllocator,
+            host_alloc(),
         )?;
-        let mut dst1 = Image::<u8, 1, _>::from_size_val(
+        let mut dst1 = Image::<u8, 1>::from_size_val(
             ImageSize {
                 width: 2,
                 height: 2,
             },
             0,
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         pyrup_u8(&src1, &mut dst1)?;
@@ -1264,22 +1246,22 @@ mod tests {
     #[test]
     fn test_pyrdown_u8_flat() -> Result<(), ImageError> {
         let val = 100u8;
-        let src = Image::<u8, 1, _>::new(
+        let src = Image::<u8, 1>::new(
             ImageSize {
                 width: 16,
                 height: 16,
             },
             vec![val; 16 * 16],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut dst = Image::<u8, 1, _>::from_size_val(
+        let mut dst = Image::<u8, 1>::from_size_val(
             ImageSize {
                 width: 8,
                 height: 8,
             },
             0,
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         pyrdown_u8(&src, &mut dst)?;
@@ -1299,22 +1281,22 @@ mod tests {
     }
     #[test]
     fn test_pyrdown_u8_invalid_size() -> Result<(), ImageError> {
-        let src = Image::<u8, 1, _>::new(
+        let src = Image::<u8, 1>::new(
             ImageSize {
                 width: 4,
                 height: 4,
             },
             vec![0; 16],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut dst = Image::<u8, 1, _>::from_size_val(
+        let mut dst = Image::<u8, 1>::from_size_val(
             ImageSize {
                 width: 3,
                 height: 3,
             },
             0,
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let result = pyrdown_u8(&src, &mut dst);
@@ -1325,22 +1307,22 @@ mod tests {
 
     #[test]
     fn test_pyrdown_u8_odd_dims() -> Result<(), ImageError> {
-        let src = Image::<u8, 1, _>::new(
+        let src = Image::<u8, 1>::new(
             ImageSize {
                 width: 5,
                 height: 7,
             },
             (0..(5 * 7)).map(|x| x as u8).collect(),
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut dst = Image::<u8, 1, _>::from_size_val(
+        let mut dst = Image::<u8, 1>::from_size_val(
             ImageSize {
                 width: 3,
                 height: 4,
             },
             0,
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         pyrdown_u8(&src, &mut dst)?;
@@ -1353,42 +1335,42 @@ mod tests {
 
     #[test]
     fn test_pyrdown_u8_min_sizes() -> Result<(), ImageError> {
-        let src1 = Image::<u8, 1, _>::new(
+        let src1 = Image::<u8, 1>::new(
             ImageSize {
                 width: 1,
                 height: 1,
             },
             vec![42],
-            CpuAllocator,
+            host_alloc(),
         )?;
-        let mut dst1 = Image::<u8, 1, _>::from_size_val(
+        let mut dst1 = Image::<u8, 1>::from_size_val(
             ImageSize {
                 width: 1,
                 height: 1,
             },
             0,
-            CpuAllocator,
+            host_alloc(),
         )?;
         pyrdown_u8(&src1, &mut dst1)?;
         assert_eq!(dst1.width(), 1);
         assert_eq!(dst1.height(), 1);
         assert_eq!(dst1.get_pixel(0, 0, 0).unwrap(), &42); // Should be preserved (or close)
 
-        let src2 = Image::<u8, 1, _>::new(
+        let src2 = Image::<u8, 1>::new(
             ImageSize {
                 width: 1,
                 height: 2,
             },
             vec![10, 20],
-            CpuAllocator,
+            host_alloc(),
         )?;
-        let mut dst2 = Image::<u8, 1, _>::from_size_val(
+        let mut dst2 = Image::<u8, 1>::from_size_val(
             ImageSize {
                 width: 1,
                 height: 1,
             },
             0,
-            CpuAllocator,
+            host_alloc(),
         )?;
         pyrdown_u8(&src2, &mut dst2)?;
         assert_eq!(dst2.width(), 1);
@@ -1402,22 +1384,22 @@ mod tests {
         // NOTE: verified with opencv
         // src = np.arange(4*4*3, dtype=np.uint8).reshape(4,4,3)
         // dst = cv2.pyrDown(src)
-        let src = Image::<u8, 3, _>::new(
+        let src = Image::<u8, 3>::new(
             ImageSize {
                 width: 4,
                 height: 4,
             },
             (0..48).map(|x| x as u8).collect(),
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut dst = Image::<u8, 3, _>::from_size_val(
+        let mut dst = Image::<u8, 3>::from_size_val(
             ImageSize {
                 width: 2,
                 height: 2,
             },
             0,
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         pyrdown_u8(&src, &mut dst)?;
@@ -1449,7 +1431,7 @@ mod tests {
 
     #[test]
     fn test_pyrup_u8_3c() -> Result<(), ImageError> {
-        let src = Image::<u8, 3, _>::new(
+        let src = Image::<u8, 3>::new(
             ImageSize {
                 width: 2,
                 height: 2,
@@ -1460,16 +1442,16 @@ mod tests {
                 70, 80, 90, // (1,0)
                 100, 110, 120, // (1,1)
             ],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut dst = Image::<u8, 3, _>::from_size_val(
+        let mut dst = Image::<u8, 3>::from_size_val(
             ImageSize {
                 width: 4,
                 height: 4,
             },
             0,
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         pyrup_u8(&src, &mut dst)?;

--- a/crates/kornia-imgproc/src/resize/fused.rs
+++ b/crates/kornia-imgproc/src/resize/fused.rs
@@ -337,68 +337,72 @@ unsafe fn fused_bilinear_row_neon(
     dst_w: usize,
     params: &NormalizeParams<3>,
 ) {
-    use std::arch::aarch64::*;
-    let sc = [
-        vdupq_n_f32(params.scale[0]),
-        vdupq_n_f32(params.scale[1]),
-        vdupq_n_f32(params.scale[2]),
-    ];
-    let bi = [
-        vdupq_n_f32(params.bias[0]),
-        vdupq_n_f32(params.bias[1]),
-        vdupq_n_f32(params.bias[2]),
-    ];
-    let wy4 = vdupq_n_f32(wy);
+    unsafe {
+        use std::arch::aarch64::*;
+        let sc = [
+            vdupq_n_f32(params.scale[0]),
+            vdupq_n_f32(params.scale[1]),
+            vdupq_n_f32(params.scale[2]),
+        ];
+        let bi = [
+            vdupq_n_f32(params.bias[0]),
+            vdupq_n_f32(params.bias[1]),
+            vdupq_n_f32(params.bias[2]),
+        ];
+        let wy4 = vdupq_n_f32(wy);
 
-    let bulk = dst_w & !3;
-    let mut dx = 0;
-    while dx < bulk {
-        let wx4 = vld1q_f32(wx.as_ptr().add(dx));
-        // Gather the 4 corner samples for the 4 output pixels, all channels.
-        let (mut p00, mut p01, mut p10, mut p11) = ([0f32; 12], [0f32; 12], [0f32; 12], [0f32; 12]);
-        for k in 0..4 {
-            let o0 = *x0b.get_unchecked(dx + k);
-            let o1 = *x1b.get_unchecked(dx + k);
-            for c in 0..3 {
-                p00[k * 3 + c] = *row0.get_unchecked(o0 + c) as f32;
-                p01[k * 3 + c] = *row0.get_unchecked(o1 + c) as f32;
-                p10[k * 3 + c] = *row1.get_unchecked(o0 + c) as f32;
-                p11[k * 3 + c] = *row1.get_unchecked(o1 + c) as f32;
+        let bulk = dst_w & !3;
+        let mut dx = 0;
+        while dx < bulk {
+            let wx4 = vld1q_f32(wx.as_ptr().add(dx));
+            // Gather the 4 corner samples for the 4 output pixels, all channels.
+            let (mut p00, mut p01, mut p10, mut p11) =
+                ([0f32; 12], [0f32; 12], [0f32; 12], [0f32; 12]);
+            for k in 0..4 {
+                let o0 = *x0b.get_unchecked(dx + k);
+                let o1 = *x1b.get_unchecked(dx + k);
+                for c in 0..3 {
+                    p00[k * 3 + c] = *row0.get_unchecked(o0 + c) as f32;
+                    p01[k * 3 + c] = *row0.get_unchecked(o1 + c) as f32;
+                    p10[k * 3 + c] = *row1.get_unchecked(o0 + c) as f32;
+                    p11[k * 3 + c] = *row1.get_unchecked(o1 + c) as f32;
+                }
             }
+            // Per channel: deinterleave the 4 lanes via a strided load into f32x4,
+            // bilinear blend, scale/bias, contiguous store.
+            for (c, out) in [r_out.as_mut_ptr(), g_out.as_mut_ptr(), b_out.as_mut_ptr()]
+                .into_iter()
+                .enumerate()
+            {
+                let gather = |arr: &[f32; 12]| {
+                    vld1q_f32([arr[c], arr[3 + c], arr[6 + c], arr[9 + c]].as_ptr())
+                };
+                let a = gather(&p00);
+                let b = gather(&p01);
+                let cc = gather(&p10);
+                let d = gather(&p11);
+                let top = vfmaq_f32(a, wx4, vsubq_f32(b, a));
+                let bot = vfmaq_f32(cc, wx4, vsubq_f32(d, cc));
+                let val = vfmaq_f32(top, wy4, vsubq_f32(bot, top));
+                vst1q_f32(out.add(dx), vfmaq_f32(bi[c], val, sc[c]));
+            }
+            dx += 4;
         }
-        // Per channel: deinterleave the 4 lanes via a strided load into f32x4,
-        // bilinear blend, scale/bias, contiguous store.
-        for (c, out) in [r_out.as_mut_ptr(), g_out.as_mut_ptr(), b_out.as_mut_ptr()]
-            .into_iter()
-            .enumerate()
-        {
-            let gather =
-                |arr: &[f32; 12]| vld1q_f32([arr[c], arr[3 + c], arr[6 + c], arr[9 + c]].as_ptr());
-            let a = gather(&p00);
-            let b = gather(&p01);
-            let cc = gather(&p10);
-            let d = gather(&p11);
-            let top = vfmaq_f32(a, wx4, vsubq_f32(b, a));
-            let bot = vfmaq_f32(cc, wx4, vsubq_f32(d, cc));
-            let val = vfmaq_f32(top, wy4, vsubq_f32(bot, top));
-            vst1q_f32(out.add(dx), vfmaq_f32(bi[c], val, sc[c]));
+        if dx < dst_w {
+            fused_bilinear_row_scalar(
+                row0,
+                row1,
+                &x0b[dx..],
+                &x1b[dx..],
+                &wx[dx..],
+                wy,
+                &mut r_out[dx..],
+                &mut g_out[dx..],
+                &mut b_out[dx..],
+                dst_w - dx,
+                params,
+            );
         }
-        dx += 4;
-    }
-    if dx < dst_w {
-        fused_bilinear_row_scalar(
-            row0,
-            row1,
-            &x0b[dx..],
-            &x1b[dx..],
-            &wx[dx..],
-            wy,
-            &mut r_out[dx..],
-            &mut g_out[dx..],
-            &mut b_out[dx..],
-            dst_w - dx,
-            params,
-        );
     }
 }
 
@@ -565,83 +569,85 @@ unsafe fn fused_row_neon(
     dst_w: usize,
     params: &NormalizeParams<3>,
 ) {
-    use std::arch::aarch64::*;
+    unsafe {
+        use std::arch::aarch64::*;
 
-    // Fold the 2×2 average's /4 into scale so the hot loop is pure FMA —
-    // no integer rounding, no u8 requantization.
-    let sr = vdupq_n_f32(params.scale[0] * 0.25);
-    let sg = vdupq_n_f32(params.scale[1] * 0.25);
-    let sb = vdupq_n_f32(params.scale[2] * 0.25);
-    let br = vdupq_n_f32(params.bias[0]);
-    let bg = vdupq_n_f32(params.bias[1]);
-    let bb = vdupq_n_f32(params.bias[2]);
+        // Fold the 2×2 average's /4 into scale so the hot loop is pure FMA —
+        // no integer rounding, no u8 requantization.
+        let sr = vdupq_n_f32(params.scale[0] * 0.25);
+        let sg = vdupq_n_f32(params.scale[1] * 0.25);
+        let sb = vdupq_n_f32(params.scale[2] * 0.25);
+        let br = vdupq_n_f32(params.bias[0]);
+        let bg = vdupq_n_f32(params.bias[1]);
+        let bb = vdupq_n_f32(params.bias[2]);
 
-    // Per-channel 16-output-pixel emitter. Takes the 4 deinterleaved u8x16
-    // channel lanes (two adjacent src chunks per row, two rows), computes
-    // the 2×2 sum in u16, then widens→cvts→FMAs into 4 f32x4 stores.
-    //
-    // Written as a macro (not a closure) because unsafe + captured `_v`
-    // vectors inside `#[target_feature]` contexts are easier to reason about
-    // when fully inlined, and Rust closures don't inherit target_feature.
-    macro_rules! emit_channel {
-        ($a:expr, $b:expr, $c:expr, $d:expr, $scale:expr, $bias:expr, $out:expr) => {{
-            let lo = vaddq_u16(vpaddlq_u8($a), vpaddlq_u8($c)); // out px 0..7
-            let hi = vaddq_u16(vpaddlq_u8($b), vpaddlq_u8($d)); // out px 8..15
-            let f0 = vcvtq_f32_u32(vmovl_u16(vget_low_u16(lo)));
-            let f1 = vcvtq_f32_u32(vmovl_high_u16(lo));
-            let f2 = vcvtq_f32_u32(vmovl_u16(vget_low_u16(hi)));
-            let f3 = vcvtq_f32_u32(vmovl_high_u16(hi));
-            vst1q_f32($out, vfmaq_f32($bias, f0, $scale));
-            vst1q_f32($out.add(4), vfmaq_f32($bias, f1, $scale));
-            vst1q_f32($out.add(8), vfmaq_f32($bias, f2, $scale));
-            vst1q_f32($out.add(12), vfmaq_f32($bias, f3, $scale));
-        }};
-    }
+        // Per-channel 16-output-pixel emitter. Takes the 4 deinterleaved u8x16
+        // channel lanes (two adjacent src chunks per row, two rows), computes
+        // the 2×2 sum in u16, then widens→cvts→FMAs into 4 f32x4 stores.
+        //
+        // Written as a macro (not a closure) because unsafe + captured `_v`
+        // vectors inside `#[target_feature]` contexts are easier to reason about
+        // when fully inlined, and Rust closures don't inherit target_feature.
+        macro_rules! emit_channel {
+            ($a:expr_2021, $b:expr_2021, $c:expr_2021, $d:expr_2021, $scale:expr_2021, $bias:expr_2021, $out:expr_2021) => {{
+                let lo = vaddq_u16(vpaddlq_u8($a), vpaddlq_u8($c)); // out px 0..7
+                let hi = vaddq_u16(vpaddlq_u8($b), vpaddlq_u8($d)); // out px 8..15
+                let f0 = vcvtq_f32_u32(vmovl_u16(vget_low_u16(lo)));
+                let f1 = vcvtq_f32_u32(vmovl_high_u16(lo));
+                let f2 = vcvtq_f32_u32(vmovl_u16(vget_low_u16(hi)));
+                let f3 = vcvtq_f32_u32(vmovl_high_u16(hi));
+                vst1q_f32($out, vfmaq_f32($bias, f0, $scale));
+                vst1q_f32($out.add(4), vfmaq_f32($bias, f1, $scale));
+                vst1q_f32($out.add(8), vfmaq_f32($bias, f2, $scale));
+                vst1q_f32($out.add(12), vfmaq_f32($bias, f3, $scale));
+            }};
+        }
 
-    let bulk = dst_w & !15;
-    let mut x = 0usize;
-    while x < bulk {
-        // 16 dst px → 32 src px per row → 2 × vld3q_u8 per row.
-        let src0 = r0.as_ptr().add(x * 2 * 3);
-        let src1 = r1.as_ptr().add(x * 2 * 3);
-        let s0 = vld3q_u8(src0);
-        let s1 = vld3q_u8(src0.add(48));
-        let s2 = vld3q_u8(src1);
-        let s3 = vld3q_u8(src1.add(48));
+        let bulk = dst_w & !15;
+        let mut x = 0usize;
+        while x < bulk {
+            // 16 dst px → 32 src px per row → 2 × vld3q_u8 per row.
+            let src0 = r0.as_ptr().add(x * 2 * 3);
+            let src1 = r1.as_ptr().add(x * 2 * 3);
+            let s0 = vld3q_u8(src0);
+            let s1 = vld3q_u8(src0.add(48));
+            let s2 = vld3q_u8(src1);
+            let s3 = vld3q_u8(src1.add(48));
 
-        emit_channel!(s0.0, s1.0, s2.0, s3.0, sr, br, r_out.as_mut_ptr().add(x));
-        emit_channel!(s0.1, s1.1, s2.1, s3.1, sg, bg, g_out.as_mut_ptr().add(x));
-        emit_channel!(s0.2, s1.2, s2.2, s3.2, sb, bb, b_out.as_mut_ptr().add(x));
+            emit_channel!(s0.0, s1.0, s2.0, s3.0, sr, br, r_out.as_mut_ptr().add(x));
+            emit_channel!(s0.1, s1.1, s2.1, s3.1, sg, bg, g_out.as_mut_ptr().add(x));
+            emit_channel!(s0.2, s1.2, s2.2, s3.2, sb, bb, b_out.as_mut_ptr().add(x));
 
-        x += 16;
-    }
+            x += 16;
+        }
 
-    // Scalar tail for the last (dst_w % 16) pixels.
-    let sr_s = params.scale[0] * 0.25;
-    let sg_s = params.scale[1] * 0.25;
-    let sb_s = params.scale[2] * 0.25;
-    let br_s = params.bias[0];
-    let bg_s = params.bias[1];
-    let bb_s = params.bias[2];
-    while x < dst_w {
-        let base0 = 2 * x * 3;
-        let base1 = base0 + 3;
-        let sum_r = *r0.get_unchecked(base0) as u32
-            + *r0.get_unchecked(base1) as u32
-            + *r1.get_unchecked(base0) as u32
-            + *r1.get_unchecked(base1) as u32;
-        let sum_g = *r0.get_unchecked(base0 + 1) as u32
-            + *r0.get_unchecked(base1 + 1) as u32
-            + *r1.get_unchecked(base0 + 1) as u32
-            + *r1.get_unchecked(base1 + 1) as u32;
-        let sum_b = *r0.get_unchecked(base0 + 2) as u32
-            + *r0.get_unchecked(base1 + 2) as u32
-            + *r1.get_unchecked(base0 + 2) as u32
-            + *r1.get_unchecked(base1 + 2) as u32;
-        *r_out.get_unchecked_mut(x) = (sum_r as f32) * sr_s + br_s;
-        *g_out.get_unchecked_mut(x) = (sum_g as f32) * sg_s + bg_s;
-        *b_out.get_unchecked_mut(x) = (sum_b as f32) * sb_s + bb_s;
-        x += 1;
+        // Scalar tail for the last (dst_w % 16) pixels.
+        let sr_s = params.scale[0] * 0.25;
+        let sg_s = params.scale[1] * 0.25;
+        let sb_s = params.scale[2] * 0.25;
+        let br_s = params.bias[0];
+        let bg_s = params.bias[1];
+        let bb_s = params.bias[2];
+        while x < dst_w {
+            let base0 = 2 * x * 3;
+            let base1 = base0 + 3;
+            let sum_r = *r0.get_unchecked(base0) as u32
+                + *r0.get_unchecked(base1) as u32
+                + *r1.get_unchecked(base0) as u32
+                + *r1.get_unchecked(base1) as u32;
+            let sum_g = *r0.get_unchecked(base0 + 1) as u32
+                + *r0.get_unchecked(base1 + 1) as u32
+                + *r1.get_unchecked(base0 + 1) as u32
+                + *r1.get_unchecked(base1 + 1) as u32;
+            let sum_b = *r0.get_unchecked(base0 + 2) as u32
+                + *r0.get_unchecked(base1 + 2) as u32
+                + *r1.get_unchecked(base0 + 2) as u32
+                + *r1.get_unchecked(base1 + 2) as u32;
+            *r_out.get_unchecked_mut(x) = (sum_r as f32) * sr_s + br_s;
+            *g_out.get_unchecked_mut(x) = (sum_g as f32) * sg_s + bg_s;
+            *b_out.get_unchecked_mut(x) = (sum_b as f32) * sb_s + bb_s;
+            x += 1;
+        }
     }
 }
 

--- a/crates/kornia-imgproc/src/resize/kernels.rs
+++ b/crates/kornia-imgproc/src/resize/kernels.rs
@@ -71,70 +71,72 @@ fn pyrdown_row_rgb_u8_scalar(r0: &[u8], r1: &[u8], dst: &mut [u8], dst_w: usize)
 #[cfg(target_arch = "aarch64")]
 #[target_feature(enable = "neon")]
 unsafe fn pyrdown_row_rgb_u8_neon(r0: &[u8], r1: &[u8], dst: &mut [u8], dst_w: usize) {
-    use std::arch::aarch64::*;
-    // Process 16 output pixels (= 48 bytes dst, 96 bytes per src row) per iter.
-    let bulk = dst_w & !15;
-    let mut x = 0usize;
-    while x < bulk {
-        let s0 = vld3q_u8(r0.as_ptr().add(x * 2 * 3));
-        let s1 = vld3q_u8(r0.as_ptr().add(x * 2 * 3 + 48));
-        let s2 = vld3q_u8(r1.as_ptr().add(x * 2 * 3));
-        let s3 = vld3q_u8(r1.as_ptr().add(x * 2 * 3 + 48));
-        // Each of s*.N is 16 u8 (two adjacent src pixels per output).
-        // Sum adjacent pairs within a row via vpaddlq_u8 → 8 u16 per half,
-        // then sum the two rows and rshift-narrow by 2 for /4 with rounding.
-        let mut out = uint8x16x3_t(vdupq_n_u8(0), vdupq_n_u8(0), vdupq_n_u8(0));
-        let mut k = 0;
-        while k < 3 {
-            let a = match k {
-                0 => s0.0,
-                1 => s0.1,
-                _ => s0.2,
-            };
-            let b = match k {
-                0 => s1.0,
-                1 => s1.1,
-                _ => s1.2,
-            };
-            let c = match k {
-                0 => s2.0,
-                1 => s2.1,
-                _ => s2.2,
-            };
-            let d = match k {
-                0 => s3.0,
-                1 => s3.1,
-                _ => s3.2,
-            };
-            let ab_lo = vpaddlq_u8(a);
-            let ab_hi = vpaddlq_u8(b);
-            let cd_lo = vpaddlq_u8(c);
-            let cd_hi = vpaddlq_u8(d);
-            let sum_lo = vaddq_u16(ab_lo, cd_lo);
-            let sum_hi = vaddq_u16(ab_hi, cd_hi);
-            let o_lo = vrshrn_n_u16(sum_lo, 2);
-            let o_hi = vrshrn_n_u16(sum_hi, 2);
-            let o = vcombine_u8(o_lo, o_hi);
-            match k {
-                0 => out.0 = o,
-                1 => out.1 = o,
-                _ => out.2 = o,
+    unsafe {
+        use std::arch::aarch64::*;
+        // Process 16 output pixels (= 48 bytes dst, 96 bytes per src row) per iter.
+        let bulk = dst_w & !15;
+        let mut x = 0usize;
+        while x < bulk {
+            let s0 = vld3q_u8(r0.as_ptr().add(x * 2 * 3));
+            let s1 = vld3q_u8(r0.as_ptr().add(x * 2 * 3 + 48));
+            let s2 = vld3q_u8(r1.as_ptr().add(x * 2 * 3));
+            let s3 = vld3q_u8(r1.as_ptr().add(x * 2 * 3 + 48));
+            // Each of s*.N is 16 u8 (two adjacent src pixels per output).
+            // Sum adjacent pairs within a row via vpaddlq_u8 → 8 u16 per half,
+            // then sum the two rows and rshift-narrow by 2 for /4 with rounding.
+            let mut out = uint8x16x3_t(vdupq_n_u8(0), vdupq_n_u8(0), vdupq_n_u8(0));
+            let mut k = 0;
+            while k < 3 {
+                let a = match k {
+                    0 => s0.0,
+                    1 => s0.1,
+                    _ => s0.2,
+                };
+                let b = match k {
+                    0 => s1.0,
+                    1 => s1.1,
+                    _ => s1.2,
+                };
+                let c = match k {
+                    0 => s2.0,
+                    1 => s2.1,
+                    _ => s2.2,
+                };
+                let d = match k {
+                    0 => s3.0,
+                    1 => s3.1,
+                    _ => s3.2,
+                };
+                let ab_lo = vpaddlq_u8(a);
+                let ab_hi = vpaddlq_u8(b);
+                let cd_lo = vpaddlq_u8(c);
+                let cd_hi = vpaddlq_u8(d);
+                let sum_lo = vaddq_u16(ab_lo, cd_lo);
+                let sum_hi = vaddq_u16(ab_hi, cd_hi);
+                let o_lo = vrshrn_n_u16(sum_lo, 2);
+                let o_hi = vrshrn_n_u16(sum_hi, 2);
+                let o = vcombine_u8(o_lo, o_hi);
+                match k {
+                    0 => out.0 = o,
+                    1 => out.1 = o,
+                    _ => out.2 = o,
+                }
+                k += 1;
             }
-            k += 1;
+            vst3q_u8(dst.as_mut_ptr().add(x * 3), out);
+            x += 16;
         }
-        vst3q_u8(dst.as_mut_ptr().add(x * 3), out);
-        x += 16;
-    }
-    // Scalar tail.
-    while x < dst_w {
-        for ch in 0..3 {
-            let sum = r0[(2 * x) * 3 + ch] as u16
-                + r0[(2 * x + 1) * 3 + ch] as u16
-                + r1[(2 * x) * 3 + ch] as u16
-                + r1[(2 * x + 1) * 3 + ch] as u16;
-            dst[x * 3 + ch] = ((sum + 2) >> 2) as u8;
+        // Scalar tail.
+        while x < dst_w {
+            for ch in 0..3 {
+                let sum = r0[(2 * x) * 3 + ch] as u16
+                    + r0[(2 * x + 1) * 3 + ch] as u16
+                    + r1[(2 * x) * 3 + ch] as u16
+                    + r1[(2 * x + 1) * 3 + ch] as u16;
+                dst[x * 3 + ch] = ((sum + 2) >> 2) as u8;
+            }
+            x += 1;
         }
-        x += 1;
     }
 }
 
@@ -176,62 +178,64 @@ fn hinterp_row_rgb_u8_scalar(src: &[u8], dst: &mut [u8], src_w: usize) {
 #[cfg(target_arch = "aarch64")]
 #[target_feature(enable = "neon")]
 unsafe fn hinterp_row_rgb_u8_neon(src: &[u8], dst: &mut [u8], src_w: usize) {
-    use std::arch::aarch64::*;
-    let s = src.as_ptr();
-    let d = dst.as_mut_ptr();
+    unsafe {
+        use std::arch::aarch64::*;
+        let s = src.as_ptr();
+        let d = dst.as_mut_ptr();
 
-    // Edge: dst[0] ← src[0] (clamped f=0 for dst_x=0).
-    for ch in 0..3 {
-        *d.add(ch) = *s.add(ch);
-    }
-
-    // Bulk: 16 src pixel pairs per iter → 32 dst pixels via vld3q / vst3q.
-    // Each iter reads pixels [J..J+15] and [J+1..J+16], so needs J+16 ≤ src_w-1.
-    let mut j = 0usize;
-    while j + 17 <= src_w {
-        let s_a = vld3q_u8(s.add(j * 3));
-        let s_b = vld3q_u8(s.add((j + 1) * 3));
-
-        // For each channel: compute both 0.75a+0.25b and 0.25a+0.75b via the
-        // double-rhadd identity, then interleave so adjacent dst pixels
-        // alternate (hi, lo) — matching the dst[2J+1], dst[2J+2] pattern.
-        let blend = |ac: uint8x16_t, bc: uint8x16_t| -> (uint8x16_t, uint8x16_t) {
-            let avg = vrhaddq_u8(ac, bc);
-            let hi = vrhaddq_u8(ac, avg); // 0.75·ac + 0.25·bc
-            let lo = vrhaddq_u8(bc, avg); // 0.25·ac + 0.75·bc
-            (vzip1q_u8(hi, lo), vzip2q_u8(hi, lo))
-        };
-
-        let (r_lo, r_hi) = blend(s_a.0, s_b.0);
-        let (g_lo, g_hi) = blend(s_a.1, s_b.1);
-        let (b_lo, b_hi) = blend(s_a.2, s_b.2);
-
-        let out_low = uint8x16x3_t(r_lo, g_lo, b_lo);
-        let out_high = uint8x16x3_t(r_hi, g_hi, b_hi);
-
-        vst3q_u8(d.add((2 * j + 1) * 3), out_low);
-        vst3q_u8(d.add((2 * j + 17) * 3), out_high);
-
-        j += 16;
-    }
-
-    // Scalar tail for the remaining (src_w - 1 - j) interior pairs.
-    while j + 1 < src_w {
-        let ja = j * 3;
-        let jb = (j + 1) * 3;
+        // Edge: dst[0] ← src[0] (clamped f=0 for dst_x=0).
         for ch in 0..3 {
-            let a = *s.add(ja + ch) as u16;
-            let b = *s.add(jb + ch) as u16;
-            let avg = (a + b + 1) >> 1;
-            *d.add((2 * j + 1) * 3 + ch) = ((a + avg + 1) >> 1) as u8;
-            *d.add((2 * j + 2) * 3 + ch) = ((b + avg + 1) >> 1) as u8;
+            *d.add(ch) = *s.add(ch);
         }
-        j += 1;
-    }
 
-    // Edge: dst[2·src_w-1] ← src[src_w-1] (clamped f=1 for last dst_x).
-    for ch in 0..3 {
-        *d.add((2 * src_w - 1) * 3 + ch) = *s.add((src_w - 1) * 3 + ch);
+        // Bulk: 16 src pixel pairs per iter → 32 dst pixels via vld3q / vst3q.
+        // Each iter reads pixels [J..J+15] and [J+1..J+16], so needs J+16 ≤ src_w-1.
+        let mut j = 0usize;
+        while j + 17 <= src_w {
+            let s_a = vld3q_u8(s.add(j * 3));
+            let s_b = vld3q_u8(s.add((j + 1) * 3));
+
+            // For each channel: compute both 0.75a+0.25b and 0.25a+0.75b via the
+            // double-rhadd identity, then interleave so adjacent dst pixels
+            // alternate (hi, lo) — matching the dst[2J+1], dst[2J+2] pattern.
+            let blend = |ac: uint8x16_t, bc: uint8x16_t| -> (uint8x16_t, uint8x16_t) {
+                let avg = vrhaddq_u8(ac, bc);
+                let hi = vrhaddq_u8(ac, avg); // 0.75·ac + 0.25·bc
+                let lo = vrhaddq_u8(bc, avg); // 0.25·ac + 0.75·bc
+                (vzip1q_u8(hi, lo), vzip2q_u8(hi, lo))
+            };
+
+            let (r_lo, r_hi) = blend(s_a.0, s_b.0);
+            let (g_lo, g_hi) = blend(s_a.1, s_b.1);
+            let (b_lo, b_hi) = blend(s_a.2, s_b.2);
+
+            let out_low = uint8x16x3_t(r_lo, g_lo, b_lo);
+            let out_high = uint8x16x3_t(r_hi, g_hi, b_hi);
+
+            vst3q_u8(d.add((2 * j + 1) * 3), out_low);
+            vst3q_u8(d.add((2 * j + 17) * 3), out_high);
+
+            j += 16;
+        }
+
+        // Scalar tail for the remaining (src_w - 1 - j) interior pairs.
+        while j + 1 < src_w {
+            let ja = j * 3;
+            let jb = (j + 1) * 3;
+            for ch in 0..3 {
+                let a = *s.add(ja + ch) as u16;
+                let b = *s.add(jb + ch) as u16;
+                let avg = (a + b + 1) >> 1;
+                *d.add((2 * j + 1) * 3 + ch) = ((a + avg + 1) >> 1) as u8;
+                *d.add((2 * j + 2) * 3 + ch) = ((b + avg + 1) >> 1) as u8;
+            }
+            j += 1;
+        }
+
+        // Edge: dst[2·src_w-1] ← src[src_w-1] (clamped f=1 for last dst_x).
+        for ch in 0..3 {
+            *d.add((2 * src_w - 1) * 3 + ch) = *s.add((src_w - 1) * 3 + ch);
+        }
     }
 }
 
@@ -311,37 +315,39 @@ unsafe fn blend_75_25_row_avx2(a: &[u8], b: &[u8], dst: &mut [u8]) {
 #[cfg(target_arch = "aarch64")]
 #[target_feature(enable = "neon")]
 unsafe fn blend_75_25_row_neon(a: &[u8], b: &[u8], dst: &mut [u8]) {
-    use std::arch::aarch64::*;
-    let n = dst.len();
-    let bulk = n & !31; // unroll 2× for Cortex-A78AE dual-issue load pair
-    let mut i = 0;
-    while i < bulk {
-        let va0 = vld1q_u8(a.as_ptr().add(i));
-        let vb0 = vld1q_u8(b.as_ptr().add(i));
-        let va1 = vld1q_u8(a.as_ptr().add(i + 16));
-        let vb1 = vld1q_u8(b.as_ptr().add(i + 16));
-        let avg0 = vrhaddq_u8(va0, vb0);
-        let avg1 = vrhaddq_u8(va1, vb1);
-        let out0 = vrhaddq_u8(va0, avg0);
-        let out1 = vrhaddq_u8(va1, avg1);
-        vst1q_u8(dst.as_mut_ptr().add(i), out0);
-        vst1q_u8(dst.as_mut_ptr().add(i + 16), out1);
-        i += 32;
-    }
-    while i + 16 <= n {
-        let va = vld1q_u8(a.as_ptr().add(i));
-        let vb = vld1q_u8(b.as_ptr().add(i));
-        let avg = vrhaddq_u8(va, vb);
-        let out = vrhaddq_u8(va, avg);
-        vst1q_u8(dst.as_mut_ptr().add(i), out);
-        i += 16;
-    }
-    while i < n {
-        let av = a[i] as u16;
-        let bv = b[i] as u16;
-        let avg = (av + bv + 1) >> 1;
-        dst[i] = ((av + avg + 1) >> 1) as u8;
-        i += 1;
+    unsafe {
+        use std::arch::aarch64::*;
+        let n = dst.len();
+        let bulk = n & !31; // unroll 2× for Cortex-A78AE dual-issue load pair
+        let mut i = 0;
+        while i < bulk {
+            let va0 = vld1q_u8(a.as_ptr().add(i));
+            let vb0 = vld1q_u8(b.as_ptr().add(i));
+            let va1 = vld1q_u8(a.as_ptr().add(i + 16));
+            let vb1 = vld1q_u8(b.as_ptr().add(i + 16));
+            let avg0 = vrhaddq_u8(va0, vb0);
+            let avg1 = vrhaddq_u8(va1, vb1);
+            let out0 = vrhaddq_u8(va0, avg0);
+            let out1 = vrhaddq_u8(va1, avg1);
+            vst1q_u8(dst.as_mut_ptr().add(i), out0);
+            vst1q_u8(dst.as_mut_ptr().add(i + 16), out1);
+            i += 32;
+        }
+        while i + 16 <= n {
+            let va = vld1q_u8(a.as_ptr().add(i));
+            let vb = vld1q_u8(b.as_ptr().add(i));
+            let avg = vrhaddq_u8(va, vb);
+            let out = vrhaddq_u8(va, avg);
+            vst1q_u8(dst.as_mut_ptr().add(i), out);
+            i += 16;
+        }
+        while i < n {
+            let av = a[i] as u16;
+            let bv = b[i] as u16;
+            let avg = (av + bv + 1) >> 1;
+            dst[i] = ((av + avg + 1) >> 1) as u8;
+            i += 1;
+        }
     }
 }
 
@@ -417,16 +423,20 @@ fn horizontal_row_scalar<const C: usize>(
 #[cfg(target_arch = "aarch64")]
 #[inline(always)]
 unsafe fn load_px(p: *const u8) -> std::arch::aarch64::int16x4_t {
-    use std::arch::aarch64::*;
-    vreinterpret_s16_u16(vget_low_u16(vmovl_u8(vld1_u8(p))))
+    unsafe {
+        use std::arch::aarch64::*;
+        vreinterpret_s16_u16(vget_low_u16(vmovl_u8(vld1_u8(p))))
+    }
 }
 
 #[cfg(target_arch = "aarch64")]
 #[inline(always)]
 unsafe fn load_px_edge(p: *const u8) -> std::arch::aarch64::int16x4_t {
-    use std::arch::aarch64::*;
-    let t: [i16; 4] = [*p as i16, *p.add(1) as i16, *p.add(2) as i16, 0];
-    vld1_s16(t.as_ptr())
+    unsafe {
+        use std::arch::aarch64::*;
+        let t: [i16; 4] = [*p as i16, *p.add(1) as i16, *p.add(2) as i16, 0];
+        vld1_s16(t.as_ptr())
+    }
 }
 
 #[cfg(target_arch = "aarch64")]
@@ -442,95 +452,97 @@ unsafe fn horizontal_row_c3_neon(
     last_sx_safe: usize,
     round1: i32,
 ) {
-    use std::arch::aarch64::*;
-    let round_v = vdupq_n_s32(round1);
-    // 4-wide unroll: four independent accumulators hide the ~4-cycle
-    // vmlal latency on A-class cores, nearly quadrupling MAC throughput
-    // when kx is large (lanczos, bicubic at strong downscales).
-    let mut x = 0;
-    while x + 4 <= dst_w {
-        let b0 = x * kx;
-        let b1 = (x + 1) * kx;
-        let b2 = (x + 2) * kx;
-        let b3 = (x + 3) * kx;
-        let mut a0 = round_v;
-        let mut a1 = round_v;
-        let mut a2 = round_v;
-        let mut a3 = round_v;
-        for t in 0..kx {
-            let sx0 = *xsrc.get_unchecked(b0 + t) as usize;
-            let sx1 = *xsrc.get_unchecked(b1 + t) as usize;
-            let sx2 = *xsrc.get_unchecked(b2 + t) as usize;
-            let sx3 = *xsrc.get_unchecked(b3 + t) as usize;
-            let w0 = *xw.get_unchecked(b0 + t);
-            let w1 = *xw.get_unchecked(b1 + t);
-            let w2 = *xw.get_unchecked(b2 + t);
-            let w3 = *xw.get_unchecked(b3 + t);
-            let base = src_row.as_ptr();
-            let p0 = if sx0 < last_sx_safe {
-                load_px(base.add(sx0 * 3))
-            } else {
-                load_px_edge(base.add(sx0 * 3))
-            };
-            let p1 = if sx1 < last_sx_safe {
-                load_px(base.add(sx1 * 3))
-            } else {
-                load_px_edge(base.add(sx1 * 3))
-            };
-            let p2 = if sx2 < last_sx_safe {
-                load_px(base.add(sx2 * 3))
-            } else {
-                load_px_edge(base.add(sx2 * 3))
-            };
-            let p3 = if sx3 < last_sx_safe {
-                load_px(base.add(sx3 * 3))
-            } else {
-                load_px_edge(base.add(sx3 * 3))
-            };
-            a0 = vmlal_n_s16(a0, p0, w0);
-            a1 = vmlal_n_s16(a1, p1, w1);
-            a2 = vmlal_n_s16(a2, p2, w2);
-            a3 = vmlal_n_s16(a3, p3, w3);
+    unsafe {
+        use std::arch::aarch64::*;
+        let round_v = vdupq_n_s32(round1);
+        // 4-wide unroll: four independent accumulators hide the ~4-cycle
+        // vmlal latency on A-class cores, nearly quadrupling MAC throughput
+        // when kx is large (lanczos, bicubic at strong downscales).
+        let mut x = 0;
+        while x + 4 <= dst_w {
+            let b0 = x * kx;
+            let b1 = (x + 1) * kx;
+            let b2 = (x + 2) * kx;
+            let b3 = (x + 3) * kx;
+            let mut a0 = round_v;
+            let mut a1 = round_v;
+            let mut a2 = round_v;
+            let mut a3 = round_v;
+            for t in 0..kx {
+                let sx0 = *xsrc.get_unchecked(b0 + t) as usize;
+                let sx1 = *xsrc.get_unchecked(b1 + t) as usize;
+                let sx2 = *xsrc.get_unchecked(b2 + t) as usize;
+                let sx3 = *xsrc.get_unchecked(b3 + t) as usize;
+                let w0 = *xw.get_unchecked(b0 + t);
+                let w1 = *xw.get_unchecked(b1 + t);
+                let w2 = *xw.get_unchecked(b2 + t);
+                let w3 = *xw.get_unchecked(b3 + t);
+                let base = src_row.as_ptr();
+                let p0 = if sx0 < last_sx_safe {
+                    load_px(base.add(sx0 * 3))
+                } else {
+                    load_px_edge(base.add(sx0 * 3))
+                };
+                let p1 = if sx1 < last_sx_safe {
+                    load_px(base.add(sx1 * 3))
+                } else {
+                    load_px_edge(base.add(sx1 * 3))
+                };
+                let p2 = if sx2 < last_sx_safe {
+                    load_px(base.add(sx2 * 3))
+                } else {
+                    load_px_edge(base.add(sx2 * 3))
+                };
+                let p3 = if sx3 < last_sx_safe {
+                    load_px(base.add(sx3 * 3))
+                } else {
+                    load_px_edge(base.add(sx3 * 3))
+                };
+                a0 = vmlal_n_s16(a0, p0, w0);
+                a1 = vmlal_n_s16(a1, p1, w1);
+                a2 = vmlal_n_s16(a2, p2, w2);
+                a3 = vmlal_n_s16(a3, p3, w3);
+            }
+            let s0 = vqmovn_s32(vshrq_n_s32::<14>(a0));
+            let s1 = vqmovn_s32(vshrq_n_s32::<14>(a1));
+            let s2 = vqmovn_s32(vshrq_n_s32::<14>(a2));
+            let s3 = vqmovn_s32(vshrq_n_s32::<14>(a3));
+            let o = out.as_mut_ptr().add(x * 3);
+            *o = vget_lane_s16::<0>(s0);
+            *o.add(1) = vget_lane_s16::<1>(s0);
+            *o.add(2) = vget_lane_s16::<2>(s0);
+            *o.add(3) = vget_lane_s16::<0>(s1);
+            *o.add(4) = vget_lane_s16::<1>(s1);
+            *o.add(5) = vget_lane_s16::<2>(s1);
+            *o.add(6) = vget_lane_s16::<0>(s2);
+            *o.add(7) = vget_lane_s16::<1>(s2);
+            *o.add(8) = vget_lane_s16::<2>(s2);
+            *o.add(9) = vget_lane_s16::<0>(s3);
+            *o.add(10) = vget_lane_s16::<1>(s3);
+            *o.add(11) = vget_lane_s16::<2>(s3);
+            x += 4;
         }
-        let s0 = vqmovn_s32(vshrq_n_s32::<14>(a0));
-        let s1 = vqmovn_s32(vshrq_n_s32::<14>(a1));
-        let s2 = vqmovn_s32(vshrq_n_s32::<14>(a2));
-        let s3 = vqmovn_s32(vshrq_n_s32::<14>(a3));
-        let o = out.as_mut_ptr().add(x * 3);
-        *o = vget_lane_s16::<0>(s0);
-        *o.add(1) = vget_lane_s16::<1>(s0);
-        *o.add(2) = vget_lane_s16::<2>(s0);
-        *o.add(3) = vget_lane_s16::<0>(s1);
-        *o.add(4) = vget_lane_s16::<1>(s1);
-        *o.add(5) = vget_lane_s16::<2>(s1);
-        *o.add(6) = vget_lane_s16::<0>(s2);
-        *o.add(7) = vget_lane_s16::<1>(s2);
-        *o.add(8) = vget_lane_s16::<2>(s2);
-        *o.add(9) = vget_lane_s16::<0>(s3);
-        *o.add(10) = vget_lane_s16::<1>(s3);
-        *o.add(11) = vget_lane_s16::<2>(s3);
-        x += 4;
-    }
-    while x < dst_w {
-        let ibase = x * kx;
-        let mut acc = round_v;
-        for t in 0..kx {
-            let sx = *xsrc.get_unchecked(ibase + t) as usize;
-            let w = *xw.get_unchecked(ibase + t);
-            let p = src_row.as_ptr().add(sx * 3);
-            let px = if sx < last_sx_safe {
-                load_px(p)
-            } else {
-                load_px_edge(p)
-            };
-            acc = vmlal_n_s16(acc, px, w);
+        while x < dst_w {
+            let ibase = x * kx;
+            let mut acc = round_v;
+            for t in 0..kx {
+                let sx = *xsrc.get_unchecked(ibase + t) as usize;
+                let w = *xw.get_unchecked(ibase + t);
+                let p = src_row.as_ptr().add(sx * 3);
+                let px = if sx < last_sx_safe {
+                    load_px(p)
+                } else {
+                    load_px_edge(p)
+                };
+                acc = vmlal_n_s16(acc, px, w);
+            }
+            let sat = vqmovn_s32(vshrq_n_s32::<14>(acc));
+            let o = out.as_mut_ptr().add(x * 3);
+            *o = vget_lane_s16::<0>(sat);
+            *o.add(1) = vget_lane_s16::<1>(sat);
+            *o.add(2) = vget_lane_s16::<2>(sat);
+            x += 1;
         }
-        let sat = vqmovn_s32(vshrq_n_s32::<14>(acc));
-        let o = out.as_mut_ptr().add(x * 3);
-        *o = vget_lane_s16::<0>(sat);
-        *o.add(1) = vget_lane_s16::<1>(sat);
-        *o.add(2) = vget_lane_s16::<2>(sat);
-        x += 1;
     }
 }
 
@@ -561,91 +573,93 @@ pub(super) unsafe fn horizontal_rows_rgb_u8_x4(
     last_sx_safe: usize,
     round1: i32,
 ) {
-    use std::arch::aarch64::*;
-    let round_v = vdupq_n_s32(round1);
-    let [s0p, s1p, s2p, s3p] = [
-        src_rows[0].as_ptr(),
-        src_rows[1].as_ptr(),
-        src_rows[2].as_ptr(),
-        src_rows[3].as_ptr(),
-    ];
-    let [mut o0, mut o1, mut o2, mut o3] = {
-        let [a, b, c, d] = outs;
-        [
-            a.as_mut_ptr(),
-            b.as_mut_ptr(),
-            c.as_mut_ptr(),
-            d.as_mut_ptr(),
-        ]
-    };
-    let last_x = dst_w.saturating_sub(1);
-    for x in 0..dst_w {
-        let ibase = x * kx;
-        let mut a0 = round_v;
-        let mut a1 = round_v;
-        let mut a2 = round_v;
-        let mut a3 = round_v;
-        for t in 0..kx {
-            let sx = *xsrc.get_unchecked(ibase + t) as usize;
-            let w = *xw.get_unchecked(ibase + t);
-            let safe = sx < last_sx_safe;
-            let off = sx * 3;
-            let p0 = if safe {
-                load_px(s0p.add(off))
+    unsafe {
+        use std::arch::aarch64::*;
+        let round_v = vdupq_n_s32(round1);
+        let [s0p, s1p, s2p, s3p] = [
+            src_rows[0].as_ptr(),
+            src_rows[1].as_ptr(),
+            src_rows[2].as_ptr(),
+            src_rows[3].as_ptr(),
+        ];
+        let [mut o0, mut o1, mut o2, mut o3] = {
+            let [a, b, c, d] = outs;
+            [
+                a.as_mut_ptr(),
+                b.as_mut_ptr(),
+                c.as_mut_ptr(),
+                d.as_mut_ptr(),
+            ]
+        };
+        let last_x = dst_w.saturating_sub(1);
+        for x in 0..dst_w {
+            let ibase = x * kx;
+            let mut a0 = round_v;
+            let mut a1 = round_v;
+            let mut a2 = round_v;
+            let mut a3 = round_v;
+            for t in 0..kx {
+                let sx = *xsrc.get_unchecked(ibase + t) as usize;
+                let w = *xw.get_unchecked(ibase + t);
+                let safe = sx < last_sx_safe;
+                let off = sx * 3;
+                let p0 = if safe {
+                    load_px(s0p.add(off))
+                } else {
+                    load_px_edge(s0p.add(off))
+                };
+                let p1 = if safe {
+                    load_px(s1p.add(off))
+                } else {
+                    load_px_edge(s1p.add(off))
+                };
+                let p2 = if safe {
+                    load_px(s2p.add(off))
+                } else {
+                    load_px_edge(s2p.add(off))
+                };
+                let p3 = if safe {
+                    load_px(s3p.add(off))
+                } else {
+                    load_px_edge(s3p.add(off))
+                };
+                a0 = vmlal_n_s16(a0, p0, w);
+                a1 = vmlal_n_s16(a1, p1, w);
+                a2 = vmlal_n_s16(a2, p2, w);
+                a3 = vmlal_n_s16(a3, p3, w);
+            }
+            let s0 = vqmovn_s32(vshrq_n_s32::<14>(a0));
+            let s1 = vqmovn_s32(vshrq_n_s32::<14>(a1));
+            let s2 = vqmovn_s32(vshrq_n_s32::<14>(a2));
+            let s3 = vqmovn_s32(vshrq_n_s32::<14>(a3));
+            if x < last_x {
+                // Interior: store 8 bytes (4 × i16). Lane 3's garbage lands on
+                // the next pixel's R slot and is overwritten by its lane 0 on
+                // the next iteration, so it's benign.
+                vst1_s16(o0, s0);
+                vst1_s16(o1, s1);
+                vst1_s16(o2, s2);
+                vst1_s16(o3, s3);
             } else {
-                load_px_edge(s0p.add(off))
-            };
-            let p1 = if safe {
-                load_px(s1p.add(off))
-            } else {
-                load_px_edge(s1p.add(off))
-            };
-            let p2 = if safe {
-                load_px(s2p.add(off))
-            } else {
-                load_px_edge(s2p.add(off))
-            };
-            let p3 = if safe {
-                load_px(s3p.add(off))
-            } else {
-                load_px_edge(s3p.add(off))
-            };
-            a0 = vmlal_n_s16(a0, p0, w);
-            a1 = vmlal_n_s16(a1, p1, w);
-            a2 = vmlal_n_s16(a2, p2, w);
-            a3 = vmlal_n_s16(a3, p3, w);
+                // Last pixel: scalar stores (no room for overflow).
+                *o0 = vget_lane_s16::<0>(s0);
+                *o0.add(1) = vget_lane_s16::<1>(s0);
+                *o0.add(2) = vget_lane_s16::<2>(s0);
+                *o1 = vget_lane_s16::<0>(s1);
+                *o1.add(1) = vget_lane_s16::<1>(s1);
+                *o1.add(2) = vget_lane_s16::<2>(s1);
+                *o2 = vget_lane_s16::<0>(s2);
+                *o2.add(1) = vget_lane_s16::<1>(s2);
+                *o2.add(2) = vget_lane_s16::<2>(s2);
+                *o3 = vget_lane_s16::<0>(s3);
+                *o3.add(1) = vget_lane_s16::<1>(s3);
+                *o3.add(2) = vget_lane_s16::<2>(s3);
+            }
+            o0 = o0.add(3);
+            o1 = o1.add(3);
+            o2 = o2.add(3);
+            o3 = o3.add(3);
         }
-        let s0 = vqmovn_s32(vshrq_n_s32::<14>(a0));
-        let s1 = vqmovn_s32(vshrq_n_s32::<14>(a1));
-        let s2 = vqmovn_s32(vshrq_n_s32::<14>(a2));
-        let s3 = vqmovn_s32(vshrq_n_s32::<14>(a3));
-        if x < last_x {
-            // Interior: store 8 bytes (4 × i16). Lane 3's garbage lands on
-            // the next pixel's R slot and is overwritten by its lane 0 on
-            // the next iteration, so it's benign.
-            vst1_s16(o0, s0);
-            vst1_s16(o1, s1);
-            vst1_s16(o2, s2);
-            vst1_s16(o3, s3);
-        } else {
-            // Last pixel: scalar stores (no room for overflow).
-            *o0 = vget_lane_s16::<0>(s0);
-            *o0.add(1) = vget_lane_s16::<1>(s0);
-            *o0.add(2) = vget_lane_s16::<2>(s0);
-            *o1 = vget_lane_s16::<0>(s1);
-            *o1.add(1) = vget_lane_s16::<1>(s1);
-            *o1.add(2) = vget_lane_s16::<2>(s1);
-            *o2 = vget_lane_s16::<0>(s2);
-            *o2.add(1) = vget_lane_s16::<1>(s2);
-            *o2.add(2) = vget_lane_s16::<2>(s2);
-            *o3 = vget_lane_s16::<0>(s3);
-            *o3.add(1) = vget_lane_s16::<1>(s3);
-            *o3.add(2) = vget_lane_s16::<2>(s3);
-        }
-        o0 = o0.add(3);
-        o1 = o1.add(3);
-        o2 = o2.add(3);
-        o3 = o3.add(3);
     }
 }
 
@@ -691,186 +705,188 @@ fn vertical_row_scalar(rows: &[&[i16]], w: &[i16], dst_row: &mut [u8], n: usize,
 #[cfg(target_arch = "aarch64")]
 #[target_feature(enable = "neon")]
 unsafe fn vertical_row_neon(rows: &[&[i16]], w: &[i16], dst_row: &mut [u8], n: usize, round2: i32) {
-    use std::arch::aarch64::*;
-    let ky = rows.len();
-    let round_v = vdupq_n_s32(round2);
-    let zero = vdupq_n_s32(0);
-    let mut i = 0usize;
-    // 16-lane path: two parallel 8-lane halves (L=left, R=right), each with
-    // its own 4-chain rolling accumulator set. Doubles MAC throughput per
-    // outer-iter and hides loop overhead; register file is 32 v-regs so
-    // 16 accumulators + scratch fits comfortably.
-    while i + 16 <= n {
-        let mut a0ll = round_v;
-        let mut a1ll = zero;
-        let mut a2ll = zero;
-        let mut a3ll = zero;
-        let mut a0lh = round_v;
-        let mut a1lh = zero;
-        let mut a2lh = zero;
-        let mut a3lh = zero;
-        let mut a0rl = round_v;
-        let mut a1rl = zero;
-        let mut a2rl = zero;
-        let mut a3rl = zero;
-        let mut a0rh = round_v;
-        let mut a1rh = zero;
-        let mut a2rh = zero;
-        let mut a3rh = zero;
+    unsafe {
+        use std::arch::aarch64::*;
+        let ky = rows.len();
+        let round_v = vdupq_n_s32(round2);
+        let zero = vdupq_n_s32(0);
+        let mut i = 0usize;
+        // 16-lane path: two parallel 8-lane halves (L=left, R=right), each with
+        // its own 4-chain rolling accumulator set. Doubles MAC throughput per
+        // outer-iter and hides loop overhead; register file is 32 v-regs so
+        // 16 accumulators + scratch fits comfortably.
+        while i + 16 <= n {
+            let mut a0ll = round_v;
+            let mut a1ll = zero;
+            let mut a2ll = zero;
+            let mut a3ll = zero;
+            let mut a0lh = round_v;
+            let mut a1lh = zero;
+            let mut a2lh = zero;
+            let mut a3lh = zero;
+            let mut a0rl = round_v;
+            let mut a1rl = zero;
+            let mut a2rl = zero;
+            let mut a3rl = zero;
+            let mut a0rh = round_v;
+            let mut a1rh = zero;
+            let mut a2rh = zero;
+            let mut a3rh = zero;
 
-        let mut k = 0;
-        while k + 4 <= ky {
-            let p0 = rows.get_unchecked(k).as_ptr().add(i);
-            let p1 = rows.get_unchecked(k + 1).as_ptr().add(i);
-            let p2 = rows.get_unchecked(k + 2).as_ptr().add(i);
-            let p3 = rows.get_unchecked(k + 3).as_ptr().add(i);
-            let v0l = vld1q_s16(p0);
-            let v1l = vld1q_s16(p1);
-            let v2l = vld1q_s16(p2);
-            let v3l = vld1q_s16(p3);
-            let v0r = vld1q_s16(p0.add(8));
-            let v1r = vld1q_s16(p1.add(8));
-            let v2r = vld1q_s16(p2.add(8));
-            let v3r = vld1q_s16(p3.add(8));
-            let w0 = vdup_n_s16(*w.get_unchecked(k));
-            let w1 = vdup_n_s16(*w.get_unchecked(k + 1));
-            let w2 = vdup_n_s16(*w.get_unchecked(k + 2));
-            let w3 = vdup_n_s16(*w.get_unchecked(k + 3));
-            a0ll = vmlal_s16(a0ll, vget_low_s16(v0l), w0);
-            a1ll = vmlal_s16(a1ll, vget_low_s16(v1l), w1);
-            a2ll = vmlal_s16(a2ll, vget_low_s16(v2l), w2);
-            a3ll = vmlal_s16(a3ll, vget_low_s16(v3l), w3);
-            a0lh = vmlal_s16(a0lh, vget_high_s16(v0l), w0);
-            a1lh = vmlal_s16(a1lh, vget_high_s16(v1l), w1);
-            a2lh = vmlal_s16(a2lh, vget_high_s16(v2l), w2);
-            a3lh = vmlal_s16(a3lh, vget_high_s16(v3l), w3);
-            a0rl = vmlal_s16(a0rl, vget_low_s16(v0r), w0);
-            a1rl = vmlal_s16(a1rl, vget_low_s16(v1r), w1);
-            a2rl = vmlal_s16(a2rl, vget_low_s16(v2r), w2);
-            a3rl = vmlal_s16(a3rl, vget_low_s16(v3r), w3);
-            a0rh = vmlal_s16(a0rh, vget_high_s16(v0r), w0);
-            a1rh = vmlal_s16(a1rh, vget_high_s16(v1r), w1);
-            a2rh = vmlal_s16(a2rh, vget_high_s16(v2r), w2);
-            a3rh = vmlal_s16(a3rh, vget_high_s16(v3r), w3);
-            k += 4;
-        }
-        while k < ky {
-            let p = rows.get_unchecked(k).as_ptr().add(i);
-            let vl = vld1q_s16(p);
-            let vr = vld1q_s16(p.add(8));
-            let wk = vdup_n_s16(*w.get_unchecked(k));
-            let vll = vget_low_s16(vl);
-            let vlh = vget_high_s16(vl);
-            let vrl = vget_low_s16(vr);
-            let vrh = vget_high_s16(vr);
-            match k & 3 {
-                0 => {
-                    a0ll = vmlal_s16(a0ll, vll, wk);
-                    a0lh = vmlal_s16(a0lh, vlh, wk);
-                    a0rl = vmlal_s16(a0rl, vrl, wk);
-                    a0rh = vmlal_s16(a0rh, vrh, wk);
-                }
-                1 => {
-                    a1ll = vmlal_s16(a1ll, vll, wk);
-                    a1lh = vmlal_s16(a1lh, vlh, wk);
-                    a1rl = vmlal_s16(a1rl, vrl, wk);
-                    a1rh = vmlal_s16(a1rh, vrh, wk);
-                }
-                _ => {
-                    a2ll = vmlal_s16(a2ll, vll, wk);
-                    a2lh = vmlal_s16(a2lh, vlh, wk);
-                    a2rl = vmlal_s16(a2rl, vrl, wk);
-                    a2rh = vmlal_s16(a2rh, vrh, wk);
-                }
+            let mut k = 0;
+            while k + 4 <= ky {
+                let p0 = rows.get_unchecked(k).as_ptr().add(i);
+                let p1 = rows.get_unchecked(k + 1).as_ptr().add(i);
+                let p2 = rows.get_unchecked(k + 2).as_ptr().add(i);
+                let p3 = rows.get_unchecked(k + 3).as_ptr().add(i);
+                let v0l = vld1q_s16(p0);
+                let v1l = vld1q_s16(p1);
+                let v2l = vld1q_s16(p2);
+                let v3l = vld1q_s16(p3);
+                let v0r = vld1q_s16(p0.add(8));
+                let v1r = vld1q_s16(p1.add(8));
+                let v2r = vld1q_s16(p2.add(8));
+                let v3r = vld1q_s16(p3.add(8));
+                let w0 = vdup_n_s16(*w.get_unchecked(k));
+                let w1 = vdup_n_s16(*w.get_unchecked(k + 1));
+                let w2 = vdup_n_s16(*w.get_unchecked(k + 2));
+                let w3 = vdup_n_s16(*w.get_unchecked(k + 3));
+                a0ll = vmlal_s16(a0ll, vget_low_s16(v0l), w0);
+                a1ll = vmlal_s16(a1ll, vget_low_s16(v1l), w1);
+                a2ll = vmlal_s16(a2ll, vget_low_s16(v2l), w2);
+                a3ll = vmlal_s16(a3ll, vget_low_s16(v3l), w3);
+                a0lh = vmlal_s16(a0lh, vget_high_s16(v0l), w0);
+                a1lh = vmlal_s16(a1lh, vget_high_s16(v1l), w1);
+                a2lh = vmlal_s16(a2lh, vget_high_s16(v2l), w2);
+                a3lh = vmlal_s16(a3lh, vget_high_s16(v3l), w3);
+                a0rl = vmlal_s16(a0rl, vget_low_s16(v0r), w0);
+                a1rl = vmlal_s16(a1rl, vget_low_s16(v1r), w1);
+                a2rl = vmlal_s16(a2rl, vget_low_s16(v2r), w2);
+                a3rl = vmlal_s16(a3rl, vget_low_s16(v3r), w3);
+                a0rh = vmlal_s16(a0rh, vget_high_s16(v0r), w0);
+                a1rh = vmlal_s16(a1rh, vget_high_s16(v1r), w1);
+                a2rh = vmlal_s16(a2rh, vget_high_s16(v2r), w2);
+                a3rh = vmlal_s16(a3rh, vget_high_s16(v3r), w3);
+                k += 4;
             }
-            k += 1;
-        }
+            while k < ky {
+                let p = rows.get_unchecked(k).as_ptr().add(i);
+                let vl = vld1q_s16(p);
+                let vr = vld1q_s16(p.add(8));
+                let wk = vdup_n_s16(*w.get_unchecked(k));
+                let vll = vget_low_s16(vl);
+                let vlh = vget_high_s16(vl);
+                let vrl = vget_low_s16(vr);
+                let vrh = vget_high_s16(vr);
+                match k & 3 {
+                    0 => {
+                        a0ll = vmlal_s16(a0ll, vll, wk);
+                        a0lh = vmlal_s16(a0lh, vlh, wk);
+                        a0rl = vmlal_s16(a0rl, vrl, wk);
+                        a0rh = vmlal_s16(a0rh, vrh, wk);
+                    }
+                    1 => {
+                        a1ll = vmlal_s16(a1ll, vll, wk);
+                        a1lh = vmlal_s16(a1lh, vlh, wk);
+                        a1rl = vmlal_s16(a1rl, vrl, wk);
+                        a1rh = vmlal_s16(a1rh, vrh, wk);
+                    }
+                    _ => {
+                        a2ll = vmlal_s16(a2ll, vll, wk);
+                        a2lh = vmlal_s16(a2lh, vlh, wk);
+                        a2rl = vmlal_s16(a2rl, vrl, wk);
+                        a2rh = vmlal_s16(a2rh, vrh, wk);
+                    }
+                }
+                k += 1;
+            }
 
-        let acc_ll = vaddq_s32(vaddq_s32(a0ll, a1ll), vaddq_s32(a2ll, a3ll));
-        let acc_lh = vaddq_s32(vaddq_s32(a0lh, a1lh), vaddq_s32(a2lh, a3lh));
-        let acc_rl = vaddq_s32(vaddq_s32(a0rl, a1rl), vaddq_s32(a2rl, a3rl));
-        let acc_rh = vaddq_s32(vaddq_s32(a0rh, a1rh), vaddq_s32(a2rh, a3rh));
-        let packed_l = vcombine_s16(
-            vqmovn_s32(vshrq_n_s32::<14>(acc_ll)),
-            vqmovn_s32(vshrq_n_s32::<14>(acc_lh)),
-        );
-        let packed_r = vcombine_s16(
-            vqmovn_s32(vshrq_n_s32::<14>(acc_rl)),
-            vqmovn_s32(vshrq_n_s32::<14>(acc_rh)),
-        );
-        // Saturate both halves to u8, pack into one q-reg, store 16 bytes.
-        let out = vcombine_u8(vqmovun_s16(packed_l), vqmovun_s16(packed_r));
-        vst1q_u8(dst_row.as_mut_ptr().add(i), out);
-        i += 16;
-    }
-    // 8-lane fallback for a remaining half-vector.
-    if i + 8 <= n {
-        let mut a0l = round_v;
-        let mut a1l = zero;
-        let mut a2l = zero;
-        let mut a3l = zero;
-        let mut a0h = round_v;
-        let mut a1h = zero;
-        let mut a2h = zero;
-        let mut a3h = zero;
-        let mut k = 0;
-        while k + 4 <= ky {
-            let v0 = vld1q_s16(rows.get_unchecked(k).as_ptr().add(i));
-            let v1 = vld1q_s16(rows.get_unchecked(k + 1).as_ptr().add(i));
-            let v2 = vld1q_s16(rows.get_unchecked(k + 2).as_ptr().add(i));
-            let v3 = vld1q_s16(rows.get_unchecked(k + 3).as_ptr().add(i));
-            let w0 = vdup_n_s16(*w.get_unchecked(k));
-            let w1 = vdup_n_s16(*w.get_unchecked(k + 1));
-            let w2 = vdup_n_s16(*w.get_unchecked(k + 2));
-            let w3 = vdup_n_s16(*w.get_unchecked(k + 3));
-            a0l = vmlal_s16(a0l, vget_low_s16(v0), w0);
-            a1l = vmlal_s16(a1l, vget_low_s16(v1), w1);
-            a2l = vmlal_s16(a2l, vget_low_s16(v2), w2);
-            a3l = vmlal_s16(a3l, vget_low_s16(v3), w3);
-            a0h = vmlal_s16(a0h, vget_high_s16(v0), w0);
-            a1h = vmlal_s16(a1h, vget_high_s16(v1), w1);
-            a2h = vmlal_s16(a2h, vget_high_s16(v2), w2);
-            a3h = vmlal_s16(a3h, vget_high_s16(v3), w3);
-            k += 4;
+            let acc_ll = vaddq_s32(vaddq_s32(a0ll, a1ll), vaddq_s32(a2ll, a3ll));
+            let acc_lh = vaddq_s32(vaddq_s32(a0lh, a1lh), vaddq_s32(a2lh, a3lh));
+            let acc_rl = vaddq_s32(vaddq_s32(a0rl, a1rl), vaddq_s32(a2rl, a3rl));
+            let acc_rh = vaddq_s32(vaddq_s32(a0rh, a1rh), vaddq_s32(a2rh, a3rh));
+            let packed_l = vcombine_s16(
+                vqmovn_s32(vshrq_n_s32::<14>(acc_ll)),
+                vqmovn_s32(vshrq_n_s32::<14>(acc_lh)),
+            );
+            let packed_r = vcombine_s16(
+                vqmovn_s32(vshrq_n_s32::<14>(acc_rl)),
+                vqmovn_s32(vshrq_n_s32::<14>(acc_rh)),
+            );
+            // Saturate both halves to u8, pack into one q-reg, store 16 bytes.
+            let out = vcombine_u8(vqmovun_s16(packed_l), vqmovun_s16(packed_r));
+            vst1q_u8(dst_row.as_mut_ptr().add(i), out);
+            i += 16;
         }
-        while k < ky {
-            let v = vld1q_s16(rows.get_unchecked(k).as_ptr().add(i));
-            let wk = vdup_n_s16(*w.get_unchecked(k));
-            let vl = vget_low_s16(v);
-            let vh = vget_high_s16(v);
-            match k & 3 {
-                0 => {
-                    a0l = vmlal_s16(a0l, vl, wk);
-                    a0h = vmlal_s16(a0h, vh, wk);
-                }
-                1 => {
-                    a1l = vmlal_s16(a1l, vl, wk);
-                    a1h = vmlal_s16(a1h, vh, wk);
-                }
-                _ => {
-                    a2l = vmlal_s16(a2l, vl, wk);
-                    a2h = vmlal_s16(a2h, vh, wk);
-                }
+        // 8-lane fallback for a remaining half-vector.
+        if i + 8 <= n {
+            let mut a0l = round_v;
+            let mut a1l = zero;
+            let mut a2l = zero;
+            let mut a3l = zero;
+            let mut a0h = round_v;
+            let mut a1h = zero;
+            let mut a2h = zero;
+            let mut a3h = zero;
+            let mut k = 0;
+            while k + 4 <= ky {
+                let v0 = vld1q_s16(rows.get_unchecked(k).as_ptr().add(i));
+                let v1 = vld1q_s16(rows.get_unchecked(k + 1).as_ptr().add(i));
+                let v2 = vld1q_s16(rows.get_unchecked(k + 2).as_ptr().add(i));
+                let v3 = vld1q_s16(rows.get_unchecked(k + 3).as_ptr().add(i));
+                let w0 = vdup_n_s16(*w.get_unchecked(k));
+                let w1 = vdup_n_s16(*w.get_unchecked(k + 1));
+                let w2 = vdup_n_s16(*w.get_unchecked(k + 2));
+                let w3 = vdup_n_s16(*w.get_unchecked(k + 3));
+                a0l = vmlal_s16(a0l, vget_low_s16(v0), w0);
+                a1l = vmlal_s16(a1l, vget_low_s16(v1), w1);
+                a2l = vmlal_s16(a2l, vget_low_s16(v2), w2);
+                a3l = vmlal_s16(a3l, vget_low_s16(v3), w3);
+                a0h = vmlal_s16(a0h, vget_high_s16(v0), w0);
+                a1h = vmlal_s16(a1h, vget_high_s16(v1), w1);
+                a2h = vmlal_s16(a2h, vget_high_s16(v2), w2);
+                a3h = vmlal_s16(a3h, vget_high_s16(v3), w3);
+                k += 4;
             }
-            k += 1;
+            while k < ky {
+                let v = vld1q_s16(rows.get_unchecked(k).as_ptr().add(i));
+                let wk = vdup_n_s16(*w.get_unchecked(k));
+                let vl = vget_low_s16(v);
+                let vh = vget_high_s16(v);
+                match k & 3 {
+                    0 => {
+                        a0l = vmlal_s16(a0l, vl, wk);
+                        a0h = vmlal_s16(a0h, vh, wk);
+                    }
+                    1 => {
+                        a1l = vmlal_s16(a1l, vl, wk);
+                        a1h = vmlal_s16(a1h, vh, wk);
+                    }
+                    _ => {
+                        a2l = vmlal_s16(a2l, vl, wk);
+                        a2h = vmlal_s16(a2h, vh, wk);
+                    }
+                }
+                k += 1;
+            }
+            let acc_lo = vaddq_s32(vaddq_s32(a0l, a1l), vaddq_s32(a2l, a3l));
+            let acc_hi = vaddq_s32(vaddq_s32(a0h, a1h), vaddq_s32(a2h, a3h));
+            let packed = vcombine_s16(
+                vqmovn_s32(vshrq_n_s32::<14>(acc_lo)),
+                vqmovn_s32(vshrq_n_s32::<14>(acc_hi)),
+            );
+            vst1_u8(dst_row.as_mut_ptr().add(i), vqmovun_s16(packed));
+            i += 8;
         }
-        let acc_lo = vaddq_s32(vaddq_s32(a0l, a1l), vaddq_s32(a2l, a3l));
-        let acc_hi = vaddq_s32(vaddq_s32(a0h, a1h), vaddq_s32(a2h, a3h));
-        let packed = vcombine_s16(
-            vqmovn_s32(vshrq_n_s32::<14>(acc_lo)),
-            vqmovn_s32(vshrq_n_s32::<14>(acc_hi)),
-        );
-        vst1_u8(dst_row.as_mut_ptr().add(i), vqmovun_s16(packed));
-        i += 8;
-    }
-    // Scalar tail.
-    while i < n {
-        let mut acc: i32 = 0;
-        for k in 0..ky {
-            acc += rows[k][i] as i32 * w[k] as i32;
+        // Scalar tail.
+        while i < n {
+            let mut acc: i32 = 0;
+            for k in 0..ky {
+                acc += rows[k][i] as i32 * w[k] as i32;
+            }
+            dst_row[i] = (((acc + round2) >> 14).clamp(0, 255)) as u8;
+            i += 1;
         }
-        dst_row[i] = (((acc + round2) >> 14).clamp(0, 255)) as u8;
-        i += 1;
     }
 }
 

--- a/crates/kornia-imgproc/src/resize/mod.rs
+++ b/crates/kornia-imgproc/src/resize/mod.rs
@@ -32,7 +32,7 @@ use crate::{
     },
     parallel,
 };
-use kornia_image::{allocator::ImageAllocator, Image, ImageError};
+use kornia_image::{Image, ImageError};
 
 use common::FilterKind;
 
@@ -55,17 +55,17 @@ use common::FilterKind;
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::resize::resize_native;
 /// use kornia_imgproc::interpolation::InterpolationMode;
 ///
-/// let image = Image::<_, 3, _>::new(
+/// let image = Image::<_, 3>::new(
 ///     ImageSize {
 ///         width: 4,
 ///         height: 5,
 ///     },
 ///     vec![0f32; 4 * 5 * 3],
-///     CpuAllocator
+///     host_alloc()
 /// )
 /// .unwrap();
 ///
@@ -74,7 +74,7 @@ use common::FilterKind;
 ///     height: 3,
 /// };
 ///
-/// let mut image_resized = Image::<_, 3, _>::from_size_val(new_size, 0.0, CpuAllocator).unwrap();
+/// let mut image_resized = Image::<_, 3>::from_size_val(new_size, 0.0, host_alloc()).unwrap();
 ///
 /// resize_native(
 ///     &image,
@@ -87,9 +87,9 @@ use common::FilterKind;
 /// assert_eq!(image_resized.size().width, 2);
 /// assert_eq!(image_resized.size().height, 3);
 /// ```
-pub fn resize_native<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<f32, C, A1>,
-    dst: &mut Image<f32, C, A2>,
+pub fn resize_native<const C: usize>(
+    src: &Image<f32, C>,
+    dst: &mut Image<f32, C>,
     interpolation: InterpolationMode,
 ) -> Result<(), ImageError> {
     validate_interpolation(interpolation)?;
@@ -130,17 +130,17 @@ pub fn resize_native<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::resize::resize_fast_rgb;
 /// use kornia_imgproc::interpolation::InterpolationMode;
 ///
-/// let image = Image::<_, 3, _>::new(
+/// let image = Image::<_, 3>::new(
 ///     ImageSize {
 ///         width: 4,
 ///         height: 5,
 ///     },
 ///     vec![0u8; 4 * 5 * 3],
-///     CpuAllocator
+///     host_alloc()
 /// )
 /// .unwrap();
 ///
@@ -149,7 +149,7 @@ pub fn resize_native<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
 ///   height: 3,
 /// };
 ///
-/// let mut image_resized = Image::<_, 3, _>::from_size_val(new_size, 0, CpuAllocator).unwrap();
+/// let mut image_resized = Image::<_, 3>::from_size_val(new_size, 0, host_alloc()).unwrap();
 ///
 /// resize_fast_rgb(
 ///   &image,
@@ -162,21 +162,21 @@ pub fn resize_native<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
 /// assert_eq!(image_resized.size().width, 2);
 /// assert_eq!(image_resized.size().height, 3);
 /// ```
-pub fn resize_fast_rgb<A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<u8, 3, A1>,
-    dst: &mut Image<u8, 3, A2>,
+pub fn resize_fast_rgb(
+    src: &Image<u8, 3>,
+    dst: &mut Image<u8, 3>,
     interpolation: InterpolationMode,
 ) -> Result<(), ImageError> {
-    resize_fast_u8::<3, _, _>(src, dst, interpolation)
+    resize_fast_u8::<3>(src, dst, interpolation)
 }
 
 /// Generic fast u8 resize for 1/3/4-channel images (PIL-quality antialiased downscale).
-pub fn resize_fast_u8<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<u8, C, A1>,
-    dst: &mut Image<u8, C, A2>,
+pub fn resize_fast_u8<const C: usize>(
+    src: &Image<u8, C>,
+    dst: &mut Image<u8, C>,
     interpolation: InterpolationMode,
 ) -> Result<(), ImageError> {
-    resize_fast_u8_aa::<C, _, _>(src, dst, interpolation, true)
+    resize_fast_u8_aa::<C>(src, dst, interpolation, true)
 }
 
 /// Generic fast u8 resize with explicit antialias control.
@@ -190,9 +190,9 @@ pub fn resize_fast_u8<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
 /// downscale but does not anti-alias.
 ///
 /// `Nearest` and `Bilinear` are unaffected by this flag.
-pub fn resize_fast_u8_aa<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<u8, C, A1>,
-    dst: &mut Image<u8, C, A2>,
+pub fn resize_fast_u8_aa<const C: usize>(
+    src: &Image<u8, C>,
+    dst: &mut Image<u8, C>,
     interpolation: InterpolationMode,
     antialias: bool,
 ) -> Result<(), ImageError> {
@@ -253,40 +253,40 @@ pub fn resize_fast_u8_aa<const C: usize, A1: ImageAllocator, A2: ImageAllocator>
 }
 
 /// Resize a 1-channel u8 image. Convenience wrapper around [`resize_fast_u8`].
-pub fn resize_fast_mono<A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<u8, 1, A1>,
-    dst: &mut Image<u8, 1, A2>,
+pub fn resize_fast_mono(
+    src: &Image<u8, 1>,
+    dst: &mut Image<u8, 1>,
     interpolation: InterpolationMode,
 ) -> Result<(), ImageError> {
-    resize_fast_u8::<1, _, _>(src, dst, interpolation)
+    resize_fast_u8::<1>(src, dst, interpolation)
 }
 
 /// Grayscale resize with explicit antialias control. See [`resize_fast_u8_aa`].
-pub fn resize_fast_mono_aa<A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<u8, 1, A1>,
-    dst: &mut Image<u8, 1, A2>,
+pub fn resize_fast_mono_aa(
+    src: &Image<u8, 1>,
+    dst: &mut Image<u8, 1>,
     interpolation: InterpolationMode,
     antialias: bool,
 ) -> Result<(), ImageError> {
-    resize_fast_u8_aa::<1, _, _>(src, dst, interpolation, antialias)
+    resize_fast_u8_aa::<1>(src, dst, interpolation, antialias)
 }
 
 /// RGB resize with explicit antialias control. See [`resize_fast_u8_aa`].
-pub fn resize_fast_rgb_aa<A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<u8, 3, A1>,
-    dst: &mut Image<u8, 3, A2>,
+pub fn resize_fast_rgb_aa(
+    src: &Image<u8, 3>,
+    dst: &mut Image<u8, 3>,
     interpolation: InterpolationMode,
     antialias: bool,
 ) -> Result<(), ImageError> {
-    resize_fast_u8_aa::<3, _, _>(src, dst, interpolation, antialias)
+    resize_fast_u8_aa::<3>(src, dst, interpolation, antialias)
 }
 
 /// Slow-path per-interpolation dispatch for cases that didn't take the
 /// fast paths in [`resize_fast_u8_aa`] (primarily bicubic / lanczos and
 /// non-exact-2× bilinear on unusual channel counts).
-fn resize_fast_impl<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<u8, C, A1>,
-    dst: &mut Image<u8, C, A2>,
+fn resize_fast_impl<const C: usize>(
+    src: &Image<u8, C>,
+    dst: &mut Image<u8, C>,
     interpolation: InterpolationMode,
     antialias: bool,
 ) -> Result<(), ImageError> {
@@ -347,17 +347,17 @@ fn resize_fast_impl<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::{CpuAllocator, TensorError};
+    use kornia_tensor::{host_alloc, TensorError};
 
     #[test]
     fn resize_smoke_ch3() -> Result<(), ImageError> {
-        let image = Image::<_, 3, _>::new(
+        let image = Image::<_, 3>::new(
             ImageSize {
                 width: 3,
                 height: 4,
             },
             (0..3 * 4 * 3).map(|x| x as f32).collect::<Vec<f32>>(),
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let new_size = ImageSize {
@@ -365,7 +365,7 @@ mod tests {
             height: 3,
         };
 
-        let mut image_resized = Image::<_, 3, _>::from_size_val(new_size, 0.0, CpuAllocator)?;
+        let mut image_resized = Image::<_, 3>::from_size_val(new_size, 0.0, host_alloc())?;
 
         super::resize_native(
             &image,
@@ -391,13 +391,13 @@ mod tests {
     #[test]
     fn resize_smoke_ch1() -> Result<(), ImageError> {
         use kornia_image::{Image, ImageSize};
-        let image = Image::<_, 1, _>::new(
+        let image = Image::<_, 1>::new(
             ImageSize {
                 width: 2,
                 height: 3,
             },
             vec![0.0f32, 1.0, 2.0, 3.0, 4.0, 5.0],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let new_size = ImageSize {
@@ -405,7 +405,7 @@ mod tests {
             height: 3,
         };
 
-        let mut image_resized = Image::<_, 1, _>::from_size_val(new_size, 0.0f32, CpuAllocator)?;
+        let mut image_resized = Image::<_, 1>::from_size_val(new_size, 0.0f32, host_alloc())?;
 
         super::resize_native(
             &image,
@@ -439,22 +439,22 @@ mod tests {
 
     #[test]
     fn resize_native_unsupported_interpolation() -> Result<(), ImageError> {
-        let image = Image::<_, 1, _>::new(
+        let image = Image::<_, 1>::new(
             ImageSize {
                 width: 2,
                 height: 2,
             },
             vec![0.0f32; 4],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut dst = Image::<_, 1, _>::from_size_val(
+        let mut dst = Image::<_, 1>::from_size_val(
             ImageSize {
                 width: 1,
                 height: 1,
             },
             0.0f32,
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let err = super::resize_native(&image, &mut dst, super::InterpolationMode::Bicubic);
@@ -468,13 +468,13 @@ mod tests {
     #[test]
     fn resize_fast() -> Result<(), ImageError> {
         use kornia_image::{Image, ImageSize};
-        let image = Image::<_, 3, _>::new(
+        let image = Image::<_, 3>::new(
             ImageSize {
                 width: 4,
                 height: 5,
             },
             vec![0u8; 4 * 5 * 3],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let new_size = ImageSize {
@@ -482,7 +482,7 @@ mod tests {
             height: 3,
         };
 
-        let mut image_resized = Image::<_, 3, _>::from_size_val(new_size, 0, CpuAllocator)?;
+        let mut image_resized = Image::<_, 3>::from_size_val(new_size, 0, host_alloc())?;
 
         super::resize_fast_rgb(
             &image,
@@ -505,21 +505,21 @@ mod tests {
 
         for (w, h) in [(2, 2), (3, 4), (17, 9), (32, 5), (33, 6)] {
             let data: Vec<u8> = (0..w * h * 3).map(|x| (x % 251) as u8).collect();
-            let image = Image::<_, 3, _>::new(
+            let image = Image::<_, 3>::new(
                 ImageSize {
                     width: w,
                     height: h,
                 },
                 data,
-                CpuAllocator,
+                host_alloc(),
             )?;
-            let mut dst = Image::<_, 3, _>::from_size_val(
+            let mut dst = Image::<_, 3>::from_size_val(
                 ImageSize {
                     width: 2 * w,
                     height: 2 * h,
                 },
                 0u8,
-                CpuAllocator,
+                host_alloc(),
             )?;
             super::resize_fast_rgb(&image, &mut dst, super::InterpolationMode::Bilinear)?;
 

--- a/crates/kornia-imgproc/src/resize/mod.rs
+++ b/crates/kornia-imgproc/src/resize/mod.rs
@@ -55,7 +55,6 @@ use common::FilterKind;
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::resize::resize_native;
 /// use kornia_imgproc::interpolation::InterpolationMode;
 ///
@@ -65,7 +64,6 @@ use common::FilterKind;
 ///         height: 5,
 ///     },
 ///     vec![0f32; 4 * 5 * 3],
-///     host_alloc()
 /// )
 /// .unwrap();
 ///
@@ -74,7 +72,7 @@ use common::FilterKind;
 ///     height: 3,
 /// };
 ///
-/// let mut image_resized = Image::<_, 3>::from_size_val(new_size, 0.0, host_alloc()).unwrap();
+/// let mut image_resized = Image::<_, 3>::from_size_val(new_size, 0.0).unwrap();
 ///
 /// resize_native(
 ///     &image,
@@ -130,7 +128,6 @@ pub fn resize_native<const C: usize>(
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::resize::resize_fast_rgb;
 /// use kornia_imgproc::interpolation::InterpolationMode;
 ///
@@ -140,7 +137,6 @@ pub fn resize_native<const C: usize>(
 ///         height: 5,
 ///     },
 ///     vec![0u8; 4 * 5 * 3],
-///     host_alloc()
 /// )
 /// .unwrap();
 ///
@@ -149,7 +145,7 @@ pub fn resize_native<const C: usize>(
 ///   height: 3,
 /// };
 ///
-/// let mut image_resized = Image::<_, 3>::from_size_val(new_size, 0, host_alloc()).unwrap();
+/// let mut image_resized = Image::<_, 3>::from_size_val(new_size, 0).unwrap();
 ///
 /// resize_fast_rgb(
 ///   &image,
@@ -347,7 +343,7 @@ fn resize_fast_impl<const C: usize>(
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::{host_alloc, TensorError};
+    use kornia_tensor::TensorError;
 
     #[test]
     fn resize_smoke_ch3() -> Result<(), ImageError> {
@@ -357,7 +353,6 @@ mod tests {
                 height: 4,
             },
             (0..3 * 4 * 3).map(|x| x as f32).collect::<Vec<f32>>(),
-            host_alloc(),
         )?;
 
         let new_size = ImageSize {
@@ -365,7 +360,7 @@ mod tests {
             height: 3,
         };
 
-        let mut image_resized = Image::<_, 3>::from_size_val(new_size, 0.0, host_alloc())?;
+        let mut image_resized = Image::<_, 3>::from_size_val(new_size, 0.0)?;
 
         super::resize_native(
             &image,
@@ -397,7 +392,6 @@ mod tests {
                 height: 3,
             },
             vec![0.0f32, 1.0, 2.0, 3.0, 4.0, 5.0],
-            host_alloc(),
         )?;
 
         let new_size = ImageSize {
@@ -405,7 +399,7 @@ mod tests {
             height: 3,
         };
 
-        let mut image_resized = Image::<_, 1>::from_size_val(new_size, 0.0f32, host_alloc())?;
+        let mut image_resized = Image::<_, 1>::from_size_val(new_size, 0.0f32)?;
 
         super::resize_native(
             &image,
@@ -445,7 +439,6 @@ mod tests {
                 height: 2,
             },
             vec![0.0f32; 4],
-            host_alloc(),
         )?;
 
         let mut dst = Image::<_, 1>::from_size_val(
@@ -454,7 +447,6 @@ mod tests {
                 height: 1,
             },
             0.0f32,
-            host_alloc(),
         )?;
 
         let err = super::resize_native(&image, &mut dst, super::InterpolationMode::Bicubic);
@@ -474,7 +466,6 @@ mod tests {
                 height: 5,
             },
             vec![0u8; 4 * 5 * 3],
-            host_alloc(),
         )?;
 
         let new_size = ImageSize {
@@ -482,7 +473,7 @@ mod tests {
             height: 3,
         };
 
-        let mut image_resized = Image::<_, 3>::from_size_val(new_size, 0, host_alloc())?;
+        let mut image_resized = Image::<_, 3>::from_size_val(new_size, 0)?;
 
         super::resize_fast_rgb(
             &image,
@@ -511,7 +502,6 @@ mod tests {
                     height: h,
                 },
                 data,
-                host_alloc(),
             )?;
             let mut dst = Image::<_, 3>::from_size_val(
                 ImageSize {
@@ -519,7 +509,6 @@ mod tests {
                     height: 2 * h,
                 },
                 0u8,
-                host_alloc(),
             )?;
             super::resize_fast_rgb(&image, &mut dst, super::InterpolationMode::Bilinear)?;
 

--- a/crates/kornia-imgproc/src/threshold.rs
+++ b/crates/kornia-imgproc/src/threshold.rs
@@ -22,13 +22,12 @@ use crate::parallel;
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::threshold::threshold_binary;
 ///
 /// let data = vec![100u8, 200, 50, 150, 200, 250];
-/// let image = Image::<_, 1>::new(ImageSize { width: 2, height: 3 }, data, host_alloc()).unwrap();
+/// let image = Image::<_, 1>::new(ImageSize { width: 2, height: 3 }, data).unwrap();
 ///
-/// let mut thresholded = Image::<_, 1>::from_size_val(image.size(), 0, host_alloc()).unwrap();
+/// let mut thresholded = Image::<_, 1>::from_size_val(image.size(), 0).unwrap();
 ///
 /// threshold_binary(&image, &mut thresholded, 100, 255).unwrap();
 /// assert_eq!(thresholded.num_channels(), 1);
@@ -82,13 +81,12 @@ where
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::threshold::threshold_binary_inverse;
 ///
 /// let data = vec![100u8, 200, 50, 150, 200, 250];
-/// let image = Image::<_, 1>::new(ImageSize { width: 2, height: 3 }, data, host_alloc()).unwrap();
+/// let image = Image::<_, 1>::new(ImageSize { width: 2, height: 3 }, data).unwrap();
 ///
-/// let mut thresholded = Image::<_, 1>::from_size_val(image.size(), 0, host_alloc()).unwrap();
+/// let mut thresholded = Image::<_, 1>::from_size_val(image.size(), 0).unwrap();
 ///
 /// threshold_binary_inverse(&image, &mut thresholded, 100, 255).unwrap();
 /// assert_eq!(thresholded.num_channels(), 1);
@@ -140,13 +138,12 @@ where
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::threshold::threshold_truncate;
 ///
 /// let data = vec![100u8, 200, 50, 150, 200, 250];
-/// let image = Image::<_, 1>::new(ImageSize { width: 2, height: 3 }, data, host_alloc()).unwrap();
+/// let image = Image::<_, 1>::new(ImageSize { width: 2, height: 3 }, data).unwrap();
 ///
-/// let mut thresholded = Image::<_, 1>::from_size_val(image.size(), 0, host_alloc()).unwrap();
+/// let mut thresholded = Image::<_, 1>::from_size_val(image.size(), 0).unwrap();
 ///
 /// threshold_truncate(&image, &mut thresholded, 150).unwrap();
 /// assert_eq!(thresholded.num_channels(), 1);
@@ -197,13 +194,12 @@ where
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::threshold::threshold_to_zero;
 ///
 /// let data = vec![100u8, 200, 50, 150, 200, 250];
-/// let image = Image::<_, 3>::new(ImageSize { width: 2, height: 1 }, data, host_alloc()).unwrap();
+/// let image = Image::<_, 3>::new(ImageSize { width: 2, height: 1 }, data).unwrap();
 ///
-/// let mut thresholded = Image::<_, 3>::from_size_val(image.size(), 0, host_alloc()).unwrap();
+/// let mut thresholded = Image::<_, 3>::from_size_val(image.size(), 0).unwrap();
 ///
 /// threshold_to_zero(&image, &mut thresholded, 150).unwrap();
 /// assert_eq!(thresholded.num_channels(), 3);
@@ -254,13 +250,12 @@ where
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::threshold::threshold_to_zero_inverse;
 ///
 /// let data = vec![100u8, 200, 50, 150, 200, 250];
-/// let image = Image::<_, 3>::new(ImageSize { width: 2, height: 1 }, data, host_alloc()).unwrap();
+/// let image = Image::<_, 3>::new(ImageSize { width: 2, height: 1 }, data).unwrap();
 ///
-/// let mut thresholded = Image::<_, 3>::from_size_val(image.size(), 0, host_alloc()).unwrap();
+/// let mut thresholded = Image::<_, 3>::from_size_val(image.size(), 0).unwrap();
 ///
 /// threshold_to_zero_inverse(&image, &mut thresholded, 150).unwrap();
 /// assert_eq!(thresholded.num_channels(), 3);
@@ -315,7 +310,6 @@ where
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::threshold::in_range;
 ///
 /// let data = vec![100u8, 200, 50, 150, 200, 250];
@@ -326,11 +320,10 @@ where
 ///       height: 1,
 ///    },
 ///    data,
-///    host_alloc()
 /// )
 /// .unwrap();
 ///
-/// let mut thresholded = Image::<u8, 1>::from_size_val(image.size(), 0, host_alloc()).unwrap();
+/// let mut thresholded = Image::<u8, 1>::from_size_val(image.size(), 0).unwrap();
 ///
 /// in_range(&image, &mut thresholded, &[100, 150, 0], &[200, 200, 200]).unwrap();
 /// assert_eq!(thresholded.num_channels(), 1);
@@ -377,7 +370,6 @@ where
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::host_alloc;
 
     #[test]
     fn threshold_binary() -> Result<(), ImageError> {
@@ -389,10 +381,9 @@ mod tests {
                 height: 3,
             },
             data,
-            host_alloc(),
         )?;
 
-        let mut thresholded = Image::<_, 1>::from_size_val(image.size(), 0, host_alloc())?;
+        let mut thresholded = Image::<_, 1>::from_size_val(image.size(), 0)?;
 
         super::threshold_binary(&image, &mut thresholded, 100, 255)?;
 
@@ -415,10 +406,9 @@ mod tests {
                 height: 3,
             },
             data,
-            host_alloc(),
         )?;
 
-        let mut thresholded = Image::<_, 1>::from_size_val(image.size(), 0, host_alloc())?;
+        let mut thresholded = Image::<_, 1>::from_size_val(image.size(), 0)?;
 
         super::threshold_binary_inverse(&image, &mut thresholded, 100, 255)?;
 
@@ -441,10 +431,9 @@ mod tests {
                 height: 3,
             },
             data,
-            host_alloc(),
         )?;
 
-        let mut thresholded = Image::<_, 1>::from_size_val(image.size(), 0, host_alloc())?;
+        let mut thresholded = Image::<_, 1>::from_size_val(image.size(), 0)?;
 
         super::threshold_truncate(&image, &mut thresholded, 150)?;
 
@@ -467,10 +456,9 @@ mod tests {
                 height: 1,
             },
             data,
-            host_alloc(),
         )?;
 
-        let mut thresholded = Image::<_, 3>::from_size_val(image.size(), 0, host_alloc())?;
+        let mut thresholded = Image::<_, 3>::from_size_val(image.size(), 0)?;
 
         super::threshold_to_zero(&image, &mut thresholded, 150)?;
 
@@ -493,10 +481,9 @@ mod tests {
                 height: 1,
             },
             data,
-            host_alloc(),
         )?;
 
-        let mut thresholded = Image::<_, 3>::from_size_val(image.size(), 0, host_alloc())?;
+        let mut thresholded = Image::<_, 3>::from_size_val(image.size(), 0)?;
 
         super::threshold_to_zero_inverse(&image, &mut thresholded, 150)?;
 
@@ -521,10 +508,9 @@ mod tests {
                 height: 1,
             },
             data,
-            host_alloc(),
         )?;
 
-        let mut thresholded = Image::<_, 1>::from_size_val(image.size(), 0, host_alloc())?;
+        let mut thresholded = Image::<_, 1>::from_size_val(image.size(), 0)?;
 
         super::threshold_binary(&image, &mut thresholded, 100, 255)?;
 
@@ -545,10 +531,9 @@ mod tests {
                 height: 1,
             },
             data,
-            host_alloc(),
         )?;
 
-        let mut thresholded = Image::<u8, 1>::from_size_val(image.size(), 0, host_alloc())?;
+        let mut thresholded = Image::<u8, 1>::from_size_val(image.size(), 0)?;
 
         super::in_range(&image, &mut thresholded, &[100, 150, 0], &[200, 200, 200])?;
 

--- a/crates/kornia-imgproc/src/threshold.rs
+++ b/crates/kornia-imgproc/src/threshold.rs
@@ -1,7 +1,7 @@
 use num_traits::Zero;
 use std::cmp::PartialOrd;
 
-use kornia_image::{allocator::ImageAllocator, Image, ImageError};
+use kornia_image::{Image, ImageError};
 
 use crate::parallel;
 
@@ -22,22 +22,22 @@ use crate::parallel;
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::threshold::threshold_binary;
 ///
 /// let data = vec![100u8, 200, 50, 150, 200, 250];
-/// let image = Image::<_, 1, _>::new(ImageSize { width: 2, height: 3 }, data, CpuAllocator).unwrap();
+/// let image = Image::<_, 1>::new(ImageSize { width: 2, height: 3 }, data, host_alloc()).unwrap();
 ///
-/// let mut thresholded = Image::<_, 1, _>::from_size_val(image.size(), 0, CpuAllocator).unwrap();
+/// let mut thresholded = Image::<_, 1>::from_size_val(image.size(), 0, host_alloc()).unwrap();
 ///
 /// threshold_binary(&image, &mut thresholded, 100, 255).unwrap();
 /// assert_eq!(thresholded.num_channels(), 1);
 /// assert_eq!(thresholded.size().width, 2);
 /// assert_eq!(thresholded.size().height, 3);
 /// ```
-pub fn threshold_binary<T, const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<T, C, A1>,
-    dst: &mut Image<T, C, A2>,
+pub fn threshold_binary<T, const C: usize>(
+    src: &Image<T, C>,
+    dst: &mut Image<T, C>,
     threshold: T,
     max_value: T,
 ) -> Result<(), ImageError>
@@ -82,22 +82,22 @@ where
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::threshold::threshold_binary_inverse;
 ///
 /// let data = vec![100u8, 200, 50, 150, 200, 250];
-/// let image = Image::<_, 1, _>::new(ImageSize { width: 2, height: 3 }, data, CpuAllocator).unwrap();
+/// let image = Image::<_, 1>::new(ImageSize { width: 2, height: 3 }, data, host_alloc()).unwrap();
 ///
-/// let mut thresholded = Image::<_, 1, _>::from_size_val(image.size(), 0, CpuAllocator).unwrap();
+/// let mut thresholded = Image::<_, 1>::from_size_val(image.size(), 0, host_alloc()).unwrap();
 ///
 /// threshold_binary_inverse(&image, &mut thresholded, 100, 255).unwrap();
 /// assert_eq!(thresholded.num_channels(), 1);
 /// assert_eq!(thresholded.size().width, 2);
 /// assert_eq!(thresholded.size().height, 3);
 /// ```
-pub fn threshold_binary_inverse<T, const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<T, C, A1>,
-    dst: &mut Image<T, C, A2>,
+pub fn threshold_binary_inverse<T, const C: usize>(
+    src: &Image<T, C>,
+    dst: &mut Image<T, C>,
     threshold: T,
     max_value: T,
 ) -> Result<(), ImageError>
@@ -140,22 +140,22 @@ where
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::threshold::threshold_truncate;
 ///
 /// let data = vec![100u8, 200, 50, 150, 200, 250];
-/// let image = Image::<_, 1, _>::new(ImageSize { width: 2, height: 3 }, data, CpuAllocator).unwrap();
+/// let image = Image::<_, 1>::new(ImageSize { width: 2, height: 3 }, data, host_alloc()).unwrap();
 ///
-/// let mut thresholded = Image::<_, 1, _>::from_size_val(image.size(), 0, CpuAllocator).unwrap();
+/// let mut thresholded = Image::<_, 1>::from_size_val(image.size(), 0, host_alloc()).unwrap();
 ///
 /// threshold_truncate(&image, &mut thresholded, 150).unwrap();
 /// assert_eq!(thresholded.num_channels(), 1);
 /// assert_eq!(thresholded.size().width, 2);
 /// assert_eq!(thresholded.size().height, 3);
 /// ```
-pub fn threshold_truncate<T, const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<T, C, A1>,
-    dst: &mut Image<T, C, A2>,
+pub fn threshold_truncate<T, const C: usize>(
+    src: &Image<T, C>,
+    dst: &mut Image<T, C>,
     threshold: T,
 ) -> Result<(), ImageError>
 where
@@ -197,22 +197,22 @@ where
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::threshold::threshold_to_zero;
 ///
 /// let data = vec![100u8, 200, 50, 150, 200, 250];
-/// let image = Image::<_, 3, _>::new(ImageSize { width: 2, height: 1 }, data, CpuAllocator).unwrap();
+/// let image = Image::<_, 3>::new(ImageSize { width: 2, height: 1 }, data, host_alloc()).unwrap();
 ///
-/// let mut thresholded = Image::<_, 3, _>::from_size_val(image.size(), 0, CpuAllocator).unwrap();
+/// let mut thresholded = Image::<_, 3>::from_size_val(image.size(), 0, host_alloc()).unwrap();
 ///
 /// threshold_to_zero(&image, &mut thresholded, 150).unwrap();
 /// assert_eq!(thresholded.num_channels(), 3);
 /// assert_eq!(thresholded.size().width, 2);
 /// assert_eq!(thresholded.size().height, 1);
 /// ```
-pub fn threshold_to_zero<T, const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<T, C, A1>,
-    dst: &mut Image<T, C, A2>,
+pub fn threshold_to_zero<T, const C: usize>(
+    src: &Image<T, C>,
+    dst: &mut Image<T, C>,
     threshold: T,
 ) -> Result<(), ImageError>
 where
@@ -254,22 +254,22 @@ where
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::threshold::threshold_to_zero_inverse;
 ///
 /// let data = vec![100u8, 200, 50, 150, 200, 250];
-/// let image = Image::<_, 3, _>::new(ImageSize { width: 2, height: 1 }, data, CpuAllocator).unwrap();
+/// let image = Image::<_, 3>::new(ImageSize { width: 2, height: 1 }, data, host_alloc()).unwrap();
 ///
-/// let mut thresholded = Image::<_, 3, _>::from_size_val(image.size(), 0, CpuAllocator).unwrap();
+/// let mut thresholded = Image::<_, 3>::from_size_val(image.size(), 0, host_alloc()).unwrap();
 ///
 /// threshold_to_zero_inverse(&image, &mut thresholded, 150).unwrap();
 /// assert_eq!(thresholded.num_channels(), 3);
 /// assert_eq!(thresholded.size().width, 2);
 /// assert_eq!(thresholded.size().height, 1);
 /// ```
-pub fn threshold_to_zero_inverse<T, const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<T, C, A1>,
-    dst: &mut Image<T, C, A2>,
+pub fn threshold_to_zero_inverse<T, const C: usize>(
+    src: &Image<T, C>,
+    dst: &mut Image<T, C>,
     threshold: T,
 ) -> Result<(), ImageError>
 where
@@ -315,22 +315,22 @@ where
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::threshold::in_range;
 ///
 /// let data = vec![100u8, 200, 50, 150, 200, 250];
 ///
-/// let image = Image::<u8, 3, _>::new(
+/// let image = Image::<u8, 3>::new(
 ///    ImageSize {
 ///       width: 2,
 ///       height: 1,
 ///    },
 ///    data,
-///    CpuAllocator
+///    host_alloc()
 /// )
 /// .unwrap();
 ///
-/// let mut thresholded = Image::<u8, 1, _>::from_size_val(image.size(), 0, CpuAllocator).unwrap();
+/// let mut thresholded = Image::<u8, 1>::from_size_val(image.size(), 0, host_alloc()).unwrap();
 ///
 /// in_range(&image, &mut thresholded, &[100, 150, 0], &[200, 200, 200]).unwrap();
 /// assert_eq!(thresholded.num_channels(), 1);
@@ -339,9 +339,9 @@ where
 /// assert_eq!(thresholded.get_pixel(0, 0, 0).unwrap(), &255);
 /// assert_eq!(thresholded.get_pixel(1, 0, 0).unwrap(), &0);
 /// ```
-pub fn in_range<T, const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<T, C, A1>,
-    dst: &mut Image<u8, 1, A2>,
+pub fn in_range<T, const C: usize>(
+    src: &Image<T, C>,
+    dst: &mut Image<u8, 1>,
     lower_bound: &[T; C],
     upper_bound: &[T; C],
 ) -> Result<(), ImageError>
@@ -377,22 +377,22 @@ where
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::CpuAllocator;
+    use kornia_tensor::host_alloc;
 
     #[test]
     fn threshold_binary() -> Result<(), ImageError> {
         let data = vec![100u8, 200, 50, 150, 200, 250];
         let data_expected = [0u8, 255, 0, 255, 255, 255];
-        let image = Image::<_, 1, _>::new(
+        let image = Image::<_, 1>::new(
             ImageSize {
                 width: 2,
                 height: 3,
             },
             data,
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut thresholded = Image::<_, 1, _>::from_size_val(image.size(), 0, CpuAllocator)?;
+        let mut thresholded = Image::<_, 1>::from_size_val(image.size(), 0, host_alloc())?;
 
         super::threshold_binary(&image, &mut thresholded, 100, 255)?;
 
@@ -409,16 +409,16 @@ mod tests {
     fn threshold_binary_inverse() -> Result<(), ImageError> {
         let data = vec![100u8, 200, 50, 150, 200, 250];
         let data_expected = [255u8, 0, 255, 0, 0, 0];
-        let image = Image::<_, 1, _>::new(
+        let image = Image::<_, 1>::new(
             ImageSize {
                 width: 2,
                 height: 3,
             },
             data,
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut thresholded = Image::<_, 1, _>::from_size_val(image.size(), 0, CpuAllocator)?;
+        let mut thresholded = Image::<_, 1>::from_size_val(image.size(), 0, host_alloc())?;
 
         super::threshold_binary_inverse(&image, &mut thresholded, 100, 255)?;
 
@@ -435,16 +435,16 @@ mod tests {
     fn threshold_truncate() -> Result<(), ImageError> {
         let data = vec![100u8, 200, 50, 150, 200, 250];
         let data_expected = [100u8, 150, 50, 150, 150, 150];
-        let image = Image::<_, 1, _>::new(
+        let image = Image::<_, 1>::new(
             ImageSize {
                 width: 2,
                 height: 3,
             },
             data,
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut thresholded = Image::<_, 1, _>::from_size_val(image.size(), 0, CpuAllocator)?;
+        let mut thresholded = Image::<_, 1>::from_size_val(image.size(), 0, host_alloc())?;
 
         super::threshold_truncate(&image, &mut thresholded, 150)?;
 
@@ -461,16 +461,16 @@ mod tests {
     fn threshold_to_zero() -> Result<(), ImageError> {
         let data = vec![100u8, 200, 50, 150, 200, 250];
         let data_expected = [0u8, 200, 0, 0, 200, 250];
-        let image = Image::<_, 3, _>::new(
+        let image = Image::<_, 3>::new(
             ImageSize {
                 width: 2,
                 height: 1,
             },
             data,
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut thresholded = Image::<_, 3, _>::from_size_val(image.size(), 0, CpuAllocator)?;
+        let mut thresholded = Image::<_, 3>::from_size_val(image.size(), 0, host_alloc())?;
 
         super::threshold_to_zero(&image, &mut thresholded, 150)?;
 
@@ -487,16 +487,16 @@ mod tests {
     fn threshold_to_zero_inverse() -> Result<(), ImageError> {
         let data = vec![100u8, 200, 50, 150, 200, 250];
         let data_expected = [100u8, 0, 50, 150, 0, 0];
-        let image = Image::<_, 3, _>::new(
+        let image = Image::<_, 3>::new(
             ImageSize {
                 width: 2,
                 height: 1,
             },
             data,
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut thresholded = Image::<_, 3, _>::from_size_val(image.size(), 0, CpuAllocator)?;
+        let mut thresholded = Image::<_, 3>::from_size_val(image.size(), 0, host_alloc())?;
 
         super::threshold_to_zero_inverse(&image, &mut thresholded, 150)?;
 
@@ -515,16 +515,16 @@ mod tests {
         // exactly equals the threshold is treated as NOT exceeding it and maps to
         // zero rather than max_val.  Pin that boundary behaviour here.
         let data = vec![100u8, 101, 99];
-        let image = Image::<_, 1, _>::new(
+        let image = Image::<_, 1>::new(
             ImageSize {
                 width: 3,
                 height: 1,
             },
             data,
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut thresholded = Image::<_, 1, _>::from_size_val(image.size(), 0, CpuAllocator)?;
+        let mut thresholded = Image::<_, 1>::from_size_val(image.size(), 0, host_alloc())?;
 
         super::threshold_binary(&image, &mut thresholded, 100, 255)?;
 
@@ -539,16 +539,16 @@ mod tests {
     #[test]
     fn test_in_range() -> Result<(), ImageError> {
         let data = vec![100u8, 200, 50, 150, 200, 250];
-        let image = Image::<_, 3, _>::new(
+        let image = Image::<_, 3>::new(
             ImageSize {
                 width: 2,
                 height: 1,
             },
             data,
-            CpuAllocator,
+            host_alloc(),
         )?;
 
-        let mut thresholded = Image::<u8, 1, _>::from_size_val(image.size(), 0, CpuAllocator)?;
+        let mut thresholded = Image::<u8, 1>::from_size_val(image.size(), 0, host_alloc())?;
 
         super::in_range(&image, &mut thresholded, &[100, 150, 0], &[200, 200, 200])?;
 

--- a/crates/kornia-imgproc/src/warp/affine.rs
+++ b/crates/kornia-imgproc/src/warp/affine.rs
@@ -102,7 +102,6 @@ fn transform_point(x: f32, y: f32, m: &[f32; 6]) -> (f32, f32) {
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::interpolation::InterpolationMode;
 /// use kornia_imgproc::warp::warp_affine;
 ///
@@ -112,7 +111,6 @@ fn transform_point(x: f32, y: f32, m: &[f32; 6]) -> (f32, f32) {
 ///      height: 5,
 ///  },
 ///  1f32,
-///  host_alloc()
 /// ).unwrap();
 ///
 /// let m = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
@@ -121,7 +119,7 @@ fn transform_point(x: f32, y: f32, m: &[f32; 6]) -> (f32, f32) {
 ///   height: 5,
 /// };
 ///
-/// let mut dst = Image::<_, 3>::from_size_val(new_size, 0.0, host_alloc()).unwrap();
+/// let mut dst = Image::<_, 3>::from_size_val(new_size, 0.0).unwrap();
 ///
 /// warp_affine(&src, &mut dst, &m, InterpolationMode::Nearest).unwrap();
 ///
@@ -267,7 +265,7 @@ pub fn warp_affine_u8<const C: usize>(
 mod tests {
 
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::host_alloc;
+
     #[test]
     fn warp_affine_smoke_ch3() -> Result<(), ImageError> {
         let image = Image::<_, 3>::new(
@@ -276,7 +274,6 @@ mod tests {
                 height: 5,
             },
             vec![0f32; 4 * 5 * 3],
-            host_alloc(),
         )?;
 
         let new_size = ImageSize {
@@ -284,7 +281,7 @@ mod tests {
             height: 3,
         };
 
-        let mut image_transformed = Image::<_, 3>::from_size_val(new_size, 0.0, host_alloc())?;
+        let mut image_transformed = Image::<_, 3>::from_size_val(new_size, 0.0)?;
 
         super::warp_affine(
             &image,
@@ -308,7 +305,6 @@ mod tests {
                 height: 2,
             },
             0.0f32,
-            host_alloc(),
         )?;
         let mut dst = Image::<_, 1>::from_size_val(
             ImageSize {
@@ -316,7 +312,6 @@ mod tests {
                 height: 2,
             },
             0.0f32,
-            host_alloc(),
         )?;
         let m = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
         let err = super::warp_affine(&src, &mut dst, &m, super::InterpolationMode::Bicubic);
@@ -333,7 +328,6 @@ mod tests {
                 height: 5,
             },
             vec![0f32; 4 * 5],
-            host_alloc(),
         )?;
 
         let new_size = ImageSize {
@@ -341,7 +335,7 @@ mod tests {
             height: 3,
         };
 
-        let mut image_transformed = Image::<_, 1>::from_size_val(new_size, 0.0, host_alloc())?;
+        let mut image_transformed = Image::<_, 1>::from_size_val(new_size, 0.0)?;
 
         super::warp_affine(
             &image,
@@ -366,7 +360,6 @@ mod tests {
                 height: 5,
             },
             (0..20).map(|x| x as f32).collect(),
-            host_alloc(),
         )?;
 
         let new_size = ImageSize {
@@ -374,7 +367,7 @@ mod tests {
             height: 5,
         };
 
-        let mut image_transformed = Image::<_, 1>::from_size_val(new_size, 0.0, host_alloc())?;
+        let mut image_transformed = Image::<_, 1>::from_size_val(new_size, 0.0)?;
 
         super::warp_affine(
             &image,
@@ -398,7 +391,6 @@ mod tests {
                 height: 2,
             },
             vec![0.0f32, 1.0f32, 2.0f32, 3.0f32],
-            host_alloc(),
         )?;
 
         let new_size = ImageSize {
@@ -406,7 +398,7 @@ mod tests {
             height: 2,
         };
 
-        let mut image_transformed = Image::<_, 1>::from_size_val(new_size, 0.0, host_alloc())?;
+        let mut image_transformed = Image::<_, 1>::from_size_val(new_size, 0.0)?;
 
         super::warp_affine(
             &image,

--- a/crates/kornia-imgproc/src/warp/affine.rs
+++ b/crates/kornia-imgproc/src/warp/affine.rs
@@ -1,6 +1,5 @@
 use std::f32::consts::PI;
 
-use kornia_image::allocator::ImageAllocator;
 use kornia_image::{Image, ImageError};
 
 use super::kernels::process_affine_span;
@@ -103,17 +102,17 @@ fn transform_point(x: f32, y: f32, m: &[f32; 6]) -> (f32, f32) {
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::interpolation::InterpolationMode;
 /// use kornia_imgproc::warp::warp_affine;
 ///
-/// let src = Image::<_, 3, _>::from_size_val(
+/// let src = Image::<_, 3>::from_size_val(
 ///    ImageSize {
 ///       width: 4,
 ///      height: 5,
 ///  },
 ///  1f32,
-///  CpuAllocator
+///  host_alloc()
 /// ).unwrap();
 ///
 /// let m = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
@@ -122,16 +121,16 @@ fn transform_point(x: f32, y: f32, m: &[f32; 6]) -> (f32, f32) {
 ///   height: 5,
 /// };
 ///
-/// let mut dst = Image::<_, 3, _>::from_size_val(new_size, 0.0, CpuAllocator).unwrap();
+/// let mut dst = Image::<_, 3>::from_size_val(new_size, 0.0, host_alloc()).unwrap();
 ///
 /// warp_affine(&src, &mut dst, &m, InterpolationMode::Nearest).unwrap();
 ///
 /// assert_eq!(dst.size().width, 4);
 /// assert_eq!(dst.size().height, 5);
 /// ```
-pub fn warp_affine<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<f32, C, A1>,
-    dst: &mut Image<f32, C, A2>,
+pub fn warp_affine<const C: usize>(
+    src: &Image<f32, C>,
+    dst: &mut Image<f32, C>,
     m: &[f32; 6],
     interpolation: InterpolationMode,
 ) -> Result<(), ImageError> {
@@ -163,9 +162,9 @@ pub fn warp_affine<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
 /// fixed-point bilinear weights.
 ///
 /// `m` is the forward 2x3 transform; this function inverts it.
-pub fn warp_affine_u8<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<u8, C, A1>,
-    dst: &mut Image<u8, C, A2>,
+pub fn warp_affine_u8<const C: usize>(
+    src: &Image<u8, C>,
+    dst: &mut Image<u8, C>,
     m: &[f32; 6],
 ) -> Result<(), ImageError> {
     use rayon::prelude::*;
@@ -268,16 +267,16 @@ pub fn warp_affine_u8<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
 mod tests {
 
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::CpuAllocator;
+    use kornia_tensor::host_alloc;
     #[test]
     fn warp_affine_smoke_ch3() -> Result<(), ImageError> {
-        let image = Image::<_, 3, _>::new(
+        let image = Image::<_, 3>::new(
             ImageSize {
                 width: 4,
                 height: 5,
             },
             vec![0f32; 4 * 5 * 3],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let new_size = ImageSize {
@@ -285,7 +284,7 @@ mod tests {
             height: 3,
         };
 
-        let mut image_transformed = Image::<_, 3, _>::from_size_val(new_size, 0.0, CpuAllocator)?;
+        let mut image_transformed = Image::<_, 3>::from_size_val(new_size, 0.0, host_alloc())?;
 
         super::warp_affine(
             &image,
@@ -303,21 +302,21 @@ mod tests {
 
     #[test]
     fn warp_affine_unsupported_interpolation() -> Result<(), ImageError> {
-        let src = Image::<_, 1, _>::from_size_val(
+        let src = Image::<_, 1>::from_size_val(
             ImageSize {
                 width: 2,
                 height: 2,
             },
             0.0f32,
-            CpuAllocator,
+            host_alloc(),
         )?;
-        let mut dst = Image::<_, 1, _>::from_size_val(
+        let mut dst = Image::<_, 1>::from_size_val(
             ImageSize {
                 width: 2,
                 height: 2,
             },
             0.0f32,
-            CpuAllocator,
+            host_alloc(),
         )?;
         let m = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
         let err = super::warp_affine(&src, &mut dst, &m, super::InterpolationMode::Bicubic);
@@ -328,13 +327,13 @@ mod tests {
     #[test]
     fn warp_affine_smoke_ch1() -> Result<(), ImageError> {
         use kornia_image::{Image, ImageSize};
-        let image = Image::<_, 1, _>::new(
+        let image = Image::<_, 1>::new(
             ImageSize {
                 width: 4,
                 height: 5,
             },
             vec![0f32; 4 * 5],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let new_size = ImageSize {
@@ -342,7 +341,7 @@ mod tests {
             height: 3,
         };
 
-        let mut image_transformed = Image::<_, 1, _>::from_size_val(new_size, 0.0, CpuAllocator)?;
+        let mut image_transformed = Image::<_, 1>::from_size_val(new_size, 0.0, host_alloc())?;
 
         super::warp_affine(
             &image,
@@ -361,13 +360,13 @@ mod tests {
     #[test]
     fn warp_affine_correctness_identity() -> Result<(), ImageError> {
         use kornia_image::{Image, ImageSize};
-        let image = Image::<_, 1, _>::new(
+        let image = Image::<_, 1>::new(
             ImageSize {
                 width: 4,
                 height: 5,
             },
             (0..20).map(|x| x as f32).collect(),
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let new_size = ImageSize {
@@ -375,7 +374,7 @@ mod tests {
             height: 5,
         };
 
-        let mut image_transformed = Image::<_, 1, _>::from_size_val(new_size, 0.0, CpuAllocator)?;
+        let mut image_transformed = Image::<_, 1>::from_size_val(new_size, 0.0, host_alloc())?;
 
         super::warp_affine(
             &image,
@@ -393,13 +392,13 @@ mod tests {
     #[test]
     fn warp_affine_correctness_rot90() -> Result<(), ImageError> {
         use kornia_image::{Image, ImageSize};
-        let image = Image::<_, 1, _>::new(
+        let image = Image::<_, 1>::new(
             ImageSize {
                 width: 2,
                 height: 2,
             },
             vec![0.0f32, 1.0f32, 2.0f32, 3.0f32],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let new_size = ImageSize {
@@ -407,7 +406,7 @@ mod tests {
             height: 2,
         };
 
-        let mut image_transformed = Image::<_, 1, _>::from_size_val(new_size, 0.0, CpuAllocator)?;
+        let mut image_transformed = Image::<_, 1>::from_size_val(new_size, 0.0, host_alloc())?;
 
         super::warp_affine(
             &image,

--- a/crates/kornia-imgproc/src/warp/common.rs
+++ b/crates/kornia-imgproc/src/warp/common.rs
@@ -189,59 +189,61 @@ unsafe fn bilinear_sample_u8_valid_c3_neon(
     fy_q10: u32,
     dst_pixel: *mut u8,
 ) {
-    use std::arch::aarch64::*;
+    unsafe {
+        use std::arch::aarch64::*;
 
-    let xi1 = if xi + 1 < src_w {
-        (xi + 1) as usize
-    } else {
-        xi as usize
-    };
-    let yi1 = if yi + 1 < src_h {
-        (yi + 1) as usize
-    } else {
-        yi as usize
-    };
+        let xi1 = if xi + 1 < src_w {
+            (xi + 1) as usize
+        } else {
+            xi as usize
+        };
+        let yi1 = if yi + 1 < src_h {
+            (yi + 1) as usize
+        } else {
+            yi as usize
+        };
 
-    let row0 = (yi as usize) * src_stride;
-    let row1 = yi1 * src_stride;
-    let xoff0 = (xi as usize) * 3;
-    let xoff1 = xi1 * 3;
+        let row0 = (yi as usize) * src_stride;
+        let row1 = yi1 * src_stride;
+        let xoff0 = (xi as usize) * 3;
+        let xoff1 = xi1 * 3;
 
-    // Load 4 bytes per corner via unaligned u32 read, widen u8x4 → u32x4.
-    // Lane 3 is garbage (next pixel's R or padding) — ignored by the
-    // narrow at the end since we only store 3 bytes.
-    let load = |off: usize| -> uint32x4_t {
-        let raw = core::ptr::read_unaligned(src.add(off) as *const u32);
-        let u8_vec = vreinterpret_u8_u32(vcreate_u32(raw as u64));
-        let u16_vec = vmovl_u8(u8_vec);
-        vmovl_u16(vget_low_u16(u16_vec))
-    };
+        // Load 4 bytes per corner via unaligned u32 read, widen u8x4 → u32x4.
+        // Lane 3 is garbage (next pixel's R or padding) — ignored by the
+        // narrow at the end since we only store 3 bytes.
+        let load = |off: usize| -> uint32x4_t {
+            let raw = core::ptr::read_unaligned(src.add(off) as *const u32);
+            let u8_vec = vreinterpret_u8_u32(vcreate_u32(raw as u64));
+            let u16_vec = vmovl_u8(u8_vec);
+            vmovl_u16(vget_low_u16(u16_vec))
+        };
 
-    let p00 = load(row0 + xoff0);
-    let p01 = load(row0 + xoff1);
-    let p10 = load(row1 + xoff0);
-    let p11 = load(row1 + xoff1);
+        let p00 = load(row0 + xoff0);
+        let p01 = load(row0 + xoff1);
+        let p10 = load(row1 + xoff0);
+        let p11 = load(row1 + xoff1);
 
-    let fx_v = vdupq_n_u32(fx_q10);
-    let fx1_v = vdupq_n_u32(1024 - fx_q10);
-    let fy_v = vdupq_n_u32(fy_q10);
-    let fy1_v = vdupq_n_u32(1024 - fy_q10);
+        let fx_v = vdupq_n_u32(fx_q10);
+        let fx1_v = vdupq_n_u32(1024 - fx_q10);
+        let fy_v = vdupq_n_u32(fy_q10);
+        let fy1_v = vdupq_n_u32(1024 - fy_q10);
 
-    // top = p00 * fx1 + p01 * fx   (values ≤ 255 * 1024 * 2 = 522k, fits u32)
-    // bot = p10 * fx1 + p11 * fx
-    let top = vmlaq_u32(vmulq_u32(p00, fx1_v), p01, fx_v);
-    let bot = vmlaq_u32(vmulq_u32(p10, fx1_v), p11, fx_v);
-    // sum = top * fy1 + bot * fy + (1<<19)  (≤ 522k * 1024 + 522k * 1024 = 1.07e9, fits u32)
-    let sum = vmlaq_u32(vmulq_u32(top, fy1_v), bot, fy_v);
-    let sum = vaddq_u32(sum, vdupq_n_u32(1 << 19));
-    let res = vshrq_n_u32::<20>(sum);
+        // top = p00 * fx1 + p01 * fx   (values ≤ 255 * 1024 * 2 = 522k, fits u32)
+        // bot = p10 * fx1 + p11 * fx
+        let top = vmlaq_u32(vmulq_u32(p00, fx1_v), p01, fx_v);
+        let bot = vmlaq_u32(vmulq_u32(p10, fx1_v), p11, fx_v);
+        // sum = top * fy1 + bot * fy + (1<<19)  (≤ 522k * 1024 + 522k * 1024 = 1.07e9, fits u32)
+        let sum = vmlaq_u32(vmulq_u32(top, fy1_v), bot, fy_v);
+        let sum = vaddq_u32(sum, vdupq_n_u32(1 << 19));
+        let res = vshrq_n_u32::<20>(sum);
 
-    // Narrow u32x4 → u8 (first 3 bytes are R, G, B).
-    let u16x4 = vmovn_u32(res);
-    let u8x8 = vmovn_u16(vcombine_u16(u16x4, u16x4));
-    *dst_pixel.add(0) = vget_lane_u8::<0>(u8x8);
-    *dst_pixel.add(1) = vget_lane_u8::<1>(u8x8);
-    *dst_pixel.add(2) = vget_lane_u8::<2>(u8x8);
+        // Narrow u32x4 → u8 (first 3 bytes are R, G, B).
+        let u16x4 = vmovn_u32(res);
+        let u8x8 = vmovn_u16(vcombine_u16(u16x4, u16x4));
+        *dst_pixel.add(0) = vget_lane_u8::<0>(u8x8);
+        *dst_pixel.add(1) = vget_lane_u8::<1>(u8x8);
+        *dst_pixel.add(2) = vget_lane_u8::<2>(u8x8);
+    }
 }
 
 /// AVX2 u8 bilinear sampler, C=3 specialization.

--- a/crates/kornia-imgproc/src/warp/kernels.rs
+++ b/crates/kornia-imgproc/src/warp/kernels.rs
@@ -159,71 +159,73 @@ unsafe fn process_perspective_span_neon<const C: usize>(
     dny: f32,
     dnd: f32,
 ) {
-    use std::arch::aarch64::*;
+    unsafe {
+        use std::arch::aarch64::*;
 
-    let n4 = (x_hi - x_lo) & !3;
-    if n4 >= 4 {
-        let dnx_v = vdupq_n_f32(dnx);
-        let dny_v = vdupq_n_f32(dny);
-        let dnd_v = vdupq_n_f32(dnd);
-        let lane_offsets: [f32; 4] = [0.0, 1.0, 2.0, 3.0];
-        let lo_v = vld1q_f32(lane_offsets.as_ptr());
-        let mut nx_v = vaddq_f32(vdupq_n_f32(nx), vmulq_f32(dnx_v, lo_v));
-        let mut ny_v = vaddq_f32(vdupq_n_f32(ny), vmulq_f32(dny_v, lo_v));
-        let mut nd_v = vaddq_f32(vdupq_n_f32(nd), vmulq_f32(dnd_v, lo_v));
-        let step_nx = vmulq_n_f32(dnx_v, 4.0);
-        let step_ny = vmulq_n_f32(dny_v, 4.0);
-        let step_nd = vmulq_n_f32(dnd_v, 4.0);
-        let q10_v = vdupq_n_f32(1024.0);
+        let n4 = (x_hi - x_lo) & !3;
+        if n4 >= 4 {
+            let dnx_v = vdupq_n_f32(dnx);
+            let dny_v = vdupq_n_f32(dny);
+            let dnd_v = vdupq_n_f32(dnd);
+            let lane_offsets: [f32; 4] = [0.0, 1.0, 2.0, 3.0];
+            let lo_v = vld1q_f32(lane_offsets.as_ptr());
+            let mut nx_v = vaddq_f32(vdupq_n_f32(nx), vmulq_f32(dnx_v, lo_v));
+            let mut ny_v = vaddq_f32(vdupq_n_f32(ny), vmulq_f32(dny_v, lo_v));
+            let mut nd_v = vaddq_f32(vdupq_n_f32(nd), vmulq_f32(dnd_v, lo_v));
+            let step_nx = vmulq_n_f32(dnx_v, 4.0);
+            let step_ny = vmulq_n_f32(dny_v, 4.0);
+            let step_nd = vmulq_n_f32(dnd_v, 4.0);
+            let q10_v = vdupq_n_f32(1024.0);
 
-        let mut xs = [0i32; 4];
-        let mut ys = [0i32; 4];
-        let mut fxs = [0u32; 4];
-        let mut fys = [0u32; 4];
+            let mut xs = [0i32; 4];
+            let mut ys = [0i32; 4];
+            let mut fxs = [0u32; 4];
+            let mut fys = [0u32; 4];
 
-        let end = x_lo + n4;
-        let mut xi = x_lo;
-        while xi < end {
-            // Reciprocal: 1 NR step → ~17-bit precision, sufficient for
-            // image-domain coords (worst-case fractional weight error
-            // below 1 Q10 ULP).
-            let r0 = vrecpeq_f32(nd_v);
-            let inv_nd = vmulq_f32(vrecpsq_f32(nd_v, r0), r0);
-            let xf = vmulq_f32(nx_v, inv_nd);
-            let yf = vmulq_f32(ny_v, inv_nd);
-            let xi_v = vcvtq_s32_f32(vrndmq_f32(xf));
-            let yi_v = vcvtq_s32_f32(vrndmq_f32(yf));
-            let fx_v = vcvtq_u32_f32(vmulq_f32(vsubq_f32(xf, vcvtq_f32_s32(xi_v)), q10_v));
-            let fy_v = vcvtq_u32_f32(vmulq_f32(vsubq_f32(yf, vcvtq_f32_s32(yi_v)), q10_v));
-            vst1q_s32(xs.as_mut_ptr(), xi_v);
-            vst1q_s32(ys.as_mut_ptr(), yi_v);
-            vst1q_u32(fxs.as_mut_ptr(), fx_v);
-            vst1q_u32(fys.as_mut_ptr(), fy_v);
+            let end = x_lo + n4;
+            let mut xi = x_lo;
+            while xi < end {
+                // Reciprocal: 1 NR step → ~17-bit precision, sufficient for
+                // image-domain coords (worst-case fractional weight error
+                // below 1 Q10 ULP).
+                let r0 = vrecpeq_f32(nd_v);
+                let inv_nd = vmulq_f32(vrecpsq_f32(nd_v, r0), r0);
+                let xf = vmulq_f32(nx_v, inv_nd);
+                let yf = vmulq_f32(ny_v, inv_nd);
+                let xi_v = vcvtq_s32_f32(vrndmq_f32(xf));
+                let yi_v = vcvtq_s32_f32(vrndmq_f32(yf));
+                let fx_v = vcvtq_u32_f32(vmulq_f32(vsubq_f32(xf, vcvtq_f32_s32(xi_v)), q10_v));
+                let fy_v = vcvtq_u32_f32(vmulq_f32(vsubq_f32(yf, vcvtq_f32_s32(yi_v)), q10_v));
+                vst1q_s32(xs.as_mut_ptr(), xi_v);
+                vst1q_s32(ys.as_mut_ptr(), yi_v);
+                vst1q_u32(fxs.as_mut_ptr(), fx_v);
+                vst1q_u32(fys.as_mut_ptr(), fy_v);
 
-            for lane in 0..4 {
-                let dst_pixel = &mut dst_row[(xi + lane) * C..(xi + lane) * C + C];
-                bilinear_sample_u8_valid::<C>(
-                    src, src_w, src_h, src_stride, xs[lane], ys[lane], fxs[lane], fys[lane],
-                    dst_pixel,
-                );
+                for lane in 0..4 {
+                    let dst_pixel = &mut dst_row[(xi + lane) * C..(xi + lane) * C + C];
+                    bilinear_sample_u8_valid::<C>(
+                        src, src_w, src_h, src_stride, xs[lane], ys[lane], fxs[lane], fys[lane],
+                        dst_pixel,
+                    );
+                }
+
+                nx_v = vaddq_f32(nx_v, step_nx);
+                ny_v = vaddq_f32(ny_v, step_ny);
+                nd_v = vaddq_f32(nd_v, step_nd);
+                xi += 4;
             }
-
-            nx_v = vaddq_f32(nx_v, step_nx);
-            ny_v = vaddq_f32(ny_v, step_ny);
-            nd_v = vaddq_f32(nd_v, step_nd);
-            xi += 4;
+            // Pull scalar state from vector lane 0 for the tail.
+            nx = vgetq_lane_f32::<0>(nx_v);
+            ny = vgetq_lane_f32::<0>(ny_v);
+            nd = vgetq_lane_f32::<0>(nd_v);
         }
-        // Pull scalar state from vector lane 0 for the tail.
-        nx = vgetq_lane_f32::<0>(nx_v);
-        ny = vgetq_lane_f32::<0>(ny_v);
-        nd = vgetq_lane_f32::<0>(nd_v);
-    }
 
-    // 1-3 trailing columns: scalar tail.
-    let tail_start = x_lo + n4;
-    process_perspective_span_scalar::<C>(
-        src, src_w, src_h, src_stride, dst_row, tail_start, x_hi, nx, ny, nd, dnx, dny, dnd,
-    );
+        // 1-3 trailing columns: scalar tail.
+        let tail_start = x_lo + n4;
+        process_perspective_span_scalar::<C>(
+            src, src_w, src_h, src_stride, dst_row, tail_start, x_hi, nx, ny, nd, dnx, dny, dnd,
+        );
+    }
 }
 
 /// AVX2 implementation: 4-wide reciprocal (rcp + Newton–Raphson refine) +

--- a/crates/kornia-imgproc/src/warp/perspective.rs
+++ b/crates/kornia-imgproc/src/warp/perspective.rs
@@ -5,7 +5,7 @@ use crate::{
     parallel,
 };
 
-use kornia_image::{allocator::ImageAllocator, Image, ImageError};
+use kornia_image::{Image, ImageError};
 
 #[rustfmt::skip]
 fn determinant3x3(m: &[f32; 9]) -> f32 {
@@ -70,28 +70,28 @@ fn transform_point(x: f32, y: f32, m: &[f32; 9]) -> (f32, f32) {
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_image::allocator::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::interpolation::InterpolationMode;
 /// use kornia_imgproc::warp::warp_perspective;
 ///
-/// let src = Image::<f32, 1, _>::new(
+/// let src = Image::<f32, 1>::new(
 ///   ImageSize {
 ///     width: 4,
 ///     height: 5,
 ///   },
 ///   vec![0.0f32; 4 * 5],
-///   CpuAllocator
+///   host_alloc()
 /// ).unwrap();
 ///
 /// let m = [1.0, 0.0, -1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0];
 ///
-/// let mut dst = Image::<f32, 1, _>::from_size_val(
+/// let mut dst = Image::<f32, 1>::from_size_val(
 ///   ImageSize {
 ///     width: 2,
 ///     height: 3,
 ///   },
 ///   0.0,
-///   CpuAllocator
+///   host_alloc()
 /// ).unwrap();
 ///
 /// warp_perspective(&src, &mut dst, &m, InterpolationMode::Bilinear).unwrap();
@@ -99,9 +99,9 @@ fn transform_point(x: f32, y: f32, m: &[f32; 9]) -> (f32, f32) {
 /// assert_eq!(dst.size().width, 2);
 /// assert_eq!(dst.size().height, 3);
 /// ```
-pub fn warp_perspective<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<f32, C, A1>,
-    dst: &mut Image<f32, C, A2>,
+pub fn warp_perspective<const C: usize>(
+    src: &Image<f32, C>,
+    dst: &mut Image<f32, C>,
     m: &[f32; 9],
     interpolation: InterpolationMode,
 ) -> Result<(), ImageError> {
@@ -139,9 +139,9 @@ pub fn warp_perspective<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
 /// (NEON C=3 path on aarch64). Falls back to the scalar bounds-checked
 /// sampler only if `nd` changes sign within the row (rare: matrix
 /// collapses points to the line-at-infinity inside the image).
-pub fn warp_perspective_u8<const C: usize, A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<u8, C, A1>,
-    dst: &mut Image<u8, C, A2>,
+pub fn warp_perspective_u8<const C: usize>(
+    src: &Image<u8, C>,
+    dst: &mut Image<u8, C>,
     m: &[f32; 9],
 ) -> Result<(), ImageError> {
     use rayon::prelude::*;
@@ -310,7 +310,7 @@ pub fn warp_perspective_u8<const C: usize, A1: ImageAllocator, A2: ImageAllocato
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::CpuAllocator;
+    use kornia_tensor::host_alloc;
 
     #[test]
     fn inverse_perspective_matrix() -> Result<(), ImageError> {
@@ -332,13 +332,13 @@ mod tests {
 
     #[test]
     fn warp_perspective_identity() -> Result<(), ImageError> {
-        let image: Image<f32, 3, _> = Image::from_size_val(
+        let image: Image<f32, 3> = Image::from_size_val(
             ImageSize {
                 width: 4,
                 height: 5,
             },
             0.0f32,
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         // identity matrix
@@ -349,7 +349,7 @@ mod tests {
             height: 3,
         };
 
-        let mut image_transformed = Image::from_size_val(new_size, 0.0, CpuAllocator)?;
+        let mut image_transformed = Image::from_size_val(new_size, 0.0, host_alloc())?;
 
         super::warp_perspective(
             &image,
@@ -367,21 +367,21 @@ mod tests {
 
     #[test]
     fn warp_perspective_unsupported_interpolation() -> Result<(), ImageError> {
-        let src = Image::<f32, 1, _>::from_size_val(
+        let src = Image::<f32, 1>::from_size_val(
             ImageSize {
                 width: 2,
                 height: 2,
             },
             0.0,
-            CpuAllocator,
+            host_alloc(),
         )?;
-        let mut dst = Image::<f32, 1, _>::from_size_val(
+        let mut dst = Image::<f32, 1>::from_size_val(
             ImageSize {
                 width: 2,
                 height: 2,
             },
             0.0,
-            CpuAllocator,
+            host_alloc(),
         )?;
         let m = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
         let err = super::warp_perspective(&src, &mut dst, &m, super::InterpolationMode::Lanczos);
@@ -391,13 +391,13 @@ mod tests {
 
     #[test]
     fn warp_perspective_hflip() -> Result<(), ImageError> {
-        let image = Image::<_, 1, _>::new(
+        let image = Image::<_, 1>::new(
             ImageSize {
                 width: 2,
                 height: 3,
             },
             vec![0.0f32, 1.0, 2.0, 3.0, 4.0, 5.0],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let image_expected = vec![1.0, 0.0, 3.0, 2.0, 5.0, 4.0];
@@ -410,7 +410,7 @@ mod tests {
             height: 3,
         };
 
-        let mut image_transformed = Image::<_, 1, _>::from_size_val(new_size, 0.0, CpuAllocator)?;
+        let mut image_transformed = Image::<_, 1>::from_size_val(new_size, 0.0, host_alloc())?;
 
         super::warp_perspective(
             &image,
@@ -430,7 +430,7 @@ mod tests {
 
     #[test]
     fn test_warp_perspective_resize() -> Result<(), ImageError> {
-        let image = Image::<_, 1, _>::new(
+        let image = Image::<_, 1>::new(
             ImageSize {
                 width: 4,
                 height: 4,
@@ -439,7 +439,7 @@ mod tests {
                 0.0f32, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0,
                 15.0,
             ],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         // resize matrix (from get_perspective_transform)
@@ -452,7 +452,7 @@ mod tests {
             height: 2,
         };
 
-        let mut image_transformed = Image::<_, 1, _>::from_size_val(new_size, 0.0, CpuAllocator)?;
+        let mut image_transformed = Image::<_, 1>::from_size_val(new_size, 0.0, host_alloc())?;
 
         super::warp_perspective(
             &image,
@@ -461,7 +461,7 @@ mod tests {
             super::InterpolationMode::Bilinear,
         )?;
 
-        let mut image_resized = Image::<_, 1, _>::from_size_val(new_size, 0.0, CpuAllocator)?;
+        let mut image_resized = Image::<_, 1>::from_size_val(new_size, 0.0, host_alloc())?;
 
         crate::resize::resize_native(
             &image,
@@ -481,7 +481,7 @@ mod tests {
 
     #[test]
     fn test_warp_perspective_shift() -> Result<(), ImageError> {
-        let image = Image::<_, 1, _>::new(
+        let image = Image::<_, 1>::new(
             ImageSize {
                 width: 4,
                 height: 4,
@@ -490,7 +490,7 @@ mod tests {
                 0.0f32, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0,
                 15.0,
             ],
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         // shift left by 1 pixel
@@ -506,7 +506,7 @@ mod tests {
             height: image.cols(),
         };
 
-        let mut image_transformed = Image::<_, 1, _>::from_size_val(new_size, 0.0, CpuAllocator)?;
+        let mut image_transformed = Image::<_, 1>::from_size_val(new_size, 0.0, host_alloc())?;
 
         super::warp_perspective(
             &image,
@@ -534,22 +534,22 @@ mod tests {
         for (i, v) in data.iter_mut().enumerate() {
             *v = ((i.wrapping_mul(37)) & 0xFF) as u8;
         }
-        let src = Image::<u8, 3, _>::new(
+        let src = Image::<u8, 3>::new(
             ImageSize {
                 width: w,
                 height: h,
             },
             data,
-            CpuAllocator,
+            host_alloc(),
         )?;
         let m = [1.02, 0.03, -5.0, -0.03, 1.01, 2.0, 0.00005, 0.00003, 1.0];
-        let mut dst = Image::<u8, 3, _>::from_size_val(
+        let mut dst = Image::<u8, 3>::from_size_val(
             ImageSize {
                 width: w,
                 height: h,
             },
             0u8,
-            CpuAllocator,
+            host_alloc(),
         )?;
         super::warp_perspective_u8(&src, &mut dst, &m)?;
         // Sample a few deterministic pixels that must be non-zero (i.e.

--- a/crates/kornia-imgproc/src/warp/perspective.rs
+++ b/crates/kornia-imgproc/src/warp/perspective.rs
@@ -70,7 +70,6 @@ fn transform_point(x: f32, y: f32, m: &[f32; 9]) -> (f32, f32) {
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_tensor::host_alloc;
 /// use kornia_imgproc::interpolation::InterpolationMode;
 /// use kornia_imgproc::warp::warp_perspective;
 ///
@@ -80,7 +79,6 @@ fn transform_point(x: f32, y: f32, m: &[f32; 9]) -> (f32, f32) {
 ///     height: 5,
 ///   },
 ///   vec![0.0f32; 4 * 5],
-///   host_alloc()
 /// ).unwrap();
 ///
 /// let m = [1.0, 0.0, -1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0];
@@ -91,7 +89,6 @@ fn transform_point(x: f32, y: f32, m: &[f32; 9]) -> (f32, f32) {
 ///     height: 3,
 ///   },
 ///   0.0,
-///   host_alloc()
 /// ).unwrap();
 ///
 /// warp_perspective(&src, &mut dst, &m, InterpolationMode::Bilinear).unwrap();
@@ -310,7 +307,6 @@ pub fn warp_perspective_u8<const C: usize>(
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
-    use kornia_tensor::host_alloc;
 
     #[test]
     fn inverse_perspective_matrix() -> Result<(), ImageError> {
@@ -338,7 +334,6 @@ mod tests {
                 height: 5,
             },
             0.0f32,
-            host_alloc(),
         )?;
 
         // identity matrix
@@ -349,7 +344,7 @@ mod tests {
             height: 3,
         };
 
-        let mut image_transformed = Image::from_size_val(new_size, 0.0, host_alloc())?;
+        let mut image_transformed = Image::from_size_val(new_size, 0.0)?;
 
         super::warp_perspective(
             &image,
@@ -373,7 +368,6 @@ mod tests {
                 height: 2,
             },
             0.0,
-            host_alloc(),
         )?;
         let mut dst = Image::<f32, 1>::from_size_val(
             ImageSize {
@@ -381,7 +375,6 @@ mod tests {
                 height: 2,
             },
             0.0,
-            host_alloc(),
         )?;
         let m = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
         let err = super::warp_perspective(&src, &mut dst, &m, super::InterpolationMode::Lanczos);
@@ -397,7 +390,6 @@ mod tests {
                 height: 3,
             },
             vec![0.0f32, 1.0, 2.0, 3.0, 4.0, 5.0],
-            host_alloc(),
         )?;
 
         let image_expected = vec![1.0, 0.0, 3.0, 2.0, 5.0, 4.0];
@@ -410,7 +402,7 @@ mod tests {
             height: 3,
         };
 
-        let mut image_transformed = Image::<_, 1>::from_size_val(new_size, 0.0, host_alloc())?;
+        let mut image_transformed = Image::<_, 1>::from_size_val(new_size, 0.0)?;
 
         super::warp_perspective(
             &image,
@@ -439,7 +431,6 @@ mod tests {
                 0.0f32, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0,
                 15.0,
             ],
-            host_alloc(),
         )?;
 
         // resize matrix (from get_perspective_transform)
@@ -452,7 +443,7 @@ mod tests {
             height: 2,
         };
 
-        let mut image_transformed = Image::<_, 1>::from_size_val(new_size, 0.0, host_alloc())?;
+        let mut image_transformed = Image::<_, 1>::from_size_val(new_size, 0.0)?;
 
         super::warp_perspective(
             &image,
@@ -461,7 +452,7 @@ mod tests {
             super::InterpolationMode::Bilinear,
         )?;
 
-        let mut image_resized = Image::<_, 1>::from_size_val(new_size, 0.0, host_alloc())?;
+        let mut image_resized = Image::<_, 1>::from_size_val(new_size, 0.0)?;
 
         crate::resize::resize_native(
             &image,
@@ -490,7 +481,6 @@ mod tests {
                 0.0f32, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0,
                 15.0,
             ],
-            host_alloc(),
         )?;
 
         // shift left by 1 pixel
@@ -506,7 +496,7 @@ mod tests {
             height: image.cols(),
         };
 
-        let mut image_transformed = Image::<_, 1>::from_size_val(new_size, 0.0, host_alloc())?;
+        let mut image_transformed = Image::<_, 1>::from_size_val(new_size, 0.0)?;
 
         super::warp_perspective(
             &image,
@@ -540,7 +530,6 @@ mod tests {
                 height: h,
             },
             data,
-            host_alloc(),
         )?;
         let m = [1.02, 0.03, -5.0, -0.03, 1.01, 2.0, 0.00005, 0.00003, 1.0];
         let mut dst = Image::<u8, 3>::from_size_val(
@@ -549,7 +538,6 @@ mod tests {
                 height: h,
             },
             0u8,
-            host_alloc(),
         )?;
         super::warp_perspective_u8(&src, &mut dst, &m)?;
         // Sample a few deterministic pixels that must be non-zero (i.e.

--- a/crates/kornia-imgproc/tests/contours_real_images.rs
+++ b/crates/kornia-imgproc/tests/contours_real_images.rs
@@ -22,7 +22,6 @@
 
 use kornia_image::{Image, ImageSize};
 use kornia_imgproc::contours::{find_contours, ContourApproximationMode, RetrievalMode};
-use kornia_tensor::host_alloc;
 use std::path::PathBuf;
 
 /// Loads a fixture PNG, binarises it at threshold 127, returns the image
@@ -43,7 +42,6 @@ fn load_binary(name: &str) -> Option<Image<u8, 1>> {
             height: h,
         },
         0,
-        host_alloc(),
     )
     .ok()?;
     kornia_imgproc::color::gray_from_rgb_u8(&rgb, &mut gray).ok()?;
@@ -53,7 +51,6 @@ fn load_binary(name: &str) -> Option<Image<u8, 1>> {
             height: h,
         },
         0,
-        host_alloc(),
     )
     .ok()?;
     kornia_imgproc::threshold::threshold_binary(&gray, &mut bw, 127, 1).ok()?;

--- a/crates/kornia-imgproc/tests/contours_real_images.rs
+++ b/crates/kornia-imgproc/tests/contours_real_images.rs
@@ -20,13 +20,14 @@
 //! pic4 (400x300):   844 contours (many disjoint shapes)
 //! ```
 
-use kornia_image::{allocator::CpuAllocator, Image, ImageSize};
+use kornia_image::{Image, ImageSize};
 use kornia_imgproc::contours::{find_contours, ContourApproximationMode, RetrievalMode};
+use kornia_tensor::host_alloc;
 use std::path::PathBuf;
 
 /// Loads a fixture PNG, binarises it at threshold 127, returns the image
 /// or None if the file is missing.
-fn load_binary(name: &str) -> Option<Image<u8, 1, CpuAllocator>> {
+fn load_binary(name: &str) -> Option<Image<u8, 1>> {
     let path: PathBuf = ["crates", "kornia-imgproc", "examples", "data", name]
         .iter()
         .collect();
@@ -36,30 +37,30 @@ fn load_binary(name: &str) -> Option<Image<u8, 1, CpuAllocator>> {
     }
     let rgb = kornia_io::png::read_image_png_rgb8(&path).ok()?;
     let (w, h) = (rgb.width(), rgb.height());
-    let mut gray = Image::<u8, 1, _>::from_size_val(
+    let mut gray = Image::<u8, 1>::from_size_val(
         ImageSize {
             width: w,
             height: h,
         },
         0,
-        CpuAllocator,
+        host_alloc(),
     )
     .ok()?;
     kornia_imgproc::color::gray_from_rgb_u8(&rgb, &mut gray).ok()?;
-    let mut bw = Image::<u8, 1, _>::from_size_val(
+    let mut bw = Image::<u8, 1>::from_size_val(
         ImageSize {
             width: w,
             height: h,
         },
         0,
-        CpuAllocator,
+        host_alloc(),
     )
     .ok()?;
     kornia_imgproc::threshold::threshold_binary(&gray, &mut bw, 127, 1).ok()?;
     Some(bw)
 }
 
-fn ext_count(img: &Image<u8, 1, CpuAllocator>) -> usize {
+fn ext_count(img: &Image<u8, 1>) -> usize {
     let r = find_contours(
         img,
         RetrievalMode::External,

--- a/crates/kornia-imgproc/tests/contours_snapshots.rs
+++ b/crates/kornia-imgproc/tests/contours_snapshots.rs
@@ -20,8 +20,9 @@
 //!
 //! Tests are skipped (not failed) when fixture PNGs aren't downloaded.
 
-use kornia_image::{allocator::CpuAllocator, Image, ImageSize};
+use kornia_image::{Image, ImageSize};
 use kornia_imgproc::contours::{find_contours, ContourApproximationMode, RetrievalMode};
+use kornia_tensor::host_alloc;
 use std::fmt::Write as _;
 use std::path::PathBuf;
 
@@ -132,7 +133,7 @@ fn emit_json(contours: &[Vec<[i32; 2]>]) -> String {
     s
 }
 
-fn load_binary(name: &str) -> Option<Image<u8, 1, CpuAllocator>> {
+fn load_binary(name: &str) -> Option<Image<u8, 1>> {
     let path: PathBuf = [env!("CARGO_MANIFEST_DIR"), "examples", "data", name]
         .iter()
         .collect();
@@ -141,23 +142,23 @@ fn load_binary(name: &str) -> Option<Image<u8, 1, CpuAllocator>> {
     }
     let rgb = kornia_io::png::read_image_png_rgb8(&path).ok()?;
     let (w, h) = (rgb.width(), rgb.height());
-    let mut gray = Image::<u8, 1, _>::from_size_val(
+    let mut gray = Image::<u8, 1>::from_size_val(
         ImageSize {
             width: w,
             height: h,
         },
         0,
-        CpuAllocator,
+        host_alloc(),
     )
     .ok()?;
     kornia_imgproc::color::gray_from_rgb_u8(&rgb, &mut gray).ok()?;
-    let mut bw = Image::<u8, 1, _>::from_size_val(
+    let mut bw = Image::<u8, 1>::from_size_val(
         ImageSize {
             width: w,
             height: h,
         },
         0,
-        CpuAllocator,
+        host_alloc(),
     )
     .ok()?;
     kornia_imgproc::threshold::threshold_binary(&gray, &mut bw, 127, 1).ok()?;

--- a/crates/kornia-imgproc/tests/contours_snapshots.rs
+++ b/crates/kornia-imgproc/tests/contours_snapshots.rs
@@ -22,7 +22,6 @@
 
 use kornia_image::{Image, ImageSize};
 use kornia_imgproc::contours::{find_contours, ContourApproximationMode, RetrievalMode};
-use kornia_tensor::host_alloc;
 use std::fmt::Write as _;
 use std::path::PathBuf;
 
@@ -148,7 +147,6 @@ fn load_binary(name: &str) -> Option<Image<u8, 1>> {
             height: h,
         },
         0,
-        host_alloc(),
     )
     .ok()?;
     kornia_imgproc::color::gray_from_rgb_u8(&rgb, &mut gray).ok()?;
@@ -158,7 +156,6 @@ fn load_binary(name: &str) -> Option<Image<u8, 1>> {
             height: h,
         },
         0,
-        host_alloc(),
     )
     .ok()?;
     kornia_imgproc::threshold::threshold_binary(&gray, &mut bw, 127, 1).ok()?;

--- a/crates/kornia-io/src/functional.rs
+++ b/crates/kornia-io/src/functional.rs
@@ -33,7 +33,7 @@ use std::path::Path;
 /// use kornia_io::functional as F;
 /// use kornia_image::color_spaces::Rgb8;
 ///
-/// let image: Rgb8<_> = F::read_image_any_rgb8("../../tests/data/dog.jpeg").unwrap();
+/// let image: Rgb8 = F::read_image_any_rgb8("../../tests/data/dog.jpeg").unwrap();
 ///
 /// assert_eq!(image.cols(), 258);
 /// assert_eq!(image.rows(), 195);

--- a/crates/kornia-io/src/functional.rs
+++ b/crates/kornia-io/src/functional.rs
@@ -2,7 +2,7 @@ use crate::{
     error::IoError, jpeg::read_image_jpeg_rgb8, png::read_image_png_rgb8,
     tiff::read_image_tiff_rgb8, webp::read_image_webp_rgb8,
 };
-use kornia_image::{allocator::CpuAllocator, color_spaces::Rgb8};
+use kornia_image::color_spaces::Rgb8;
 use std::path::Path;
 
 /// Reads a RGB8 image from the given file path.
@@ -39,7 +39,7 @@ use std::path::Path;
 /// assert_eq!(image.rows(), 195);
 /// assert_eq!(image.num_channels(), 3);
 /// ```
-pub fn read_image_any_rgb8(file_path: impl AsRef<Path>) -> Result<Rgb8<CpuAllocator>, IoError> {
+pub fn read_image_any_rgb8(file_path: impl AsRef<Path>) -> Result<Rgb8, IoError> {
     let file_path = file_path.as_ref().to_owned();
 
     // verify the file exists

--- a/crates/kornia-io/src/gstreamer/capture.rs
+++ b/crates/kornia-io/src/gstreamer/capture.rs
@@ -3,7 +3,6 @@ use crate::stream::error::StreamCaptureError;
 use circular_buffer::CircularBuffer;
 use gstreamer::prelude::*;
 use kornia_image::{Image, ImageSize};
-use kornia_tensor::allocator::ForeignAllocator;
 use std::sync::{Arc, Mutex};
 
 // utility struct to store the frame buffer
@@ -135,9 +134,7 @@ impl StreamCapture {
     /// # Returns
     ///
     /// An Option containing the last captured Image or None if no image has been captured yet.
-    pub fn grab_rgb8(
-        &mut self,
-    ) -> Result<Option<Image<u8, 3, ForeignAllocator>>, StreamCaptureError> {
+    pub fn grab_rgb8(&mut self) -> Result<Option<Image<u8, 3>>, StreamCaptureError> {
         let mut circular_buffer = self
             .circular_buffer
             .lock()

--- a/crates/kornia-io/src/gstreamer/mod.rs
+++ b/crates/kornia-io/src/gstreamer/mod.rs
@@ -28,8 +28,6 @@ use std::sync::Arc;
 
 use kornia_tensor::resource::{MemoryDomain, MemoryResource};
 
-pub use kornia_tensor::allocator::ForeignAllocator;
-
 /// A proper [`MemoryResource`] for a GStreamer-mapped buffer (sysmem).
 ///
 /// Holds a `MappedBuffer<Readable>` which:
@@ -91,7 +89,7 @@ impl MemoryResource for GstResource {
 ///
 /// # Returns
 ///
-/// An `Image<u8, 3, ForeignAllocator>` whose memory is the GStreamer buffer.
+/// An `Image<u8, 3>` whose memory is the GStreamer buffer.
 /// The buffer remains live (and the pointer valid) for exactly the lifetime of the
 /// returned `Image`; dropping the `Image` releases the buffer ref exactly once.
 ///
@@ -101,8 +99,7 @@ impl MemoryResource for GstResource {
 pub(crate) fn image_from_gst_buffer(
     size: kornia_image::ImageSize,
     mapped_buffer: gstreamer::buffer::MappedBuffer<gstreamer::buffer::Readable>,
-) -> Result<kornia_image::Image<u8, 3, ForeignAllocator>, crate::stream::error::StreamCaptureError>
-{
+) -> Result<kornia_image::Image<u8, 3>, crate::stream::error::StreamCaptureError> {
     use kornia_tensor::storage::{MemoryDomain, TensorStorage};
     use kornia_tensor::Tensor;
 
@@ -145,11 +142,11 @@ pub(crate) fn image_from_gst_buffer(
     //   - The memory is host-accessible (MemoryDomain::Host).
     //   - The keepalive (Arc<GstResource>) holds the map alive for the storage's lifetime.
     //   - The storage is read-only: `as_mut_slice` will panic (GstMappedBuffer is Readable).
-    let storage: TensorStorage<u8, ForeignAllocator> = unsafe {
+    let storage: TensorStorage<u8> = unsafe {
         TensorStorage::from_borrowed_readonly(
             data_ptr,
             data_len,
-            ForeignAllocator,
+            kornia_tensor::host_alloc(),
             MemoryDomain::Host,
             keepalive,
         )
@@ -165,7 +162,7 @@ pub(crate) fn image_from_gst_buffer(
         strides,
     };
 
-    // TryFrom<Tensor3<T, A>> for Image<T, C, A> validates that shape[2] == C (== 3).
+    // TryFrom<Tensor3<T, >> for Image<T, C> validates that shape[2] == C (== 3).
     kornia_image::Image::try_from(tensor)
         .map_err(crate::stream::error::StreamCaptureError::ImageError)
 }

--- a/crates/kornia-io/src/gstreamer/video.rs
+++ b/crates/kornia-io/src/gstreamer/video.rs
@@ -1,7 +1,6 @@
 use super::{capture::StreamerState, error::VideoReaderError, StreamCapture, StreamCaptureError};
 use gstreamer::prelude::*;
-use kornia_image::{allocator::ImageAllocator, Image, ImageSize};
-use kornia_tensor::allocator::ForeignAllocator;
+use kornia_image::{Image, ImageSize};
 use std::{path::Path, time::Duration};
 
 pub use gstreamer::SeekFlags;
@@ -177,10 +176,7 @@ impl VideoWriter {
     ///
     /// * `img` - The image to write to the video file.
     // TODO: explore supporting write_async
-    pub fn write<const C: usize, A: ImageAllocator>(
-        &mut self,
-        img: &Image<u8, C, A>,
-    ) -> Result<(), StreamCaptureError> {
+    pub fn write<const C: usize>(&mut self, img: &Image<u8, C>) -> Result<(), StreamCaptureError> {
         // check if the image channels are correct
         match self.format {
             ImageFormat::Mono8 => {
@@ -297,9 +293,7 @@ impl VideoReader {
     ///
     /// An Option containing the last captured Image or None if no image has been captured yet.
     #[inline]
-    pub fn grab_rgb8(
-        &mut self,
-    ) -> Result<Option<Image<u8, 3, ForeignAllocator>>, VideoReaderError> {
+    pub fn grab_rgb8(&mut self) -> Result<Option<Image<u8, 3>>, VideoReaderError> {
         self.0
             .grab_rgb8()
             .map_err(VideoReaderError::StreamCaptureError)
@@ -421,7 +415,7 @@ impl VideoReader {
 #[cfg(test)]
 mod tests {
     use super::{ImageFormat, VideoCodec, VideoWriter};
-    use kornia_image::{allocator::CpuAllocator, Image, ImageSize};
+    use kornia_image::{Image, ImageSize};
 
     #[ignore = "need gstreamer in CI"]
     #[test]
@@ -440,8 +434,11 @@ mod tests {
             VideoWriter::new(&file_path, VideoCodec::H264, ImageFormat::Rgb8, 30, size)?;
         writer.start()?;
 
-        let img =
-            Image::<u8, 3, _>::new(size, vec![0; size.width * size.height * 3], CpuAllocator)?;
+        let img = Image::<u8, 3>::new(
+            size,
+            vec![0; size.width * size.height * 3],
+            kornia_tensor::host_alloc(),
+        )?;
         writer.write(&img)?;
         writer.close()?;
 
@@ -467,7 +464,11 @@ mod tests {
             VideoWriter::new(&file_path, VideoCodec::H264, ImageFormat::Mono8, 30, size)?;
         writer.start()?;
 
-        let img = Image::<u8, 1, _>::new(size, vec![0; size.width * size.height], CpuAllocator)?;
+        let img = Image::<u8, 1>::new(
+            size,
+            vec![0; size.width * size.height],
+            kornia_tensor::host_alloc(),
+        )?;
         writer.write(&img)?;
         writer.close()?;
 

--- a/crates/kornia-io/src/gstreamer/video.rs
+++ b/crates/kornia-io/src/gstreamer/video.rs
@@ -434,11 +434,7 @@ mod tests {
             VideoWriter::new(&file_path, VideoCodec::H264, ImageFormat::Rgb8, 30, size)?;
         writer.start()?;
 
-        let img = Image::<u8, 3>::new(
-            size,
-            vec![0; size.width * size.height * 3],
-            kornia_tensor::host_alloc(),
-        )?;
+        let img = Image::<u8, 3>::new(size, vec![0; size.width * size.height * 3])?;
         writer.write(&img)?;
         writer.close()?;
 
@@ -464,11 +460,7 @@ mod tests {
             VideoWriter::new(&file_path, VideoCodec::H264, ImageFormat::Mono8, 30, size)?;
         writer.start()?;
 
-        let img = Image::<u8, 1>::new(
-            size,
-            vec![0; size.width * size.height],
-            kornia_tensor::host_alloc(),
-        )?;
+        let img = Image::<u8, 1>::new(size, vec![0; size.width * size.height])?;
         writer.write(&img)?;
         writer.close()?;
 

--- a/crates/kornia-io/src/jpeg.rs
+++ b/crates/kornia-io/src/jpeg.rs
@@ -1,7 +1,6 @@
 use crate::error::IoError;
 use jpeg_encoder::{ColorType, Encoder};
 use kornia_image::{
-    allocator::{CpuAllocator, ImageAllocator},
     color_spaces::{Gray8, Rgb8},
     Image, ImageLayout, ImageSize, PixelFormat,
 };
@@ -14,9 +13,9 @@ use std::{fs, io::Cursor, path::Path};
 /// - `file_path` - The path to the JPEG image.
 /// - `image` - The RGB8 image to write
 /// - `quality` - The quality of the JPEG encoding, range from 0 (lowest) to 100 (highest)
-pub fn write_image_jpeg_rgb8<A: ImageAllocator>(
+pub fn write_image_jpeg_rgb8(
     file_path: impl AsRef<Path>,
-    image: &Image<u8, 3, A>,
+    image: &Image<u8, 3>,
     quality: u8,
 ) -> Result<(), IoError> {
     write_image_jpeg_imp(file_path, image, ColorType::Rgb, quality)
@@ -29,9 +28,9 @@ pub fn write_image_jpeg_rgb8<A: ImageAllocator>(
 /// - `file_path` - The path to the JPEG image.
 /// - `image` - The grayscale image to write
 /// - `quality` - The quality of the JPEG encoding, range from 0 (lowest) to 100 (highest)
-pub fn write_image_jpeg_gray8<A: ImageAllocator>(
+pub fn write_image_jpeg_gray8(
     file_path: impl AsRef<Path>,
-    image: &Image<u8, 1, A>,
+    image: &Image<u8, 1>,
     quality: u8,
 ) -> Result<(), IoError> {
     write_image_jpeg_imp(file_path, image, ColorType::Luma, quality)
@@ -56,14 +55,14 @@ pub fn write_image_jpeg_gray8<A: ImageAllocator>(
 ///
 /// ```rust
 /// use kornia_io::jpeg::encode_image_jpeg_rgb8;
-/// use kornia_image::{Image, allocator::CpuAllocator};
+/// use kornia_image::{Image};
 ///
-/// let image = Image::<u8, 3, CpuAllocator>::from_size_val([258, 195].into(), 0, CpuAllocator).expect("Failed to create image");
+/// let image = Image::<u8, 3>::from_size_val([258, 195].into(), 0, kornia_tensor::host_alloc()).expect("Failed to create image");
 /// let mut buffer = Vec::new();
 /// encode_image_jpeg_rgb8(&image, 100, &mut buffer).expect("Failed to encode image");
 /// ```
-pub fn encode_image_jpeg_rgb8<A: ImageAllocator>(
-    image: &Image<u8, 3, A>,
+pub fn encode_image_jpeg_rgb8(
+    image: &Image<u8, 3>,
     quality: u8,
     buffer: &mut Vec<u8>,
 ) -> Result<(), IoError> {
@@ -96,11 +95,11 @@ pub fn encode_image_jpeg_rgb8<A: ImageAllocator>(
 /// # Example
 ///
 /// ```no_run
-/// use kornia_image::{Image, allocator::CpuAllocator};
+/// use kornia_image::{Image};
 /// use kornia_io::jpeg;
 ///
 /// let bgra_data = vec![0u8; 640 * 480 * 4]; // BGRA pixels from graphics API
-/// let image = Image::<u8, 4, _>::new([640, 480].into(), bgra_data, CpuAllocator)?;
+/// let image = Image::<u8, 4>::new([640, 480].into(), bgra_data, kornia_tensor::host_alloc())?;
 ///
 /// let mut buffer = Vec::new();
 /// jpeg::encode_image_jpeg_bgra8(&image, 90, &mut buffer)?;
@@ -109,8 +108,8 @@ pub fn encode_image_jpeg_rgb8<A: ImageAllocator>(
 /// std::fs::write("output.jpg", &buffer)?;
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
-pub fn encode_image_jpeg_bgra8<A: ImageAllocator>(
-    image: &Image<u8, 4, A>,
+pub fn encode_image_jpeg_bgra8(
+    image: &Image<u8, 4>,
     quality: u8,
     buffer: &mut Vec<u8>,
 ) -> Result<(), IoError> {
@@ -138,8 +137,8 @@ pub fn encode_image_jpeg_bgra8<A: ImageAllocator>(
 ///
 /// The caller is responsible for clearing the buffer if needed. The encoded data will be
 /// appended to any existing content in the buffer.
-pub fn encode_image_jpeg_gray8<A: ImageAllocator>(
-    image: &Image<u8, 1, A>,
+pub fn encode_image_jpeg_gray8(
+    image: &Image<u8, 1>,
     quality: u8,
     buffer: &mut Vec<u8>,
 ) -> Result<(), IoError> {
@@ -153,9 +152,9 @@ pub fn encode_image_jpeg_gray8<A: ImageAllocator>(
     Ok(())
 }
 
-fn write_image_jpeg_imp<const N: usize, A: ImageAllocator>(
+fn write_image_jpeg_imp<const N: usize>(
     file_path: impl AsRef<Path>,
-    image: &Image<u8, N, A>,
+    image: &Image<u8, N>,
     color_type: ColorType,
     quality: u8,
 ) -> Result<(), IoError> {
@@ -179,12 +178,12 @@ fn write_image_jpeg_imp<const N: usize, A: ImageAllocator>(
 /// # Returns
 ///
 /// An RGB8 typed image.
-pub fn read_image_jpeg_rgb8(file_path: impl AsRef<Path>) -> Result<Rgb8<CpuAllocator>, IoError> {
+pub fn read_image_jpeg_rgb8(file_path: impl AsRef<Path>) -> Result<Rgb8, IoError> {
     let img = read_image_jpeg_impl::<3>(file_path)?;
     Ok(Rgb8::from_size_vec(
         img.size(),
         img.into_vec(),
-        CpuAllocator,
+        kornia_tensor::host_alloc(),
     )?)
 }
 
@@ -197,12 +196,12 @@ pub fn read_image_jpeg_rgb8(file_path: impl AsRef<Path>) -> Result<Rgb8<CpuAlloc
 /// # Returns
 ///
 /// A Gray8 typed image.
-pub fn read_image_jpeg_mono8(file_path: impl AsRef<Path>) -> Result<Gray8<CpuAllocator>, IoError> {
+pub fn read_image_jpeg_mono8(file_path: impl AsRef<Path>) -> Result<Gray8, IoError> {
     let img = read_image_jpeg_impl::<1>(file_path)?;
     Ok(Gray8::from_size_vec(
         img.size(),
         img.into_vec(),
-        CpuAllocator,
+        kornia_tensor::host_alloc(),
     )?)
 }
 
@@ -212,10 +211,7 @@ pub fn read_image_jpeg_mono8(file_path: impl AsRef<Path>) -> Result<Gray8<CpuAll
 ///
 /// - `src` - Raw bytes of the jpeg file
 /// - `dst` - A mutable reference to your `Rgb8` image
-pub fn decode_image_jpeg_rgb8<A: ImageAllocator>(
-    src: &[u8],
-    dst: &mut Image<u8, 3, A>,
-) -> Result<(), IoError> {
+pub fn decode_image_jpeg_rgb8(src: &[u8], dst: &mut Image<u8, 3>) -> Result<(), IoError> {
     decode_jpeg_impl(src, dst)
 }
 
@@ -225,16 +221,13 @@ pub fn decode_image_jpeg_rgb8<A: ImageAllocator>(
 ///
 /// - `src` - Raw bytes of the jpeg file
 /// - `dst` - A mutable reference to your `Gray8` image
-pub fn decode_image_jpeg_mono8<A: ImageAllocator>(
-    src: &[u8],
-    dst: &mut Image<u8, 1, A>,
-) -> Result<(), IoError> {
+pub fn decode_image_jpeg_mono8(src: &[u8], dst: &mut Image<u8, 1>) -> Result<(), IoError> {
     decode_jpeg_impl(src, dst)
 }
 
 fn read_image_jpeg_impl<const N: usize>(
     file_path: impl AsRef<Path>,
-) -> Result<Image<u8, N, CpuAllocator>, IoError> {
+) -> Result<Image<u8, N>, IoError> {
     use zune_jpeg::zune_core::colorspace::ColorSpace;
     use zune_jpeg::zune_core::options::DecoderOptions;
 
@@ -296,13 +289,14 @@ fn read_image_jpeg_impl<const N: usize>(
     let mut decoder = zune_jpeg::JpegDecoder::new_with_options(Cursor::new(&jpeg_data), options);
     let img_data = decoder.decode()?;
 
-    Ok(Image::new(image_size, img_data, CpuAllocator)?)
+    Ok(Image::new(
+        image_size,
+        img_data,
+        kornia_tensor::host_alloc(),
+    )?)
 }
 
-fn decode_jpeg_impl<const C: usize, A: ImageAllocator>(
-    src: &[u8],
-    dst: &mut Image<u8, C, A>,
-) -> Result<(), IoError> {
+fn decode_jpeg_impl<const C: usize>(src: &[u8], dst: &mut Image<u8, C>) -> Result<(), IoError> {
     use zune_jpeg::zune_core::colorspace::ColorSpace;
     use zune_jpeg::zune_core::options::DecoderOptions;
 
@@ -421,7 +415,7 @@ mod tests {
     #[test]
     fn test_decode_jpeg() -> Result<(), IoError> {
         let bytes = read("../../tests/data/dog.jpeg")?;
-        let mut image = Rgb8::from_size_val([258, 195].into(), 0, CpuAllocator)?;
+        let mut image = Rgb8::from_size_val([258, 195].into(), 0, kornia_tensor::host_alloc())?;
         decode_image_jpeg_rgb8(&bytes, &mut image)?;
 
         assert_eq!(image.cols(), 258);
@@ -454,8 +448,8 @@ mod tests {
         assert_eq!(buffer[1], 0xD8, "Invalid JPEG magic byte 2");
 
         // Verify we can decode it back
-        let mut decoded: Image<u8, 3, _> =
-            Image::from_size_val([258, 195].into(), 0, CpuAllocator)?;
+        let mut decoded: Image<u8, 3> =
+            Image::from_size_val([258, 195].into(), 0, kornia_tensor::host_alloc())?;
         decode_image_jpeg_rgb8(&buffer, &mut decoded)?;
         assert_eq!(decoded.cols(), 258);
         assert_eq!(decoded.rows(), 195);
@@ -466,7 +460,8 @@ mod tests {
     #[test]
     fn test_encode_jpeg_gray8_with_buffer() -> Result<(), IoError> {
         // Create a synthetic grayscale image for testing
-        let image = Image::<u8, 1, _>::from_size_val([258, 195].into(), 128, CpuAllocator)?;
+        let image =
+            Image::<u8, 1>::from_size_val([258, 195].into(), 128, kornia_tensor::host_alloc())?;
 
         let mut buffer = Vec::new();
         encode_image_jpeg_gray8(&image, 100, &mut buffer)?;
@@ -477,8 +472,8 @@ mod tests {
         assert_eq!(buffer[1], 0xD8, "Invalid JPEG magic byte 2");
 
         // Verify we can decode it back
-        let mut decoded: Image<u8, 1, _> =
-            Image::from_size_val([258, 195].into(), 0, CpuAllocator)?;
+        let mut decoded: Image<u8, 1> =
+            Image::from_size_val([258, 195].into(), 0, kornia_tensor::host_alloc())?;
         decode_image_jpeg_mono8(&buffer, &mut decoded)?;
         assert_eq!(decoded.cols(), 258);
         assert_eq!(decoded.rows(), 195);
@@ -489,7 +484,8 @@ mod tests {
     #[test]
     fn test_encode_jpeg_buffer_reuse() -> Result<(), IoError> {
         let image1 = read_image_jpeg_rgb8("../../tests/data/dog.jpeg")?;
-        let image2 = Image::<u8, 3, _>::from_size_val([100, 100].into(), 255, CpuAllocator)?;
+        let image2 =
+            Image::<u8, 3>::from_size_val([100, 100].into(), 255, kornia_tensor::host_alloc())?;
 
         // Reuse the same buffer for multiple encodes
         let mut buffer = Vec::new();

--- a/crates/kornia-io/src/jpeg.rs
+++ b/crates/kornia-io/src/jpeg.rs
@@ -57,7 +57,7 @@ pub fn write_image_jpeg_gray8(
 /// use kornia_io::jpeg::encode_image_jpeg_rgb8;
 /// use kornia_image::{Image};
 ///
-/// let image = Image::<u8, 3>::from_size_val([258, 195].into(), 0, kornia_tensor::host_alloc()).expect("Failed to create image");
+/// let image = Image::<u8, 3>::from_size_val([258, 195].into(), 0).expect("Failed to create image");
 /// let mut buffer = Vec::new();
 /// encode_image_jpeg_rgb8(&image, 100, &mut buffer).expect("Failed to encode image");
 /// ```
@@ -99,7 +99,7 @@ pub fn encode_image_jpeg_rgb8(
 /// use kornia_io::jpeg;
 ///
 /// let bgra_data = vec![0u8; 640 * 480 * 4]; // BGRA pixels from graphics API
-/// let image = Image::<u8, 4>::new([640, 480].into(), bgra_data, kornia_tensor::host_alloc())?;
+/// let image = Image::<u8, 4>::new([640, 480].into(), bgra_data)?;
 ///
 /// let mut buffer = Vec::new();
 /// jpeg::encode_image_jpeg_bgra8(&image, 90, &mut buffer)?;
@@ -180,11 +180,7 @@ fn write_image_jpeg_imp<const N: usize>(
 /// An RGB8 typed image.
 pub fn read_image_jpeg_rgb8(file_path: impl AsRef<Path>) -> Result<Rgb8, IoError> {
     let img = read_image_jpeg_impl::<3>(file_path)?;
-    Ok(Rgb8::from_size_vec(
-        img.size(),
-        img.into_vec(),
-        kornia_tensor::host_alloc(),
-    )?)
+    Ok(Rgb8::from_size_vec(img.size(), img.into_vec())?)
 }
 
 /// Reads a JPEG file as grayscale.
@@ -198,11 +194,7 @@ pub fn read_image_jpeg_rgb8(file_path: impl AsRef<Path>) -> Result<Rgb8, IoError
 /// A Gray8 typed image.
 pub fn read_image_jpeg_mono8(file_path: impl AsRef<Path>) -> Result<Gray8, IoError> {
     let img = read_image_jpeg_impl::<1>(file_path)?;
-    Ok(Gray8::from_size_vec(
-        img.size(),
-        img.into_vec(),
-        kornia_tensor::host_alloc(),
-    )?)
+    Ok(Gray8::from_size_vec(img.size(), img.into_vec())?)
 }
 
 /// Decodes a JPEG image with as RGB8 from raw bytes.
@@ -289,11 +281,7 @@ fn read_image_jpeg_impl<const N: usize>(
     let mut decoder = zune_jpeg::JpegDecoder::new_with_options(Cursor::new(&jpeg_data), options);
     let img_data = decoder.decode()?;
 
-    Ok(Image::new(
-        image_size,
-        img_data,
-        kornia_tensor::host_alloc(),
-    )?)
+    Ok(Image::new(image_size, img_data)?)
 }
 
 fn decode_jpeg_impl<const C: usize>(src: &[u8], dst: &mut Image<u8, C>) -> Result<(), IoError> {
@@ -415,7 +403,7 @@ mod tests {
     #[test]
     fn test_decode_jpeg() -> Result<(), IoError> {
         let bytes = read("../../tests/data/dog.jpeg")?;
-        let mut image = Rgb8::from_size_val([258, 195].into(), 0, kornia_tensor::host_alloc())?;
+        let mut image = Rgb8::from_size_val([258, 195].into(), 0)?;
         decode_image_jpeg_rgb8(&bytes, &mut image)?;
 
         assert_eq!(image.cols(), 258);
@@ -448,8 +436,7 @@ mod tests {
         assert_eq!(buffer[1], 0xD8, "Invalid JPEG magic byte 2");
 
         // Verify we can decode it back
-        let mut decoded: Image<u8, 3> =
-            Image::from_size_val([258, 195].into(), 0, kornia_tensor::host_alloc())?;
+        let mut decoded: Image<u8, 3> = Image::from_size_val([258, 195].into(), 0)?;
         decode_image_jpeg_rgb8(&buffer, &mut decoded)?;
         assert_eq!(decoded.cols(), 258);
         assert_eq!(decoded.rows(), 195);
@@ -460,8 +447,7 @@ mod tests {
     #[test]
     fn test_encode_jpeg_gray8_with_buffer() -> Result<(), IoError> {
         // Create a synthetic grayscale image for testing
-        let image =
-            Image::<u8, 1>::from_size_val([258, 195].into(), 128, kornia_tensor::host_alloc())?;
+        let image = Image::<u8, 1>::from_size_val([258, 195].into(), 128)?;
 
         let mut buffer = Vec::new();
         encode_image_jpeg_gray8(&image, 100, &mut buffer)?;
@@ -472,8 +458,7 @@ mod tests {
         assert_eq!(buffer[1], 0xD8, "Invalid JPEG magic byte 2");
 
         // Verify we can decode it back
-        let mut decoded: Image<u8, 1> =
-            Image::from_size_val([258, 195].into(), 0, kornia_tensor::host_alloc())?;
+        let mut decoded: Image<u8, 1> = Image::from_size_val([258, 195].into(), 0)?;
         decode_image_jpeg_mono8(&buffer, &mut decoded)?;
         assert_eq!(decoded.cols(), 258);
         assert_eq!(decoded.rows(), 195);
@@ -484,8 +469,7 @@ mod tests {
     #[test]
     fn test_encode_jpeg_buffer_reuse() -> Result<(), IoError> {
         let image1 = read_image_jpeg_rgb8("../../tests/data/dog.jpeg")?;
-        let image2 =
-            Image::<u8, 3>::from_size_val([100, 100].into(), 255, kornia_tensor::host_alloc())?;
+        let image2 = Image::<u8, 3>::from_size_val([100, 100].into(), 255)?;
 
         // Reuse the same buffer for multiple encodes
         let mut buffer = Vec::new();

--- a/crates/kornia-io/src/jpegturbo.rs
+++ b/crates/kornia-io/src/jpegturbo.rs
@@ -154,7 +154,7 @@ impl JpegTurboDecoder {
     /// Decodes the given JPEG data as RGB8 image.
     pub fn decode_rgb8(&self, jpeg_data: &[u8]) -> Result<Image<u8, 3>, JpegTurboError> {
         let image_size = self.read_header(jpeg_data)?;
-        let mut dst = Image::from_size_val(image_size, 0u8, kornia_tensor::host_alloc())?;
+        let mut dst = Image::from_size_val(image_size, 0u8)?;
         self.decode_rgb8_into(jpeg_data, &mut dst)?;
         Ok(dst)
     }
@@ -162,7 +162,7 @@ impl JpegTurboDecoder {
     /// Decodes the given JPEG data as Gray/Mono8 image.
     pub fn decode_gray8(&self, jpeg_data: &[u8]) -> Result<Image<u8, 1>, JpegTurboError> {
         let image_size = self.read_header(jpeg_data)?;
-        let mut dst = Image::from_size_val(image_size, 0u8, kornia_tensor::host_alloc())?;
+        let mut dst = Image::from_size_val(image_size, 0u8)?;
         self.decode_gray8_into(jpeg_data, &mut dst)?;
         Ok(dst)
     }

--- a/crates/kornia-io/src/jpegturbo.rs
+++ b/crates/kornia-io/src/jpegturbo.rs
@@ -1,8 +1,5 @@
 use crate::error::IoError;
-use kornia_image::{
-    allocator::{CpuAllocator, ImageAllocator},
-    Image, ImageError, ImageSize,
-};
+use kornia_image::{Image, ImageError, ImageSize};
 use std::{path::Path, sync::Mutex};
 use turbojpeg;
 
@@ -69,10 +66,7 @@ impl JpegTurboEncoder {
     /// # Returns
     ///
     /// The encoded data as `Vec<u8>`.
-    pub fn encode_rgb8<A: ImageAllocator>(
-        &self,
-        image: &Image<u8, 3, A>,
-    ) -> Result<Vec<u8>, JpegTurboError> {
+    pub fn encode_rgb8(&self, image: &Image<u8, 3>) -> Result<Vec<u8>, JpegTurboError> {
         // get the image data
         let image_data = image.as_slice();
 
@@ -158,32 +152,26 @@ impl JpegTurboDecoder {
     }
 
     /// Decodes the given JPEG data as RGB8 image.
-    pub fn decode_rgb8(
-        &self,
-        jpeg_data: &[u8],
-    ) -> Result<Image<u8, 3, CpuAllocator>, JpegTurboError> {
+    pub fn decode_rgb8(&self, jpeg_data: &[u8]) -> Result<Image<u8, 3>, JpegTurboError> {
         let image_size = self.read_header(jpeg_data)?;
-        let mut dst = Image::from_size_val(image_size, 0u8, CpuAllocator)?;
+        let mut dst = Image::from_size_val(image_size, 0u8, kornia_tensor::host_alloc())?;
         self.decode_rgb8_into(jpeg_data, &mut dst)?;
         Ok(dst)
     }
 
     /// Decodes the given JPEG data as Gray/Mono8 image.
-    pub fn decode_gray8(
-        &self,
-        jpeg_data: &[u8],
-    ) -> Result<Image<u8, 1, CpuAllocator>, JpegTurboError> {
+    pub fn decode_gray8(&self, jpeg_data: &[u8]) -> Result<Image<u8, 1>, JpegTurboError> {
         let image_size = self.read_header(jpeg_data)?;
-        let mut dst = Image::from_size_val(image_size, 0u8, CpuAllocator)?;
+        let mut dst = Image::from_size_val(image_size, 0u8, kornia_tensor::host_alloc())?;
         self.decode_gray8_into(jpeg_data, &mut dst)?;
         Ok(dst)
     }
 
     /// Decodes JPEG bytes as RGB8 into a pre-allocated buffer.
-    pub fn decode_rgb8_into<A: ImageAllocator>(
+    pub fn decode_rgb8_into(
         &self,
         jpeg_data: &[u8],
-        dst: &mut Image<u8, 3, A>,
+        dst: &mut Image<u8, 3>,
     ) -> Result<(), JpegTurboError> {
         let size = dst.size();
         self.decode_into(
@@ -195,10 +183,10 @@ impl JpegTurboDecoder {
     }
 
     /// Decodes JPEG bytes as Gray/Mono8 into a pre-allocated buffer.
-    pub fn decode_gray8_into<A: ImageAllocator>(
+    pub fn decode_gray8_into(
         &self,
         jpeg_data: &[u8],
-        dst: &mut Image<u8, 1, A>,
+        dst: &mut Image<u8, 1>,
     ) -> Result<(), JpegTurboError> {
         let size = dst.size();
         self.decode_into(
@@ -263,15 +251,13 @@ impl JpegTurboDecoder {
 /// use kornia_image::Image;
 /// use kornia_io::jpegturbo as F;
 ///
-/// let image: Image<u8, 3, _> = F::read_image_jpegturbo_rgb8("../../tests/data/dog.jpeg").unwrap();
+/// let image: Image<u8, 3> = F::read_image_jpegturbo_rgb8("../../tests/data/dog.jpeg").unwrap();
 ///
 /// assert_eq!(image.cols(), 258);
 /// assert_eq!(image.rows(), 195);
 /// assert_eq!(image.num_channels(), 3);
 /// ```
-pub fn read_image_jpegturbo_rgb8(
-    file_path: impl AsRef<Path>,
-) -> Result<Image<u8, 3, CpuAllocator>, IoError> {
+pub fn read_image_jpegturbo_rgb8(file_path: impl AsRef<Path>) -> Result<Image<u8, 3>, IoError> {
     let file_path = file_path.as_ref().to_owned();
     // verify the file exists and is a JPEG
     if !file_path.exists() {
@@ -304,9 +290,9 @@ pub fn read_image_jpegturbo_rgb8(
 /// * `file_path` - The path to the JPEG image.
 /// * `image` - The tensor containing the JPEG image data.
 /// * `quality` - The quality of the JPEG encoding, range from 0 (lowest) to 100 (highest)
-pub fn write_image_jpegturbo_rgb8<A: ImageAllocator>(
+pub fn write_image_jpegturbo_rgb8(
     file_path: impl AsRef<Path>,
-    image: &Image<u8, 3, A>,
+    image: &Image<u8, 3>,
     quality: u8,
 ) -> Result<(), IoError> {
     let file_path = file_path.as_ref().to_owned();

--- a/crates/kornia-io/src/metadata.rs
+++ b/crates/kornia-io/src/metadata.rs
@@ -282,7 +282,6 @@ mod orientation_tests {
                 height: 2,
             },
             0.0,
-            kornia_tensor::host_alloc(),
         )
         .unwrap();
         img.set_pixel(0, 0, 0, 10.0).unwrap();
@@ -385,8 +384,8 @@ pub fn apply_exif_orientation(
         _ => return Err(IoError::InvalidOrientation(o as u16)),
     };
 
-    let mut dst = Image::<f32, 3>::from_size_val(out_size, 0.0, kornia_tensor::host_alloc())
-        .map_err(IoError::ImageCreationError)?;
+    let mut dst =
+        Image::<f32, 3>::from_size_val(out_size, 0.0).map_err(IoError::ImageCreationError)?;
 
     for sy in 0..src_h {
         for sx in 0..src_w {

--- a/crates/kornia-io/src/metadata.rs
+++ b/crates/kornia-io/src/metadata.rs
@@ -4,7 +4,6 @@ use std::num::NonZeroU8;
 use std::path::Path;
 
 use crate::error::IoError;
-use kornia_image::allocator::CpuAllocator;
 use kornia_image::{Image, ImageSize};
 use little_exif::filetype::FileExtension;
 
@@ -272,18 +271,18 @@ mod tests {
 #[cfg(test)]
 mod orientation_tests {
     use super::*;
-    use kornia_image::{allocator::CpuAllocator, Image, ImageSize};
+    use kornia_image::{Image, ImageSize};
     use std::num::NonZeroU8;
 
-    // 1. make_test_image returns Image<f32, 3, CpuAllocator>
-    fn make_test_image() -> Image<f32, 3, CpuAllocator> {
-        let mut img = Image::<f32, 3, _>::from_size_val(
+    // 1. make_test_image returns Image<f32, 3>
+    fn make_test_image() -> Image<f32, 3> {
+        let mut img = Image::<f32, 3>::from_size_val(
             ImageSize {
                 width: 3,
                 height: 2,
             },
             0.0,
-            CpuAllocator,
+            kornia_tensor::host_alloc(),
         )
         .unwrap();
         img.set_pixel(0, 0, 0, 10.0).unwrap();
@@ -367,9 +366,9 @@ use crate::jpeg::read_image_jpeg_rgb8;
 
 /// Applies EXIF orientation correction using exact pixel remapping.
 pub fn apply_exif_orientation(
-    image: Image<f32, 3, CpuAllocator>,
+    image: Image<f32, 3>,
     orientation: NonZeroU8,
-) -> Result<Image<f32, 3, CpuAllocator>, IoError> {
+) -> Result<Image<f32, 3>, IoError> {
     let src_w = image.size().width;
     let src_h = image.size().height;
     let o = orientation.get();
@@ -386,7 +385,7 @@ pub fn apply_exif_orientation(
         _ => return Err(IoError::InvalidOrientation(o as u16)),
     };
 
-    let mut dst = Image::<f32, 3, CpuAllocator>::from_size_val(out_size, 0.0, CpuAllocator)
+    let mut dst = Image::<f32, 3>::from_size_val(out_size, 0.0, kornia_tensor::host_alloc())
         .map_err(IoError::ImageCreationError)?;
 
     for sy in 0..src_h {
@@ -416,9 +415,7 @@ pub fn apply_exif_orientation(
 
 /// Convenience reader: loads JPEG and applies EXIF orientation if present.
 /// Returns an f32 image in [0, 255] range.
-pub fn read_image_jpeg_auto_orient<P: AsRef<Path>>(
-    path: P,
-) -> Result<Image<f32, 3, CpuAllocator>, IoError> {
+pub fn read_image_jpeg_auto_orient<P: AsRef<Path>>(path: P) -> Result<Image<f32, 3>, IoError> {
     let meta = read_image_metadata(&path)?;
     let rgb8 = read_image_jpeg_rgb8(&path)?;
     // Convert Rgb8 → Image<f32, 3>

--- a/crates/kornia-io/src/png.rs
+++ b/crates/kornia-io/src/png.rs
@@ -25,11 +25,7 @@ use std::{
 /// A grayscale image (Gray8).
 pub fn read_image_png_mono8(file_path: impl AsRef<Path>) -> Result<Gray8, IoError> {
     let (buf, size) = read_png_impl(file_path)?;
-    Ok(Gray8::from_size_vec(
-        size.into(),
-        buf,
-        kornia_tensor::host_alloc(),
-    )?)
+    Ok(Gray8::from_size_vec(size.into(), buf)?)
 }
 
 /// Read a PNG image as RGB8.
@@ -43,11 +39,7 @@ pub fn read_image_png_mono8(file_path: impl AsRef<Path>) -> Result<Gray8, IoErro
 /// An RGB8 typed image.
 pub fn read_image_png_rgb8(file_path: impl AsRef<Path>) -> Result<Rgb8, IoError> {
     let (buf, size) = read_png_impl(file_path)?;
-    Ok(Rgb8::from_size_vec(
-        size.into(),
-        buf,
-        kornia_tensor::host_alloc(),
-    )?)
+    Ok(Rgb8::from_size_vec(size.into(), buf)?)
 }
 
 /// Read a PNG image as RGBA8.
@@ -61,11 +53,7 @@ pub fn read_image_png_rgb8(file_path: impl AsRef<Path>) -> Result<Rgb8, IoError>
 /// An RGBA8 typed image.
 pub fn read_image_png_rgba8(file_path: impl AsRef<Path>) -> Result<Rgba8, IoError> {
     let (buf, size) = read_png_impl(file_path)?;
-    Ok(Rgba8::from_size_vec(
-        size.into(),
-        buf,
-        kornia_tensor::host_alloc(),
-    )?)
+    Ok(Rgba8::from_size_vec(size.into(), buf)?)
 }
 
 /// Read a PNG image as RGB16.
@@ -81,11 +69,7 @@ pub fn read_image_png_rgb16(file_path: impl AsRef<Path>) -> Result<Rgb16, IoErro
     let (buf, size) = read_png_impl(file_path)?;
     let buf_u16 = convert_buf_u8_u16(buf);
 
-    Ok(Rgb16::from_size_vec(
-        size.into(),
-        buf_u16,
-        kornia_tensor::host_alloc(),
-    )?)
+    Ok(Rgb16::from_size_vec(size.into(), buf_u16)?)
 }
 
 /// Read a PNG image as RGBA16.
@@ -101,11 +85,7 @@ pub fn read_image_png_rgba16(file_path: impl AsRef<Path>) -> Result<Rgba16, IoEr
     let (buf, size) = read_png_impl(file_path)?;
     let buf_u16 = convert_buf_u8_u16(buf);
 
-    Ok(Rgba16::from_size_vec(
-        size.into(),
-        buf_u16,
-        kornia_tensor::host_alloc(),
-    )?)
+    Ok(Rgba16::from_size_vec(size.into(), buf_u16)?)
 }
 
 /// Read a PNG image as grayscale (Gray16).
@@ -121,11 +101,7 @@ pub fn read_image_png_mono16(file_path: impl AsRef<Path>) -> Result<Gray16, IoEr
     let (buf, size) = read_png_impl(file_path)?;
     let buf_u16 = convert_buf_u8_u16(buf);
 
-    Ok(Gray16::from_size_vec(
-        size.into(),
-        buf_u16,
-        kornia_tensor::host_alloc(),
-    )?)
+    Ok(Gray16::from_size_vec(size.into(), buf_u16)?)
 }
 
 /// Decodes a PNG image with as grayscale (Gray8) from Raw Bytes.
@@ -669,7 +645,7 @@ mod tests {
     #[test]
     fn decode_png() -> Result<(), IoError> {
         let bytes = read("../../tests/data/dog-rgb8.png")?;
-        let mut image = Rgb8::from_size_val([258, 195].into(), 0, kornia_tensor::host_alloc())?;
+        let mut image = Rgb8::from_size_val([258, 195].into(), 0)?;
         decode_image_png_rgb8(&bytes, &mut image)?;
 
         assert_eq!(image.cols(), 258);
@@ -692,7 +668,7 @@ mod tests {
         // PNG magic header
         assert_eq!(&buffer[..8], b"\x89PNG\r\n\x1a\n");
 
-        let mut decoded = Rgb8::from_size_val(src.size(), 0, kornia_tensor::host_alloc())?;
+        let mut decoded = Rgb8::from_size_val(src.size(), 0)?;
         decode_image_png_rgb8(&buffer, &mut decoded)?;
         assert_eq!(decoded.size(), src.size());
         assert_eq!(decoded.as_slice(), src.as_slice());
@@ -706,13 +682,13 @@ mod tests {
         for (i, b) in data.iter_mut().enumerate() {
             *b = (i % 251) as u8;
         }
-        let src = Rgba8::from_size_vec([16, 16].into(), data, kornia_tensor::host_alloc())?;
+        let src = Rgba8::from_size_vec([16, 16].into(), data)?;
 
         let mut buffer = Vec::new();
         encode_image_png_rgba8(&src, &mut buffer, None)?;
         assert_eq!(&buffer[..8], b"\x89PNG\r\n\x1a\n");
 
-        let mut decoded = Rgba8::from_size_val(src.size(), 0, kornia_tensor::host_alloc())?;
+        let mut decoded = Rgba8::from_size_val(src.size(), 0)?;
         decode_image_png_rgba8(&buffer, &mut decoded)?;
         assert_eq!(decoded.as_slice(), src.as_slice());
         Ok(())
@@ -725,7 +701,7 @@ mod tests {
         encode_image_png_gray8(&src, &mut buffer, None)?;
         assert_eq!(&buffer[..8], b"\x89PNG\r\n\x1a\n");
 
-        let mut decoded = Gray8::from_size_val(src.size(), 0, kornia_tensor::host_alloc())?;
+        let mut decoded = Gray8::from_size_val(src.size(), 0)?;
         decode_image_png_mono8(&buffer, &mut decoded)?;
         assert_eq!(decoded.as_slice(), src.as_slice());
         Ok(())
@@ -738,7 +714,7 @@ mod tests {
         encode_image_png_rgb16(&src, &mut buffer, None)?;
         assert_eq!(&buffer[..8], b"\x89PNG\r\n\x1a\n");
 
-        let mut decoded = Rgb16::from_size_val(src.size(), 0, kornia_tensor::host_alloc())?;
+        let mut decoded = Rgb16::from_size_val(src.size(), 0)?;
         decode_image_png_rgb16(&buffer, &mut decoded)?;
         assert_eq!(decoded.as_slice(), src.as_slice());
         Ok(())
@@ -760,13 +736,13 @@ mod tests {
                 data[y * w + x] = 500;
             }
         }
-        let src = Gray16::from_size_vec([w, h].into(), data, kornia_tensor::host_alloc())?;
+        let src = Gray16::from_size_vec([w, h].into(), data)?;
 
         let mut buffer = Vec::new();
         encode_image_png_gray16(&src, &mut buffer, None)?;
         assert_eq!(&buffer[..8], b"\x89PNG\r\n\x1a\n");
         // Lossless u16 round-trip is the whole point of this codec for depth.
-        let mut decoded = Gray16::from_size_val(src.size(), 0, kornia_tensor::host_alloc())?;
+        let mut decoded = Gray16::from_size_val(src.size(), 0)?;
         decode_image_png_mono16(&buffer, &mut decoded)?;
         assert_eq!(decoded.as_slice(), src.as_slice());
         Ok(())
@@ -788,7 +764,7 @@ mod tests {
 
         // Capacity should not have grown on the second encode (allocation reuse).
         assert!(buffer.capacity() <= cap_after_first.max(buffer.len()));
-        let mut decoded = Rgb8::from_size_val(src.size(), 0, kornia_tensor::host_alloc())?;
+        let mut decoded = Rgb8::from_size_val(src.size(), 0)?;
         decode_image_png_rgb8(&buffer, &mut decoded)?;
         assert_eq!(decoded.as_slice(), src.as_slice());
         Ok(())

--- a/crates/kornia-io/src/png.rs
+++ b/crates/kornia-io/src/png.rs
@@ -3,7 +3,6 @@ use crate::{
     error::IoError,
 };
 use kornia_image::{
-    allocator::{CpuAllocator, ImageAllocator},
     color_spaces::{Gray16, Gray8, Rgb16, Rgb8, Rgba16, Rgba8},
     Image, ImageLayout, ImageSize, PixelFormat,
 };
@@ -24,9 +23,13 @@ use std::{
 /// # Returns
 ///
 /// A grayscale image (Gray8).
-pub fn read_image_png_mono8(file_path: impl AsRef<Path>) -> Result<Gray8<CpuAllocator>, IoError> {
+pub fn read_image_png_mono8(file_path: impl AsRef<Path>) -> Result<Gray8, IoError> {
     let (buf, size) = read_png_impl(file_path)?;
-    Ok(Gray8::from_size_vec(size.into(), buf, CpuAllocator)?)
+    Ok(Gray8::from_size_vec(
+        size.into(),
+        buf,
+        kornia_tensor::host_alloc(),
+    )?)
 }
 
 /// Read a PNG image as RGB8.
@@ -38,9 +41,13 @@ pub fn read_image_png_mono8(file_path: impl AsRef<Path>) -> Result<Gray8<CpuAllo
 /// # Returns
 ///
 /// An RGB8 typed image.
-pub fn read_image_png_rgb8(file_path: impl AsRef<Path>) -> Result<Rgb8<CpuAllocator>, IoError> {
+pub fn read_image_png_rgb8(file_path: impl AsRef<Path>) -> Result<Rgb8, IoError> {
     let (buf, size) = read_png_impl(file_path)?;
-    Ok(Rgb8::from_size_vec(size.into(), buf, CpuAllocator)?)
+    Ok(Rgb8::from_size_vec(
+        size.into(),
+        buf,
+        kornia_tensor::host_alloc(),
+    )?)
 }
 
 /// Read a PNG image as RGBA8.
@@ -52,9 +59,13 @@ pub fn read_image_png_rgb8(file_path: impl AsRef<Path>) -> Result<Rgb8<CpuAlloca
 /// # Returns
 ///
 /// An RGBA8 typed image.
-pub fn read_image_png_rgba8(file_path: impl AsRef<Path>) -> Result<Rgba8<CpuAllocator>, IoError> {
+pub fn read_image_png_rgba8(file_path: impl AsRef<Path>) -> Result<Rgba8, IoError> {
     let (buf, size) = read_png_impl(file_path)?;
-    Ok(Rgba8::from_size_vec(size.into(), buf, CpuAllocator)?)
+    Ok(Rgba8::from_size_vec(
+        size.into(),
+        buf,
+        kornia_tensor::host_alloc(),
+    )?)
 }
 
 /// Read a PNG image as RGB16.
@@ -66,11 +77,15 @@ pub fn read_image_png_rgba8(file_path: impl AsRef<Path>) -> Result<Rgba8<CpuAllo
 /// # Returns
 ///
 /// An RGB16 typed image.
-pub fn read_image_png_rgb16(file_path: impl AsRef<Path>) -> Result<Rgb16<CpuAllocator>, IoError> {
+pub fn read_image_png_rgb16(file_path: impl AsRef<Path>) -> Result<Rgb16, IoError> {
     let (buf, size) = read_png_impl(file_path)?;
     let buf_u16 = convert_buf_u8_u16(buf);
 
-    Ok(Rgb16::from_size_vec(size.into(), buf_u16, CpuAllocator)?)
+    Ok(Rgb16::from_size_vec(
+        size.into(),
+        buf_u16,
+        kornia_tensor::host_alloc(),
+    )?)
 }
 
 /// Read a PNG image as RGBA16.
@@ -82,11 +97,15 @@ pub fn read_image_png_rgb16(file_path: impl AsRef<Path>) -> Result<Rgb16<CpuAllo
 /// # Returns
 ///
 /// An RGBA16 typed image.
-pub fn read_image_png_rgba16(file_path: impl AsRef<Path>) -> Result<Rgba16<CpuAllocator>, IoError> {
+pub fn read_image_png_rgba16(file_path: impl AsRef<Path>) -> Result<Rgba16, IoError> {
     let (buf, size) = read_png_impl(file_path)?;
     let buf_u16 = convert_buf_u8_u16(buf);
 
-    Ok(Rgba16::from_size_vec(size.into(), buf_u16, CpuAllocator)?)
+    Ok(Rgba16::from_size_vec(
+        size.into(),
+        buf_u16,
+        kornia_tensor::host_alloc(),
+    )?)
 }
 
 /// Read a PNG image as grayscale (Gray16).
@@ -98,11 +117,15 @@ pub fn read_image_png_rgba16(file_path: impl AsRef<Path>) -> Result<Rgba16<CpuAl
 /// # Returns
 ///
 /// A Gray16 typed image.
-pub fn read_image_png_mono16(file_path: impl AsRef<Path>) -> Result<Gray16<CpuAllocator>, IoError> {
+pub fn read_image_png_mono16(file_path: impl AsRef<Path>) -> Result<Gray16, IoError> {
     let (buf, size) = read_png_impl(file_path)?;
     let buf_u16 = convert_buf_u8_u16(buf);
 
-    Ok(Gray16::from_size_vec(size.into(), buf_u16, CpuAllocator)?)
+    Ok(Gray16::from_size_vec(
+        size.into(),
+        buf_u16,
+        kornia_tensor::host_alloc(),
+    )?)
 }
 
 /// Decodes a PNG image with as grayscale (Gray8) from Raw Bytes.
@@ -111,10 +134,7 @@ pub fn read_image_png_mono16(file_path: impl AsRef<Path>) -> Result<Gray16<CpuAl
 ///
 /// - `src` - Raw bytes of the png file
 /// - `dst` - A mutable reference to your `Gray8` image
-pub fn decode_image_png_mono8<A: ImageAllocator>(
-    src: &[u8],
-    dst: &mut Gray8<A>,
-) -> Result<(), IoError> {
+pub fn decode_image_png_mono8(src: &[u8], dst: &mut Gray8) -> Result<(), IoError> {
     let size = dst.size();
     decode_png_impl::<1>(src, dst.as_slice_mut(), size)
 }
@@ -125,10 +145,7 @@ pub fn decode_image_png_mono8<A: ImageAllocator>(
 ///
 /// - `src` - Raw bytes of the png file
 /// - `dst` - A mutable reference to your `Rgb8` image
-pub fn decode_image_png_rgb8<A: ImageAllocator>(
-    src: &[u8],
-    dst: &mut Rgb8<A>,
-) -> Result<(), IoError> {
+pub fn decode_image_png_rgb8(src: &[u8], dst: &mut Rgb8) -> Result<(), IoError> {
     let size = dst.size();
     decode_png_impl::<3>(src, dst.as_slice_mut(), size)
 }
@@ -139,10 +156,7 @@ pub fn decode_image_png_rgb8<A: ImageAllocator>(
 ///
 /// - `src` - Raw bytes of the png file
 /// - `dst` - A mutable reference to your `Rgba8` image
-pub fn decode_image_png_rgba8<A: ImageAllocator>(
-    src: &[u8],
-    dst: &mut Rgba8<A>,
-) -> Result<(), IoError> {
+pub fn decode_image_png_rgba8(src: &[u8], dst: &mut Rgba8) -> Result<(), IoError> {
     let size = dst.size();
     decode_png_impl::<4>(src, dst.as_slice_mut(), size)
 }
@@ -153,10 +167,7 @@ pub fn decode_image_png_rgba8<A: ImageAllocator>(
 ///
 /// - `src` - Raw bytes of the png file
 /// - `dst` - A mutable reference to your `Gray16` image
-pub fn decode_image_png_mono16<A: ImageAllocator>(
-    src: &[u8],
-    dst: &mut Gray16<A>,
-) -> Result<(), IoError> {
+pub fn decode_image_png_mono16(src: &[u8], dst: &mut Gray16) -> Result<(), IoError> {
     let mut image_u8 = convert_buf_u16_u8(dst.as_slice());
     decode_png_impl::<1>(src, image_u8.as_mut_slice(), dst.size())?;
     convert_buf_u8_u16_into_slice(image_u8.as_slice(), dst.as_slice_mut());
@@ -169,10 +180,7 @@ pub fn decode_image_png_mono16<A: ImageAllocator>(
 ///
 /// - `src` - Raw bytes of the png file
 /// - `dst` - A mutable reference to your `Rgb16` image
-pub fn decode_image_png_rgb16<A: ImageAllocator>(
-    src: &[u8],
-    dst: &mut Rgb16<A>,
-) -> Result<(), IoError> {
+pub fn decode_image_png_rgb16(src: &[u8], dst: &mut Rgb16) -> Result<(), IoError> {
     let mut image_u8 = convert_buf_u16_u8(dst.as_slice());
     decode_png_impl::<3>(src, image_u8.as_mut_slice(), dst.size())?;
     convert_buf_u8_u16_into_slice(image_u8.as_slice(), dst.as_slice_mut());
@@ -185,10 +193,7 @@ pub fn decode_image_png_rgb16<A: ImageAllocator>(
 ///
 /// - `src` - Raw bytes of the png file
 /// - `dst` - A mutable reference to your `Rgba16` image
-pub fn decode_image_png_rgba16<A: ImageAllocator>(
-    src: &[u8],
-    dst: &mut Rgba16<A>,
-) -> Result<(), IoError> {
+pub fn decode_image_png_rgba16(src: &[u8], dst: &mut Rgba16) -> Result<(), IoError> {
     let mut image_u8 = convert_buf_u16_u8(dst.as_slice());
     decode_png_impl::<4>(src, image_u8.as_mut_slice(), dst.size())?;
     convert_buf_u8_u16_into_slice(image_u8.as_slice(), dst.as_slice_mut());
@@ -315,9 +320,9 @@ fn decode_png_impl<const C: usize>(
 ///
 /// - `file_path` - The path to the PNG image.
 /// - `image` - The Rgb8 image to write.
-pub fn write_image_png_rgb8<A: ImageAllocator>(
+pub fn write_image_png_rgb8(
     file_path: impl AsRef<Path>,
-    image: &Image<u8, 3, A>,
+    image: &Image<u8, 3>,
 ) -> Result<(), IoError> {
     write_png_impl(
         file_path,
@@ -334,9 +339,9 @@ pub fn write_image_png_rgb8<A: ImageAllocator>(
 ///
 /// - `file_path` - The path to the PNG image.
 /// - `image` - The Rgba8 image to write.
-pub fn write_image_png_rgba8<A: ImageAllocator>(
+pub fn write_image_png_rgba8(
     file_path: impl AsRef<Path>,
-    image: &Image<u8, 4, A>,
+    image: &Image<u8, 4>,
 ) -> Result<(), IoError> {
     write_png_impl(
         file_path,
@@ -353,9 +358,9 @@ pub fn write_image_png_rgba8<A: ImageAllocator>(
 ///
 /// - `file_path` - The path to the PNG image.
 /// - `image` - The Gray8 image to write.
-pub fn write_image_png_gray8<A: ImageAllocator>(
+pub fn write_image_png_gray8(
     file_path: impl AsRef<Path>,
-    image: &Image<u8, 1, A>,
+    image: &Image<u8, 1>,
 ) -> Result<(), IoError> {
     write_png_impl(
         file_path,
@@ -372,9 +377,9 @@ pub fn write_image_png_gray8<A: ImageAllocator>(
 ///
 /// - `file_path` - The path to the PNG image.
 /// - `image` - The Rgb16 image to write.
-pub fn write_image_png_rgb16<A: ImageAllocator>(
+pub fn write_image_png_rgb16(
     file_path: impl AsRef<Path>,
-    image: &Image<u16, 3, A>,
+    image: &Image<u16, 3>,
 ) -> Result<(), IoError> {
     let image_size = image.size();
     let image_buf = convert_buf_u16_u8(image.as_slice());
@@ -394,9 +399,9 @@ pub fn write_image_png_rgb16<A: ImageAllocator>(
 ///
 /// - `file_path` - The path to the PNG image.
 /// - `image` - The Rgba16 image to write.
-pub fn write_image_png_rgba16<A: ImageAllocator>(
+pub fn write_image_png_rgba16(
     file_path: impl AsRef<Path>,
-    image: &Image<u16, 4, A>,
+    image: &Image<u16, 4>,
 ) -> Result<(), IoError> {
     let image_size = image.size();
     let image_buf = convert_buf_u16_u8(image.as_slice());
@@ -416,9 +421,9 @@ pub fn write_image_png_rgba16<A: ImageAllocator>(
 ///
 /// - `file_path` - The path to the PNG image.
 /// - `image` - The Gray16 image to write.
-pub fn write_image_png_gray16<A: ImageAllocator>(
+pub fn write_image_png_gray16(
     file_path: impl AsRef<Path>,
-    image: &Image<u16, 1, A>,
+    image: &Image<u16, 1>,
 ) -> Result<(), IoError> {
     let image_size = image.size();
     let image_buf = convert_buf_u16_u8(image.as_slice());
@@ -497,8 +502,8 @@ fn write_png_impl(
 /// faster than the default at moderately worse compression), 2..9 =
 /// zlib levels (default is 6 / "balanced"). ``None`` keeps the
 /// `png` crate default.
-pub fn encode_image_png_rgb8<A: ImageAllocator>(
-    image: &Image<u8, 3, A>,
+pub fn encode_image_png_rgb8(
+    image: &Image<u8, 3>,
     buffer: &mut Vec<u8>,
     compress_level: Option<u8>,
 ) -> Result<(), IoError> {
@@ -515,8 +520,8 @@ pub fn encode_image_png_rgb8<A: ImageAllocator>(
 
 /// Encodes an RGBA8 image as PNG bytes into `buffer`. See
 /// [`encode_image_png_rgb8`] for `compress_level` semantics.
-pub fn encode_image_png_rgba8<A: ImageAllocator>(
-    image: &Image<u8, 4, A>,
+pub fn encode_image_png_rgba8(
+    image: &Image<u8, 4>,
     buffer: &mut Vec<u8>,
     compress_level: Option<u8>,
 ) -> Result<(), IoError> {
@@ -533,8 +538,8 @@ pub fn encode_image_png_rgba8<A: ImageAllocator>(
 
 /// Encodes a grayscale 8-bit image as PNG bytes into `buffer`. See
 /// [`encode_image_png_rgb8`] for `compress_level` semantics.
-pub fn encode_image_png_gray8<A: ImageAllocator>(
-    image: &Image<u8, 1, A>,
+pub fn encode_image_png_gray8(
+    image: &Image<u8, 1>,
     buffer: &mut Vec<u8>,
     compress_level: Option<u8>,
 ) -> Result<(), IoError> {
@@ -551,8 +556,8 @@ pub fn encode_image_png_gray8<A: ImageAllocator>(
 
 /// Encodes an RGB16 image as PNG bytes into `buffer`. See
 /// [`encode_image_png_rgb8`] for `compress_level` semantics.
-pub fn encode_image_png_rgb16<A: ImageAllocator>(
-    image: &Image<u16, 3, A>,
+pub fn encode_image_png_rgb16(
+    image: &Image<u16, 3>,
     buffer: &mut Vec<u8>,
     compress_level: Option<u8>,
 ) -> Result<(), IoError> {
@@ -571,8 +576,8 @@ pub fn encode_image_png_rgb16<A: ImageAllocator>(
 
 /// Encodes an RGBA16 image as PNG bytes into `buffer`. See
 /// [`encode_image_png_rgb8`] for `compress_level` semantics.
-pub fn encode_image_png_rgba16<A: ImageAllocator>(
-    image: &Image<u16, 4, A>,
+pub fn encode_image_png_rgba16(
+    image: &Image<u16, 4>,
     buffer: &mut Vec<u8>,
     compress_level: Option<u8>,
 ) -> Result<(), IoError> {
@@ -591,8 +596,8 @@ pub fn encode_image_png_rgba16<A: ImageAllocator>(
 
 /// Encodes a grayscale 16-bit image as PNG bytes into `buffer`. See
 /// [`encode_image_png_rgb8`] for `compress_level` semantics.
-pub fn encode_image_png_gray16<A: ImageAllocator>(
-    image: &Image<u16, 1, A>,
+pub fn encode_image_png_gray16(
+    image: &Image<u16, 1>,
     buffer: &mut Vec<u8>,
     compress_level: Option<u8>,
 ) -> Result<(), IoError> {
@@ -664,7 +669,7 @@ mod tests {
     #[test]
     fn decode_png() -> Result<(), IoError> {
         let bytes = read("../../tests/data/dog-rgb8.png")?;
-        let mut image = Rgb8::from_size_val([258, 195].into(), 0, CpuAllocator)?;
+        let mut image = Rgb8::from_size_val([258, 195].into(), 0, kornia_tensor::host_alloc())?;
         decode_image_png_rgb8(&bytes, &mut image)?;
 
         assert_eq!(image.cols(), 258);
@@ -687,7 +692,7 @@ mod tests {
         // PNG magic header
         assert_eq!(&buffer[..8], b"\x89PNG\r\n\x1a\n");
 
-        let mut decoded = Rgb8::from_size_val(src.size(), 0, CpuAllocator)?;
+        let mut decoded = Rgb8::from_size_val(src.size(), 0, kornia_tensor::host_alloc())?;
         decode_image_png_rgb8(&buffer, &mut decoded)?;
         assert_eq!(decoded.size(), src.size());
         assert_eq!(decoded.as_slice(), src.as_slice());
@@ -701,13 +706,13 @@ mod tests {
         for (i, b) in data.iter_mut().enumerate() {
             *b = (i % 251) as u8;
         }
-        let src = Rgba8::from_size_vec([16, 16].into(), data, CpuAllocator)?;
+        let src = Rgba8::from_size_vec([16, 16].into(), data, kornia_tensor::host_alloc())?;
 
         let mut buffer = Vec::new();
         encode_image_png_rgba8(&src, &mut buffer, None)?;
         assert_eq!(&buffer[..8], b"\x89PNG\r\n\x1a\n");
 
-        let mut decoded = Rgba8::from_size_val(src.size(), 0, CpuAllocator)?;
+        let mut decoded = Rgba8::from_size_val(src.size(), 0, kornia_tensor::host_alloc())?;
         decode_image_png_rgba8(&buffer, &mut decoded)?;
         assert_eq!(decoded.as_slice(), src.as_slice());
         Ok(())
@@ -720,7 +725,7 @@ mod tests {
         encode_image_png_gray8(&src, &mut buffer, None)?;
         assert_eq!(&buffer[..8], b"\x89PNG\r\n\x1a\n");
 
-        let mut decoded = Gray8::from_size_val(src.size(), 0, CpuAllocator)?;
+        let mut decoded = Gray8::from_size_val(src.size(), 0, kornia_tensor::host_alloc())?;
         decode_image_png_mono8(&buffer, &mut decoded)?;
         assert_eq!(decoded.as_slice(), src.as_slice());
         Ok(())
@@ -733,7 +738,7 @@ mod tests {
         encode_image_png_rgb16(&src, &mut buffer, None)?;
         assert_eq!(&buffer[..8], b"\x89PNG\r\n\x1a\n");
 
-        let mut decoded = Rgb16::from_size_val(src.size(), 0, CpuAllocator)?;
+        let mut decoded = Rgb16::from_size_val(src.size(), 0, kornia_tensor::host_alloc())?;
         decode_image_png_rgb16(&buffer, &mut decoded)?;
         assert_eq!(decoded.as_slice(), src.as_slice());
         Ok(())
@@ -755,13 +760,13 @@ mod tests {
                 data[y * w + x] = 500;
             }
         }
-        let src = Gray16::from_size_vec([w, h].into(), data, CpuAllocator)?;
+        let src = Gray16::from_size_vec([w, h].into(), data, kornia_tensor::host_alloc())?;
 
         let mut buffer = Vec::new();
         encode_image_png_gray16(&src, &mut buffer, None)?;
         assert_eq!(&buffer[..8], b"\x89PNG\r\n\x1a\n");
         // Lossless u16 round-trip is the whole point of this codec for depth.
-        let mut decoded = Gray16::from_size_val(src.size(), 0, CpuAllocator)?;
+        let mut decoded = Gray16::from_size_val(src.size(), 0, kornia_tensor::host_alloc())?;
         decode_image_png_mono16(&buffer, &mut decoded)?;
         assert_eq!(decoded.as_slice(), src.as_slice());
         Ok(())
@@ -783,7 +788,7 @@ mod tests {
 
         // Capacity should not have grown on the second encode (allocation reuse).
         assert!(buffer.capacity() <= cap_after_first.max(buffer.len()));
-        let mut decoded = Rgb8::from_size_val(src.size(), 0, CpuAllocator)?;
+        let mut decoded = Rgb8::from_size_val(src.size(), 0, kornia_tensor::host_alloc())?;
         decode_image_png_rgb8(&buffer, &mut decoded)?;
         assert_eq!(decoded.as_slice(), src.as_slice());
         Ok(())

--- a/crates/kornia-io/src/rvl.rs
+++ b/crates/kornia-io/src/rvl.rs
@@ -17,10 +17,7 @@
 /// Compression ratio: ~3–5× over raw u16 for typical depth frames. Zeros (background /
 /// missing depth) compress to a single nibble (0x00) — very efficient for sparse scenes.
 use crate::error::IoError;
-use kornia_image::{
-    allocator::{CpuAllocator, ImageAllocator},
-    Image, ImageSize,
-};
+use kornia_image::{Image, ImageSize};
 use std::{fs, path::Path};
 
 const MAGIC: &[u8; 4] = b"RVL1";
@@ -255,17 +252,17 @@ unsafe fn encode_pixels_avx2(pixels: &[u16], writer: &mut NibbleWriter) -> usize
 ///
 /// ```rust
 /// use kornia_io::rvl::{encode_image_rvl, decode_image_rvl};
-/// use kornia_image::{Image, ImageSize, allocator::CpuAllocator};
+/// use kornia_image::{Image, ImageSize};
 ///
 /// let size = ImageSize { width: 4, height: 2 };
 /// let data = vec![1000u16, 1001, 1002, 1003, 0, 500, 500, 500];
-/// let img = Image::<u16, 1, _>::new(size, data, CpuAllocator).unwrap();
+/// let img = Image::<u16, 1>::new(size, data, kornia_tensor::host_alloc()).unwrap();
 ///
 /// let compressed = encode_image_rvl(&img).unwrap();
 /// let decoded = decode_image_rvl(&compressed).unwrap();
 /// assert_eq!(decoded.as_slice(), img.as_slice());
 /// ```
-pub fn encode_image_rvl<A: ImageAllocator>(image: &Image<u16, 1, A>) -> Result<Vec<u8>, IoError> {
+pub fn encode_image_rvl(image: &Image<u16, 1>) -> Result<Vec<u8>, IoError> {
     let pixels = image.as_slice();
     let w = image.width() as u32;
     let h = image.height() as u32;
@@ -289,7 +286,7 @@ pub fn encode_image_rvl<A: ImageAllocator>(image: &Image<u16, 1, A>) -> Result<V
 ///
 /// Reads the 12-byte header produced by [`encode_image_rvl`] to recover
 /// the image dimensions, then decodes the variable-length nibble stream.
-pub fn decode_image_rvl(src: &[u8]) -> Result<Image<u16, 1, CpuAllocator>, IoError> {
+pub fn decode_image_rvl(src: &[u8]) -> Result<Image<u16, 1>, IoError> {
     if src.len() < HEADER_LEN {
         return Err(IoError::RvlDecodeError(
             "buffer too short for 12-byte RVL header".into(),
@@ -321,21 +318,18 @@ pub fn decode_image_rvl(src: &[u8]) -> Result<Image<u16, 1, CpuAllocator>, IoErr
     }
 
     let size = ImageSize { width, height };
-    Ok(Image::new(size, pixels, CpuAllocator)?)
+    Ok(Image::new(size, pixels, kornia_tensor::host_alloc())?)
 }
 
 /// Writes a single-channel 16-bit depth image to an RVL file.
-pub fn write_image_rvl<A: ImageAllocator>(
-    file_path: impl AsRef<Path>,
-    image: &Image<u16, 1, A>,
-) -> Result<(), IoError> {
+pub fn write_image_rvl(file_path: impl AsRef<Path>, image: &Image<u16, 1>) -> Result<(), IoError> {
     let bytes = encode_image_rvl(image)?;
     fs::write(file_path, bytes)?;
     Ok(())
 }
 
 /// Reads an RVL file into a single-channel 16-bit depth image.
-pub fn read_image_rvl(file_path: impl AsRef<Path>) -> Result<Image<u16, 1, CpuAllocator>, IoError> {
+pub fn read_image_rvl(file_path: impl AsRef<Path>) -> Result<Image<u16, 1>, IoError> {
     let bytes = fs::read(file_path)?;
     decode_image_rvl(&bytes)
 }
@@ -346,14 +340,14 @@ pub fn read_image_rvl(file_path: impl AsRef<Path>) -> Result<Image<u16, 1, CpuAl
 mod tests {
     use super::*;
 
-    fn make_image(data: Vec<u16>, w: usize, h: usize) -> Image<u16, 1, CpuAllocator> {
+    fn make_image(data: Vec<u16>, w: usize, h: usize) -> Image<u16, 1> {
         Image::new(
             ImageSize {
                 width: w,
                 height: h,
             },
             data,
-            CpuAllocator,
+            kornia_tensor::host_alloc(),
         )
         .unwrap()
     }

--- a/crates/kornia-io/src/rvl.rs
+++ b/crates/kornia-io/src/rvl.rs
@@ -256,7 +256,7 @@ unsafe fn encode_pixels_avx2(pixels: &[u16], writer: &mut NibbleWriter) -> usize
 ///
 /// let size = ImageSize { width: 4, height: 2 };
 /// let data = vec![1000u16, 1001, 1002, 1003, 0, 500, 500, 500];
-/// let img = Image::<u16, 1>::new(size, data, kornia_tensor::host_alloc()).unwrap();
+/// let img = Image::<u16, 1>::new(size, data).unwrap();
 ///
 /// let compressed = encode_image_rvl(&img).unwrap();
 /// let decoded = decode_image_rvl(&compressed).unwrap();
@@ -318,7 +318,7 @@ pub fn decode_image_rvl(src: &[u8]) -> Result<Image<u16, 1>, IoError> {
     }
 
     let size = ImageSize { width, height };
-    Ok(Image::new(size, pixels, kornia_tensor::host_alloc())?)
+    Ok(Image::new(size, pixels)?)
 }
 
 /// Writes a single-channel 16-bit depth image to an RVL file.
@@ -347,7 +347,6 @@ mod tests {
                 height: h,
             },
             data,
-            kornia_tensor::host_alloc(),
         )
         .unwrap()
     }

--- a/crates/kornia-io/src/tiff.rs
+++ b/crates/kornia-io/src/tiff.rs
@@ -32,11 +32,7 @@ pub fn read_image_tiff_rgb8(file_path: impl AsRef<Path>) -> Result<Rgb8, IoError
         }
     };
 
-    Ok(Rgb8::from_size_vec(
-        size.into(),
-        data,
-        kornia_tensor::host_alloc(),
-    )?)
+    Ok(Rgb8::from_size_vec(size.into(), data)?)
 }
 
 /// Read a TIFF image and return it as a grayscale image.
@@ -62,11 +58,7 @@ pub fn read_image_tiff_mono8(file_path: impl AsRef<Path>) -> Result<Gray8, IoErr
         }
     };
 
-    Ok(Gray8::from_size_vec(
-        size.into(),
-        data,
-        kornia_tensor::host_alloc(),
-    )?)
+    Ok(Gray8::from_size_vec(size.into(), data)?)
 }
 
 /// Read a TIFF image and return it as a RGB16 image.
@@ -92,11 +84,7 @@ pub fn read_image_tiff_rgb16(file_path: impl AsRef<Path>) -> Result<Rgb16, IoErr
         }
     };
 
-    Ok(Rgb16::from_size_vec(
-        size.into(),
-        data,
-        kornia_tensor::host_alloc(),
-    )?)
+    Ok(Rgb16::from_size_vec(size.into(), data)?)
 }
 
 /// Read a TIFF image and return it as a grayscale 16-bit image.
@@ -122,11 +110,7 @@ pub fn read_image_tiff_mono16(file_path: impl AsRef<Path>) -> Result<Gray16, IoE
         }
     };
 
-    Ok(Gray16::from_size_vec(
-        size.into(),
-        data,
-        kornia_tensor::host_alloc(),
-    )?)
+    Ok(Gray16::from_size_vec(size.into(), data)?)
 }
 
 /// Read a TIFF image and return it as single precision floating point grayscale image.
@@ -152,11 +136,7 @@ pub fn read_image_tiff_mono32f(file_path: impl AsRef<Path>) -> Result<Grayf32, I
         }
     };
 
-    Ok(Grayf32::from_size_vec(
-        size.into(),
-        data,
-        kornia_tensor::host_alloc(),
-    )?)
+    Ok(Grayf32::from_size_vec(size.into(), data)?)
 }
 
 /// Read a TIFF image and return it as single precision floating point RGB image.
@@ -182,11 +162,7 @@ pub fn read_image_tiff_rgb32f(file_path: impl AsRef<Path>) -> Result<Rgbf32, IoE
         }
     };
 
-    Ok(Rgbf32::from_size_vec(
-        size.into(),
-        data,
-        kornia_tensor::host_alloc(),
-    )?)
+    Ok(Rgbf32::from_size_vec(size.into(), data)?)
 }
 
 fn read_image_tiff_impl(
@@ -634,7 +610,6 @@ mod tests {
                 height: height as usize,
             },
             data,
-            kornia_tensor::host_alloc(),
         )?;
 
         let file_path = tmp_dir.path().join("rgb8.tiff");
@@ -663,7 +638,6 @@ mod tests {
                 height: height as usize,
             },
             data,
-            kornia_tensor::host_alloc(),
         )?;
 
         let file_path = tmp_dir.path().join("mono8.tiff");
@@ -692,7 +666,6 @@ mod tests {
                 height: height as usize,
             },
             data,
-            kornia_tensor::host_alloc(),
         )?;
 
         let file_path = tmp_dir.path().join("rgb16.tiff");
@@ -721,7 +694,6 @@ mod tests {
                 height: height as usize,
             },
             data,
-            kornia_tensor::host_alloc(),
         )?;
 
         let file_path = tmp_dir.path().join("mono16.tiff");
@@ -749,7 +721,6 @@ mod tests {
                 height: height as usize,
             },
             data,
-            kornia_tensor::host_alloc(),
         )?;
 
         let file_path = tmp_dir.path().join("mono32f.tiff");
@@ -777,7 +748,6 @@ mod tests {
                 height: height as usize,
             },
             data,
-            kornia_tensor::host_alloc(),
         )?;
 
         let file_path = tmp_dir.path().join("rgb32f.tiff");
@@ -797,7 +767,7 @@ mod tests {
         assert_eq!(layout.image_size.height, 195);
         assert_eq!(layout.channels, 3);
 
-        let mut image = Rgb8::from_size_val(layout.image_size, 0, kornia_tensor::host_alloc())?;
+        let mut image = Rgb8::from_size_val(layout.image_size, 0)?;
         decode_image_tiff_rgb8(&bytes, &mut image)?;
 
         assert_eq!(image.cols(), layout.image_size.width);
@@ -815,7 +785,7 @@ mod tests {
         assert_eq!(layout.image_size.height, 32);
         assert_eq!(layout.channels, 3);
 
-        let mut image = Rgb16::from_size_val(layout.image_size, 0, kornia_tensor::host_alloc())?;
+        let mut image = Rgb16::from_size_val(layout.image_size, 0)?;
         decode_image_tiff_rgb16(&bytes, &mut image)?;
 
         assert_eq!(image.cols(), layout.image_size.width);
@@ -833,8 +803,7 @@ mod tests {
         assert_eq!(layout.image_size.height, 32);
         assert_eq!(layout.channels, 3);
 
-        let mut image =
-            Rgbf32::from_size_val(layout.image_size, 0.0f32, kornia_tensor::host_alloc())?;
+        let mut image = Rgbf32::from_size_val(layout.image_size, 0.0f32)?;
         decode_image_tiff_rgb32f(&bytes, &mut image)?;
 
         assert_eq!(image.cols(), layout.image_size.width);

--- a/crates/kornia-io/src/tiff.rs
+++ b/crates/kornia-io/src/tiff.rs
@@ -1,6 +1,5 @@
 use crate::error::IoError;
 use kornia_image::{
-    allocator::{CpuAllocator, ImageAllocator},
     color_spaces::{Gray16, Gray8, Grayf32, Rgb16, Rgb8, Rgbf32},
     Image, ImageLayout, ImageSize, PixelFormat,
 };
@@ -19,7 +18,7 @@ use tiff::{
 /// # Returns
 ///
 /// The RGB8 typed image.
-pub fn read_image_tiff_rgb8(file_path: impl AsRef<Path>) -> Result<Rgb8<CpuAllocator>, IoError> {
+pub fn read_image_tiff_rgb8(file_path: impl AsRef<Path>) -> Result<Rgb8, IoError> {
     let (result, size) = read_image_tiff_impl(file_path)?;
 
     let data = match result {
@@ -33,7 +32,11 @@ pub fn read_image_tiff_rgb8(file_path: impl AsRef<Path>) -> Result<Rgb8<CpuAlloc
         }
     };
 
-    Ok(Rgb8::from_size_vec(size.into(), data, CpuAllocator)?)
+    Ok(Rgb8::from_size_vec(
+        size.into(),
+        data,
+        kornia_tensor::host_alloc(),
+    )?)
 }
 
 /// Read a TIFF image and return it as a grayscale image.
@@ -45,7 +48,7 @@ pub fn read_image_tiff_rgb8(file_path: impl AsRef<Path>) -> Result<Rgb8<CpuAlloc
 /// # Returns
 ///
 /// The Gray8 typed image.
-pub fn read_image_tiff_mono8(file_path: impl AsRef<Path>) -> Result<Gray8<CpuAllocator>, IoError> {
+pub fn read_image_tiff_mono8(file_path: impl AsRef<Path>) -> Result<Gray8, IoError> {
     let (result, size) = read_image_tiff_impl(file_path)?;
 
     let data = match result {
@@ -59,7 +62,11 @@ pub fn read_image_tiff_mono8(file_path: impl AsRef<Path>) -> Result<Gray8<CpuAll
         }
     };
 
-    Ok(Gray8::from_size_vec(size.into(), data, CpuAllocator)?)
+    Ok(Gray8::from_size_vec(
+        size.into(),
+        data,
+        kornia_tensor::host_alloc(),
+    )?)
 }
 
 /// Read a TIFF image and return it as a RGB16 image.
@@ -71,7 +78,7 @@ pub fn read_image_tiff_mono8(file_path: impl AsRef<Path>) -> Result<Gray8<CpuAll
 /// # Returns
 ///
 /// The RGB16 typed image.
-pub fn read_image_tiff_rgb16(file_path: impl AsRef<Path>) -> Result<Rgb16<CpuAllocator>, IoError> {
+pub fn read_image_tiff_rgb16(file_path: impl AsRef<Path>) -> Result<Rgb16, IoError> {
     let (result, size) = read_image_tiff_impl(file_path)?;
 
     let data = match result {
@@ -85,7 +92,11 @@ pub fn read_image_tiff_rgb16(file_path: impl AsRef<Path>) -> Result<Rgb16<CpuAll
         }
     };
 
-    Ok(Rgb16::from_size_vec(size.into(), data, CpuAllocator)?)
+    Ok(Rgb16::from_size_vec(
+        size.into(),
+        data,
+        kornia_tensor::host_alloc(),
+    )?)
 }
 
 /// Read a TIFF image and return it as a grayscale 16-bit image.
@@ -97,9 +108,7 @@ pub fn read_image_tiff_rgb16(file_path: impl AsRef<Path>) -> Result<Rgb16<CpuAll
 /// # Returns
 ///
 /// The Gray16 typed image.
-pub fn read_image_tiff_mono16(
-    file_path: impl AsRef<Path>,
-) -> Result<Gray16<CpuAllocator>, IoError> {
+pub fn read_image_tiff_mono16(file_path: impl AsRef<Path>) -> Result<Gray16, IoError> {
     let (result, size) = read_image_tiff_impl(file_path)?;
 
     let data = match result {
@@ -113,7 +122,11 @@ pub fn read_image_tiff_mono16(
         }
     };
 
-    Ok(Gray16::from_size_vec(size.into(), data, CpuAllocator)?)
+    Ok(Gray16::from_size_vec(
+        size.into(),
+        data,
+        kornia_tensor::host_alloc(),
+    )?)
 }
 
 /// Read a TIFF image and return it as single precision floating point grayscale image.
@@ -125,9 +138,7 @@ pub fn read_image_tiff_mono16(
 /// # Returns
 ///
 /// The Grayf32 typed image.
-pub fn read_image_tiff_mono32f(
-    file_path: impl AsRef<Path>,
-) -> Result<Grayf32<CpuAllocator>, IoError> {
+pub fn read_image_tiff_mono32f(file_path: impl AsRef<Path>) -> Result<Grayf32, IoError> {
     let (result, size) = read_image_tiff_impl(file_path)?;
 
     let data = match result {
@@ -141,7 +152,11 @@ pub fn read_image_tiff_mono32f(
         }
     };
 
-    Ok(Grayf32::from_size_vec(size.into(), data, CpuAllocator)?)
+    Ok(Grayf32::from_size_vec(
+        size.into(),
+        data,
+        kornia_tensor::host_alloc(),
+    )?)
 }
 
 /// Read a TIFF image and return it as single precision floating point RGB image.
@@ -153,9 +168,7 @@ pub fn read_image_tiff_mono32f(
 /// # Returns
 ///
 /// The Rgbf32 typed image.
-pub fn read_image_tiff_rgb32f(
-    file_path: impl AsRef<Path>,
-) -> Result<Rgbf32<CpuAllocator>, IoError> {
+pub fn read_image_tiff_rgb32f(file_path: impl AsRef<Path>) -> Result<Rgbf32, IoError> {
     let (result, size) = read_image_tiff_impl(file_path)?;
 
     let data = match result {
@@ -169,7 +182,11 @@ pub fn read_image_tiff_rgb32f(
         }
     };
 
-    Ok(Rgbf32::from_size_vec(size.into(), data, CpuAllocator)?)
+    Ok(Rgbf32::from_size_vec(
+        size.into(),
+        data,
+        kornia_tensor::host_alloc(),
+    )?)
 }
 
 fn read_image_tiff_impl(
@@ -266,10 +283,7 @@ pub fn decode_image_tiff_layout(src: &[u8]) -> Result<ImageLayout, IoError> {
 ///
 /// - `src` - Raw bytes of the TIFF file
 /// - `dst` - A mutabl+e reference to your `Rgb8` image
-pub fn decode_image_tiff_rgb8<A: ImageAllocator>(
-    src: &[u8],
-    dst: &mut Rgb8<A>,
-) -> Result<(), IoError> {
+pub fn decode_image_tiff_rgb8(src: &[u8], dst: &mut Rgb8) -> Result<(), IoError> {
     let size = dst.size();
     decode_tiff_impl_u8(src, dst.as_slice_mut(), size, 3)
 }
@@ -280,10 +294,7 @@ pub fn decode_image_tiff_rgb8<A: ImageAllocator>(
 ///
 /// - `src` - Raw bytes of the TIFF file
 /// - `dst` - A mutable reference to your `Gray8` image
-pub fn decode_image_tiff_mono8<A: ImageAllocator>(
-    src: &[u8],
-    dst: &mut Gray8<A>,
-) -> Result<(), IoError> {
+pub fn decode_image_tiff_mono8(src: &[u8], dst: &mut Gray8) -> Result<(), IoError> {
     let size = dst.size();
     decode_tiff_impl_u8(src, dst.as_slice_mut(), size, 1)
 }
@@ -294,10 +305,7 @@ pub fn decode_image_tiff_mono8<A: ImageAllocator>(
 ///
 /// - `src` - Raw bytes of the TIFF file
 /// - `dst` - A mutable reference to your `Rgb16` image
-pub fn decode_image_tiff_rgb16<A: ImageAllocator>(
-    src: &[u8],
-    dst: &mut Rgb16<A>,
-) -> Result<(), IoError> {
+pub fn decode_image_tiff_rgb16(src: &[u8], dst: &mut Rgb16) -> Result<(), IoError> {
     let size = dst.size();
     decode_tiff_impl_u16(src, dst.as_slice_mut(), size, 3)
 }
@@ -308,10 +316,7 @@ pub fn decode_image_tiff_rgb16<A: ImageAllocator>(
 ///
 /// - `src` - Raw bytes of the TIFF file
 /// - `dst` - A mutable reference to your `Gray16` image
-pub fn decode_image_tiff_mono16<A: ImageAllocator>(
-    src: &[u8],
-    dst: &mut Gray16<A>,
-) -> Result<(), IoError> {
+pub fn decode_image_tiff_mono16(src: &[u8], dst: &mut Gray16) -> Result<(), IoError> {
     let size = dst.size();
     decode_tiff_impl_u16(src, dst.as_slice_mut(), size, 1)
 }
@@ -322,10 +327,7 @@ pub fn decode_image_tiff_mono16<A: ImageAllocator>(
 ///
 /// - `src` - Raw bytes of the TIFF file
 /// - `dst` - A mutable reference to your `Grayf32` image
-pub fn decode_image_tiff_mono32f<A: ImageAllocator>(
-    src: &[u8],
-    dst: &mut Grayf32<A>,
-) -> Result<(), IoError> {
+pub fn decode_image_tiff_mono32f(src: &[u8], dst: &mut Grayf32) -> Result<(), IoError> {
     let size = dst.size();
     decode_tiff_impl_f32(src, dst.as_slice_mut(), size, 1)
 }
@@ -336,10 +338,7 @@ pub fn decode_image_tiff_mono32f<A: ImageAllocator>(
 ///
 /// - `src` - Raw bytes of the TIFF file
 /// - `dst` - A mutable reference to your `Rgbf32` image
-pub fn decode_image_tiff_rgb32f<A: ImageAllocator>(
-    src: &[u8],
-    dst: &mut Rgbf32<A>,
-) -> Result<(), IoError> {
+pub fn decode_image_tiff_rgb32f(src: &[u8], dst: &mut Rgbf32) -> Result<(), IoError> {
     let size = dst.size();
     decode_tiff_impl_f32(src, dst.as_slice_mut(), size, 3)
 }
@@ -448,9 +447,9 @@ fn decode_tiff_impl_f32(
 ///
 /// * `file_path` - The path to the TIFF image.
 /// * `image` - The Rgb8 image to write.
-pub fn write_image_tiff_rgb8<A: ImageAllocator>(
+pub fn write_image_tiff_rgb8(
     file_path: impl AsRef<Path>,
-    image: &Image<u8, 3, A>,
+    image: &Image<u8, 3>,
 ) -> Result<(), IoError> {
     write_image_tiff_impl::<colortype::RGB8, u8>(file_path, image.as_slice(), image.size())
 }
@@ -461,9 +460,9 @@ pub fn write_image_tiff_rgb8<A: ImageAllocator>(
 ///
 /// * `file_path` - The path to the TIFF image.
 /// * `image` - The Gray8 image to write.
-pub fn write_image_tiff_mono8<A: ImageAllocator>(
+pub fn write_image_tiff_mono8(
     file_path: impl AsRef<Path>,
-    image: &Image<u8, 1, A>,
+    image: &Image<u8, 1>,
 ) -> Result<(), IoError> {
     write_image_tiff_impl::<colortype::Gray8, u8>(file_path, image.as_slice(), image.size())
 }
@@ -474,9 +473,9 @@ pub fn write_image_tiff_mono8<A: ImageAllocator>(
 ///
 /// * `file_path` - The path to the TIFF image.
 /// * `image` - The Rgb16 image to write.
-pub fn write_image_tiff_rgb16<A: ImageAllocator>(
+pub fn write_image_tiff_rgb16(
     file_path: impl AsRef<Path>,
-    image: &Image<u16, 3, A>,
+    image: &Image<u16, 3>,
 ) -> Result<(), IoError> {
     write_image_tiff_impl::<colortype::RGB16, u16>(file_path, image.as_slice(), image.size())
 }
@@ -487,9 +486,9 @@ pub fn write_image_tiff_rgb16<A: ImageAllocator>(
 ///
 /// * `file_path` - The path to the TIFF image.
 /// * `image` - The Gray16 image to write.
-pub fn write_image_tiff_mono16<A: ImageAllocator>(
+pub fn write_image_tiff_mono16(
     file_path: impl AsRef<Path>,
-    image: &Image<u16, 1, A>,
+    image: &Image<u16, 1>,
 ) -> Result<(), IoError> {
     write_image_tiff_impl::<colortype::Gray16, u16>(file_path, image.as_slice(), image.size())
 }
@@ -500,9 +499,9 @@ pub fn write_image_tiff_mono16<A: ImageAllocator>(
 ///
 /// * `file_path` - The path to the TIFF image.
 /// * `image` - The Grayf32 image to write.
-pub fn write_image_tiff_mono32f<A: ImageAllocator>(
+pub fn write_image_tiff_mono32f(
     file_path: impl AsRef<Path>,
-    image: &Image<f32, 1, A>,
+    image: &Image<f32, 1>,
 ) -> Result<(), IoError> {
     write_image_tiff_impl::<colortype::Gray32Float, f32>(file_path, image.as_slice(), image.size())
 }
@@ -513,9 +512,9 @@ pub fn write_image_tiff_mono32f<A: ImageAllocator>(
 ///
 /// * `file_path` - The path to the TIFF image.
 /// * `image` - The Rgbf32 image to write.
-pub fn write_image_tiff_rgb32f<A: ImageAllocator>(
+pub fn write_image_tiff_rgb32f(
     file_path: impl AsRef<Path>,
-    image: &Image<f32, 3, A>,
+    image: &Image<f32, 3>,
 ) -> Result<(), IoError> {
     write_image_tiff_impl::<colortype::RGB32Float, f32>(file_path, image.as_slice(), image.size())
 }
@@ -562,38 +561,29 @@ fn reserve_tiff<T: Sized>(buffer: &mut Vec<u8>, slice_len: usize) {
 }
 
 /// Encodes an RGB u8 image as TIFF bytes into `buffer` (appended).
-pub fn encode_image_tiff_rgb8<A: ImageAllocator>(
-    image: &Image<u8, 3, A>,
-    buffer: &mut Vec<u8>,
-) -> Result<(), IoError> {
+pub fn encode_image_tiff_rgb8(image: &Image<u8, 3>, buffer: &mut Vec<u8>) -> Result<(), IoError> {
     reserve_tiff::<u8>(buffer, image.as_slice().len());
     let mut cursor = std::io::Cursor::new(buffer);
     write_tiff_into::<_, colortype::RGB8, u8>(&mut cursor, image.as_slice(), image.size())
 }
 
 /// Encodes a grayscale u8 image as TIFF bytes into `buffer` (appended).
-pub fn encode_image_tiff_mono8<A: ImageAllocator>(
-    image: &Image<u8, 1, A>,
-    buffer: &mut Vec<u8>,
-) -> Result<(), IoError> {
+pub fn encode_image_tiff_mono8(image: &Image<u8, 1>, buffer: &mut Vec<u8>) -> Result<(), IoError> {
     reserve_tiff::<u8>(buffer, image.as_slice().len());
     let mut cursor = std::io::Cursor::new(buffer);
     write_tiff_into::<_, colortype::Gray8, u8>(&mut cursor, image.as_slice(), image.size())
 }
 
 /// Encodes an RGB u16 image as TIFF bytes into `buffer` (appended).
-pub fn encode_image_tiff_rgb16<A: ImageAllocator>(
-    image: &Image<u16, 3, A>,
-    buffer: &mut Vec<u8>,
-) -> Result<(), IoError> {
+pub fn encode_image_tiff_rgb16(image: &Image<u16, 3>, buffer: &mut Vec<u8>) -> Result<(), IoError> {
     reserve_tiff::<u16>(buffer, image.as_slice().len());
     let mut cursor = std::io::Cursor::new(buffer);
     write_tiff_into::<_, colortype::RGB16, u16>(&mut cursor, image.as_slice(), image.size())
 }
 
 /// Encodes a grayscale u16 image as TIFF bytes into `buffer` (appended).
-pub fn encode_image_tiff_mono16<A: ImageAllocator>(
-    image: &Image<u16, 1, A>,
+pub fn encode_image_tiff_mono16(
+    image: &Image<u16, 1>,
     buffer: &mut Vec<u8>,
 ) -> Result<(), IoError> {
     reserve_tiff::<u16>(buffer, image.as_slice().len());
@@ -602,8 +592,8 @@ pub fn encode_image_tiff_mono16<A: ImageAllocator>(
 }
 
 /// Encodes a grayscale f32 image as TIFF bytes into `buffer` (appended).
-pub fn encode_image_tiff_mono32f<A: ImageAllocator>(
-    image: &Image<f32, 1, A>,
+pub fn encode_image_tiff_mono32f(
+    image: &Image<f32, 1>,
     buffer: &mut Vec<u8>,
 ) -> Result<(), IoError> {
     reserve_tiff::<f32>(buffer, image.as_slice().len());
@@ -612,8 +602,8 @@ pub fn encode_image_tiff_mono32f<A: ImageAllocator>(
 }
 
 /// Encodes an RGB f32 image as TIFF bytes into `buffer` (appended).
-pub fn encode_image_tiff_rgb32f<A: ImageAllocator>(
-    image: &Image<f32, 3, A>,
+pub fn encode_image_tiff_rgb32f(
+    image: &Image<f32, 3>,
     buffer: &mut Vec<u8>,
 ) -> Result<(), IoError> {
     reserve_tiff::<f32>(buffer, image.as_slice().len());
@@ -644,7 +634,7 @@ mod tests {
                 height: height as usize,
             },
             data,
-            CpuAllocator,
+            kornia_tensor::host_alloc(),
         )?;
 
         let file_path = tmp_dir.path().join("rgb8.tiff");
@@ -673,7 +663,7 @@ mod tests {
                 height: height as usize,
             },
             data,
-            CpuAllocator,
+            kornia_tensor::host_alloc(),
         )?;
 
         let file_path = tmp_dir.path().join("mono8.tiff");
@@ -702,7 +692,7 @@ mod tests {
                 height: height as usize,
             },
             data,
-            CpuAllocator,
+            kornia_tensor::host_alloc(),
         )?;
 
         let file_path = tmp_dir.path().join("rgb16.tiff");
@@ -731,7 +721,7 @@ mod tests {
                 height: height as usize,
             },
             data,
-            CpuAllocator,
+            kornia_tensor::host_alloc(),
         )?;
 
         let file_path = tmp_dir.path().join("mono16.tiff");
@@ -759,7 +749,7 @@ mod tests {
                 height: height as usize,
             },
             data,
-            CpuAllocator,
+            kornia_tensor::host_alloc(),
         )?;
 
         let file_path = tmp_dir.path().join("mono32f.tiff");
@@ -787,7 +777,7 @@ mod tests {
                 height: height as usize,
             },
             data,
-            CpuAllocator,
+            kornia_tensor::host_alloc(),
         )?;
 
         let file_path = tmp_dir.path().join("rgb32f.tiff");
@@ -807,7 +797,7 @@ mod tests {
         assert_eq!(layout.image_size.height, 195);
         assert_eq!(layout.channels, 3);
 
-        let mut image = Rgb8::from_size_val(layout.image_size, 0, CpuAllocator)?;
+        let mut image = Rgb8::from_size_val(layout.image_size, 0, kornia_tensor::host_alloc())?;
         decode_image_tiff_rgb8(&bytes, &mut image)?;
 
         assert_eq!(image.cols(), layout.image_size.width);
@@ -825,7 +815,7 @@ mod tests {
         assert_eq!(layout.image_size.height, 32);
         assert_eq!(layout.channels, 3);
 
-        let mut image = Rgb16::from_size_val(layout.image_size, 0, CpuAllocator)?;
+        let mut image = Rgb16::from_size_val(layout.image_size, 0, kornia_tensor::host_alloc())?;
         decode_image_tiff_rgb16(&bytes, &mut image)?;
 
         assert_eq!(image.cols(), layout.image_size.width);
@@ -843,7 +833,8 @@ mod tests {
         assert_eq!(layout.image_size.height, 32);
         assert_eq!(layout.channels, 3);
 
-        let mut image = Rgbf32::from_size_val(layout.image_size, 0.0f32, CpuAllocator)?;
+        let mut image =
+            Rgbf32::from_size_val(layout.image_size, 0.0f32, kornia_tensor::host_alloc())?;
         decode_image_tiff_rgb32f(&bytes, &mut image)?;
 
         assert_eq!(image.cols(), layout.image_size.width);

--- a/crates/kornia-io/src/v4l/mod.rs
+++ b/crates/kornia-io/src/v4l/mod.rs
@@ -17,10 +17,7 @@ use v4l::{
 use std::any::Any;
 use std::sync::Arc;
 
-use kornia_tensor::{
-    allocator::ForeignAllocator,
-    resource::{MemoryDomain, MemoryResource},
-};
+use kornia_tensor::resource::{MemoryDomain, MemoryResource};
 
 /// A proper [`MemoryResource`] for a V4L2 mmap'd frame buffer.
 ///
@@ -87,7 +84,7 @@ impl MemoryResource for V4lResource {
 ///
 /// # Returns
 ///
-/// An `Image<u8, 3, ForeignAllocator>` whose memory is the V4L2 mmap region.
+/// An `Image<u8, 3>` whose memory is the V4L2 mmap region.
 /// The kernel buffer remains live for exactly the lifetime of the returned `Image`;
 /// dropping the `Image` releases the mmap region exactly once (via `Arc<MmapInfo>`).
 ///
@@ -100,7 +97,7 @@ impl MemoryResource for V4lResource {
 pub(crate) fn image_from_v4l_buffer(
     size: kornia_image::ImageSize,
     buffer: MmapBuffer,
-) -> Result<kornia_image::Image<u8, 3, ForeignAllocator>, kornia_image::ImageError> {
+) -> Result<kornia_image::Image<u8, 3>, kornia_image::ImageError> {
     use kornia_tensor::storage::TensorStorage;
     use kornia_tensor::Tensor;
 
@@ -119,11 +116,11 @@ pub(crate) fn image_from_v4l_buffer(
     //   - The memory is host-accessible (MemoryDomain::Host).
     //   - The keepalive (Arc<V4lResource>) holds the MmapBuffer (and Arc<MmapInfo>) alive.
     //   - The storage is read-only: `as_mut_slice` will panic (v4l mmap is read-only mapped memory).
-    let storage: TensorStorage<u8, ForeignAllocator> = unsafe {
+    let storage: TensorStorage<u8> = unsafe {
         TensorStorage::from_borrowed_readonly(
             data_ptr,
             data_len,
-            ForeignAllocator,
+            kornia_tensor::host_alloc(),
             MemoryDomain::Host,
             keepalive,
         )
@@ -138,7 +135,7 @@ pub(crate) fn image_from_v4l_buffer(
         strides,
     };
 
-    // TryFrom<Tensor3<T, A>> for Image<T, C, A> validates that shape[2] == C (== 3).
+    // TryFrom<Tensor3<T, >> for Image<T, C> validates that shape[2] == C (== 3).
     kornia_image::Image::try_from(tensor)
 }
 

--- a/crates/kornia-io/src/webp.rs
+++ b/crates/kornia-io/src/webp.rs
@@ -1,7 +1,6 @@
 use crate::error::IoError;
 use image_webp::{ColorType, WebPDecoder, WebPEncoder};
 use kornia_image::{
-    allocator::{CpuAllocator, ImageAllocator},
     color_spaces::{Gray8, Rgb8, Rgba8},
     Image, ImageLayout, ImageSize, PixelFormat,
 };
@@ -29,10 +28,14 @@ const GRAY_B: u32 = 29;
 /// # Returns
 ///
 /// A grayscale image (Gray8).
-pub fn read_image_webp_gray8(file_path: impl AsRef<Path>) -> Result<Gray8<CpuAllocator>, IoError> {
+pub fn read_image_webp_gray8(file_path: impl AsRef<Path>) -> Result<Gray8, IoError> {
     let (rgb, size, has_alpha) = read_webp_rgb_or_rgba(file_path)?;
     let gray = rgb_or_rgba_to_gray(&rgb, has_alpha);
-    Ok(Gray8::from_size_vec(size, gray, CpuAllocator)?)
+    Ok(Gray8::from_size_vec(
+        size,
+        gray,
+        kornia_tensor::host_alloc(),
+    )?)
 }
 
 /// Read a WEBP image as RGB8.
@@ -46,7 +49,7 @@ pub fn read_image_webp_gray8(file_path: impl AsRef<Path>) -> Result<Gray8<CpuAll
 /// # Returns
 ///
 /// A RGB8 typed image.
-pub fn read_image_webp_rgb8(file_path: impl AsRef<Path>) -> Result<Rgb8<CpuAllocator>, IoError> {
+pub fn read_image_webp_rgb8(file_path: impl AsRef<Path>) -> Result<Rgb8, IoError> {
     let (buf, size, has_alpha) = read_webp_rgb_or_rgba(file_path)?;
     if has_alpha {
         return Err(IoError::WebpDecodingError(
@@ -55,7 +58,7 @@ pub fn read_image_webp_rgb8(file_path: impl AsRef<Path>) -> Result<Rgb8<CpuAlloc
             ),
         ));
     }
-    Ok(Rgb8::from_size_vec(size, buf, CpuAllocator)?)
+    Ok(Rgb8::from_size_vec(size, buf, kornia_tensor::host_alloc())?)
 }
 
 /// Read a WEBP image as RGBA8.
@@ -69,7 +72,7 @@ pub fn read_image_webp_rgb8(file_path: impl AsRef<Path>) -> Result<Rgb8<CpuAlloc
 /// # Returns
 ///
 /// A RGBA8 typed image.
-pub fn read_image_webp_rgba8(file_path: impl AsRef<Path>) -> Result<Rgba8<CpuAllocator>, IoError> {
+pub fn read_image_webp_rgba8(file_path: impl AsRef<Path>) -> Result<Rgba8, IoError> {
     let (buf, size, has_alpha) = read_webp_rgb_or_rgba(file_path)?;
     if !has_alpha {
         return Err(IoError::WebpDecodingError(
@@ -78,7 +81,11 @@ pub fn read_image_webp_rgba8(file_path: impl AsRef<Path>) -> Result<Rgba8<CpuAll
             ),
         ));
     }
-    Ok(Rgba8::from_size_vec(size, buf, CpuAllocator)?)
+    Ok(Rgba8::from_size_vec(
+        size,
+        buf,
+        kornia_tensor::host_alloc(),
+    )?)
 }
 
 /// Decodes a WEBP image as RGB8 from raw bytes.
@@ -89,11 +96,8 @@ pub fn read_image_webp_rgba8(file_path: impl AsRef<Path>) -> Result<Rgba8<CpuAll
 ///
 /// - `src` - Raw bytes of the webp file
 /// - `dst` - A mutable reference to your `Rgb8` image
-pub fn decode_image_webp_rgb8<A: ImageAllocator>(
-    src: &[u8],
-    dst: &mut Image<u8, 3, A>,
-) -> Result<(), IoError> {
-    decode_webp_impl::<3, _>(src, dst, false)
+pub fn decode_image_webp_rgb8(src: &[u8], dst: &mut Image<u8, 3>) -> Result<(), IoError> {
+    decode_webp_impl::<3>(src, dst, false)
 }
 
 /// Decodes a WEBP image as RGBA8 from raw bytes.
@@ -104,11 +108,8 @@ pub fn decode_image_webp_rgb8<A: ImageAllocator>(
 ///
 /// - `src` - Raw bytes of the webp file
 /// - `dst` - A mutable reference to your `Rgba8` image
-pub fn decode_image_webp_rgba8<A: ImageAllocator>(
-    src: &[u8],
-    dst: &mut Image<u8, 4, A>,
-) -> Result<(), IoError> {
-    decode_webp_impl::<4, _>(src, dst, true)
+pub fn decode_image_webp_rgba8(src: &[u8], dst: &mut Image<u8, 4>) -> Result<(), IoError> {
+    decode_webp_impl::<4>(src, dst, true)
 }
 
 /// Decodes a WEBP image as Gray8 from raw bytes.
@@ -120,10 +121,7 @@ pub fn decode_image_webp_rgba8<A: ImageAllocator>(
 ///
 /// - `src` - Raw bytes of the webp file
 /// - `dst` - A mutable reference to your `Gray8` image
-pub fn decode_image_webp_gray8<A: ImageAllocator>(
-    src: &[u8],
-    dst: &mut Image<u8, 1, A>,
-) -> Result<(), IoError> {
+pub fn decode_image_webp_gray8(src: &[u8], dst: &mut Image<u8, 1>) -> Result<(), IoError> {
     let mut decoder = WebPDecoder::new(Cursor::new(src))?;
     let (width, height) = decoder.dimensions();
     if [width as usize, height as usize] != [dst.width(), dst.height()] {
@@ -182,9 +180,9 @@ pub fn decode_image_webp_layout(src: &[u8]) -> Result<ImageLayout, IoError> {
 }
 
 // Decodes a WEBP image into a pre-allocated Image buffer, validating channel count and size.
-fn decode_webp_impl<const C: usize, A: ImageAllocator>(
+fn decode_webp_impl<const C: usize>(
     src: &[u8],
-    dst: &mut Image<u8, C, A>,
+    dst: &mut Image<u8, C>,
     expect_alpha: bool,
 ) -> Result<(), IoError> {
     let mut decoder = WebPDecoder::new(Cursor::new(src))?;
@@ -270,10 +268,7 @@ fn rgb_or_rgba_to_gray(buf: &[u8], has_alpha: bool) -> Vec<u8> {
 /// - `image` - The RGB image to encode
 /// - `buffer` - A mutable buffer to write the WEBP bytes into. Existing contents are preserved;
 ///   the encoded data is appended.
-pub fn encode_image_webp_rgb8<A: ImageAllocator>(
-    image: &Image<u8, 3, A>,
-    buffer: &mut Vec<u8>,
-) -> Result<(), IoError> {
+pub fn encode_image_webp_rgb8(image: &Image<u8, 3>, buffer: &mut Vec<u8>) -> Result<(), IoError> {
     WebPEncoder::new(buffer).encode(
         image.as_slice(),
         image.width() as u32,
@@ -290,10 +285,7 @@ pub fn encode_image_webp_rgb8<A: ImageAllocator>(
 /// - `image` - The RGBA8 image to encode
 /// - `buffer` - A mutable buffer to write the WEBP bytes into. Existing contents are preserved;
 ///   the encoded data is appended.
-pub fn encode_image_webp_rgba8<A: ImageAllocator>(
-    image: &Image<u8, 4, A>,
-    buffer: &mut Vec<u8>,
-) -> Result<(), IoError> {
+pub fn encode_image_webp_rgba8(image: &Image<u8, 4>, buffer: &mut Vec<u8>) -> Result<(), IoError> {
     WebPEncoder::new(buffer).encode(
         image.as_slice(),
         image.width() as u32,
@@ -310,10 +302,7 @@ pub fn encode_image_webp_rgba8<A: ImageAllocator>(
 /// - `image` - The Gray8 image to encode
 /// - `buffer` - A mutable buffer to write the WEBP bytes into. Existing contents are preserved;
 ///   the encoded data is appended.
-pub fn encode_image_webp_gray8<A: ImageAllocator>(
-    image: &Image<u8, 1, A>,
-    buffer: &mut Vec<u8>,
-) -> Result<(), IoError> {
+pub fn encode_image_webp_gray8(image: &Image<u8, 1>, buffer: &mut Vec<u8>) -> Result<(), IoError> {
     WebPEncoder::new(buffer).encode(
         image.as_slice(),
         image.width() as u32,
@@ -329,9 +318,9 @@ pub fn encode_image_webp_gray8<A: ImageAllocator>(
 ///
 /// - `file_path` - The path to the WEBP image.
 /// - `image` - The grayscale image to write
-pub fn write_image_webp_gray8<A: ImageAllocator>(
+pub fn write_image_webp_gray8(
     file_path: impl AsRef<Path>,
-    image: &Image<u8, 1, A>,
+    image: &Image<u8, 1>,
 ) -> Result<(), IoError> {
     write_image_webp_impl(file_path, image, ColorType::L8)
 }
@@ -342,9 +331,9 @@ pub fn write_image_webp_gray8<A: ImageAllocator>(
 ///
 /// - `file_path` - The path to the WEBP image.
 /// - `image` - The rgb8 image to write
-pub fn write_image_webp_rgb8<A: ImageAllocator>(
+pub fn write_image_webp_rgb8(
     file_path: impl AsRef<Path>,
-    image: &Image<u8, 3, A>,
+    image: &Image<u8, 3>,
 ) -> Result<(), IoError> {
     write_image_webp_impl(file_path, image, ColorType::Rgb8)
 }
@@ -355,16 +344,16 @@ pub fn write_image_webp_rgb8<A: ImageAllocator>(
 ///
 /// - `file_path` - The path to the WEBP image.
 /// - `image` - The rgba8 image to write
-pub fn write_image_webp_rgba8<A: ImageAllocator>(
+pub fn write_image_webp_rgba8(
     file_path: impl AsRef<Path>,
-    image: &Image<u8, 4, A>,
+    image: &Image<u8, 4>,
 ) -> Result<(), IoError> {
     write_image_webp_impl(file_path, image, ColorType::Rgba8)
 }
 
-fn write_image_webp_impl<const N: usize, A: ImageAllocator>(
+fn write_image_webp_impl<const N: usize>(
     file_path: impl AsRef<Path>,
-    image: &Image<u8, N, A>,
+    image: &Image<u8, N>,
     color_type: ColorType,
 ) -> Result<(), IoError> {
     let file = fs::File::create(file_path)?;
@@ -402,7 +391,7 @@ mod tests {
     #[test]
     fn test_decode_webp() -> Result<(), IoError> {
         let bytes = read("../../tests/data/fire.webp")?;
-        let mut image = Rgb8::from_size_val([320, 235].into(), 0, CpuAllocator)?;
+        let mut image = Rgb8::from_size_val([320, 235].into(), 0, kornia_tensor::host_alloc())?;
         decode_image_webp_rgb8(&bytes, &mut image)?;
 
         assert_eq!(image.cols(), 320);
@@ -453,7 +442,7 @@ mod tests {
                 pixels.extend_from_slice(&[x as u8, y as u8, (x + y) as u8, 0x80]);
             }
         }
-        let src = Rgba8::from_size_vec([w, h].into(), pixels, CpuAllocator)?;
+        let src = Rgba8::from_size_vec([w, h].into(), pixels, kornia_tensor::host_alloc())?;
         write_image_webp_rgba8(&file_path, &src)?;
 
         let decoded = read_image_webp_rgba8(&file_path)?;
@@ -481,7 +470,7 @@ mod tests {
         let w = 4;
         let h = 4;
         let pixels = vec![0xAAu8; w * h * 4];
-        let src = Rgba8::from_size_vec([w, h].into(), pixels, CpuAllocator)?;
+        let src = Rgba8::from_size_vec([w, h].into(), pixels, kornia_tensor::host_alloc())?;
         write_image_webp_rgba8(&file_path, &src)?;
 
         match read_image_webp_rgb8(&file_path) {

--- a/crates/kornia-io/src/webp.rs
+++ b/crates/kornia-io/src/webp.rs
@@ -31,11 +31,7 @@ const GRAY_B: u32 = 29;
 pub fn read_image_webp_gray8(file_path: impl AsRef<Path>) -> Result<Gray8, IoError> {
     let (rgb, size, has_alpha) = read_webp_rgb_or_rgba(file_path)?;
     let gray = rgb_or_rgba_to_gray(&rgb, has_alpha);
-    Ok(Gray8::from_size_vec(
-        size,
-        gray,
-        kornia_tensor::host_alloc(),
-    )?)
+    Ok(Gray8::from_size_vec(size, gray)?)
 }
 
 /// Read a WEBP image as RGB8.
@@ -58,7 +54,7 @@ pub fn read_image_webp_rgb8(file_path: impl AsRef<Path>) -> Result<Rgb8, IoError
             ),
         ));
     }
-    Ok(Rgb8::from_size_vec(size, buf, kornia_tensor::host_alloc())?)
+    Ok(Rgb8::from_size_vec(size, buf)?)
 }
 
 /// Read a WEBP image as RGBA8.
@@ -81,11 +77,7 @@ pub fn read_image_webp_rgba8(file_path: impl AsRef<Path>) -> Result<Rgba8, IoErr
             ),
         ));
     }
-    Ok(Rgba8::from_size_vec(
-        size,
-        buf,
-        kornia_tensor::host_alloc(),
-    )?)
+    Ok(Rgba8::from_size_vec(size, buf)?)
 }
 
 /// Decodes a WEBP image as RGB8 from raw bytes.
@@ -391,7 +383,7 @@ mod tests {
     #[test]
     fn test_decode_webp() -> Result<(), IoError> {
         let bytes = read("../../tests/data/fire.webp")?;
-        let mut image = Rgb8::from_size_val([320, 235].into(), 0, kornia_tensor::host_alloc())?;
+        let mut image = Rgb8::from_size_val([320, 235].into(), 0)?;
         decode_image_webp_rgb8(&bytes, &mut image)?;
 
         assert_eq!(image.cols(), 320);
@@ -442,7 +434,7 @@ mod tests {
                 pixels.extend_from_slice(&[x as u8, y as u8, (x + y) as u8, 0x80]);
             }
         }
-        let src = Rgba8::from_size_vec([w, h].into(), pixels, kornia_tensor::host_alloc())?;
+        let src = Rgba8::from_size_vec([w, h].into(), pixels)?;
         write_image_webp_rgba8(&file_path, &src)?;
 
         let decoded = read_image_webp_rgba8(&file_path)?;
@@ -470,7 +462,7 @@ mod tests {
         let w = 4;
         let h = 4;
         let pixels = vec![0xAAu8; w * h * 4];
-        let src = Rgba8::from_size_vec([w, h].into(), pixels, kornia_tensor::host_alloc())?;
+        let src = Rgba8::from_size_vec([w, h].into(), pixels)?;
         write_image_webp_rgba8(&file_path, &src)?;
 
         match read_image_webp_rgb8(&file_path) {

--- a/crates/kornia-tensor-ops/benches/bench_ops.rs
+++ b/crates/kornia-tensor-ops/benches/bench_ops.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use kornia_tensor::{CpuAllocator, Tensor};
+use kornia_tensor::{host_alloc, Tensor};
 use kornia_tensor_ops::TensorOps;
 use rand::RngExt;
 
@@ -12,16 +12,12 @@ fn bench_dot_product1(c: &mut Criterion) {
     for size in test_sizes.clone() {
         let a: Vec<f32> = (0..size).map(|_| rng.random::<f32>()).collect();
         let b: Vec<f32> = (0..size).map(|_| rng.random::<f32>()).collect();
-        let a_tensor =
-            Tensor::<f32, 1, CpuAllocator>::from_shape_slice([size], &a, CpuAllocator).unwrap();
-        let b_tensor =
-            Tensor::<f32, 1, CpuAllocator>::from_shape_slice([size], &b, CpuAllocator).unwrap();
+        let a_tensor = Tensor::<f32, 1>::from_shape_slice([size], &a, host_alloc()).unwrap();
+        let b_tensor = Tensor::<f32, 1>::from_shape_slice([size], &b, host_alloc()).unwrap();
 
         group.bench_function(format!("f32_size_{size}"), |bencher| {
             bencher.iter(|| {
-                std::hint::black_box(
-                    Tensor::<f32, 1, CpuAllocator>::dot_product1(&a_tensor, &b_tensor).unwrap(),
-                )
+                std::hint::black_box(Tensor::<f32, 1>::dot_product1(&a_tensor, &b_tensor).unwrap())
             })
         });
     }
@@ -29,16 +25,12 @@ fn bench_dot_product1(c: &mut Criterion) {
     for size in test_sizes.clone() {
         let a: Vec<i8> = (0..size).map(|_| rng.random::<i8>()).collect();
         let b: Vec<i8> = (0..size).map(|_| rng.random::<i8>()).collect();
-        let a_tensor =
-            Tensor::<i8, 1, CpuAllocator>::from_shape_slice([size], &a, CpuAllocator).unwrap();
-        let b_tensor =
-            Tensor::<i8, 1, CpuAllocator>::from_shape_slice([size], &b, CpuAllocator).unwrap();
+        let a_tensor = Tensor::<i8, 1>::from_shape_slice([size], &a, host_alloc()).unwrap();
+        let b_tensor = Tensor::<i8, 1>::from_shape_slice([size], &b, host_alloc()).unwrap();
 
         group.bench_function(format!("i8_size_{size}"), |bencher| {
             bencher.iter(|| {
-                std::hint::black_box(
-                    Tensor::<i8, 1, CpuAllocator>::dot_product1(&a_tensor, &b_tensor).unwrap(),
-                )
+                std::hint::black_box(Tensor::<i8, 1>::dot_product1(&a_tensor, &b_tensor).unwrap())
             })
         });
     }
@@ -55,10 +47,8 @@ fn bench_cosine_similarity(c: &mut Criterion) {
     for size in test_sizes {
         let a: Vec<f32> = (0..size).map(|_| rng.random::<f32>()).collect();
         let b: Vec<f32> = (0..size).map(|_| rng.random::<f32>()).collect();
-        let a_tensor =
-            Tensor::<f32, 1, CpuAllocator>::from_shape_slice([size], &a, CpuAllocator).unwrap();
-        let b_tensor =
-            Tensor::<f32, 1, CpuAllocator>::from_shape_slice([size], &b, CpuAllocator).unwrap();
+        let a_tensor = Tensor::<f32, 1>::from_shape_slice([size], &a, host_alloc()).unwrap();
+        let b_tensor = Tensor::<f32, 1>::from_shape_slice([size], &b, host_alloc()).unwrap();
 
         group.bench_function(format!("f32_size_{size}"), |bencher| {
             bencher.iter(|| {

--- a/crates/kornia-tensor-ops/benches/bench_ops.rs
+++ b/crates/kornia-tensor-ops/benches/bench_ops.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use kornia_tensor::{host_alloc, Tensor};
+use kornia_tensor::Tensor;
 use kornia_tensor_ops::TensorOps;
 use rand::RngExt;
 
@@ -12,8 +12,8 @@ fn bench_dot_product1(c: &mut Criterion) {
     for size in test_sizes.clone() {
         let a: Vec<f32> = (0..size).map(|_| rng.random::<f32>()).collect();
         let b: Vec<f32> = (0..size).map(|_| rng.random::<f32>()).collect();
-        let a_tensor = Tensor::<f32, 1>::from_shape_slice([size], &a, host_alloc()).unwrap();
-        let b_tensor = Tensor::<f32, 1>::from_shape_slice([size], &b, host_alloc()).unwrap();
+        let a_tensor = Tensor::<f32, 1>::from_shape_slice([size], &a).unwrap();
+        let b_tensor = Tensor::<f32, 1>::from_shape_slice([size], &b).unwrap();
 
         group.bench_function(format!("f32_size_{size}"), |bencher| {
             bencher.iter(|| {
@@ -25,8 +25,8 @@ fn bench_dot_product1(c: &mut Criterion) {
     for size in test_sizes.clone() {
         let a: Vec<i8> = (0..size).map(|_| rng.random::<i8>()).collect();
         let b: Vec<i8> = (0..size).map(|_| rng.random::<i8>()).collect();
-        let a_tensor = Tensor::<i8, 1>::from_shape_slice([size], &a, host_alloc()).unwrap();
-        let b_tensor = Tensor::<i8, 1>::from_shape_slice([size], &b, host_alloc()).unwrap();
+        let a_tensor = Tensor::<i8, 1>::from_shape_slice([size], &a).unwrap();
+        let b_tensor = Tensor::<i8, 1>::from_shape_slice([size], &b).unwrap();
 
         group.bench_function(format!("i8_size_{size}"), |bencher| {
             bencher.iter(|| {
@@ -47,8 +47,8 @@ fn bench_cosine_similarity(c: &mut Criterion) {
     for size in test_sizes {
         let a: Vec<f32> = (0..size).map(|_| rng.random::<f32>()).collect();
         let b: Vec<f32> = (0..size).map(|_| rng.random::<f32>()).collect();
-        let a_tensor = Tensor::<f32, 1>::from_shape_slice([size], &a, host_alloc()).unwrap();
-        let b_tensor = Tensor::<f32, 1>::from_shape_slice([size], &b, host_alloc()).unwrap();
+        let a_tensor = Tensor::<f32, 1>::from_shape_slice([size], &a).unwrap();
+        let b_tensor = Tensor::<f32, 1>::from_shape_slice([size], &b).unwrap();
 
         group.bench_function(format!("f32_size_{size}"), |bencher| {
             bencher.iter(|| {

--- a/crates/kornia-tensor-ops/src/ops.rs
+++ b/crates/kornia-tensor-ops/src/ops.rs
@@ -22,11 +22,11 @@ use crate::error::TensorOpsError;
 /// # Example
 ///
 /// ```
-/// use kornia_tensor::{host_alloc, Tensor};
+/// use kornia_tensor::Tensor;
 /// use kornia_tensor_ops::TensorOps;
 ///
 /// let data: [u8; 6] = [1, 1, 1, 1, 1, 1];
-/// let t = Tensor::<u8, 2>::from_shape_slice([2, 3], &data, host_alloc()).unwrap();
+/// let t = Tensor::<u8, 2>::from_shape_slice([2, 3], &data).unwrap();
 /// let agg = Tensor::sum_elements(&t, 1).unwrap();
 /// assert_eq!(agg.shape, [2, 1]);
 /// assert_eq!(agg.as_slice(), [3, 3]);
@@ -183,14 +183,14 @@ where
 /// # Example
 ///
 /// ```
-/// use kornia_tensor::{host_alloc, Tensor};
+/// use kornia_tensor::Tensor;
 /// use kornia_tensor_ops::TensorOps;
 ///
 /// let data1: Vec<u8> = vec![1, 2, 3, 4];
-/// let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1, host_alloc()).unwrap();
+/// let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1).unwrap();
 ///
 /// let data2: Vec<u8> = vec![1, 2, 3, 4];
-/// let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2, host_alloc()).unwrap();
+/// let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2).unwrap();
 ///
 /// let t3 = t1.add(&t2).unwrap();
 /// assert_eq!(t3.as_slice(), vec![2, 4, 6, 8]);
@@ -220,14 +220,14 @@ where
 /// # Example
 ///
 /// ```
-/// use kornia_tensor::{host_alloc, Tensor};
+/// use kornia_tensor::Tensor;
 /// use kornia_tensor_ops::TensorOps;
 ///
 /// let data1: Vec<u8> = vec![1, 2, 3, 4];
-/// let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1, host_alloc()).unwrap();
+/// let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1).unwrap();
 ///
 /// let data2: Vec<u8> = vec![1, 2, 3, 4];
-/// let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2, host_alloc()).unwrap();
+/// let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2).unwrap();
 ///
 /// let t3 = t1.sub(&t2).unwrap();
 /// assert_eq!(t3.as_slice(), vec![0, 0, 0, 0]);
@@ -257,14 +257,14 @@ where
 /// # Example
 ///
 /// ```
-/// use kornia_tensor::{host_alloc, Tensor};
+/// use kornia_tensor::Tensor;
 /// use kornia_tensor_ops::TensorOps;
 ///
 /// let data1: Vec<u8> = vec![1, 2, 3, 4];
-/// let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1, host_alloc()).unwrap();
+/// let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1).unwrap();
 ///
 /// let data2: Vec<u8> = vec![1, 2, 3, 4];
-/// let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2, host_alloc()).unwrap();
+/// let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2).unwrap();
 ///
 /// let t3 = t1.mul(&t2).unwrap();
 /// assert_eq!(t3.as_slice(), vec![1, 4, 9, 16]);
@@ -294,14 +294,14 @@ where
 /// # Example
 ///
 /// ```
-/// use kornia_tensor::{host_alloc, Tensor};
+/// use kornia_tensor::Tensor;
 /// use kornia_tensor_ops::TensorOps;
 ///
 /// let data1: Vec<u8> = vec![1, 2, 3, 4];
-/// let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1, host_alloc()).unwrap();
+/// let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1).unwrap();
 ///
 /// let data2: Vec<u8> = vec![1, 2, 3, 4];
-/// let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2, host_alloc()).unwrap();
+/// let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2).unwrap();
 ///
 /// let t3 = t1.div(&t2).unwrap();
 /// assert_eq!(t3.as_slice(), vec![1, 1, 1, 1]);
@@ -335,11 +335,11 @@ where
 /// # Example
 ///
 /// ```
-/// use kornia_tensor::{host_alloc, Tensor};
+/// use kornia_tensor::Tensor;
 /// use kornia_tensor_ops::TensorOps;
 ///
-/// let a = Tensor::<i32, 1>::from_shape_slice([3], &[1, 2, 3], host_alloc()).unwrap();
-/// let b = Tensor::<i32, 1>::from_shape_slice([3], &[4, 5, 6], host_alloc()).unwrap();
+/// let a = Tensor::<i32, 1>::from_shape_slice([3], &[1, 2, 3]).unwrap();
+/// let b = Tensor::<i32, 1>::from_shape_slice([3], &[4, 5, 6]).unwrap();
 /// let result = Tensor::<i32,1>::dot_product1(&a, &b).unwrap();
 /// assert_eq!(result, 32); // 1*4 + 2*5 + 3*6 = 4 + 10 + 18 = 32
 /// ```
@@ -376,11 +376,11 @@ where
 ///
 /// Example:
 /// ```
-/// use kornia_tensor::{host_alloc, Tensor};
+/// use kornia_tensor::Tensor;
 /// use kornia_tensor_ops::TensorOps;
 ///
-/// let a = Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 2.0, 3.0], host_alloc()).unwrap();
-/// let b = Tensor::<f32, 1>::from_shape_slice([3], &[2.0, 4.0, 6.0], host_alloc()).unwrap();
+/// let a = Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 2.0, 3.0]).unwrap();
+/// let b = Tensor::<f32, 1>::from_shape_slice([3], &[2.0, 4.0, 6.0]).unwrap();
 /// let result = Tensor::cosine_similarity(&a, &b).unwrap();
 /// assert!((result - 1.0).abs() < 1e-6);
 /// ```
@@ -421,11 +421,11 @@ where
 /// # Example
 ///
 /// ```
-/// use kornia_tensor::{host_alloc, Tensor};
+/// use kornia_tensor::Tensor;
 /// use kornia_tensor_ops::TensorOps;
 ///
-/// let a = Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 2.0, 3.0], host_alloc()).unwrap();
-/// let b = Tensor::<f32, 1>::from_shape_slice([3], &[2.0, 4.0, 6.0], host_alloc()).unwrap();
+/// let a = Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 2.0, 3.0]).unwrap();
+/// let b = Tensor::<f32, 1>::from_shape_slice([3], &[2.0, 4.0, 6.0]).unwrap();
 /// let result = Tensor::<f32,1>::cosine_distance(&a, &b).unwrap();
 /// assert!(result.abs() < 1e-6);
 /// ```
@@ -459,12 +459,12 @@ where
 /// # Examples
 ///
 /// ```
-/// use kornia_tensor::{host_alloc, Tensor};
+/// use kornia_tensor::Tensor;
 /// use kornia_tensor_ops::ops::TensorOps;
 ///
 /// // Create a tensor
 /// let data = vec![1.0, 2.0, 3.0, 4.0];
-/// let t = Tensor::<f32, 2>::from_shape_vec([2, 2], data, host_alloc()).unwrap();
+/// let t = Tensor::<f32, 2>::from_shape_vec([2, 2], data).unwrap();
 ///
 /// // Use operations through the trait
 /// let scaled = t.mul_scalar(2.0);
@@ -648,7 +648,7 @@ mod tests {
     #[test]
     fn test_sum_dim_oob() -> Result<(), TensorError> {
         let data: [u8; 4] = [2, 2, 2, 2];
-        let t = Tensor::<u8, 2>::from_shape_slice([2, 2], &data, kornia_tensor::host_alloc())?;
+        let t = Tensor::<u8, 2>::from_shape_slice([2, 2], &data)?;
         let res = sum_elements(&t, 2);
         assert!(res.is_err_and(|e| e == TensorOpsError::DimOutOfBounds(2, 1)));
         Ok(())
@@ -656,10 +656,8 @@ mod tests {
 
     #[test]
     fn test_dot_product_shape_mismatch() {
-        let a = Tensor::<i32, 1>::from_shape_slice([3], &[1, 2, 3], kornia_tensor::host_alloc())
-            .unwrap();
-        let b = Tensor::<i32, 1>::from_shape_slice([4], &[4, 5, 6, 7], kornia_tensor::host_alloc())
-            .unwrap();
+        let a = Tensor::<i32, 1>::from_shape_slice([3], &[1, 2, 3]).unwrap();
+        let b = Tensor::<i32, 1>::from_shape_slice([4], &[4, 5, 6, 7]).unwrap();
         let result = dot_product1(&a, &b);
         assert!(result.is_err());
 
@@ -674,7 +672,7 @@ mod tests {
     #[test]
     fn test_sum_1d() -> Result<(), TensorError> {
         let data: [u8; 4] = [1, 1, 1, 1];
-        let t = Tensor::<u8, 1>::from_shape_slice([4], &data, kornia_tensor::host_alloc())?;
+        let t = Tensor::<u8, 1>::from_shape_slice([4], &data)?;
         let res = sum_elements(&t, 0);
 
         assert!(res.is_ok_and(|v| v.as_slice() == [4]));
@@ -684,7 +682,7 @@ mod tests {
     #[test]
     fn test_sum_2d() -> Result<(), TensorOpsError> {
         let data: [u8; 6] = [1, 2, 3, 4, 5, 6];
-        let t = Tensor::<u8, 2>::from_shape_slice([2, 3], &data, kornia_tensor::host_alloc())?;
+        let t = Tensor::<u8, 2>::from_shape_slice([2, 3], &data)?;
         let t_f32 = t.cast::<f32>();
         let t_i32 = t.cast::<i32>();
 
@@ -707,7 +705,7 @@ mod tests {
     #[test]
     fn test_sum_3d() -> Result<(), TensorOpsError> {
         let data: [u8; 24] = [1; 24];
-        let t = Tensor::<u8, 3>::from_shape_slice([2, 3, 4], &data, kornia_tensor::host_alloc())?;
+        let t = Tensor::<u8, 3>::from_shape_slice([2, 3, 4], &data)?;
         let t_f32 = t.cast::<f32>();
         let t_i32 = t.cast::<i32>();
 
@@ -735,7 +733,7 @@ mod tests {
     #[test]
     fn test_mul_scalar_f32() -> Result<(), TensorError> {
         let data: [f32; 5] = [1.0, 2.0, 3.0, 4.0, 5.0];
-        let t = Tensor::<f32, 1>::from_shape_slice([5], &data, kornia_tensor::host_alloc())?;
+        let t = Tensor::<f32, 1>::from_shape_slice([5], &data)?;
         let result = mul_scalar(&t, 2.0);
         assert_eq!(result.as_slice(), &[2.0, 4.0, 6.0, 8.0, 10.0]);
         Ok(())
@@ -744,7 +742,7 @@ mod tests {
     #[test]
     fn test_powf_f32() -> Result<(), TensorError> {
         let data: [f32; 5] = [1.0, 2.0, 3.0, 4.0, 5.0];
-        let t = Tensor::<f32, 1>::from_shape_slice([5], &data, kornia_tensor::host_alloc())?;
+        let t = Tensor::<f32, 1>::from_shape_slice([5], &data)?;
         let result = powf(&t, 2.0);
         let expected: Vec<f32> = data.iter().map(|&x| x * x).collect();
         assert_eq!(result.as_slice(), expected.as_slice());
@@ -755,10 +753,8 @@ mod tests {
     fn test_min_f32() -> Result<(), TensorError> {
         let data_a: [f32; 5] = [3.0, 1.0, 4.0, 1.0, 5.0];
         let data_b: [f32; 5] = [2.0, 7.0, 1.0, 8.0, 2.0];
-        let tensor_a =
-            Tensor::<f32, 1>::from_shape_slice([5], &data_a, kornia_tensor::host_alloc())?;
-        let tensor_b =
-            Tensor::<f32, 1>::from_shape_slice([5], &data_b, kornia_tensor::host_alloc())?;
+        let tensor_a = Tensor::<f32, 1>::from_shape_slice([5], &data_a)?;
+        let tensor_b = Tensor::<f32, 1>::from_shape_slice([5], &data_b)?;
         let result = min(&tensor_a, &tensor_b).unwrap();
         let expected = vec![2.0, 1.0, 1.0, 1.0, 2.0];
         assert_eq!(result.as_slice(), expected.as_slice());
@@ -768,7 +764,7 @@ mod tests {
     #[test]
     fn powi_and_abs() -> Result<(), TensorError> {
         let data: Vec<f32> = vec![-1.0, 2.0, -3.0, 4.0];
-        let t = Tensor::<f32, 1>::from_shape_vec([4], data, kornia_tensor::host_alloc())?;
+        let t = Tensor::<f32, 1>::from_shape_vec([4], data)?;
 
         let t_powi = powi(&t, 2);
         assert_eq!(t_powi.as_slice(), &[1.0, 4.0, 9.0, 16.0]);
@@ -782,9 +778,9 @@ mod tests {
     #[test]
     fn add_1d() -> Result<(), TensorOpsError> {
         let data1: Vec<u8> = vec![1, 2, 3, 4];
-        let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1, kornia_tensor::host_alloc())?;
+        let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1)?;
         let data2: Vec<u8> = vec![1, 2, 3, 4];
-        let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2, kornia_tensor::host_alloc())?;
+        let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2)?;
         let t3 = add(&t1, &t2)?;
         assert_eq!(t3.as_slice(), vec![2, 4, 6, 8]);
         Ok(())
@@ -793,9 +789,9 @@ mod tests {
     #[test]
     fn add_2d() -> Result<(), TensorOpsError> {
         let data1: Vec<u8> = vec![1, 2, 3, 4];
-        let t1 = Tensor::<u8, 2>::from_shape_vec([2, 2], data1, kornia_tensor::host_alloc())?;
+        let t1 = Tensor::<u8, 2>::from_shape_vec([2, 2], data1)?;
         let data2: Vec<u8> = vec![1, 2, 3, 4];
-        let t2 = Tensor::<u8, 2>::from_shape_vec([2, 2], data2, kornia_tensor::host_alloc())?;
+        let t2 = Tensor::<u8, 2>::from_shape_vec([2, 2], data2)?;
         let t3 = add(&t1, &t2)?;
         assert_eq!(t3.as_slice(), vec![2, 4, 6, 8]);
         Ok(())
@@ -804,9 +800,9 @@ mod tests {
     #[test]
     fn add_3d() -> Result<(), TensorOpsError> {
         let data1: Vec<u8> = vec![1, 2, 3, 4, 5, 6];
-        let t1 = Tensor::<u8, 3>::from_shape_vec([2, 1, 3], data1, kornia_tensor::host_alloc())?;
+        let t1 = Tensor::<u8, 3>::from_shape_vec([2, 1, 3], data1)?;
         let data2: Vec<u8> = vec![1, 2, 3, 4, 5, 6];
-        let t2 = Tensor::<u8, 3>::from_shape_vec([2, 1, 3], data2, kornia_tensor::host_alloc())?;
+        let t2 = Tensor::<u8, 3>::from_shape_vec([2, 1, 3], data2)?;
         let t3 = add(&t1, &t2)?;
         assert_eq!(t3.as_slice(), vec![2, 4, 6, 8, 10, 12]);
         Ok(())
@@ -815,9 +811,9 @@ mod tests {
     #[test]
     fn sub_1d() -> Result<(), TensorOpsError> {
         let data1: Vec<u8> = vec![1, 2, 3, 4];
-        let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1, kornia_tensor::host_alloc())?;
+        let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1)?;
         let data2: Vec<u8> = vec![1, 2, 3, 4];
-        let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2, kornia_tensor::host_alloc())?;
+        let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2)?;
         let t3 = sub(&t1, &t2)?;
         assert_eq!(t3.as_slice(), vec![0, 0, 0, 0]);
         Ok(())
@@ -826,9 +822,9 @@ mod tests {
     #[test]
     fn sub_2d() -> Result<(), TensorOpsError> {
         let data1: Vec<u8> = vec![1, 2, 3, 4];
-        let t1 = Tensor::<u8, 2>::from_shape_vec([2, 2], data1, kornia_tensor::host_alloc())?;
+        let t1 = Tensor::<u8, 2>::from_shape_vec([2, 2], data1)?;
         let data2: Vec<u8> = vec![1, 2, 3, 4];
-        let t2 = Tensor::<u8, 2>::from_shape_vec([2, 2], data2, kornia_tensor::host_alloc())?;
+        let t2 = Tensor::<u8, 2>::from_shape_vec([2, 2], data2)?;
         let t3 = sub(&t1, &t2)?;
         assert_eq!(t3.as_slice(), vec![0, 0, 0, 0]);
         Ok(())
@@ -837,9 +833,9 @@ mod tests {
     #[test]
     fn div_1d() -> Result<(), TensorOpsError> {
         let data1: Vec<u8> = vec![1, 2, 3, 4];
-        let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1, kornia_tensor::host_alloc())?;
+        let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1)?;
         let data2: Vec<u8> = vec![1, 2, 3, 4];
-        let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2, kornia_tensor::host_alloc())?;
+        let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2)?;
         let t3 = div(&t1, &t2)?;
         assert_eq!(t3.as_slice(), vec![1, 1, 1, 1]);
         Ok(())
@@ -848,9 +844,9 @@ mod tests {
     #[test]
     fn div_2d() -> Result<(), TensorOpsError> {
         let data1: Vec<u8> = vec![1, 2, 3, 4];
-        let t1 = Tensor::<u8, 2>::from_shape_vec([2, 2], data1, kornia_tensor::host_alloc())?;
+        let t1 = Tensor::<u8, 2>::from_shape_vec([2, 2], data1)?;
         let data2: Vec<u8> = vec![1, 2, 3, 4];
-        let t2 = Tensor::<u8, 2>::from_shape_vec([2, 2], data2, kornia_tensor::host_alloc())?;
+        let t2 = Tensor::<u8, 2>::from_shape_vec([2, 2], data2)?;
         let t3 = div(&t1, &t2)?;
         assert_eq!(t3.as_slice(), vec![1, 1, 1, 1]);
         Ok(())
@@ -859,9 +855,9 @@ mod tests {
     #[test]
     fn mul_1d() -> Result<(), TensorOpsError> {
         let data1: Vec<u8> = vec![1, 2, 3, 4];
-        let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1, kornia_tensor::host_alloc())?;
+        let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1)?;
         let data2: Vec<u8> = vec![1, 2, 3, 4];
-        let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2, kornia_tensor::host_alloc())?;
+        let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2)?;
         let t3 = mul(&t1, &t2)?;
         assert_eq!(t3.as_slice(), vec![1, 4, 9, 16]);
         Ok(())
@@ -870,9 +866,9 @@ mod tests {
     #[test]
     fn mul_2d() -> Result<(), TensorOpsError> {
         let data1: Vec<u8> = vec![1, 2, 3, 4];
-        let t1 = Tensor::<u8, 2>::from_shape_vec([2, 2], data1, kornia_tensor::host_alloc())?;
+        let t1 = Tensor::<u8, 2>::from_shape_vec([2, 2], data1)?;
         let data2: Vec<u8> = vec![1, 2, 3, 4];
-        let t2 = Tensor::<u8, 2>::from_shape_vec([2, 2], data2, kornia_tensor::host_alloc())?;
+        let t2 = Tensor::<u8, 2>::from_shape_vec([2, 2], data2)?;
         let t3 = mul(&t1, &t2)?;
         assert_eq!(t3.as_slice(), vec![1, 4, 9, 16]);
         Ok(())
@@ -880,10 +876,8 @@ mod tests {
 
     #[test]
     fn test_dot_product1_f32() -> Result<(), TensorOpsError> {
-        let a_f32 =
-            Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 2.0, 3.0], kornia_tensor::host_alloc())?;
-        let b_f32 =
-            Tensor::<f32, 1>::from_shape_slice([3], &[4.0, 5.0, 6.0], kornia_tensor::host_alloc())?;
+        let a_f32 = Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 2.0, 3.0])?;
+        let b_f32 = Tensor::<f32, 1>::from_shape_slice([3], &[4.0, 5.0, 6.0])?;
         let result = dot_product1(&a_f32, &b_f32)?;
         assert_eq!(result, 32.0);
         Ok(())
@@ -891,8 +885,8 @@ mod tests {
 
     #[test]
     fn test_dot_product1_u8() -> Result<(), TensorOpsError> {
-        let a_u8 = Tensor::<u8, 1>::from_shape_slice([3], &[1, 2, 3], kornia_tensor::host_alloc())?;
-        let b_u8 = Tensor::<u8, 1>::from_shape_slice([3], &[4, 5, 6], kornia_tensor::host_alloc())?;
+        let a_u8 = Tensor::<u8, 1>::from_shape_slice([3], &[1, 2, 3])?;
+        let b_u8 = Tensor::<u8, 1>::from_shape_slice([3], &[4, 5, 6])?;
         let result = dot_product1(&a_u8, &b_u8)?;
         assert_eq!(result, 32);
         Ok(())
@@ -900,10 +894,8 @@ mod tests {
 
     #[test]
     fn test_cosine_similarity_orthogonal_vectors() -> Result<(), TensorOpsError> {
-        let a =
-            Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 0.0, 0.0], kornia_tensor::host_alloc())?;
-        let b =
-            Tensor::<f32, 1>::from_shape_slice([3], &[0.0, 1.0, 0.0], kornia_tensor::host_alloc())?;
+        let a = Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 0.0, 0.0])?;
+        let b = Tensor::<f32, 1>::from_shape_slice([3], &[0.0, 1.0, 0.0])?;
         let result = cosine_similarity(&a, &b)?;
         assert_eq!(result, 0.0);
         Ok(())
@@ -911,13 +903,8 @@ mod tests {
 
     #[test]
     fn test_cosine_similarity_opposite_vectors() -> Result<(), TensorOpsError> {
-        let e =
-            Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 2.0, 3.0], kornia_tensor::host_alloc())?;
-        let f = Tensor::<f32, 1>::from_shape_slice(
-            [3],
-            &[-1.0, -2.0, -3.0],
-            kornia_tensor::host_alloc(),
-        )?;
+        let e = Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 2.0, 3.0])?;
+        let f = Tensor::<f32, 1>::from_shape_slice([3], &[-1.0, -2.0, -3.0])?;
         let result = cosine_similarity(&e, &f)?;
         assert!((result - -1.0).abs() < 1e-6);
         Ok(())
@@ -925,10 +912,8 @@ mod tests {
 
     #[test]
     fn test_cosine_similarity_zero_vector() -> Result<(), TensorOpsError> {
-        let zero =
-            Tensor::<f32, 1>::from_shape_slice([3], &[0.0, 0.0, 0.0], kornia_tensor::host_alloc())?;
-        let g =
-            Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 2.0, 3.0], kornia_tensor::host_alloc())?;
+        let zero = Tensor::<f32, 1>::from_shape_slice([3], &[0.0, 0.0, 0.0])?;
+        let g = Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 2.0, 3.0])?;
         let result = cosine_similarity(&zero, &g)?;
         assert_eq!(result, 0.0);
         Ok(())
@@ -936,13 +921,8 @@ mod tests {
 
     #[test]
     fn test_cosine_similarity_zero_dot_product() -> Result<(), TensorOpsError> {
-        let h =
-            Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 1.0, 0.0], kornia_tensor::host_alloc())?;
-        let i = Tensor::<f32, 1>::from_shape_slice(
-            [3],
-            &[-1.0, 1.0, 0.0],
-            kornia_tensor::host_alloc(),
-        )?;
+        let h = Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 1.0, 0.0])?;
+        let i = Tensor::<f32, 1>::from_shape_slice([3], &[-1.0, 1.0, 0.0])?;
         let result = cosine_similarity(&h, &i)?;
         assert!(result.abs() < 1e-6);
         Ok(())
@@ -950,27 +930,18 @@ mod tests {
 
     #[test]
     fn test_cosine_distance() -> Result<(), TensorOpsError> {
-        let a =
-            Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 2.0, 3.0], kornia_tensor::host_alloc())?;
-        let b =
-            Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 2.0, 3.0], kornia_tensor::host_alloc())?;
+        let a = Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 2.0, 3.0])?;
+        let b = Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 2.0, 3.0])?;
         let result = cosine_distance(&a, &b)?;
         assert!(result.abs() < 1e-6);
 
-        let c =
-            Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 0.0, 0.0], kornia_tensor::host_alloc())?;
-        let d =
-            Tensor::<f32, 1>::from_shape_slice([3], &[0.0, 1.0, 0.0], kornia_tensor::host_alloc())?;
+        let c = Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 0.0, 0.0])?;
+        let d = Tensor::<f32, 1>::from_shape_slice([3], &[0.0, 1.0, 0.0])?;
         let result = cosine_distance(&c, &d)?;
         assert!((result - 1.0).abs() < 1e-6);
 
-        let e =
-            Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 2.0, 3.0], kornia_tensor::host_alloc())?;
-        let f = Tensor::<f32, 1>::from_shape_slice(
-            [3],
-            &[-1.0, -2.0, -3.0],
-            kornia_tensor::host_alloc(),
-        )?;
+        let e = Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 2.0, 3.0])?;
+        let f = Tensor::<f32, 1>::from_shape_slice([3], &[-1.0, -2.0, -3.0])?;
         let result = cosine_distance(&e, &f)?;
         assert!((result - 2.0).abs() < 1e-6);
 

--- a/crates/kornia-tensor-ops/src/ops.rs
+++ b/crates/kornia-tensor-ops/src/ops.rs
@@ -1,5 +1,5 @@
 use crate::kernels::{cosine_similarity_float_kernel, dot_product1_kernel};
-use kornia_tensor::{storage::TensorStorage, CpuAllocator, Tensor, TensorAllocator, TensorError};
+use kornia_tensor::{storage::TensorStorage, Tensor, TensorError};
 use num_traits::{Float, Zero};
 
 use crate::error::TensorOpsError;
@@ -22,22 +22,21 @@ use crate::error::TensorOpsError;
 /// # Example
 ///
 /// ```
-/// use kornia_tensor::{Tensor, CpuAllocator};
+/// use kornia_tensor::{Tensor};
 /// use kornia_tensor_ops::TensorOps;
 ///
 /// let data: [u8; 6] = [1, 1, 1, 1, 1, 1];
-/// let t = Tensor::<u8, 2, CpuAllocator>::from_shape_slice([2, 3], &data, CpuAllocator).unwrap();
+/// let t = Tensor::<u8, 2>::from_shape_slice([2, 3], &data).unwrap();
 /// let agg = Tensor::sum_elements(&t, 1).unwrap();
 /// assert_eq!(agg.shape, [2, 1]);
 /// assert_eq!(agg.as_slice(), [3, 3]);
 /// ```
-fn sum_elements<T, const N: usize, A>(
-    tensor: &Tensor<T, N, A>,
+fn sum_elements<T, const N: usize>(
+    tensor: &Tensor<T, N>,
     dim: usize,
-) -> Result<Tensor<T, N, A>, TensorOpsError>
+) -> Result<Tensor<T, N>, TensorOpsError>
 where
     T: Zero + Clone + std::ops::Add<Output = T>,
-    A: TensorAllocator + Clone + 'static,
 {
     if dim >= N {
         return Err(TensorOpsError::DimOutOfBounds(dim, N - 1));
@@ -86,10 +85,9 @@ where
 /// # Returns
 ///
 /// A new image with the pixel data multiplied by the scalar.
-fn mul_scalar<T, const N: usize, A>(tensor: &Tensor<T, N, A>, n: T) -> Tensor<T, N, A>
+fn mul_scalar<T, const N: usize>(tensor: &Tensor<T, N>, n: T) -> Tensor<T, N>
 where
     T: Float + Clone,
-    A: TensorAllocator + Clone + 'static,
 {
     tensor.map(|&x| x * n)
 }
@@ -103,10 +101,9 @@ where
 /// # Returns
 ///
 /// A new image with the pixel data raised to the power.
-fn powf<T, const N: usize, A>(tensor: &Tensor<T, N, A>, n: T) -> Tensor<T, N, A>
+fn powf<T, const N: usize>(tensor: &Tensor<T, N>, n: T) -> Tensor<T, N>
 where
     T: Float + Clone,
-    A: TensorAllocator + Clone + 'static,
 {
     tensor.map(|x| x.powf(n))
 }
@@ -120,9 +117,9 @@ where
 ///
 /// A new `Tensor` instance.
 fn min<T, const N: usize>(
-    tensor: &Tensor<T, N, CpuAllocator>,
-    other: &Tensor<T, N, CpuAllocator>,
-) -> Result<Tensor<T, N, CpuAllocator>, TensorOpsError>
+    tensor: &Tensor<T, N>,
+    other: &Tensor<T, N>,
+) -> Result<Tensor<T, N>, TensorOpsError>
 where
     T: PartialOrd + Clone,
 {
@@ -140,10 +137,9 @@ where
 /// # Returns
 ///
 /// A new image with the pixel data raised to the power.
-fn powi<T, const N: usize, A>(tensor: &Tensor<T, N, A>, n: i32) -> Tensor<T, N, A>
+fn powi<T, const N: usize>(tensor: &Tensor<T, N>, n: i32) -> Tensor<T, N>
 where
     T: Float + Clone,
-    A: TensorAllocator + Clone + 'static,
 {
     tensor.map(|x| x.powi(n))
 }
@@ -153,10 +149,9 @@ where
 /// # Returns
 ///
 /// A new image with the pixel data absolute value.
-fn abs<T, const N: usize, A>(tensor: &Tensor<T, N, A>) -> Tensor<T, N, A>
+fn abs<T, const N: usize>(tensor: &Tensor<T, N>) -> Tensor<T, N>
 where
     T: Float + Clone,
-    A: TensorAllocator + Clone + 'static,
 {
     tensor.map(|x| x.abs())
 }
@@ -166,10 +161,9 @@ where
 /// # Returns
 ///
 /// The mean of the pixel data.
-fn mean<T, const N: usize, A>(tensor: &Tensor<T, N, A>) -> Result<T, TensorError>
+fn mean<T, const N: usize>(tensor: &Tensor<T, N>) -> Result<T, TensorError>
 where
     T: Float + Clone,
-    A: TensorAllocator + Clone + 'static,
 {
     let data_acc = tensor.as_slice().iter().fold(T::zero(), |acc, &x| acc + x);
     let mean = data_acc / T::from(tensor.as_slice().len()).ok_or(TensorError::CastError)?;
@@ -189,22 +183,22 @@ where
 /// # Example
 ///
 /// ```
-/// use kornia_tensor::{Tensor, CpuAllocator};
+/// use kornia_tensor::{Tensor};
 /// use kornia_tensor_ops::TensorOps;
 ///
 /// let data1: Vec<u8> = vec![1, 2, 3, 4];
-/// let t1 = Tensor::<u8, 1, CpuAllocator>::from_shape_vec([4], data1, CpuAllocator).unwrap();
+/// let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1).unwrap();
 ///
 /// let data2: Vec<u8> = vec![1, 2, 3, 4];
-/// let t2 = Tensor::<u8, 1, CpuAllocator>::from_shape_vec([4], data2, CpuAllocator).unwrap();
+/// let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2).unwrap();
 ///
 /// let t3 = t1.add(&t2).unwrap();
 /// assert_eq!(t3.as_slice(), vec![2, 4, 6, 8]);
 /// ```
 fn add<T, const N: usize>(
-    tensor: &Tensor<T, N, CpuAllocator>,
-    other: &Tensor<T, N, CpuAllocator>,
-) -> Result<Tensor<T, N, CpuAllocator>, TensorOpsError>
+    tensor: &Tensor<T, N>,
+    other: &Tensor<T, N>,
+) -> Result<Tensor<T, N>, TensorOpsError>
 where
     T: std::ops::Add<Output = T> + Clone,
 {
@@ -226,22 +220,22 @@ where
 /// # Example
 ///
 /// ```
-/// use kornia_tensor::{Tensor, CpuAllocator};
+/// use kornia_tensor::{Tensor};
 /// use kornia_tensor_ops::TensorOps;
 ///
 /// let data1: Vec<u8> = vec![1, 2, 3, 4];
-/// let t1 = Tensor::<u8, 1, CpuAllocator>::from_shape_vec([4], data1, CpuAllocator).unwrap();
+/// let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1).unwrap();
 ///
 /// let data2: Vec<u8> = vec![1, 2, 3, 4];
-/// let t2 = Tensor::<u8, 1, CpuAllocator>::from_shape_vec([4], data2, CpuAllocator).unwrap();
+/// let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2).unwrap();
 ///
 /// let t3 = t1.sub(&t2).unwrap();
 /// assert_eq!(t3.as_slice(), vec![0, 0, 0, 0]);
 /// ```
 fn sub<T, const N: usize>(
-    tensor: &Tensor<T, N, CpuAllocator>,
-    other: &Tensor<T, N, CpuAllocator>,
-) -> Result<Tensor<T, N, CpuAllocator>, TensorOpsError>
+    tensor: &Tensor<T, N>,
+    other: &Tensor<T, N>,
+) -> Result<Tensor<T, N>, TensorOpsError>
 where
     T: std::ops::Sub<Output = T> + Clone,
 {
@@ -263,22 +257,22 @@ where
 /// # Example
 ///
 /// ```
-/// use kornia_tensor::{Tensor, CpuAllocator};
+/// use kornia_tensor::{Tensor};
 /// use kornia_tensor_ops::TensorOps;
 ///
 /// let data1: Vec<u8> = vec![1, 2, 3, 4];
-/// let t1 = Tensor::<u8, 1, CpuAllocator>::from_shape_vec([4], data1, CpuAllocator).unwrap();
+/// let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1).unwrap();
 ///
 /// let data2: Vec<u8> = vec![1, 2, 3, 4];
-/// let t2 = Tensor::<u8, 1, CpuAllocator>::from_shape_vec([4], data2, CpuAllocator).unwrap();
+/// let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2).unwrap();
 ///
 /// let t3 = t1.mul(&t2).unwrap();
 /// assert_eq!(t3.as_slice(), vec![1, 4, 9, 16]);
 /// ```
 fn mul<T, const N: usize>(
-    tensor: &Tensor<T, N, CpuAllocator>,
-    other: &Tensor<T, N, CpuAllocator>,
-) -> Result<Tensor<T, N, CpuAllocator>, TensorOpsError>
+    tensor: &Tensor<T, N>,
+    other: &Tensor<T, N>,
+) -> Result<Tensor<T, N>, TensorOpsError>
 where
     T: std::ops::Mul<Output = T> + Clone,
 {
@@ -300,22 +294,22 @@ where
 /// # Example
 ///
 /// ```
-/// use kornia_tensor::{Tensor, CpuAllocator};
+/// use kornia_tensor::{Tensor};
 /// use kornia_tensor_ops::TensorOps;
 ///
 /// let data1: Vec<u8> = vec![1, 2, 3, 4];
-/// let t1 = Tensor::<u8, 1, CpuAllocator>::from_shape_vec([4], data1, CpuAllocator).unwrap();
+/// let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1).unwrap();
 ///
 /// let data2: Vec<u8> = vec![1, 2, 3, 4];
-/// let t2 = Tensor::<u8, 1, CpuAllocator>::from_shape_vec([4], data2, CpuAllocator).unwrap();
+/// let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2).unwrap();
 ///
 /// let t3 = t1.div(&t2).unwrap();
 /// assert_eq!(t3.as_slice(), vec![1, 1, 1, 1]);
 /// ```
 fn div<T, const N: usize>(
-    tensor: &Tensor<T, N, CpuAllocator>,
-    other: &Tensor<T, N, CpuAllocator>,
-) -> Result<Tensor<T, N, CpuAllocator>, TensorOpsError>
+    tensor: &Tensor<T, N>,
+    other: &Tensor<T, N>,
+) -> Result<Tensor<T, N>, TensorOpsError>
 where
     T: std::ops::Div<Output = T> + Clone,
 {
@@ -341,18 +335,17 @@ where
 /// # Example
 ///
 /// ```
-/// use kornia_tensor::{Tensor, CpuAllocator};
+/// use kornia_tensor::{Tensor};
 /// use kornia_tensor_ops::TensorOps;
 ///
-/// let a = Tensor::<i32, 1, CpuAllocator>::from_shape_slice([3], &[1, 2, 3], CpuAllocator).unwrap();
-/// let b = Tensor::<i32, 1, CpuAllocator>::from_shape_slice([3], &[4, 5, 6], CpuAllocator).unwrap();
-/// let result = Tensor::<i32,1,CpuAllocator>::dot_product1(&a, &b).unwrap();
+/// let a = Tensor::<i32, 1>::from_shape_slice([3], &[1, 2, 3]).unwrap();
+/// let b = Tensor::<i32, 1>::from_shape_slice([3], &[4, 5, 6]).unwrap();
+/// let result = Tensor::<i32,1>::dot_product1(&a, &b).unwrap();
 /// assert_eq!(result, 32); // 1*4 + 2*5 + 3*6 = 4 + 10 + 18 = 32
 /// ```
-fn dot_product1<T, A>(a: &Tensor<T, 1, A>, b: &Tensor<T, 1, A>) -> Result<T, TensorOpsError>
+fn dot_product1<T>(a: &Tensor<T, 1>, b: &Tensor<T, 1>) -> Result<T, TensorOpsError>
 where
     T: Zero + Clone + std::ops::Add<Output = T> + std::ops::Mul<Output = T> + Copy,
-    A: TensorAllocator + Clone + 'static,
 {
     if a.shape != b.shape {
         return Err(TensorOpsError::ShapeMismatch(
@@ -383,21 +376,20 @@ where
 ///
 /// Example:
 /// ```
-/// use kornia_tensor::{Tensor, CpuAllocator};
+/// use kornia_tensor::{Tensor};
 /// use kornia_tensor_ops::TensorOps;
 ///
-/// let a = Tensor::<f32, 1, CpuAllocator>::from_shape_slice([3], &[1.0, 2.0, 3.0], CpuAllocator).unwrap();
-/// let b = Tensor::<f32, 1, CpuAllocator>::from_shape_slice([3], &[2.0, 4.0, 6.0], CpuAllocator).unwrap();
+/// let a = Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 2.0, 3.0]).unwrap();
+/// let b = Tensor::<f32, 1>::from_shape_slice([3], &[2.0, 4.0, 6.0]).unwrap();
 /// let result = Tensor::cosine_similarity(&a, &b).unwrap();
 /// assert!((result - 1.0).abs() < 1e-6);
 /// ```
-fn cosine_similarity<T, const N: usize, A>(
-    a: &Tensor<T, N, A>,
-    b: &Tensor<T, N, A>,
+fn cosine_similarity<T, const N: usize>(
+    a: &Tensor<T, N>,
+    b: &Tensor<T, N>,
 ) -> Result<T, TensorOpsError>
 where
     T: num_traits::Float,
-    A: TensorAllocator + Clone + 'static,
 {
     if a.shape != b.shape {
         return Err(TensorOpsError::ShapeMismatch(
@@ -429,18 +421,17 @@ where
 /// # Example
 ///
 /// ```
-/// use kornia_tensor::{Tensor, CpuAllocator};
+/// use kornia_tensor::{Tensor};
 /// use kornia_tensor_ops::TensorOps;
 ///
-/// let a = Tensor::<f32, 1, CpuAllocator>::from_shape_slice([3], &[1.0, 2.0, 3.0], CpuAllocator).unwrap();
-/// let b = Tensor::<f32, 1, CpuAllocator>::from_shape_slice([3], &[2.0, 4.0, 6.0], CpuAllocator).unwrap();
-/// let result = Tensor::<f32,1,CpuAllocator>::cosine_distance(&a, &b).unwrap();
+/// let a = Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 2.0, 3.0]).unwrap();
+/// let b = Tensor::<f32, 1>::from_shape_slice([3], &[2.0, 4.0, 6.0]).unwrap();
+/// let result = Tensor::<f32,1>::cosine_distance(&a, &b).unwrap();
 /// assert!(result.abs() < 1e-6);
 /// ```
-fn cosine_distance<T, A>(a: &Tensor<T, 1, A>, b: &Tensor<T, 1, A>) -> Result<T, TensorOpsError>
+fn cosine_distance<T>(a: &Tensor<T, 1>, b: &Tensor<T, 1>) -> Result<T, TensorOpsError>
 where
     T: num_traits::Float,
-    A: TensorAllocator + Clone + 'static,
 {
     let similarity = cosine_similarity(a, b)?;
     Ok(T::one() - similarity)
@@ -462,18 +453,18 @@ where
 ///
 /// # Implementation
 ///
-/// This trait is implemented for `Tensor<T, N, CpuAllocator>` where `T` implements `Float`,
+/// This trait is implemented for `Tensor<T, N>` where `T` implements `Float`,
 /// meaning these operations are available for floating-point tensors on CPU.
 ///
 /// # Examples
 ///
 /// ```
-/// use kornia_tensor::{Tensor, CpuAllocator};
+/// use kornia_tensor::{Tensor};
 /// use kornia_tensor_ops::ops::TensorOps;
 ///
 /// // Create a tensor
 /// let data = vec![1.0, 2.0, 3.0, 4.0];
-/// let t = Tensor::<f32, 2, CpuAllocator>::from_shape_vec([2, 2], data, CpuAllocator).unwrap();
+/// let t = Tensor::<f32, 2>::from_shape_vec([2, 2], data).unwrap();
 ///
 /// // Use operations through the trait
 /// let scaled = t.mul_scalar(2.0);
@@ -482,37 +473,31 @@ where
 /// ```
 pub trait TensorOps<T, const N: usize> {
     /// Compute the sum of the elements in the tensor along dimension `dim`
-    fn sum_elements(
-        tensor: &Tensor<T, N, CpuAllocator>,
-        dim: usize,
-    ) -> Result<Tensor<T, N, CpuAllocator>, TensorOpsError>
+    fn sum_elements(tensor: &Tensor<T, N>, dim: usize) -> Result<Tensor<T, N>, TensorOpsError>
     where
         T: Zero + Clone + std::ops::Add<Output = T>;
 
     /// Multiply the pixel data by a scalar.
-    fn mul_scalar(&self, n: T) -> Tensor<T, N, CpuAllocator>
+    fn mul_scalar(&self, n: T) -> Tensor<T, N>
     where
         T: Float + Clone;
 
     /// Raise the pixel data to the power of a float.
-    fn powf(&self, n: T) -> Tensor<T, N, CpuAllocator>
+    fn powf(&self, n: T) -> Tensor<T, N>
     where
         T: Float + Clone;
     /// Perform an element-wise minimum operation on two tensors.
-    fn min(
-        &self,
-        other: &Tensor<T, N, CpuAllocator>,
-    ) -> Result<Tensor<T, N, CpuAllocator>, TensorOpsError>
+    fn min(&self, other: &Tensor<T, N>) -> Result<Tensor<T, N>, TensorOpsError>
     where
         T: PartialOrd + Clone;
 
     /// Apply the power function to the pixel data.
-    fn powi(&self, n: i32) -> Tensor<T, N, CpuAllocator>
+    fn powi(&self, n: i32) -> Tensor<T, N>
     where
         T: Float + Clone;
 
     /// Compute absolute value of the pixel data.
-    fn abs(&self) -> Tensor<T, N, CpuAllocator>
+    fn abs(&self) -> Tensor<T, N>
     where
         T: Float + Clone;
 
@@ -522,104 +507,77 @@ pub trait TensorOps<T, const N: usize> {
         T: Float + Clone;
 
     /// Perform an element-wise addition on two tensors.
-    fn add(
-        &self,
-        other: &Tensor<T, N, CpuAllocator>,
-    ) -> Result<Tensor<T, N, CpuAllocator>, TensorOpsError>
+    fn add(&self, other: &Tensor<T, N>) -> Result<Tensor<T, N>, TensorOpsError>
     where
         T: std::ops::Add<Output = T> + Clone;
 
     /// Perform an element-wise subtraction on two tensors.
-    fn sub(
-        &self,
-        other: &Tensor<T, N, CpuAllocator>,
-    ) -> Result<Tensor<T, N, CpuAllocator>, TensorOpsError>
+    fn sub(&self, other: &Tensor<T, N>) -> Result<Tensor<T, N>, TensorOpsError>
     where
         T: std::ops::Sub<Output = T> + Clone;
 
     /// Perform an element-wise division on two tensors.
-    fn div(
-        &self,
-        other: &Tensor<T, N, CpuAllocator>,
-    ) -> Result<Tensor<T, N, CpuAllocator>, TensorOpsError>
+    fn div(&self, other: &Tensor<T, N>) -> Result<Tensor<T, N>, TensorOpsError>
     where
         T: std::ops::Div<Output = T> + Clone;
 
     /// Perform an element-wise multiplication on two tensors.
-    fn mul(
-        &self,
-        other: &Tensor<T, N, CpuAllocator>,
-    ) -> Result<Tensor<T, N, CpuAllocator>, TensorOpsError>
+    fn mul(&self, other: &Tensor<T, N>) -> Result<Tensor<T, N>, TensorOpsError>
     where
         T: std::ops::Mul<Output = T> + Clone;
 
     /// Compute the dot product between two 1D tensors
-    fn dot_product1(
-        a: &Tensor<T, 1, CpuAllocator>,
-        b: &Tensor<T, 1, CpuAllocator>,
-    ) -> Result<T, TensorOpsError>
+    fn dot_product1(a: &Tensor<T, 1>, b: &Tensor<T, 1>) -> Result<T, TensorOpsError>
     where
         T: Zero + Clone + std::ops::Add<Output = T> + std::ops::Mul<Output = T> + Copy;
 
     /// Compute the cosine similarity between two tensors
-    fn cosine_similarity(
-        a: &Tensor<T, N, CpuAllocator>,
-        b: &Tensor<T, N, CpuAllocator>,
-    ) -> Result<T, TensorOpsError>
+    fn cosine_similarity(a: &Tensor<T, N>, b: &Tensor<T, N>) -> Result<T, TensorOpsError>
     where
         T: Float;
 
     /// Compute the cosine distance between two tensors
-    fn cosine_distance(
-        a: &Tensor<T, 1, CpuAllocator>,
-        b: &Tensor<T, 1, CpuAllocator>,
-    ) -> Result<T, TensorOpsError>
+    fn cosine_distance(a: &Tensor<T, 1>, b: &Tensor<T, 1>) -> Result<T, TensorOpsError>
     where
         T: Float;
 }
-impl<T, const N: usize> TensorOps<T, N> for Tensor<T, N, CpuAllocator> {
-    fn sum_elements(
-        tensor: &Tensor<T, N, CpuAllocator>,
-        dim: usize,
-    ) -> Result<Tensor<T, N, CpuAllocator>, TensorOpsError>
+impl<T, const N: usize> TensorOps<T, N> for Tensor<T, N> {
+    fn sum_elements(tensor: &Tensor<T, N>, dim: usize) -> Result<Tensor<T, N>, TensorOpsError>
     where
         T: Zero + Clone + std::ops::Add<Output = T>,
     {
         sum_elements(tensor, dim)
     }
 
-    fn mul_scalar(&self, n: T) -> Tensor<T, N, CpuAllocator>
+    fn mul_scalar(&self, n: T) -> Tensor<T, N>
     where
         T: Float + Clone,
     {
         mul_scalar(self, n)
     }
 
-    fn powf(&self, n: T) -> Tensor<T, N, CpuAllocator>
+    fn powf(&self, n: T) -> Tensor<T, N>
     where
         T: Float + Clone,
     {
         powf(self, n)
     }
 
-    fn min(
-        &self,
-        other: &Tensor<T, N, CpuAllocator>,
-    ) -> Result<Tensor<T, N, CpuAllocator>, TensorOpsError>
+    fn min(&self, other: &Tensor<T, N>) -> Result<Tensor<T, N>, TensorOpsError>
     where
         T: PartialOrd + Clone,
     {
         min(self, other)
     }
 
-    fn powi(&self, n: i32) -> Tensor<T, N, CpuAllocator>
+    fn powi(&self, n: i32) -> Tensor<T, N>
     where
         T: Float + Clone,
     {
         powi(self, n)
     }
 
-    fn abs(&self) -> Tensor<T, N, CpuAllocator>
+    fn abs(&self) -> Tensor<T, N>
     where
         T: Float + Clone,
     {
@@ -633,70 +591,49 @@ impl<T, const N: usize> TensorOps<T, N> for Tensor<T, N, CpuAllocator> {
         mean(self)
     }
 
-    fn add(
-        &self,
-        other: &Tensor<T, N, CpuAllocator>,
-    ) -> Result<Tensor<T, N, CpuAllocator>, TensorOpsError>
+    fn add(&self, other: &Tensor<T, N>) -> Result<Tensor<T, N>, TensorOpsError>
     where
         T: std::ops::Add<Output = T> + Clone,
     {
         add(self, other)
     }
 
-    fn sub(
-        &self,
-        other: &Tensor<T, N, CpuAllocator>,
-    ) -> Result<Tensor<T, N, CpuAllocator>, TensorOpsError>
+    fn sub(&self, other: &Tensor<T, N>) -> Result<Tensor<T, N>, TensorOpsError>
     where
         T: std::ops::Sub<Output = T> + Clone,
     {
         sub(self, other)
     }
 
-    fn div(
-        &self,
-        other: &Tensor<T, N, CpuAllocator>,
-    ) -> Result<Tensor<T, N, CpuAllocator>, TensorOpsError>
+    fn div(&self, other: &Tensor<T, N>) -> Result<Tensor<T, N>, TensorOpsError>
     where
         T: std::ops::Div<Output = T> + Clone,
     {
         div(self, other)
     }
 
-    fn mul(
-        &self,
-        other: &Tensor<T, N, CpuAllocator>,
-    ) -> Result<Tensor<T, N, CpuAllocator>, TensorOpsError>
+    fn mul(&self, other: &Tensor<T, N>) -> Result<Tensor<T, N>, TensorOpsError>
     where
         T: std::ops::Mul<Output = T> + Clone,
     {
         mul(self, other)
     }
 
-    fn dot_product1(
-        a: &Tensor<T, 1, CpuAllocator>,
-        b: &Tensor<T, 1, CpuAllocator>,
-    ) -> Result<T, TensorOpsError>
+    fn dot_product1(a: &Tensor<T, 1>, b: &Tensor<T, 1>) -> Result<T, TensorOpsError>
     where
         T: Zero + Clone + std::ops::Add<Output = T> + std::ops::Mul<Output = T> + Copy,
     {
         dot_product1(a, b)
     }
 
-    fn cosine_similarity(
-        a: &Tensor<T, N, CpuAllocator>,
-        b: &Tensor<T, N, CpuAllocator>,
-    ) -> Result<T, TensorOpsError>
+    fn cosine_similarity(a: &Tensor<T, N>, b: &Tensor<T, N>) -> Result<T, TensorOpsError>
     where
         T: Float,
     {
         cosine_similarity(a, b)
     }
 
-    fn cosine_distance(
-        a: &Tensor<T, 1, CpuAllocator>,
-        b: &Tensor<T, 1, CpuAllocator>,
-    ) -> Result<T, TensorOpsError>
+    fn cosine_distance(a: &Tensor<T, 1>, b: &Tensor<T, 1>) -> Result<T, TensorOpsError>
     where
         T: Float,
     {
@@ -711,7 +648,7 @@ mod tests {
     #[test]
     fn test_sum_dim_oob() -> Result<(), TensorError> {
         let data: [u8; 4] = [2, 2, 2, 2];
-        let t = Tensor::<u8, 2, CpuAllocator>::from_shape_slice([2, 2], &data, CpuAllocator)?;
+        let t = Tensor::<u8, 2>::from_shape_slice([2, 2], &data, kornia_tensor::host_alloc())?;
         let res = sum_elements(&t, 2);
         assert!(res.is_err_and(|e| e == TensorOpsError::DimOutOfBounds(2, 1)));
         Ok(())
@@ -719,9 +656,9 @@ mod tests {
 
     #[test]
     fn test_dot_product_shape_mismatch() {
-        let a = Tensor::<i32, 1, CpuAllocator>::from_shape_slice([3], &[1, 2, 3], CpuAllocator)
+        let a = Tensor::<i32, 1>::from_shape_slice([3], &[1, 2, 3], kornia_tensor::host_alloc())
             .unwrap();
-        let b = Tensor::<i32, 1, CpuAllocator>::from_shape_slice([4], &[4, 5, 6, 7], CpuAllocator)
+        let b = Tensor::<i32, 1>::from_shape_slice([4], &[4, 5, 6, 7], kornia_tensor::host_alloc())
             .unwrap();
         let result = dot_product1(&a, &b);
         assert!(result.is_err());
@@ -737,7 +674,7 @@ mod tests {
     #[test]
     fn test_sum_1d() -> Result<(), TensorError> {
         let data: [u8; 4] = [1, 1, 1, 1];
-        let t = Tensor::<u8, 1, CpuAllocator>::from_shape_slice([4], &data, CpuAllocator)?;
+        let t = Tensor::<u8, 1>::from_shape_slice([4], &data, kornia_tensor::host_alloc())?;
         let res = sum_elements(&t, 0);
 
         assert!(res.is_ok_and(|v| v.as_slice() == [4]));
@@ -747,7 +684,7 @@ mod tests {
     #[test]
     fn test_sum_2d() -> Result<(), TensorOpsError> {
         let data: [u8; 6] = [1, 2, 3, 4, 5, 6];
-        let t = Tensor::<u8, 2, CpuAllocator>::from_shape_slice([2, 3], &data, CpuAllocator)?;
+        let t = Tensor::<u8, 2>::from_shape_slice([2, 3], &data, kornia_tensor::host_alloc())?;
         let t_f32 = t.cast::<f32>();
         let t_i32 = t.cast::<i32>();
 
@@ -770,7 +707,7 @@ mod tests {
     #[test]
     fn test_sum_3d() -> Result<(), TensorOpsError> {
         let data: [u8; 24] = [1; 24];
-        let t = Tensor::<u8, 3, CpuAllocator>::from_shape_slice([2, 3, 4], &data, CpuAllocator)?;
+        let t = Tensor::<u8, 3>::from_shape_slice([2, 3, 4], &data, kornia_tensor::host_alloc())?;
         let t_f32 = t.cast::<f32>();
         let t_i32 = t.cast::<i32>();
 
@@ -798,7 +735,7 @@ mod tests {
     #[test]
     fn test_mul_scalar_f32() -> Result<(), TensorError> {
         let data: [f32; 5] = [1.0, 2.0, 3.0, 4.0, 5.0];
-        let t = Tensor::<f32, 1, CpuAllocator>::from_shape_slice([5], &data, CpuAllocator)?;
+        let t = Tensor::<f32, 1>::from_shape_slice([5], &data, kornia_tensor::host_alloc())?;
         let result = mul_scalar(&t, 2.0);
         assert_eq!(result.as_slice(), &[2.0, 4.0, 6.0, 8.0, 10.0]);
         Ok(())
@@ -807,7 +744,7 @@ mod tests {
     #[test]
     fn test_powf_f32() -> Result<(), TensorError> {
         let data: [f32; 5] = [1.0, 2.0, 3.0, 4.0, 5.0];
-        let t = Tensor::<f32, 1, CpuAllocator>::from_shape_slice([5], &data, CpuAllocator)?;
+        let t = Tensor::<f32, 1>::from_shape_slice([5], &data, kornia_tensor::host_alloc())?;
         let result = powf(&t, 2.0);
         let expected: Vec<f32> = data.iter().map(|&x| x * x).collect();
         assert_eq!(result.as_slice(), expected.as_slice());
@@ -819,9 +756,9 @@ mod tests {
         let data_a: [f32; 5] = [3.0, 1.0, 4.0, 1.0, 5.0];
         let data_b: [f32; 5] = [2.0, 7.0, 1.0, 8.0, 2.0];
         let tensor_a =
-            Tensor::<f32, 1, CpuAllocator>::from_shape_slice([5], &data_a, CpuAllocator)?;
+            Tensor::<f32, 1>::from_shape_slice([5], &data_a, kornia_tensor::host_alloc())?;
         let tensor_b =
-            Tensor::<f32, 1, CpuAllocator>::from_shape_slice([5], &data_b, CpuAllocator)?;
+            Tensor::<f32, 1>::from_shape_slice([5], &data_b, kornia_tensor::host_alloc())?;
         let result = min(&tensor_a, &tensor_b).unwrap();
         let expected = vec![2.0, 1.0, 1.0, 1.0, 2.0];
         assert_eq!(result.as_slice(), expected.as_slice());
@@ -831,7 +768,7 @@ mod tests {
     #[test]
     fn powi_and_abs() -> Result<(), TensorError> {
         let data: Vec<f32> = vec![-1.0, 2.0, -3.0, 4.0];
-        let t = Tensor::<f32, 1, _>::from_shape_vec([4], data, CpuAllocator)?;
+        let t = Tensor::<f32, 1>::from_shape_vec([4], data, kornia_tensor::host_alloc())?;
 
         let t_powi = powi(&t, 2);
         assert_eq!(t_powi.as_slice(), &[1.0, 4.0, 9.0, 16.0]);
@@ -845,9 +782,9 @@ mod tests {
     #[test]
     fn add_1d() -> Result<(), TensorOpsError> {
         let data1: Vec<u8> = vec![1, 2, 3, 4];
-        let t1 = Tensor::<u8, 1, _>::from_shape_vec([4], data1, CpuAllocator)?;
+        let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1, kornia_tensor::host_alloc())?;
         let data2: Vec<u8> = vec![1, 2, 3, 4];
-        let t2 = Tensor::<u8, 1, _>::from_shape_vec([4], data2, CpuAllocator)?;
+        let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2, kornia_tensor::host_alloc())?;
         let t3 = add(&t1, &t2)?;
         assert_eq!(t3.as_slice(), vec![2, 4, 6, 8]);
         Ok(())
@@ -856,9 +793,9 @@ mod tests {
     #[test]
     fn add_2d() -> Result<(), TensorOpsError> {
         let data1: Vec<u8> = vec![1, 2, 3, 4];
-        let t1 = Tensor::<u8, 2, _>::from_shape_vec([2, 2], data1, CpuAllocator)?;
+        let t1 = Tensor::<u8, 2>::from_shape_vec([2, 2], data1, kornia_tensor::host_alloc())?;
         let data2: Vec<u8> = vec![1, 2, 3, 4];
-        let t2 = Tensor::<u8, 2, _>::from_shape_vec([2, 2], data2, CpuAllocator)?;
+        let t2 = Tensor::<u8, 2>::from_shape_vec([2, 2], data2, kornia_tensor::host_alloc())?;
         let t3 = add(&t1, &t2)?;
         assert_eq!(t3.as_slice(), vec![2, 4, 6, 8]);
         Ok(())
@@ -867,9 +804,9 @@ mod tests {
     #[test]
     fn add_3d() -> Result<(), TensorOpsError> {
         let data1: Vec<u8> = vec![1, 2, 3, 4, 5, 6];
-        let t1 = Tensor::<u8, 3, _>::from_shape_vec([2, 1, 3], data1, CpuAllocator)?;
+        let t1 = Tensor::<u8, 3>::from_shape_vec([2, 1, 3], data1, kornia_tensor::host_alloc())?;
         let data2: Vec<u8> = vec![1, 2, 3, 4, 5, 6];
-        let t2 = Tensor::<u8, 3, _>::from_shape_vec([2, 1, 3], data2, CpuAllocator)?;
+        let t2 = Tensor::<u8, 3>::from_shape_vec([2, 1, 3], data2, kornia_tensor::host_alloc())?;
         let t3 = add(&t1, &t2)?;
         assert_eq!(t3.as_slice(), vec![2, 4, 6, 8, 10, 12]);
         Ok(())
@@ -878,9 +815,9 @@ mod tests {
     #[test]
     fn sub_1d() -> Result<(), TensorOpsError> {
         let data1: Vec<u8> = vec![1, 2, 3, 4];
-        let t1 = Tensor::<u8, 1, _>::from_shape_vec([4], data1, CpuAllocator)?;
+        let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1, kornia_tensor::host_alloc())?;
         let data2: Vec<u8> = vec![1, 2, 3, 4];
-        let t2 = Tensor::<u8, 1, _>::from_shape_vec([4], data2, CpuAllocator)?;
+        let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2, kornia_tensor::host_alloc())?;
         let t3 = sub(&t1, &t2)?;
         assert_eq!(t3.as_slice(), vec![0, 0, 0, 0]);
         Ok(())
@@ -889,9 +826,9 @@ mod tests {
     #[test]
     fn sub_2d() -> Result<(), TensorOpsError> {
         let data1: Vec<u8> = vec![1, 2, 3, 4];
-        let t1 = Tensor::<u8, 2, _>::from_shape_vec([2, 2], data1, CpuAllocator)?;
+        let t1 = Tensor::<u8, 2>::from_shape_vec([2, 2], data1, kornia_tensor::host_alloc())?;
         let data2: Vec<u8> = vec![1, 2, 3, 4];
-        let t2 = Tensor::<u8, 2, _>::from_shape_vec([2, 2], data2, CpuAllocator)?;
+        let t2 = Tensor::<u8, 2>::from_shape_vec([2, 2], data2, kornia_tensor::host_alloc())?;
         let t3 = sub(&t1, &t2)?;
         assert_eq!(t3.as_slice(), vec![0, 0, 0, 0]);
         Ok(())
@@ -900,9 +837,9 @@ mod tests {
     #[test]
     fn div_1d() -> Result<(), TensorOpsError> {
         let data1: Vec<u8> = vec![1, 2, 3, 4];
-        let t1 = Tensor::<u8, 1, _>::from_shape_vec([4], data1, CpuAllocator)?;
+        let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1, kornia_tensor::host_alloc())?;
         let data2: Vec<u8> = vec![1, 2, 3, 4];
-        let t2 = Tensor::<u8, 1, _>::from_shape_vec([4], data2, CpuAllocator)?;
+        let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2, kornia_tensor::host_alloc())?;
         let t3 = div(&t1, &t2)?;
         assert_eq!(t3.as_slice(), vec![1, 1, 1, 1]);
         Ok(())
@@ -911,9 +848,9 @@ mod tests {
     #[test]
     fn div_2d() -> Result<(), TensorOpsError> {
         let data1: Vec<u8> = vec![1, 2, 3, 4];
-        let t1 = Tensor::<u8, 2, _>::from_shape_vec([2, 2], data1, CpuAllocator)?;
+        let t1 = Tensor::<u8, 2>::from_shape_vec([2, 2], data1, kornia_tensor::host_alloc())?;
         let data2: Vec<u8> = vec![1, 2, 3, 4];
-        let t2 = Tensor::<u8, 2, _>::from_shape_vec([2, 2], data2, CpuAllocator)?;
+        let t2 = Tensor::<u8, 2>::from_shape_vec([2, 2], data2, kornia_tensor::host_alloc())?;
         let t3 = div(&t1, &t2)?;
         assert_eq!(t3.as_slice(), vec![1, 1, 1, 1]);
         Ok(())
@@ -922,9 +859,9 @@ mod tests {
     #[test]
     fn mul_1d() -> Result<(), TensorOpsError> {
         let data1: Vec<u8> = vec![1, 2, 3, 4];
-        let t1 = Tensor::<u8, 1, _>::from_shape_vec([4], data1, CpuAllocator)?;
+        let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1, kornia_tensor::host_alloc())?;
         let data2: Vec<u8> = vec![1, 2, 3, 4];
-        let t2 = Tensor::<u8, 1, _>::from_shape_vec([4], data2, CpuAllocator)?;
+        let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2, kornia_tensor::host_alloc())?;
         let t3 = mul(&t1, &t2)?;
         assert_eq!(t3.as_slice(), vec![1, 4, 9, 16]);
         Ok(())
@@ -933,9 +870,9 @@ mod tests {
     #[test]
     fn mul_2d() -> Result<(), TensorOpsError> {
         let data1: Vec<u8> = vec![1, 2, 3, 4];
-        let t1 = Tensor::<u8, 2, _>::from_shape_vec([2, 2], data1, CpuAllocator)?;
+        let t1 = Tensor::<u8, 2>::from_shape_vec([2, 2], data1, kornia_tensor::host_alloc())?;
         let data2: Vec<u8> = vec![1, 2, 3, 4];
-        let t2 = Tensor::<u8, 2, _>::from_shape_vec([2, 2], data2, CpuAllocator)?;
+        let t2 = Tensor::<u8, 2>::from_shape_vec([2, 2], data2, kornia_tensor::host_alloc())?;
         let t3 = mul(&t1, &t2)?;
         assert_eq!(t3.as_slice(), vec![1, 4, 9, 16]);
         Ok(())
@@ -944,9 +881,9 @@ mod tests {
     #[test]
     fn test_dot_product1_f32() -> Result<(), TensorOpsError> {
         let a_f32 =
-            Tensor::<f32, 1, CpuAllocator>::from_shape_slice([3], &[1.0, 2.0, 3.0], CpuAllocator)?;
+            Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 2.0, 3.0], kornia_tensor::host_alloc())?;
         let b_f32 =
-            Tensor::<f32, 1, CpuAllocator>::from_shape_slice([3], &[4.0, 5.0, 6.0], CpuAllocator)?;
+            Tensor::<f32, 1>::from_shape_slice([3], &[4.0, 5.0, 6.0], kornia_tensor::host_alloc())?;
         let result = dot_product1(&a_f32, &b_f32)?;
         assert_eq!(result, 32.0);
         Ok(())
@@ -954,8 +891,8 @@ mod tests {
 
     #[test]
     fn test_dot_product1_u8() -> Result<(), TensorOpsError> {
-        let a_u8 = Tensor::<u8, 1, CpuAllocator>::from_shape_slice([3], &[1, 2, 3], CpuAllocator)?;
-        let b_u8 = Tensor::<u8, 1, CpuAllocator>::from_shape_slice([3], &[4, 5, 6], CpuAllocator)?;
+        let a_u8 = Tensor::<u8, 1>::from_shape_slice([3], &[1, 2, 3], kornia_tensor::host_alloc())?;
+        let b_u8 = Tensor::<u8, 1>::from_shape_slice([3], &[4, 5, 6], kornia_tensor::host_alloc())?;
         let result = dot_product1(&a_u8, &b_u8)?;
         assert_eq!(result, 32);
         Ok(())
@@ -964,9 +901,9 @@ mod tests {
     #[test]
     fn test_cosine_similarity_orthogonal_vectors() -> Result<(), TensorOpsError> {
         let a =
-            Tensor::<f32, 1, CpuAllocator>::from_shape_slice([3], &[1.0, 0.0, 0.0], CpuAllocator)?;
+            Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 0.0, 0.0], kornia_tensor::host_alloc())?;
         let b =
-            Tensor::<f32, 1, CpuAllocator>::from_shape_slice([3], &[0.0, 1.0, 0.0], CpuAllocator)?;
+            Tensor::<f32, 1>::from_shape_slice([3], &[0.0, 1.0, 0.0], kornia_tensor::host_alloc())?;
         let result = cosine_similarity(&a, &b)?;
         assert_eq!(result, 0.0);
         Ok(())
@@ -975,11 +912,11 @@ mod tests {
     #[test]
     fn test_cosine_similarity_opposite_vectors() -> Result<(), TensorOpsError> {
         let e =
-            Tensor::<f32, 1, CpuAllocator>::from_shape_slice([3], &[1.0, 2.0, 3.0], CpuAllocator)?;
-        let f = Tensor::<f32, 1, CpuAllocator>::from_shape_slice(
+            Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 2.0, 3.0], kornia_tensor::host_alloc())?;
+        let f = Tensor::<f32, 1>::from_shape_slice(
             [3],
             &[-1.0, -2.0, -3.0],
-            CpuAllocator,
+            kornia_tensor::host_alloc(),
         )?;
         let result = cosine_similarity(&e, &f)?;
         assert!((result - -1.0).abs() < 1e-6);
@@ -989,9 +926,9 @@ mod tests {
     #[test]
     fn test_cosine_similarity_zero_vector() -> Result<(), TensorOpsError> {
         let zero =
-            Tensor::<f32, 1, CpuAllocator>::from_shape_slice([3], &[0.0, 0.0, 0.0], CpuAllocator)?;
+            Tensor::<f32, 1>::from_shape_slice([3], &[0.0, 0.0, 0.0], kornia_tensor::host_alloc())?;
         let g =
-            Tensor::<f32, 1, CpuAllocator>::from_shape_slice([3], &[1.0, 2.0, 3.0], CpuAllocator)?;
+            Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 2.0, 3.0], kornia_tensor::host_alloc())?;
         let result = cosine_similarity(&zero, &g)?;
         assert_eq!(result, 0.0);
         Ok(())
@@ -1000,9 +937,12 @@ mod tests {
     #[test]
     fn test_cosine_similarity_zero_dot_product() -> Result<(), TensorOpsError> {
         let h =
-            Tensor::<f32, 1, CpuAllocator>::from_shape_slice([3], &[1.0, 1.0, 0.0], CpuAllocator)?;
-        let i =
-            Tensor::<f32, 1, CpuAllocator>::from_shape_slice([3], &[-1.0, 1.0, 0.0], CpuAllocator)?;
+            Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 1.0, 0.0], kornia_tensor::host_alloc())?;
+        let i = Tensor::<f32, 1>::from_shape_slice(
+            [3],
+            &[-1.0, 1.0, 0.0],
+            kornia_tensor::host_alloc(),
+        )?;
         let result = cosine_similarity(&h, &i)?;
         assert!(result.abs() < 1e-6);
         Ok(())
@@ -1011,25 +951,25 @@ mod tests {
     #[test]
     fn test_cosine_distance() -> Result<(), TensorOpsError> {
         let a =
-            Tensor::<f32, 1, CpuAllocator>::from_shape_slice([3], &[1.0, 2.0, 3.0], CpuAllocator)?;
+            Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 2.0, 3.0], kornia_tensor::host_alloc())?;
         let b =
-            Tensor::<f32, 1, CpuAllocator>::from_shape_slice([3], &[1.0, 2.0, 3.0], CpuAllocator)?;
+            Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 2.0, 3.0], kornia_tensor::host_alloc())?;
         let result = cosine_distance(&a, &b)?;
         assert!(result.abs() < 1e-6);
 
         let c =
-            Tensor::<f32, 1, CpuAllocator>::from_shape_slice([3], &[1.0, 0.0, 0.0], CpuAllocator)?;
+            Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 0.0, 0.0], kornia_tensor::host_alloc())?;
         let d =
-            Tensor::<f32, 1, CpuAllocator>::from_shape_slice([3], &[0.0, 1.0, 0.0], CpuAllocator)?;
+            Tensor::<f32, 1>::from_shape_slice([3], &[0.0, 1.0, 0.0], kornia_tensor::host_alloc())?;
         let result = cosine_distance(&c, &d)?;
         assert!((result - 1.0).abs() < 1e-6);
 
         let e =
-            Tensor::<f32, 1, CpuAllocator>::from_shape_slice([3], &[1.0, 2.0, 3.0], CpuAllocator)?;
-        let f = Tensor::<f32, 1, CpuAllocator>::from_shape_slice(
+            Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 2.0, 3.0], kornia_tensor::host_alloc())?;
+        let f = Tensor::<f32, 1>::from_shape_slice(
             [3],
             &[-1.0, -2.0, -3.0],
-            CpuAllocator,
+            kornia_tensor::host_alloc(),
         )?;
         let result = cosine_distance(&e, &f)?;
         assert!((result - 2.0).abs() < 1e-6);

--- a/crates/kornia-tensor-ops/src/ops.rs
+++ b/crates/kornia-tensor-ops/src/ops.rs
@@ -22,11 +22,11 @@ use crate::error::TensorOpsError;
 /// # Example
 ///
 /// ```
-/// use kornia_tensor::{Tensor};
+/// use kornia_tensor::{host_alloc, Tensor};
 /// use kornia_tensor_ops::TensorOps;
 ///
 /// let data: [u8; 6] = [1, 1, 1, 1, 1, 1];
-/// let t = Tensor::<u8, 2>::from_shape_slice([2, 3], &data).unwrap();
+/// let t = Tensor::<u8, 2>::from_shape_slice([2, 3], &data, host_alloc()).unwrap();
 /// let agg = Tensor::sum_elements(&t, 1).unwrap();
 /// assert_eq!(agg.shape, [2, 1]);
 /// assert_eq!(agg.as_slice(), [3, 3]);
@@ -183,14 +183,14 @@ where
 /// # Example
 ///
 /// ```
-/// use kornia_tensor::{Tensor};
+/// use kornia_tensor::{host_alloc, Tensor};
 /// use kornia_tensor_ops::TensorOps;
 ///
 /// let data1: Vec<u8> = vec![1, 2, 3, 4];
-/// let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1).unwrap();
+/// let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1, host_alloc()).unwrap();
 ///
 /// let data2: Vec<u8> = vec![1, 2, 3, 4];
-/// let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2).unwrap();
+/// let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2, host_alloc()).unwrap();
 ///
 /// let t3 = t1.add(&t2).unwrap();
 /// assert_eq!(t3.as_slice(), vec![2, 4, 6, 8]);
@@ -220,14 +220,14 @@ where
 /// # Example
 ///
 /// ```
-/// use kornia_tensor::{Tensor};
+/// use kornia_tensor::{host_alloc, Tensor};
 /// use kornia_tensor_ops::TensorOps;
 ///
 /// let data1: Vec<u8> = vec![1, 2, 3, 4];
-/// let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1).unwrap();
+/// let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1, host_alloc()).unwrap();
 ///
 /// let data2: Vec<u8> = vec![1, 2, 3, 4];
-/// let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2).unwrap();
+/// let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2, host_alloc()).unwrap();
 ///
 /// let t3 = t1.sub(&t2).unwrap();
 /// assert_eq!(t3.as_slice(), vec![0, 0, 0, 0]);
@@ -257,14 +257,14 @@ where
 /// # Example
 ///
 /// ```
-/// use kornia_tensor::{Tensor};
+/// use kornia_tensor::{host_alloc, Tensor};
 /// use kornia_tensor_ops::TensorOps;
 ///
 /// let data1: Vec<u8> = vec![1, 2, 3, 4];
-/// let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1).unwrap();
+/// let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1, host_alloc()).unwrap();
 ///
 /// let data2: Vec<u8> = vec![1, 2, 3, 4];
-/// let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2).unwrap();
+/// let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2, host_alloc()).unwrap();
 ///
 /// let t3 = t1.mul(&t2).unwrap();
 /// assert_eq!(t3.as_slice(), vec![1, 4, 9, 16]);
@@ -294,14 +294,14 @@ where
 /// # Example
 ///
 /// ```
-/// use kornia_tensor::{Tensor};
+/// use kornia_tensor::{host_alloc, Tensor};
 /// use kornia_tensor_ops::TensorOps;
 ///
 /// let data1: Vec<u8> = vec![1, 2, 3, 4];
-/// let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1).unwrap();
+/// let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1, host_alloc()).unwrap();
 ///
 /// let data2: Vec<u8> = vec![1, 2, 3, 4];
-/// let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2).unwrap();
+/// let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2, host_alloc()).unwrap();
 ///
 /// let t3 = t1.div(&t2).unwrap();
 /// assert_eq!(t3.as_slice(), vec![1, 1, 1, 1]);
@@ -335,11 +335,11 @@ where
 /// # Example
 ///
 /// ```
-/// use kornia_tensor::{Tensor};
+/// use kornia_tensor::{host_alloc, Tensor};
 /// use kornia_tensor_ops::TensorOps;
 ///
-/// let a = Tensor::<i32, 1>::from_shape_slice([3], &[1, 2, 3]).unwrap();
-/// let b = Tensor::<i32, 1>::from_shape_slice([3], &[4, 5, 6]).unwrap();
+/// let a = Tensor::<i32, 1>::from_shape_slice([3], &[1, 2, 3], host_alloc()).unwrap();
+/// let b = Tensor::<i32, 1>::from_shape_slice([3], &[4, 5, 6], host_alloc()).unwrap();
 /// let result = Tensor::<i32,1>::dot_product1(&a, &b).unwrap();
 /// assert_eq!(result, 32); // 1*4 + 2*5 + 3*6 = 4 + 10 + 18 = 32
 /// ```
@@ -376,11 +376,11 @@ where
 ///
 /// Example:
 /// ```
-/// use kornia_tensor::{Tensor};
+/// use kornia_tensor::{host_alloc, Tensor};
 /// use kornia_tensor_ops::TensorOps;
 ///
-/// let a = Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 2.0, 3.0]).unwrap();
-/// let b = Tensor::<f32, 1>::from_shape_slice([3], &[2.0, 4.0, 6.0]).unwrap();
+/// let a = Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 2.0, 3.0], host_alloc()).unwrap();
+/// let b = Tensor::<f32, 1>::from_shape_slice([3], &[2.0, 4.0, 6.0], host_alloc()).unwrap();
 /// let result = Tensor::cosine_similarity(&a, &b).unwrap();
 /// assert!((result - 1.0).abs() < 1e-6);
 /// ```
@@ -421,11 +421,11 @@ where
 /// # Example
 ///
 /// ```
-/// use kornia_tensor::{Tensor};
+/// use kornia_tensor::{host_alloc, Tensor};
 /// use kornia_tensor_ops::TensorOps;
 ///
-/// let a = Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 2.0, 3.0]).unwrap();
-/// let b = Tensor::<f32, 1>::from_shape_slice([3], &[2.0, 4.0, 6.0]).unwrap();
+/// let a = Tensor::<f32, 1>::from_shape_slice([3], &[1.0, 2.0, 3.0], host_alloc()).unwrap();
+/// let b = Tensor::<f32, 1>::from_shape_slice([3], &[2.0, 4.0, 6.0], host_alloc()).unwrap();
 /// let result = Tensor::<f32,1>::cosine_distance(&a, &b).unwrap();
 /// assert!(result.abs() < 1e-6);
 /// ```
@@ -459,12 +459,12 @@ where
 /// # Examples
 ///
 /// ```
-/// use kornia_tensor::{Tensor};
+/// use kornia_tensor::{host_alloc, Tensor};
 /// use kornia_tensor_ops::ops::TensorOps;
 ///
 /// // Create a tensor
 /// let data = vec![1.0, 2.0, 3.0, 4.0];
-/// let t = Tensor::<f32, 2>::from_shape_vec([2, 2], data).unwrap();
+/// let t = Tensor::<f32, 2>::from_shape_vec([2, 2], data, host_alloc()).unwrap();
 ///
 /// // Use operations through the trait
 /// let scaled = t.mul_scalar(2.0);

--- a/crates/kornia-tensor/Cargo.toml
+++ b/crates/kornia-tensor/Cargo.toml
@@ -14,6 +14,7 @@ publish = true
 harness = false
 name = "bench_view"
 
+
 [dependencies]
 bincode = { workspace = true, optional = true }
 cubecl-cuda = { version = "=0.10.0-pre.4", optional = true }

--- a/crates/kornia-tensor/Cargo.toml
+++ b/crates/kornia-tensor/Cargo.toml
@@ -14,7 +14,6 @@ publish = true
 harness = false
 name = "bench_view"
 
-
 [dependencies]
 bincode = { workspace = true, optional = true }
 cubecl-cuda = { version = "=0.10.0-pre.4", optional = true }

--- a/crates/kornia-tensor/README.md
+++ b/crates/kornia-tensor/README.md
@@ -8,15 +8,31 @@
 
 ## 🚀 Overview
 
-`kornia-tensor` is a lightweight multi-dimensional array library designed specifically for computer vision applications. It serves as the foundational data structure for the Kornia ecosystem, providing efficient memory management, custom allocators, and safe, zero-copy operations.
+`kornia-tensor` is a lightweight multi-dimensional array library designed specifically for computer vision applications. It serves as the foundational data structure for the Kornia ecosystem, providing a runtime memory model (CPU / CUDA / unified), zero-copy interop, and safe operations.
 
 ## 🔑 Key Features
 
 *   **Multi-Dimensional Arrays:** efficient handling of N-dimensional data with arbitrary shapes and strides.
 *   **Zero-Copy Operations:** Supports views and reshaping without copying underlying data.
-*   **Custom Allocators:** Trait-based memory management allowing for different backends (CPU, generic storage).
+*   **Runtime memory model:** one concrete `Tensor<T, N>` spans Host / Device / Unified memory; the allocator is a runtime handle, not a type parameter.
+*   **Ergonomic constructors:** host is the default (no allocator argument); `_in` variants accept a custom allocator handle.
 *   **Type Safety:** Uses const generics for compile-time dimension checking (e.g., `Tensor<f32, 2>`).
 *   **Serialization:** Optional support for `serde` and `bincode` for easy data persistence.
+
+## 🧠 Memory Model
+
+A tensor's location is described at **runtime**, not in its type. `Tensor<T, N>` carries no
+allocator/device type parameter. Its `TensorStorage` holds:
+
+* an `owner: Box<dyn MemoryResource>` — frees the buffer on drop and reports the `MemoryDomain`
+  (`Host`, `Device { id }`, or `Unified { id }`);
+* an `AllocHandle` (`Arc<dyn TensorAllocator>`) — a cheap runtime handle used only when an op
+  allocates (e.g. `zeros`, `cast`); never touched on the element-access hot path;
+* a cached pointer read directly by indexing / `as_slice`.
+
+`as_slice`/`as_mut_slice` panic on a non-host (device) tensor — move data with `to_host` / `to_cuda`
+(feature `cudarc`) first. Because location is runtime, a single `Vec<Tensor<T, N>>` can hold tensors
+from different domains.
 
 ## 📦 Installation
 
@@ -32,12 +48,12 @@ kornia-tensor = "0.1.0"
 Here is a simple example of creating and using a tensor:
 
 ```rust
-use kornia_tensor::{Tensor, CpuAllocator};
+use kornia_tensor::Tensor;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // 1. Create a 2x3 tensor from a vector
+    // 1. Create a 2x3 tensor from a vector (host is the default — no allocator argument)
     let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
-    let tensor = Tensor::<f32, 2, _>::from_shape_vec([2, 3], data, CpuAllocator)?;
+    let tensor = Tensor::<f32, 2>::from_shape_vec([2, 3], data)?;
 
     // 2. Access elements
     if let Some(val) = tensor.get([1, 2]) {
@@ -49,8 +65,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Reshaped dimensions: {:?}", reshaped.shape);
 
     // 4. Create a tensor of zeros
-    let zeros = Tensor::<f32, 3, _>::zeros([2, 2, 3], CpuAllocator);
+    let zeros = Tensor::<f32, 3>::zeros([2, 2, 3]);
     println!("Zeros shape: {:?}", zeros.shape);
+
+    // 5. Custom allocator? use the `_in` variant:
+    //    let t = Tensor::<f32, 2>::from_shape_vec_in([2, 3], data, my_alloc)?;
 
     Ok(())
 }

--- a/crates/kornia-tensor/benches/bench_view.rs
+++ b/crates/kornia-tensor/benches/bench_view.rs
@@ -1,10 +1,10 @@
 use std::hint::black_box;
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use kornia_tensor::{host_alloc, Tensor};
+use kornia_tensor::Tensor;
 
 fn sample_tensor() -> Tensor<u8, 3> {
-    Tensor::from_shape_val([1080, 1080, 3], 0_u8, host_alloc())
+    Tensor::from_shape_val([1080, 1080, 3], 0_u8)
 }
 
 fn bench_image(c: &mut Criterion) {

--- a/crates/kornia-tensor/benches/bench_view.rs
+++ b/crates/kornia-tensor/benches/bench_view.rs
@@ -1,10 +1,10 @@
 use std::hint::black_box;
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use kornia_tensor::{CpuAllocator, Tensor};
+use kornia_tensor::{host_alloc, Tensor};
 
-fn sample_tensor() -> Tensor<u8, 3, CpuAllocator> {
-    Tensor::from_shape_val([1080, 1080, 3], 0_u8, CpuAllocator)
+fn sample_tensor() -> Tensor<u8, 3> {
+    Tensor::from_shape_val([1080, 1080, 3], 0_u8, host_alloc())
 }
 
 fn bench_image(c: &mut Criterion) {

--- a/crates/kornia-tensor/src/allocator.rs
+++ b/crates/kornia-tensor/src/allocator.rs
@@ -124,23 +124,6 @@ impl TensorAllocator for CpuAllocator {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::alloc::Layout;
-
-    /// Verify that `CpuAllocator::allocate` returns a zeroed, host-accessible buffer.
-    #[test]
-    fn cpu_allocate_zeroed_and_aligned() {
-        let l = Layout::from_size_align(64, 1).unwrap();
-        let r = TensorAllocator::allocate(&CpuAllocator, l).unwrap();
-        assert_eq!(r.len_bytes(), 64);
-        assert!(r.domain().is_host_accessible());
-        // Must be zeroed.
-        unsafe { assert!((0..64).all(|i| *r.as_ptr().add(i) == 0)) };
-    }
-}
-
 // ── Runtime allocator handle ──────────────────────────────────────────────────
 
 use std::sync::{Arc, LazyLock};
@@ -160,4 +143,21 @@ static HOST_ALLOC: LazyLock<AllocHandle> = LazyLock::new(|| Arc::new(CpuAllocato
 /// Returns the process-global host allocator handle.
 pub fn host_alloc() -> AllocHandle {
     HOST_ALLOC.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::alloc::Layout;
+
+    /// Verify that `CpuAllocator::allocate` returns a zeroed, host-accessible buffer.
+    #[test]
+    fn cpu_allocate_zeroed_and_aligned() {
+        let l = Layout::from_size_align(64, 1).unwrap();
+        let r = TensorAllocator::allocate(&CpuAllocator, l).unwrap();
+        assert_eq!(r.len_bytes(), 64);
+        assert!(r.domain().is_host_accessible());
+        // Must be zeroed.
+        unsafe { assert!((0..64).all(|i| *r.as_ptr().add(i) == 0)) };
+    }
 }

--- a/crates/kornia-tensor/src/allocator.rs
+++ b/crates/kornia-tensor/src/allocator.rs
@@ -27,9 +27,7 @@ pub enum TensorAllocatorError {
     ///
     /// Returned by allocators that wrap externally-owned buffers (e.g. Arrow, GStreamer);
     /// use `from_borrowed` or a wrapping constructor instead.
-    #[error(
-        "Cannot allocate with this allocator — use from_borrowed or a wrapping constructor"
-    )]
+    #[error("Cannot allocate with this allocator — use from_borrowed or a wrapping constructor")]
     CannotAllocateForeign,
 
     /// Backend allocation failed with an error message.
@@ -54,7 +52,9 @@ pub enum TensorAllocatorError {
 ///
 /// # Thread Safety
 ///
-/// Implementations must be `Clone + Send + Sync` as tensors can be shared across threads.
+/// Implementations must be `Send + Sync` as tensors can be shared across threads. The
+/// allocator is held behind an [`AllocHandle`] (`Arc<dyn TensorAllocator>`), so it is
+/// shared by reference-count, not cloned by value.
 ///
 /// # Examples
 ///
@@ -143,28 +143,21 @@ mod tests {
 
 // ── Runtime allocator handle ──────────────────────────────────────────────────
 
-use std::sync::{Arc, OnceLock};
-
-/// Object-safe subset of [`TensorAllocator`] usable behind a trait-object pointer.
-pub trait AllocDyn: Send + Sync {
-    /// Allocates memory with the given layout.
-    fn allocate(&self, layout: Layout) -> Result<Box<dyn MemoryResource>, TensorAllocatorError>;
-}
-
-/// Every [`TensorAllocator`] is automatically an [`AllocDyn`].
-impl<A: TensorAllocator> AllocDyn for A {
-    #[inline]
-    fn allocate(&self, layout: Layout) -> Result<Box<dyn MemoryResource>, TensorAllocatorError> {
-        TensorAllocator::allocate(self, layout)
-    }
-}
+use std::sync::{Arc, LazyLock};
 
 /// A cheaply-cloneable runtime allocator reference.
-pub type AllocHandle = Arc<dyn AllocDyn>;
+///
+/// `TensorAllocator` is object-safe (one non-generic method, no `Clone` supertrait),
+/// so the handle is a plain `Arc<dyn TensorAllocator>` — no separate object-safe shim.
+pub type AllocHandle = Arc<dyn TensorAllocator>;
 
-static HOST_ALLOC: OnceLock<AllocHandle> = OnceLock::new();
+/// Process-global host allocator handle, initialised once on first use.
+///
+/// `CpuAllocator` is a stateless ZST, so a single shared `Arc` is safe to hand out to
+/// every host tensor; cloning it is one atomic increment with no per-tensor heap box.
+static HOST_ALLOC: LazyLock<AllocHandle> = LazyLock::new(|| Arc::new(CpuAllocator));
 
 /// Returns the process-global host allocator handle.
 pub fn host_alloc() -> AllocHandle {
-    HOST_ALLOC.get_or_init(|| Arc::new(CpuAllocator)).clone()
+    HOST_ALLOC.clone()
 }

--- a/crates/kornia-tensor/src/allocator.rs
+++ b/crates/kornia-tensor/src/allocator.rs
@@ -156,7 +156,7 @@ mod tests {
     #[test]
     fn cpu_allocate_zeroed_and_aligned() {
         let l = Layout::from_size_align(64, 1).unwrap();
-        let r = CpuAllocator.allocate(l).unwrap();
+        let r = TensorAllocator::allocate(&CpuAllocator, l).unwrap();
         assert_eq!(r.len_bytes(), 64);
         assert!(r.domain().is_host_accessible());
         // Must be zeroed.
@@ -167,7 +167,7 @@ mod tests {
     #[test]
     fn foreign_allocate_returns_error() {
         let l = Layout::from_size_align(64, 1).unwrap();
-        match ForeignAllocator.allocate(l) {
+        match TensorAllocator::allocate(&ForeignAllocator, l) {
             Err(TensorAllocatorError::CannotAllocateForeign) => {}
             other => panic!("expected CannotAllocateForeign, got {:?}", other.err()),
         }
@@ -179,4 +179,32 @@ mod tests {
         let _a = CpuAllocator.clone();
         let _b = ForeignAllocator.clone();
     }
+}
+
+// ── Runtime allocator handle ──────────────────────────────────────────────────
+
+use std::sync::{Arc, OnceLock};
+
+/// Object-safe subset of [`TensorAllocator`] usable behind a trait-object pointer.
+pub trait AllocDyn: Send + Sync {
+    /// Allocates memory with the given layout.
+    fn allocate(&self, layout: Layout) -> Result<Box<dyn MemoryResource>, TensorAllocatorError>;
+}
+
+/// Every [`TensorAllocator`] is automatically an [`AllocDyn`].
+impl<A: TensorAllocator> AllocDyn for A {
+    #[inline]
+    fn allocate(&self, layout: Layout) -> Result<Box<dyn MemoryResource>, TensorAllocatorError> {
+        TensorAllocator::allocate(self, layout)
+    }
+}
+
+/// A cheaply-cloneable runtime allocator reference.
+pub type AllocHandle = Arc<dyn AllocDyn>;
+
+static HOST_ALLOC: OnceLock<AllocHandle> = OnceLock::new();
+
+/// Returns the process-global host allocator handle.
+pub fn host_alloc() -> AllocHandle {
+    HOST_ALLOC.get_or_init(|| Arc::new(CpuAllocator)).clone()
 }

--- a/crates/kornia-tensor/src/allocator.rs
+++ b/crates/kornia-tensor/src/allocator.rs
@@ -23,12 +23,12 @@ pub enum TensorAllocatorError {
     #[error("Null pointer")]
     NullPointer,
 
-    /// A foreign allocator was asked to allocate memory, which it never does.
+    /// An allocator was asked to allocate memory but does not support it.
     ///
-    /// [`ForeignAllocator`] exists only as a type tag for externally-owned buffers;
-    /// calling `allocate` on it is always an error.
+    /// Returned by allocators that wrap externally-owned buffers (e.g. Arrow, GStreamer);
+    /// use `from_borrowed` or a wrapping constructor instead.
     #[error(
-        "Cannot allocate with a foreign allocator — use from_borrowed or a wrapping constructor"
+        "Cannot allocate with this allocator — use from_borrowed or a wrapping constructor"
     )]
     CannotAllocateForeign,
 
@@ -70,7 +70,7 @@ pub enum TensorAllocatorError {
 /// assert_eq!(resource.len_bytes(), 64);
 /// assert!(resource.domain().is_host_accessible());
 /// ```
-pub trait TensorAllocator: Clone + Send + Sync {
+pub trait TensorAllocator: Send + Sync {
     /// Allocates memory for a tensor with the given layout and returns an owning handle.
     ///
     /// # Arguments
@@ -84,7 +84,7 @@ pub trait TensorAllocator: Clone + Send + Sync {
     /// # Errors
     ///
     /// - [`TensorAllocatorError::NullPointer`] if the allocator returns a null pointer.
-    /// - [`TensorAllocatorError::CannotAllocateForeign`] if called on [`ForeignAllocator`].
+    /// - [`TensorAllocatorError::CannotAllocateForeign`] if the allocator wraps foreign memory.
     fn allocate(&self, layout: Layout) -> Result<Box<dyn MemoryResource>, TensorAllocatorError>;
 }
 
@@ -124,29 +124,6 @@ impl TensorAllocator for CpuAllocator {
     }
 }
 
-/// A no-op allocator for foreign (externally managed) memory.
-///
-/// Used as a type tag when wrapping memory that is owned by an external system
-/// (e.g. numpy arrays, GStreamer buffers, or other external allocations). Calling [`allocate`](TensorAllocator::allocate)
-/// on `ForeignAllocator` always returns [`TensorAllocatorError::CannotAllocateForeign`];
-/// use `from_borrowed` or a wrapping constructor instead.
-#[derive(Clone)]
-pub struct ForeignAllocator;
-
-// SAFETY: ForeignAllocator is a zero-size unit struct with no interior mutability.
-unsafe impl Send for ForeignAllocator {}
-unsafe impl Sync for ForeignAllocator {}
-
-impl TensorAllocator for ForeignAllocator {
-    /// Always returns [`TensorAllocatorError::CannotAllocateForeign`].
-    ///
-    /// Foreign allocators never allocate — they are pure type tags for externally
-    /// owned buffers.
-    fn allocate(&self, _layout: Layout) -> Result<Box<dyn MemoryResource>, TensorAllocatorError> {
-        Err(TensorAllocatorError::CannotAllocateForeign)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -161,23 +138,6 @@ mod tests {
         assert!(r.domain().is_host_accessible());
         // Must be zeroed.
         unsafe { assert!((0..64).all(|i| *r.as_ptr().add(i) == 0)) };
-    }
-
-    /// `ForeignAllocator::allocate` must always return `CannotAllocateForeign`.
-    #[test]
-    fn foreign_allocate_returns_error() {
-        let l = Layout::from_size_align(64, 1).unwrap();
-        match TensorAllocator::allocate(&ForeignAllocator, l) {
-            Err(TensorAllocatorError::CannotAllocateForeign) => {}
-            other => panic!("expected CannotAllocateForeign, got {:?}", other.err()),
-        }
-    }
-
-    /// Allocator types must be `Clone`.
-    #[test]
-    fn allocators_are_clone() {
-        let _a = CpuAllocator.clone();
-        let _b = ForeignAllocator.clone();
     }
 }
 

--- a/crates/kornia-tensor/src/backend/cubecl.rs
+++ b/crates/kornia-tensor/src/backend/cubecl.rs
@@ -15,9 +15,12 @@ compile_error!(
 );
 
 use std::alloc::Layout;
+use std::sync::Arc;
 
 use cubecl_core::client::ComputeClient;
 use cubecl_core::Runtime;
+
+use crate::allocator::AllocHandle;
 
 use super::{Backend, GpuAllocator};
 
@@ -87,13 +90,13 @@ impl<R: Runtime> Backend for CubeclBackend<R> {
     }
 }
 
-/// Create a [`GpuAllocator`] backed by the default CUDA device.
+/// Create an [`AllocHandle`] backed by the default CUDA device.
 ///
-/// Hides the cubecl runtime types from callers; use this instead of constructing
-/// [`CubeclBackend`] and [`GpuAllocator`] manually in tests and application code.
-pub fn new_cuda_allocator() -> GpuAllocator<CubeclBackend<cubecl_cuda::CudaRuntime>> {
+/// Wraps [`GpuAllocator`] in an `Arc` so it can be used directly as a `Tensor<T, N>`
+/// allocator without exposing the cubecl runtime types to callers.
+pub fn new_cuda_allocator() -> AllocHandle {
     use cubecl_core::Runtime;
     let device = <cubecl_cuda::CudaRuntime as Runtime>::Device::default();
     let client = cubecl_cuda::CudaRuntime::client(&device);
-    GpuAllocator::new(CubeclBackend::new(client))
+    Arc::new(GpuAllocator::new(CubeclBackend::new(client))) as AllocHandle
 }

--- a/crates/kornia-tensor/src/backend/mod.rs
+++ b/crates/kornia-tensor/src/backend/mod.rs
@@ -2,7 +2,8 @@
 //!
 //! This module defines the [`Backend`] trait and the [`GpuAllocator`] wrapper that bridges
 //! any `Backend` impl into the existing [`TensorAllocator`](crate::allocator::TensorAllocator)
-//! interface, letting `Tensor<T, N, GpuAllocator<B>>` work without changes to the core type.
+//! interface. `GpuAllocator<B>` implements `TensorAllocator` and can be wrapped in an
+//! [`AllocHandle`](crate::allocator::AllocHandle) (`Arc<dyn AllocDyn>`) for use with `Tensor<T, N>`.
 //!
 //! # Swap-in story
 //!

--- a/crates/kornia-tensor/src/backend/mod.rs
+++ b/crates/kornia-tensor/src/backend/mod.rs
@@ -3,7 +3,7 @@
 //! This module defines the [`Backend`] trait and the [`GpuAllocator`] wrapper that bridges
 //! any `Backend` impl into the existing [`TensorAllocator`](crate::allocator::TensorAllocator)
 //! interface. `GpuAllocator<B>` implements `TensorAllocator` and can be wrapped in an
-//! [`AllocHandle`](crate::allocator::AllocHandle) (`Arc<dyn AllocDyn>`) for use with `Tensor<T, N>`.
+//! [`AllocHandle`](crate::allocator::AllocHandle) (`Arc<dyn TensorAllocator>`) for use with `Tensor<T, N>`.
 //!
 //! # Swap-in story
 //!

--- a/crates/kornia-tensor/src/bincode.rs
+++ b/crates/kornia-tensor/src/bincode.rs
@@ -40,7 +40,7 @@ mod tests {
 
     #[test]
     fn test_bincode() -> Result<(), Box<dyn std::error::Error>> {
-        let tensor = Tensor::<u8, 2>::from_shape_vec([2, 3], vec![1, 2, 3, 4, 5, 6], host_alloc())?;
+        let tensor = Tensor::<u8, 2>::from_shape_vec([2, 3], vec![1, 2, 3, 4, 5, 6])?;
         let mut serialized = vec![0u8; 100];
         let config = bincode::config::standard();
         let length = bincode::encode_into_slice(&tensor, &mut serialized, config)?;

--- a/crates/kornia-tensor/src/bincode.rs
+++ b/crates/kornia-tensor/src/bincode.rs
@@ -1,10 +1,6 @@
-use crate::{
-    allocator::{CpuAllocator, TensorAllocator},
-    storage::TensorStorage,
-    Tensor,
-};
+use crate::{allocator::host_alloc, storage::TensorStorage, Tensor};
 
-impl<T, const N: usize, A: TensorAllocator + 'static> bincode::enc::Encode for Tensor<T, N, A>
+impl<T, const N: usize> bincode::enc::Encode for Tensor<T, N>
 where
     T: bincode::enc::Encode,
 {
@@ -19,7 +15,7 @@ where
     }
 }
 
-impl<T, const N: usize, C> bincode::de::Decode<C> for Tensor<T, N, CpuAllocator>
+impl<T, const N: usize, C> bincode::de::Decode<C> for Tensor<T, N>
 where
     T: bincode::de::Decode<C>,
 {
@@ -32,7 +28,7 @@ where
         Ok(Self {
             shape,
             strides,
-            storage: TensorStorage::from_vec(data, CpuAllocator),
+            storage: TensorStorage::from_vec(data, host_alloc()),
         })
     }
 }
@@ -40,18 +36,15 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::allocator::host_alloc;
 
     #[test]
     fn test_bincode() -> Result<(), Box<dyn std::error::Error>> {
-        let tensor = Tensor::<u8, 2, CpuAllocator>::from_shape_vec(
-            [2, 3],
-            vec![1, 2, 3, 4, 5, 6],
-            CpuAllocator,
-        )?;
+        let tensor = Tensor::<u8, 2>::from_shape_vec([2, 3], vec![1, 2, 3, 4, 5, 6], host_alloc())?;
         let mut serialized = vec![0u8; 100];
         let config = bincode::config::standard();
         let length = bincode::encode_into_slice(&tensor, &mut serialized, config)?;
-        let deserialized: (Tensor<u8, 2, CpuAllocator>, usize) =
+        let deserialized: (Tensor<u8, 2>, usize) =
             bincode::decode_from_slice(&serialized[..length], config)?;
         assert_eq!(tensor.as_slice(), deserialized.0.as_slice());
         Ok(())

--- a/crates/kornia-tensor/src/bincode.rs
+++ b/crates/kornia-tensor/src/bincode.rs
@@ -36,7 +36,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::allocator::host_alloc;
 
     #[test]
     fn test_bincode() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/kornia-tensor/src/cuda.rs
+++ b/crates/kornia-tensor/src/cuda.rs
@@ -643,7 +643,7 @@ mod tests {
         let ctx = CudaContext::new(0).unwrap();
         let stream = ctx.default_stream();
 
-        let host = Tensor::<u8, 1>::from_shape_vec([4], vec![1, 2, 3, 4], host_alloc()).unwrap();
+        let host = Tensor::<u8, 1>::from_shape_vec([4], vec![1, 2, 3, 4]).unwrap();
 
         let dev = host.to_cuda(&stream).unwrap();
         assert!(
@@ -673,7 +673,7 @@ mod tests {
         let stream = ctx.default_stream();
 
         // Device tensor backed by CudaResource<u8> (via to_cuda).
-        let host = Tensor::<u8, 1>::from_shape_vec([4], vec![1, 2, 3, 4], host_alloc()).unwrap();
+        let host = Tensor::<u8, 1>::from_shape_vec([4], vec![1, 2, 3, 4]).unwrap();
         let mut dev = host.to_cuda(&stream).unwrap();
 
         // Some: same element type u8.
@@ -709,7 +709,7 @@ mod tests {
     fn as_slice_on_device_panics() {
         let ctx = CudaContext::new(0).unwrap();
         let stream = ctx.default_stream();
-        let host = Tensor::<u8, 1>::from_shape_vec([4], vec![1, 2, 3, 4], host_alloc()).unwrap();
+        let host = Tensor::<u8, 1>::from_shape_vec([4], vec![1, 2, 3, 4]).unwrap();
         let dev = host.to_cuda(&stream).unwrap();
         let _ = dev.as_slice(); // must panic: Device is not host-accessible
     }
@@ -721,7 +721,7 @@ mod tests {
         let ctx = CudaContext::new(0).unwrap();
         let stream = ctx.default_stream();
 
-        let host = Tensor::<u8, 1>::from_shape_vec([8], vec![10u8; 8], host_alloc()).unwrap();
+        let host = Tensor::<u8, 1>::from_shape_vec([8], vec![10u8; 8]).unwrap();
         let dev = host.to_cuda(&stream).unwrap();
         let slice = dev.into_cudaslice().ok().expect("must be cuda-backed");
         // The slice now owns the device memory.  Drop it — cudarc frees exactly once.

--- a/crates/kornia-tensor/src/cuda.rs
+++ b/crates/kornia-tensor/src/cuda.rs
@@ -56,7 +56,7 @@ use cudarc::driver::{
 use cudarc::nvrtc::{compile_ptx_with_opts, CompileOptions};
 
 use crate::{
-    allocator::{CpuAllocator, TensorAllocator, TensorAllocatorError},
+    allocator::{host_alloc, AllocHandle, TensorAllocator, TensorAllocatorError},
     resource::{MemoryDomain, MemoryResource},
     storage::TensorStorage,
     tensor::{get_strides_from_shape, Tensor, TensorError},
@@ -336,15 +336,11 @@ impl<'a> CudaLaunchBuilder<'a> {
 pub fn zeros_cuda<T, const N: usize>(
     shape: [usize; N],
     stream: &Arc<CudaStream>,
-) -> Result<Tensor<T, N, CudaAllocator>, CudaError>
+) -> Result<Tensor<T, N>, CudaError>
 where
     T: DeviceRepr + ValidAsZeroBits + 'static,
 {
     let ctx = stream.context().clone();
-    let alloc = CudaAllocator {
-        ctx: ctx.clone(),
-        stream: stream.clone(),
-    };
 
     let numel: usize = shape.iter().product();
     let n_bytes = numel * std::mem::size_of::<T>();
@@ -363,6 +359,10 @@ where
     };
 
     let resource = CudaResource::<u8> { slice, ptr, id };
+    let alloc: AllocHandle = Arc::new(CudaAllocator {
+        ctx: ctx.clone(),
+        stream: stream.clone(),
+    });
 
     // SAFETY: `ptr` is the device pointer inside `resource`; `n_bytes` is the
     // allocation size; `resource` is the sole owner of that device memory.
@@ -377,7 +377,7 @@ where
 
 // ── Helper: build a TensorStorage from a CudaResource ─────────────────────────
 
-/// Build a `TensorStorage<T, A>` that owns the given [`CudaResource<R>`].
+/// Build a `TensorStorage<T>` that owns the given [`CudaResource<R>`].
 ///
 /// `R` is the element type of the wrapped `CudaSlice` (e.g. `u8` from the allocator,
 /// or `T` from `from_cudaslice`); `T` is the tensor's element type.
@@ -387,15 +387,14 @@ where
 /// `ptr` must be the device pointer inside `resource` (cached from
 /// `resource.slice.device_ptr(stream)`).  It must be valid for `len_bytes` bytes on
 /// the device.  The caller guarantees `resource` is the sole owner of that allocation.
-unsafe fn storage_from_cuda_resource<T, R, A>(
+unsafe fn storage_from_cuda_resource<T, R>(
     resource: CudaResource<R>,
     ptr: *mut T,
     len_bytes: usize,
-    alloc: A,
-) -> TensorStorage<T, A>
+    alloc: AllocHandle,
+) -> TensorStorage<T>
 where
     R: 'static,
-    A: TensorAllocator,
 {
     let owner: Box<dyn MemoryResource> = Box::new(resource);
     let nn_ptr = NonNull::new_unchecked(ptr);
@@ -410,7 +409,7 @@ where
 
 // ── Tensor: from_cudaslice / as_cudaslice / into_cudaslice ────────────────────
 
-impl<T, const N: usize> Tensor<T, N, CudaAllocator>
+impl<T, const N: usize> Tensor<T, N>
 where
     T: DeviceRepr + ValidAsZeroBits + 'static,
 {
@@ -454,7 +453,7 @@ where
             // _sync drops here, releasing the borrow on `slice`
         };
 
-        let alloc = CudaAllocator { ctx, stream };
+        let alloc: AllocHandle = Arc::new(CudaAllocator { ctx, stream });
         // Move the original CudaSlice<T> in, unchanged — this is the aliasing wrap.
         let resource = CudaResource::<T> { slice, ptr, id };
 
@@ -526,7 +525,7 @@ where
         // Read `owner` out of the ManuallyDrop without running TensorStorage's Drop.
         // SAFETY: We are the sole owner; ManuallyDrop prevents double-drop of the storage.
         let owner: Box<dyn MemoryResource> = unsafe { std::ptr::read(&md_storage.owner) };
-        // Drop the allocator field explicitly (Arc fields drop normally).
+        // Drop the allocator handle (Arc) explicitly.
         let _alloc = unsafe { std::ptr::read(&md_storage.alloc) };
         // ptr/len/marker are Copy/ZST — nothing else to drop.
 
@@ -548,20 +547,16 @@ where
 
 // ── Tensor::to_cuda (host → device) ──────────────────────────────────────────
 
-impl<T, const N: usize, A: TensorAllocator> Tensor<T, N, A>
+impl<T, const N: usize> Tensor<T, N>
 where
     T: DeviceRepr + ValidAsZeroBits + Clone + Default + 'static,
-    A: 'static,
 {
     /// Copy this host tensor to a new device-backed tensor on `stream`.
     ///
     /// # Errors
     ///
     /// Returns [`CudaError::Driver`] on CUDA failure.
-    pub fn to_cuda(
-        &self,
-        stream: &Arc<CudaStream>,
-    ) -> Result<Tensor<T, N, CudaAllocator>, CudaError> {
+    pub fn to_cuda(&self, stream: &Arc<CudaStream>) -> Result<Tensor<T, N>, CudaError> {
         let src_slice = self.as_slice(); // panics (correctly) if non-host-accessible
 
         let ctx = stream.context().clone();
@@ -579,10 +574,10 @@ where
             cu_ptr as *mut u8
             // _sync drops here
         };
-        let alloc = CudaAllocator {
+        let alloc: AllocHandle = Arc::new(CudaAllocator {
             ctx,
             stream: stream.clone(),
-        };
+        });
         // Store as CudaResource<T> so as_cudaslice::<T>() also works on to_cuda results.
         let resource = CudaResource::<T> {
             slice: dev_slice,
@@ -598,14 +593,7 @@ where
             strides,
         })
     }
-}
 
-// ── Tensor::to_host (device → host) ──────────────────────────────────────────
-
-impl<T, const N: usize> Tensor<T, N, CudaAllocator>
-where
-    T: DeviceRepr + ValidAsZeroBits + Clone + Default + 'static,
-{
     /// Copy this device tensor to a new host-backed tensor.
     ///
     /// Synchronizes the stream before returning so the host data is valid.
@@ -614,10 +602,7 @@ where
     ///
     /// Returns [`CudaError::Driver`] on CUDA failure or [`CudaError::NotCudaBacked`]
     /// if the storage owner is not a [`CudaResource<T>`].
-    pub fn to_host(
-        &self,
-        stream: &Arc<CudaStream>,
-    ) -> Result<Tensor<T, N, CpuAllocator>, CudaError> {
+    pub fn to_host(&self, stream: &Arc<CudaStream>) -> Result<Tensor<T, N>, CudaError> {
         let cuda_res = self
             .storage
             .owner
@@ -633,7 +618,7 @@ where
             .synchronize()
             .map_err(|e| CudaError::Driver(e.to_string()))?;
 
-        let storage = TensorStorage::from_vec(host_data, CpuAllocator);
+        let storage = TensorStorage::from_vec(host_data, host_alloc());
         let strides = get_strides_from_shape(self.shape);
         Ok(Tensor {
             storage,
@@ -648,7 +633,8 @@ where
 #[cfg(all(test, feature = "cudarc"))]
 mod tests {
     use super::*;
-    use crate::{CpuAllocator, Tensor};
+    use crate::allocator::host_alloc;
+    use crate::Tensor;
 
     /// Device round-trip: host → GPU → host, bytes must match exactly.
     /// Also verifies domain is Device and as_cudaslice is Some.
@@ -657,9 +643,7 @@ mod tests {
         let ctx = CudaContext::new(0).unwrap();
         let stream = ctx.default_stream();
 
-        let host =
-            Tensor::<u8, 1, CpuAllocator>::from_shape_vec([4], vec![1, 2, 3, 4], CpuAllocator)
-                .unwrap();
+        let host = Tensor::<u8, 1>::from_shape_vec([4], vec![1, 2, 3, 4], host_alloc()).unwrap();
 
         let dev = host.to_cuda(&stream).unwrap();
         assert!(
@@ -689,9 +673,7 @@ mod tests {
         let stream = ctx.default_stream();
 
         // Device tensor backed by CudaResource<u8> (via to_cuda).
-        let host =
-            Tensor::<u8, 1, CpuAllocator>::from_shape_vec([4], vec![1, 2, 3, 4], CpuAllocator)
-                .unwrap();
+        let host = Tensor::<u8, 1>::from_shape_vec([4], vec![1, 2, 3, 4], host_alloc()).unwrap();
         let mut dev = host.to_cuda(&stream).unwrap();
 
         // Some: same element type u8.
@@ -714,7 +696,7 @@ mod tests {
 
         // None branch: `zeros_cuda` always stores a `CudaResource<u8>`, so an i16 device
         // tensor's owner does NOT downcast to `CudaResource<i16>` — the mutable query is None.
-        let mut dev_i16: Tensor<i16, 1, CudaAllocator> = zeros_cuda([4], &stream).unwrap();
+        let mut dev_i16: Tensor<i16, 1> = zeros_cuda([4], &stream).unwrap();
         assert!(
             dev_i16.as_cudaslice_mut().is_none(),
             "zeros_cuda stores CudaResource<u8>; querying as CudaSlice<i16> must be None"
@@ -727,9 +709,7 @@ mod tests {
     fn as_slice_on_device_panics() {
         let ctx = CudaContext::new(0).unwrap();
         let stream = ctx.default_stream();
-        let host =
-            Tensor::<u8, 1, CpuAllocator>::from_shape_vec([4], vec![1, 2, 3, 4], CpuAllocator)
-                .unwrap();
+        let host = Tensor::<u8, 1>::from_shape_vec([4], vec![1, 2, 3, 4], host_alloc()).unwrap();
         let dev = host.to_cuda(&stream).unwrap();
         let _ = dev.as_slice(); // must panic: Device is not host-accessible
     }
@@ -741,8 +721,7 @@ mod tests {
         let ctx = CudaContext::new(0).unwrap();
         let stream = ctx.default_stream();
 
-        let host = Tensor::<u8, 1, CpuAllocator>::from_shape_vec([8], vec![10u8; 8], CpuAllocator)
-            .unwrap();
+        let host = Tensor::<u8, 1>::from_shape_vec([8], vec![10u8; 8], host_alloc()).unwrap();
         let dev = host.to_cuda(&stream).unwrap();
         let slice = dev.into_cudaslice().ok().expect("must be cuda-backed");
         // The slice now owns the device memory.  Drop it — cudarc frees exactly once.
@@ -761,8 +740,7 @@ mod tests {
 
         // Allocate on device directly via cudarc.
         let dev_slice: CudaSlice<u8> = stream.alloc_zeros::<u8>(16).unwrap();
-        let tensor =
-            Tensor::<u8, 1, CudaAllocator>::from_cudaslice(dev_slice, [16], stream.clone());
+        let tensor = Tensor::<u8, 1>::from_cudaslice(dev_slice, [16], stream.clone());
         // Drop tensor → TensorStorage drops → Box<CudaResource> drops → CudaSlice::drop
         // → cudarc frees the device memory exactly once.
         drop(tensor);
@@ -844,8 +822,7 @@ mod tests {
             cu_ptr as usize
         };
 
-        let tensor =
-            Tensor::<u8, 1, CudaAllocator>::from_cudaslice(dev_slice, [32], stream.clone());
+        let tensor = Tensor::<u8, 1>::from_cudaslice(dev_slice, [32], stream.clone());
 
         // The tensor's cached device pointer must equal the original allocation's pointer
         // → same device memory → aliased, not copied.

--- a/crates/kornia-tensor/src/dlpack.rs
+++ b/crates/kornia-tensor/src/dlpack.rs
@@ -13,10 +13,9 @@ use dlpack_rs::{
 };
 
 use crate::{
-    allocator::ForeignAllocator,
+    allocator::host_alloc,
     storage::MemoryDomain,
     tensor::{Tensor, TensorError},
-    TensorAllocator,
 };
 
 // ── DlpackElem trait ─────────────────────────────────────────────────────────
@@ -71,16 +70,18 @@ impl_dlpack_elem!(f64, 2u32, 64, 1);
 /// # Panics
 ///
 /// Panics if `T` does not implement [`DlpackElem`] (compile-time, via trait bound).
-pub fn tensor_to_dlpack<T, const N: usize, A>(t: Tensor<T, N, A>) -> *mut DLManagedTensor
+pub fn tensor_to_dlpack<T, const N: usize>(t: Tensor<T, N>) -> *mut DLManagedTensor
 where
     T: DlpackElem + 'static + Send,
-    A: TensorAllocator + Send + 'static,
 {
     let dtype = T::dl_dtype();
     let device = match t.storage.domain() {
         MemoryDomain::Host => safe::cpu_device(),
         MemoryDomain::Device { id } => safe::cuda_device(id),
-        MemoryDomain::Unified { id } => safe::cuda_device(id),
+        MemoryDomain::Unified { id } => dlpack_rs::ffi::DLDevice {
+            device_type: dlpack_rs::ffi::DLDeviceType::kDLCUDAManaged,
+            device_id: id,
+        },
     };
     let data_ptr = t.storage.as_ptr() as *mut std::ffi::c_void;
     let shape: Vec<i64> = t.shape.iter().map(|&s| s as i64).collect();
@@ -172,7 +173,7 @@ impl std::error::Error for DlpackError {}
 pub unsafe fn tensor_from_dlpack_raw<T, const N: usize>(
     mt: *mut DLManagedTensor,
     keepalive: Arc<dyn core::any::Any + Send + Sync>,
-) -> Result<Tensor<T, N, ForeignAllocator>, DlpackError>
+) -> Result<Tensor<T, N>, DlpackError>
 where
     T: DlpackElem + Clone,
 {
@@ -256,7 +257,7 @@ where
         crate::storage::TensorStorage::from_borrowed(
             data_ptr,
             len_bytes,
-            ForeignAllocator,
+            host_alloc(),
             domain,
             keepalive,
         )
@@ -273,9 +274,17 @@ where
 
 /// Maps a `DLDevice` to `(MemoryDomain, device_id)`.
 fn map_dl_device(device: DLDevice) -> (MemoryDomain, i32) {
-    use dlpack_rs::ffi::K_DL_CPU;
+    use dlpack_rs::ffi::{DLDeviceType, K_DL_CPU};
     if device.device_type == K_DL_CPU {
         (MemoryDomain::Host, 0)
+    } else if device.device_type == DLDeviceType::kDLCUDAManaged {
+        // kDLCUDAManaged -> Unified (CUDA managed / unified memory)
+        (
+            MemoryDomain::Unified {
+                id: device.device_id,
+            },
+            device.device_id,
+        )
     } else {
         // kDLCUDA and any other device type -> Device domain.
         (
@@ -317,10 +326,10 @@ mod tests {
         let keep: Arc<dyn core::any::Any + Send + Sync> = Arc::new(DropCounter(counter.clone()));
         let tensor = unsafe {
             use crate::storage::TensorStorage;
-            let storage = TensorStorage::<f32, crate::allocator::ForeignAllocator>::from_borrowed(
+            let storage = TensorStorage::<f32>::from_borrowed(
                 data.as_ptr(),
                 data.len() * std::mem::size_of::<f32>(),
-                crate::allocator::ForeignAllocator,
+                crate::allocator::host_alloc(),
                 crate::storage::MemoryDomain::Host,
                 keep,
             );

--- a/crates/kornia-tensor/src/lib.rs
+++ b/crates/kornia-tensor/src/lib.rs
@@ -27,8 +27,9 @@
 //!   - [`Device { id }`](resource::MemoryDomain::Device) — CUDA device memory,
 //!   - [`Unified { id }`](resource::MemoryDomain::Unified) — CUDA managed/unified memory;
 //! - an [`AllocHandle`] (`Arc<dyn `[`TensorAllocator`]`>`) — a cheap, reference-counted runtime
-//!   handle used **only** when an op needs to allocate (e.g. `zeros`, `cast`); it is propagated to
-//!   derived tensors, never consulted on the hot path;
+//!   handle propagated to derived tensors (`cast`, `map`, `as_contiguous`, …). It is an **advisory
+//!   tag**: host buffers are currently allocated through the global allocator (via `Vec`), so the
+//!   handle is not yet consulted to allocate host memory; it is never touched on the hot path;
 //! - a cached `NonNull<T>` pointer read directly by element access — so domain/handle add **zero**
 //!   overhead to `as_ptr`/`as_slice`/indexing.
 //!
@@ -52,10 +53,12 @@
 //! let b = Tensor::<f32, 2>::from_shape_vec_in([2, 3], vec![0.0; 6], host_alloc()).unwrap();
 //! ```
 //!
-//! Every host-default constructor has an `_in` counterpart taking an [`AllocHandle`]:
+//! Every host-default constructor has an `_in` counterpart taking an explicit [`AllocHandle`]
+//! (which it threads onto the storage as the advisory tag described above — the buffer itself is
+//! still allocated through the global allocator):
 //! `from_shape_vec`/`_in`, `from_shape_slice`/`_in`, `from_shape_val`/`_in`, `from_shape_fn`/`_in`,
 //! `zeros`/`_in`. Low-level / non-host constructors always take an explicit handle or resource:
-//! [`from_vec`](storage::TensorStorage::from_vec), `from_resource`, `from_borrowed`, `from_raw_parts`.
+//! [`from_vec`](storage::TensorStorage::from_vec), `from_raw_host`, `from_borrowed`, `from_raw_parts`.
 //! Device tensors are created through the stream-based CUDA API rather than a handle —
 //! `to_cuda`, `zeros_cuda`, `from_cudaslice` (feature `cudarc`) — which build the device
 //! allocator handle internally from the supplied `CudaStream`.

--- a/crates/kornia-tensor/src/lib.rs
+++ b/crates/kornia-tensor/src/lib.rs
@@ -158,9 +158,7 @@ pub mod tensor;
 /// into existing tensor data.
 pub mod view;
 
-pub use crate::allocator::{
-    host_alloc, AllocDyn, AllocHandle, CpuAllocator, TensorAllocator,
-};
+pub use crate::allocator::{host_alloc, AllocHandle, CpuAllocator, TensorAllocator};
 pub use crate::resource::{ForeignResource, HostResource, MemoryDomain, MemoryResource};
 // Keep backward-compatible re-export: `use kornia_tensor::storage::MemoryDomain` still resolves
 // because storage.rs now re-exports from resource.

--- a/crates/kornia-tensor/src/lib.rs
+++ b/crates/kornia-tensor/src/lib.rs
@@ -159,7 +159,7 @@ pub mod tensor;
 pub mod view;
 
 pub use crate::allocator::{
-    host_alloc, AllocDyn, AllocHandle, CpuAllocator, ForeignAllocator, TensorAllocator,
+    host_alloc, AllocDyn, AllocHandle, CpuAllocator, TensorAllocator,
 };
 pub use crate::resource::{ForeignResource, HostResource, MemoryDomain, MemoryResource};
 // Keep backward-compatible re-export: `use kornia_tensor::storage::MemoryDomain` still resolves

--- a/crates/kornia-tensor/src/lib.rs
+++ b/crates/kornia-tensor/src/lib.rs
@@ -29,11 +29,11 @@
 //! Creating and manipulating tensors:
 //!
 //! ```rust
-//! use kornia_tensor::{Tensor, CpuAllocator};
+//! use kornia_tensor::{Tensor, host_alloc};
 //!
 //! // Create a 2x3 tensor from a vector
 //! let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
-//! let tensor = Tensor::<f32, 2, _>::from_shape_vec([2, 3], data, CpuAllocator).unwrap();
+//! let tensor = Tensor::<f32, 2>::from_shape_vec([2, 3], data, host_alloc()).unwrap();
 //!
 //! // Access elements
 //! assert_eq!(tensor.get([0, 0]), Some(&1.0));
@@ -47,14 +47,14 @@
 //! Using tensor operations:
 //!
 //! ```rust
-//! use kornia_tensor::{Tensor, CpuAllocator};
+//! use kornia_tensor::{Tensor, host_alloc};
 //!
 //! // Create tensors with specific values
-//! let zeros = Tensor::<f32, 2, _>::zeros([3, 3], CpuAllocator);
-//! let ones = Tensor::<f32, 2, _>::from_shape_val([3, 3], 1.0, CpuAllocator);
+//! let zeros = Tensor::<f32, 2>::zeros([3, 3], host_alloc());
+//! let ones = Tensor::<f32, 2>::from_shape_val([3, 3], 1.0, host_alloc());
 //!
 //! // Generate data with a function
-//! let identity = Tensor::<f32, 2, _>::from_shape_fn([3, 3], CpuAllocator, |[i, j]| {
+//! let identity = Tensor::<f32, 2>::from_shape_fn([3, 3], host_alloc(), |[i, j]| {
 //!     if i == j { 1.0 } else { 0.0 }
 //! });
 //!
@@ -65,10 +65,10 @@
 //! Working with views:
 //!
 //! ```rust
-//! use kornia_tensor::{Tensor, CpuAllocator};
+//! use kornia_tensor::{Tensor, host_alloc};
 //!
 //! let data = vec![1, 2, 3, 4, 5, 6];
-//! let tensor = Tensor::<i32, 1, _>::from_shape_vec([6], data, CpuAllocator).unwrap();
+//! let tensor = Tensor::<i32, 1>::from_shape_vec([6], data, host_alloc()).unwrap();
 //!
 //! // Create a reshaped view without copying data
 //! let view = tensor.reshape([2, 3]).unwrap();
@@ -85,7 +85,7 @@
 //! - [`Tensor2`]: Two-dimensional tensor (matrix)
 //! - [`Tensor3`]: Three-dimensional tensor
 //! - [`Tensor4`]: Four-dimensional tensor
-//! - [`CpuTensor2`]: Two-dimensional CPU tensor (most common)
+//! - [`CpuTensor2`]: Two-dimensional tensor backed by CPU memory
 
 /// Allocator module containing memory management utilities.
 ///
@@ -158,28 +158,28 @@ pub mod tensor;
 /// into existing tensor data.
 pub mod view;
 
-pub use crate::allocator::{CpuAllocator, ForeignAllocator, TensorAllocator};
+pub use crate::allocator::{
+    host_alloc, AllocDyn, AllocHandle, CpuAllocator, ForeignAllocator, TensorAllocator,
+};
 pub use crate::resource::{ForeignResource, HostResource, MemoryDomain, MemoryResource};
 // Keep backward-compatible re-export: `use kornia_tensor::storage::MemoryDomain` still resolves
 // because storage.rs now re-exports from resource.
 pub(crate) use crate::tensor::get_strides_from_shape;
 pub use crate::tensor::{Tensor, TensorError};
 
-// Note: Rust does not propagate type-parameter defaults through type aliases, so these
-// aliases require an explicit allocator argument. Use `Tensor<T, N>` directly to rely
-// on the `A = CpuAllocator` default, or use the `CpuTensor2` / similar helpers below.
+// Note: type aliases no longer carry an allocator parameter — the allocator is runtime.
 
 /// Type alias for a 1-dimensional tensor.
-pub type Tensor1<T, A> = Tensor<T, 1, A>;
+pub type Tensor1<T> = Tensor<T, 1>;
 
 /// Type alias for a 2-dimensional tensor.
-pub type Tensor2<T, A> = Tensor<T, 2, A>;
+pub type Tensor2<T> = Tensor<T, 2>;
 
 /// Type alias for a 3-dimensional tensor.
-pub type Tensor3<T, A> = Tensor<T, 3, A>;
+pub type Tensor3<T> = Tensor<T, 3>;
 
 /// Type alias for a 4-dimensional tensor.
-pub type Tensor4<T, A> = Tensor<T, 4, A>;
+pub type Tensor4<T> = Tensor<T, 4>;
 
-/// Type alias for a 2-dimensional tensor with CPU allocator.
-pub type CpuTensor2<T> = Tensor2<T, CpuAllocator>;
+/// Type alias for a 2-dimensional tensor backed by CPU memory.
+pub type CpuTensor2<T> = Tensor2<T>;

--- a/crates/kornia-tensor/src/lib.rs
+++ b/crates/kornia-tensor/src/lib.rs
@@ -29,11 +29,11 @@
 //! Creating and manipulating tensors:
 //!
 //! ```rust
-//! use kornia_tensor::{Tensor, host_alloc};
+//! use kornia_tensor::Tensor;
 //!
 //! // Create a 2x3 tensor from a vector
 //! let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
-//! let tensor = Tensor::<f32, 2>::from_shape_vec([2, 3], data, host_alloc()).unwrap();
+//! let tensor = Tensor::<f32, 2>::from_shape_vec([2, 3], data).unwrap();
 //!
 //! // Access elements
 //! assert_eq!(tensor.get([0, 0]), Some(&1.0));
@@ -47,14 +47,14 @@
 //! Using tensor operations:
 //!
 //! ```rust
-//! use kornia_tensor::{Tensor, host_alloc};
+//! use kornia_tensor::Tensor;
 //!
 //! // Create tensors with specific values
-//! let zeros = Tensor::<f32, 2>::zeros([3, 3], host_alloc());
-//! let ones = Tensor::<f32, 2>::from_shape_val([3, 3], 1.0, host_alloc());
+//! let zeros = Tensor::<f32, 2>::zeros([3, 3]);
+//! let ones = Tensor::<f32, 2>::from_shape_val([3, 3], 1.0);
 //!
 //! // Generate data with a function
-//! let identity = Tensor::<f32, 2>::from_shape_fn([3, 3], host_alloc(), |[i, j]| {
+//! let identity = Tensor::<f32, 2>::from_shape_fn([3, 3], |[i, j]| {
 //!     if i == j { 1.0 } else { 0.0 }
 //! });
 //!
@@ -65,10 +65,10 @@
 //! Working with views:
 //!
 //! ```rust
-//! use kornia_tensor::{Tensor, host_alloc};
+//! use kornia_tensor::Tensor;
 //!
 //! let data = vec![1, 2, 3, 4, 5, 6];
-//! let tensor = Tensor::<i32, 1>::from_shape_vec([6], data, host_alloc()).unwrap();
+//! let tensor = Tensor::<i32, 1>::from_shape_vec([6], data).unwrap();
 //!
 //! // Create a reshaped view without copying data
 //! let view = tensor.reshape([2, 3]).unwrap();

--- a/crates/kornia-tensor/src/lib.rs
+++ b/crates/kornia-tensor/src/lib.rs
@@ -12,17 +12,62 @@
 //! The crate is organized into several key components:
 //!
 //! - **Tensor**: The main data structure representing multi-dimensional arrays with shape and stride information
-//! - **TensorStorage**: Low-level memory buffer management with custom allocator support
+//! - **TensorStorage**: Low-level memory buffer management holding a runtime allocator handle
 //! - **TensorView**: Non-owning views into tensor data for efficient memory sharing
 //! - **TensorAllocator**: Trait-based memory allocation system for different memory backends
+//!
+//! # Memory Model
+//!
+//! A tensor's location is described at **runtime**, not in its type. `Tensor<T, N>` has no
+//! allocator/device type parameter; instead [`TensorStorage`](storage::TensorStorage) carries:
+//!
+//! - an `owner: Box<dyn `[`MemoryResource`](resource::MemoryResource)`>` — the single source of
+//!   truth that frees the buffer on `Drop` and reports its [`MemoryDomain`](resource::MemoryDomain):
+//!   - [`Host`](resource::MemoryDomain::Host) — kornia- or foreign-owned CPU memory,
+//!   - [`Device { id }`](resource::MemoryDomain::Device) — CUDA device memory,
+//!   - [`Unified { id }`](resource::MemoryDomain::Unified) — CUDA managed/unified memory;
+//! - an [`AllocHandle`] (`Arc<dyn `[`TensorAllocator`]`>`) — a cheap, reference-counted runtime
+//!   handle used **only** when an op needs to allocate (e.g. `zeros`, `cast`); it is propagated to
+//!   derived tensors, never consulted on the hot path;
+//! - a cached `NonNull<T>` pointer read directly by element access — so domain/handle add **zero**
+//!   overhead to `as_ptr`/`as_slice`/indexing.
+//!
+//! **Host-accessibility gate.** Element access is checked at runtime, not by the type system:
+//! [`as_slice`](storage::TensorStorage::as_slice)/`as_mut_slice` (and indexing) **panic** on a
+//! non-host-accessible (`Device`) tensor. Move data with `to_host` / `to_cuda` first. A single
+//! concrete `Tensor<T, N>` can therefore live in a `Vec` alongside tensors on other domains.
+//!
+//! # Unified Constructor API
+//!
+//! The common host case needs **no** allocator argument (mirrors `Vec::new` / `Vec::new_in`):
+//!
+//! ```rust
+//! use kornia_tensor::{Tensor, host_alloc};
+//!
+//! // Host (default) — no allocator argument:
+//! let a = Tensor::<f32, 2>::from_shape_vec([2, 3], vec![0.0; 6]).unwrap();
+//! let z = Tensor::<f32, 2>::zeros([2, 3]);
+//!
+//! // Explicit allocator handle via the `_in` variants (custom/arena/device allocators):
+//! let b = Tensor::<f32, 2>::from_shape_vec_in([2, 3], vec![0.0; 6], host_alloc()).unwrap();
+//! ```
+//!
+//! Every host-default constructor has an `_in` counterpart taking an [`AllocHandle`]:
+//! `from_shape_vec`/`_in`, `from_shape_slice`/`_in`, `from_shape_val`/`_in`, `from_shape_fn`/`_in`,
+//! `zeros`/`_in`. Low-level / non-host constructors always take an explicit handle or resource:
+//! [`from_vec`](storage::TensorStorage::from_vec), `from_resource`, `from_borrowed`, `from_raw_parts`.
+//! Device tensors are created through the stream-based CUDA API rather than a handle —
+//! `to_cuda`, `zeros_cuda`, `from_cudaslice` (feature `cudarc`) — which build the device
+//! allocator handle internally from the supplied `CudaStream`.
 //!
 //! # Key Features
 //!
 //! - **Zero-copy operations**: Views and reshaping operations avoid data copying when possible
-//! - **Custom allocators**: Support for different memory backends (CPU, GPU, etc.)
+//! - **Runtime device model**: one concrete `Tensor<T, N>` spans Host / Device / Unified memory
+//! - **Ergonomic host default**: host constructors need no allocator; `_in` variants for custom ones
 //! - **Type-safe dimensions**: Compile-time dimensional checking using const generics
 //! - **Standard memory layouts**: Automatic stride calculation for contiguous memory
-//! - **Thread-safe**: All components are Send + Sync when using thread-safe allocators
+//! - **Thread-safe**: All components are Send + Sync (allocator handle is `Arc<dyn TensorAllocator>`)
 //!
 //! # Quick Start
 //!

--- a/crates/kornia-tensor/src/serde.rs
+++ b/crates/kornia-tensor/src/serde.rs
@@ -66,7 +66,7 @@ mod tests {
     #[test]
     fn test_serde() -> Result<(), Box<dyn std::error::Error>> {
         let data = vec![1, 2, 3, 4, 5, 6];
-        let tensor = Tensor::<u8, 2>::from_shape_vec([2, 3], data, host_alloc())?;
+        let tensor = Tensor::<u8, 2>::from_shape_vec([2, 3], data)?;
         let serialized = serde_json::to_string(&tensor)?;
         let deserialized: Tensor<u8, 2> = serde_json::from_str(&serialized)?;
         assert_eq!(tensor.as_slice(), deserialized.as_slice());

--- a/crates/kornia-tensor/src/serde.rs
+++ b/crates/kornia-tensor/src/serde.rs
@@ -1,12 +1,11 @@
-use crate::{allocator::TensorAllocator, storage::TensorStorage, Tensor};
+use crate::{allocator::host_alloc, storage::TensorStorage, Tensor};
 
 use serde::ser::SerializeStruct;
 use serde::Deserialize;
 
-impl<T, const N: usize, A> serde::Serialize for Tensor<T, N, A>
+impl<T, const N: usize> serde::Serialize for Tensor<T, N>
 where
     T: serde::Serialize,
-    A: TensorAllocator + 'static,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -20,8 +19,7 @@ where
     }
 }
 
-impl<'de, T, const N: usize, A: TensorAllocator + Default + 'static> serde::Deserialize<'de>
-    for Tensor<T, N, A>
+impl<'de, T, const N: usize> serde::Deserialize<'de> for Tensor<T, N>
 where
     T: serde::Deserialize<'de>,
 {
@@ -42,7 +40,7 @@ where
             strides,
         } = TensorData::deserialize(deserializer)?;
 
-        let storage_array = TensorStorage::from_vec(data, A::default());
+        let storage_array = TensorStorage::from_vec(data, host_alloc());
 
         let shape_array: [usize; N] = shape
             .try_into()
@@ -63,14 +61,14 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::allocator::CpuAllocator;
+    use crate::allocator::host_alloc;
 
     #[test]
     fn test_serde() -> Result<(), Box<dyn std::error::Error>> {
         let data = vec![1, 2, 3, 4, 5, 6];
-        let tensor = Tensor::<u8, 2, CpuAllocator>::from_shape_vec([2, 3], data, CpuAllocator)?;
+        let tensor = Tensor::<u8, 2>::from_shape_vec([2, 3], data, host_alloc())?;
         let serialized = serde_json::to_string(&tensor)?;
-        let deserialized: Tensor<u8, 2, CpuAllocator> = serde_json::from_str(&serialized)?;
+        let deserialized: Tensor<u8, 2> = serde_json::from_str(&serialized)?;
         assert_eq!(tensor.as_slice(), deserialized.as_slice());
         Ok(())
     }

--- a/crates/kornia-tensor/src/serde.rs
+++ b/crates/kornia-tensor/src/serde.rs
@@ -61,7 +61,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::allocator::host_alloc;
 
     #[test]
     fn test_serde() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/kornia-tensor/src/storage.rs
+++ b/crates/kornia-tensor/src/storage.rs
@@ -1,6 +1,6 @@
 use std::{alloc::Layout, marker::PhantomData, ptr::NonNull};
 
-use crate::allocator::{CpuAllocator, TensorAllocator};
+use crate::allocator::AllocHandle;
 use crate::resource::{ForeignResource, HostResource, MemoryResource};
 
 // MemoryDomain is now defined in `resource` and re-exported from there.
@@ -22,7 +22,7 @@ pub use crate::resource::MemoryDomain;
 ///
 /// # Thread Safety
 ///
-/// `TensorStorage` is `Send` and `Sync` when the allocator is thread-safe and `T: Send + Sync`,
+/// `TensorStorage` is `Send` and `Sync` when `T: Send + Sync`,
 /// allowing tensors to be safely shared across threads.
 ///
 /// # Examples
@@ -30,10 +30,10 @@ pub use crate::resource::MemoryDomain;
 /// Creating storage from a vector:
 ///
 /// ```rust
-/// use kornia_tensor::{storage::TensorStorage, CpuAllocator};
+/// use kornia_tensor::{storage::TensorStorage, host_alloc};
 ///
 /// let data = vec![1, 2, 3, 4, 5];
-/// let storage = TensorStorage::from_vec(data, CpuAllocator);
+/// let storage = TensorStorage::from_vec(data, host_alloc());
 ///
 /// assert_eq!(storage.as_slice(), &[1, 2, 3, 4, 5]);
 /// assert!(!storage.is_empty());
@@ -42,27 +42,27 @@ pub use crate::resource::MemoryDomain;
 /// Converting back to a vector:
 ///
 /// ```rust
-/// use kornia_tensor::{storage::TensorStorage, CpuAllocator};
+/// use kornia_tensor::{storage::TensorStorage, host_alloc};
 ///
 /// let data = vec![1.0, 2.0, 3.0];
-/// let storage = TensorStorage::from_vec(data, CpuAllocator);
+/// let storage = TensorStorage::from_vec(data, host_alloc());
 /// let recovered = storage.into_vec();
 ///
 /// assert_eq!(recovered, vec![1.0, 2.0, 3.0]);
 /// ```
-pub struct TensorStorage<T, A: TensorAllocator = CpuAllocator> {
+pub struct TensorStorage<T> {
     /// Cached hot-path pointer to the first element of the backing buffer.
     pub(crate) ptr: NonNull<T>,
     /// Length of the backing buffer in bytes (NOT number of elements).
     pub(crate) len: usize,
     /// Owning handle that frees the backing buffer correctly on Drop.
     pub(crate) owner: Box<dyn MemoryResource>,
-    /// The allocator associated with this storage (type tag / future allocation use).
-    pub(crate) alloc: A,
+    /// The allocator associated with this storage (runtime handle).
+    pub(crate) alloc: AllocHandle,
     pub(crate) _marker: PhantomData<T>,
 }
 
-impl<T, A: TensorAllocator> TensorStorage<T, A> {
+impl<T> TensorStorage<T> {
     /// Returns a raw const pointer to the storage's first element.
     #[inline]
     pub fn as_ptr(&self) -> *const T {
@@ -158,9 +158,9 @@ impl<T, A: TensorAllocator> TensorStorage<T, A> {
         )
     }
 
-    /// Returns a reference to the allocator used by this storage.
+    /// Returns a reference to the allocator handle used by this storage.
     #[inline]
-    pub fn alloc(&self) -> &A {
+    pub fn alloc(&self) -> &AllocHandle {
         &self.alloc
     }
 
@@ -173,8 +173,8 @@ impl<T, A: TensorAllocator> TensorStorage<T, A> {
     /// # Arguments
     ///
     /// * `value` - The vector to convert into storage
-    /// * `alloc` - The allocator to associate with this storage
-    pub fn from_vec(value: Vec<T>, alloc: A) -> Self {
+    /// * `alloc` - The allocator handle to associate with this storage
+    pub fn from_vec(value: Vec<T>, alloc: AllocHandle) -> Self {
         // Extract the Vec's innards without copying.
         // SAFETY: Vec::as_ptr is non-null for non-zero-capacity vecs; for cap == 0
         // the pointer is dangling but len == 0 so we never dereference it.
@@ -214,18 +214,20 @@ impl<T, A: TensorAllocator> TensorStorage<T, A> {
     /// - The pointer is non-null and properly aligned.
     /// - The memory region is valid for `len` bytes for the entire lifetime of this storage.
     /// - No other code will free this memory while this storage exists.
-    pub unsafe fn from_raw_parts(data: *const T, len: usize, alloc: A) -> Self {
-        let ptr = NonNull::new_unchecked(data as *mut T);
-        let owner: Box<dyn MemoryResource> = Box::new(
-            ForeignResource::new(data as *mut u8, len, MemoryDomain::Host, None)
-                .expect("non-null pointer required"),
-        );
-        Self {
-            ptr,
-            len,
-            owner,
-            alloc,
-            _marker: PhantomData,
+    pub unsafe fn from_raw_parts(data: *const T, len: usize, alloc: AllocHandle) -> Self {
+        unsafe {
+            let ptr = NonNull::new_unchecked(data as *mut T);
+            let owner: Box<dyn MemoryResource> = Box::new(
+                ForeignResource::new(data as *mut u8, len, MemoryDomain::Host, None)
+                    .expect("non-null pointer required"),
+            );
+            Self {
+                ptr,
+                len,
+                owner,
+                alloc,
+                _marker: PhantomData,
+            }
         }
     }
 
@@ -242,30 +244,38 @@ impl<T, A: TensorAllocator> TensorStorage<T, A> {
     ///   global allocator.
     /// - Ownership is transferred; `HostResource::Drop` will call
     ///   `std::alloc::dealloc(data, layout)` on drop.
-    pub unsafe fn from_raw_host(data: *mut T, len_bytes: usize, layout: Layout, alloc: A) -> Self {
-        // The viewed length must lie within the allocation `layout` describes; otherwise
-        // `as_slice` (len = len_bytes / size_of::<T>()) reads out of bounds and `into_vec`
-        // would build a Vec with len > capacity (instant UB). Enforce the documented
-        // contract rather than trusting the caller.
-        assert!(
+    pub unsafe fn from_raw_host(
+        data: *mut T,
+        len_bytes: usize,
+        layout: Layout,
+        alloc: AllocHandle,
+    ) -> Self {
+        unsafe {
+            // The viewed length must lie within the allocation `layout` describes; otherwise
+            // `as_slice` (len = len_bytes / size_of::<T>()) reads out of bounds and `into_vec`
+            // would build a Vec with len > capacity (instant UB). Enforce the documented
+            // contract rather than trusting the caller.
+            assert!(
             layout.size() >= len_bytes,
             "from_raw_host: layout.size() ({}) < len_bytes ({}) — buffer too small for the view",
             layout.size(),
             len_bytes,
         );
-        // Defense-in-depth: a null pointer here is always a caller bug; make it a clear
-        // panic rather than undefined behaviour via `new_unchecked`.
-        let ptr = NonNull::new(data)
-            .expect("from_raw_host: null pointer — data must be a valid, non-null host pointer");
-        let owner: Box<dyn MemoryResource> = Box::new(
-            HostResource::from_raw(data as *mut u8, layout).expect("non-null pointer required"),
-        );
-        Self {
-            ptr,
-            len: len_bytes,
-            owner,
-            alloc,
-            _marker: PhantomData,
+            // Defense-in-depth: a null pointer here is always a caller bug; make it a clear
+            // panic rather than undefined behaviour via `new_unchecked`.
+            let ptr = NonNull::new(data).expect(
+                "from_raw_host: null pointer — data must be a valid, non-null host pointer",
+            );
+            let owner: Box<dyn MemoryResource> = Box::new(
+                HostResource::from_raw(data as *mut u8, layout).expect("non-null pointer required"),
+            );
+            Self {
+                ptr,
+                len: len_bytes,
+                owner,
+                alloc,
+                _marker: PhantomData,
+            }
         }
     }
 
@@ -279,7 +289,7 @@ impl<T, A: TensorAllocator> TensorStorage<T, A> {
     ///
     /// * `data`      - Pointer to the first element of the buffer.
     /// * `len_bytes` - Byte length of the buffer.
-    /// * `alloc`     - Allocator type tag.
+    /// * `alloc`     - Allocator handle.
     /// * `domain`    - Accessibility of the buffer (`Host`, `Device{id}`, or `Unified{id}`).
     /// * `keepalive` - Owned arc whose `Drop` releases the underlying allocation.
     ///
@@ -292,21 +302,23 @@ impl<T, A: TensorAllocator> TensorStorage<T, A> {
     pub unsafe fn from_borrowed(
         data: *const T,
         len_bytes: usize,
-        alloc: A,
+        alloc: AllocHandle,
         domain: MemoryDomain,
         keepalive: std::sync::Arc<dyn core::any::Any + Send + Sync>,
     ) -> Self {
-        let ptr = NonNull::new_unchecked(data as *mut T);
-        let owner: Box<dyn MemoryResource> = Box::new(
-            ForeignResource::new(data as *mut u8, len_bytes, domain, Some(keepalive))
-                .expect("non-null pointer required"),
-        );
-        Self {
-            ptr,
-            len: len_bytes,
-            owner,
-            alloc,
-            _marker: PhantomData,
+        unsafe {
+            let ptr = NonNull::new_unchecked(data as *mut T);
+            let owner: Box<dyn MemoryResource> = Box::new(
+                ForeignResource::new(data as *mut u8, len_bytes, domain, Some(keepalive))
+                    .expect("non-null pointer required"),
+            );
+            Self {
+                ptr,
+                len: len_bytes,
+                owner,
+                alloc,
+                _marker: PhantomData,
+            }
         }
     }
 
@@ -324,7 +336,7 @@ impl<T, A: TensorAllocator> TensorStorage<T, A> {
     ///
     /// * `data`      - Pointer to the first element of the buffer.
     /// * `len_bytes` - Byte length of the buffer.
-    /// * `alloc`     - Allocator type tag.
+    /// * `alloc`     - Allocator handle.
     /// * `domain`    - Accessibility of the buffer.
     /// * `keepalive` - Owned arc whose `Drop` releases the underlying allocation.
     ///
@@ -338,21 +350,23 @@ impl<T, A: TensorAllocator> TensorStorage<T, A> {
     pub unsafe fn from_borrowed_readonly(
         data: *const T,
         len_bytes: usize,
-        alloc: A,
+        alloc: AllocHandle,
         domain: MemoryDomain,
         keepalive: std::sync::Arc<dyn core::any::Any + Send + Sync>,
     ) -> Self {
-        let ptr = NonNull::new_unchecked(data as *mut T);
-        let owner: Box<dyn MemoryResource> = Box::new(
-            ForeignResource::new_readonly(data as *mut u8, len_bytes, domain, Some(keepalive))
-                .expect("non-null pointer required"),
-        );
-        Self {
-            ptr,
-            len: len_bytes,
-            owner,
-            alloc,
-            _marker: PhantomData,
+        unsafe {
+            let ptr = NonNull::new_unchecked(data as *mut T);
+            let owner: Box<dyn MemoryResource> = Box::new(
+                ForeignResource::new_readonly(data as *mut u8, len_bytes, domain, Some(keepalive))
+                    .expect("non-null pointer required"),
+            );
+            Self {
+                ptr,
+                len: len_bytes,
+                owner,
+                alloc,
+                _marker: PhantomData,
+            }
         }
     }
 
@@ -401,7 +415,7 @@ impl<T, A: TensorAllocator> TensorStorage<T, A> {
         let vec_capacity = unsafe {
             // Read the Box and alloc out of the ManuallyDrop (does NOT run their Drop).
             let owner_box: Box<dyn MemoryResource> = std::ptr::read(&this.owner);
-            // Drop the allocator field (unit struct for CpuAllocator/ForeignAllocator, but be explicit).
+            // Drop the allocator handle (Arc).
             drop(std::ptr::read(&this.alloc));
             // Convert the Box<dyn MemoryResource> into a raw fat pointer.
             let raw: *mut dyn MemoryResource = Box::into_raw(owner_box);
@@ -426,15 +440,15 @@ impl<T, A: TensorAllocator> TensorStorage<T, A> {
 
 // SAFETY: TensorStorage is the sole owner of the pointed-to memory.
 // Sending it across threads is safe iff T is Send (same rule as Vec<T>).
-unsafe impl<T: Send, A: TensorAllocator> Send for TensorStorage<T, A> {}
+unsafe impl<T: Send> Send for TensorStorage<T> {}
 // SAFETY: Shared references to TensorStorage only allow reading T.
 // This is safe iff T is Sync (same rule as &[T]).
-unsafe impl<T: Sync, A: TensorAllocator> Sync for TensorStorage<T, A> {}
+unsafe impl<T: Sync> Sync for TensorStorage<T> {}
 
 /// Drop is empty: the `owner: Box<dyn MemoryResource>` field drops itself,
 /// calling the correct deallocation path (HostResource::dealloc, or ForeignResource
 /// dropping its keepalive Arc, etc.) exactly once.
-impl<T, A: TensorAllocator> Drop for TensorStorage<T, A> {
+impl<T> Drop for TensorStorage<T> {
     fn drop(&mut self) {
         // Nothing to do — `owner` drops automatically via Box<dyn MemoryResource>.
     }
@@ -442,17 +456,13 @@ impl<T, A: TensorAllocator> Drop for TensorStorage<T, A> {
 
 /// Clones the storage by creating a new storage with copied data.
 ///
-/// This performs a deep copy of the storage data using the cloned allocator.
+/// This performs a deep copy of the storage data using the cloned allocator handle.
 ///
 /// # Panics
 ///
 /// Panics if the storage is non-host-accessible. Device-to-device copy is not yet
 /// implemented; use an explicit transfer API when it becomes available.
-impl<T, A> Clone for TensorStorage<T, A>
-where
-    T: Clone,
-    A: TensorAllocator,
-{
+impl<T: Clone> Clone for TensorStorage<T> {
     fn clone(&self) -> Self {
         let domain = self.owner.domain();
         assert!(
@@ -467,7 +477,7 @@ where
 mod tests {
 
     use super::TensorStorage;
-    use crate::allocator::{CpuAllocator, ForeignAllocator, TensorAllocatorError};
+    use crate::allocator::{host_alloc, TensorAllocatorError};
     use crate::resource::{ForeignResource, HostResource, MemoryDomain, MemoryResource};
     use crate::TensorAllocator;
     use std::alloc::Layout;
@@ -482,7 +492,7 @@ mod tests {
     ///
     /// Uses a custom `FakeDeviceResource` that wraps a real `HostResource` allocation but
     /// reports `Device` domain, so the memory is properly freed on Drop (no leaks under miri).
-    fn make_device_storage() -> TensorStorage<u8, CpuAllocator> {
+    fn make_device_storage() -> TensorStorage<u8> {
         /// Wraps a properly-allocated HostResource but reports Device domain.
         /// This lets us test Device-domain guards without any real GPU or leaked memory.
         struct FakeDeviceResource {
@@ -517,7 +527,7 @@ mod tests {
             ptr,
             len: 1,
             owner,
-            alloc: CpuAllocator,
+            alloc: host_alloc(),
             _marker: PhantomData,
         }
     }
@@ -533,7 +543,7 @@ mod tests {
         let ptr = unsafe { NonNull::new_unchecked(ptr_raw) };
 
         let buffer = TensorStorage {
-            alloc: CpuAllocator,
+            alloc: host_alloc(),
             len: size * std::mem::size_of::<u8>(),
             owner,
             ptr,
@@ -553,7 +563,7 @@ mod tests {
     fn test_tensor_buffer_ptr() -> Result<(), TensorAllocatorError> {
         let size = 8;
         let layout = Layout::array::<u8>(size).map_err(TensorAllocatorError::LayoutError)?;
-        let r = CpuAllocator.allocate(layout)?;
+        let r = HostResource::from_layout(layout)?;
 
         // check alignment
         let ptr_raw = r.as_ptr() as usize;
@@ -576,12 +586,7 @@ mod tests {
         // from_raw_host takes ownership and will store the 64-byte-aligned layout in
         // HostResource, which into_vec will detect and reject.
         let storage = unsafe {
-            TensorStorage::<f32, CpuAllocator>::from_raw_host(
-                raw_ptr,
-                layout.size(),
-                layout,
-                CpuAllocator,
-            )
+            TensorStorage::<f32>::from_raw_host(raw_ptr, layout.size(), layout, host_alloc())
         };
         let _ = storage.into_vec();
     }
@@ -594,7 +599,7 @@ mod tests {
         let ptr = unsafe { NonNull::new_unchecked(owner.as_ptr() as *mut f32) };
 
         let buffer = TensorStorage {
-            alloc: CpuAllocator,
+            alloc: host_alloc(),
             len: size,
             owner,
             ptr,
@@ -642,7 +647,7 @@ mod tests {
             let vec_ptr = vec.as_ptr();
             let vec_capacity = vec.capacity();
 
-            let buffer = TensorStorage::from_vec(vec, allocator.clone());
+            let buffer = TensorStorage::from_vec(vec, host_alloc());
             assert_eq!(allocator.bytes_allocated.load(Ordering::SeqCst), 0);
 
             let result_vec = buffer.into_vec();
@@ -662,7 +667,7 @@ mod tests {
         let vec_ptr = vec.as_ptr();
         let vec_len = vec.len();
 
-        let buffer = TensorStorage::<_, CpuAllocator>::from_vec(vec, CpuAllocator);
+        let buffer = TensorStorage::from_vec(vec, host_alloc());
 
         // check NO copy
         let buffer_ptr = buffer.as_ptr();
@@ -707,7 +712,7 @@ mod tests {
         let vec_ptr = vec.as_ptr();
         let vec_len = vec.len();
 
-        let buffer = TensorStorage::<_, CpuAllocator>::from_vec(vec, CpuAllocator);
+        let buffer = TensorStorage::from_vec(vec, host_alloc());
 
         // check NO copy
         let buffer_ptr = buffer.as_ptr();
@@ -726,7 +731,7 @@ mod tests {
         let vec_ptr = vec.as_ptr();
         let vec_cap = vec.capacity();
 
-        let buffer = TensorStorage::<_, CpuAllocator>::from_vec(vec, CpuAllocator);
+        let buffer = TensorStorage::from_vec(vec, host_alloc());
 
         // convert back to vec (no copy)
         let result_vec = buffer.into_vec();
@@ -740,7 +745,7 @@ mod tests {
     #[test]
     fn test_tensor_mutability() -> Result<(), TensorAllocatorError> {
         let vec: Vec<i32> = vec![1, 2, 3, 4, 5];
-        let mut buffer = TensorStorage::<_, CpuAllocator>::from_vec(vec, CpuAllocator);
+        let mut buffer = TensorStorage::from_vec(vec, host_alloc());
         let ptr_mut = buffer.as_mut_ptr();
         unsafe {
             *ptr_mut.add(0) = 10;
@@ -775,7 +780,7 @@ mod tests {
     /// from_vec roundtrip + verify Host domain.
     #[test]
     fn from_vec_roundtrip_and_host_domain() {
-        let s = TensorStorage::from_vec(vec![1u8, 2, 3, 4], CpuAllocator);
+        let s = TensorStorage::from_vec(vec![1u8, 2, 3, 4], host_alloc());
         assert_eq!(s.as_slice(), &[1, 2, 3, 4]);
         assert!(matches!(s.domain(), MemoryDomain::Host));
         assert_eq!(s.into_vec(), vec![1u8, 2, 3, 4]);
@@ -805,10 +810,10 @@ mod tests {
         {
             let keep: Arc<dyn core::any::Any + Send + Sync> = Arc::new(Guard(n.clone()));
             let s = unsafe {
-                TensorStorage::<u8, ForeignAllocator>::from_borrowed(
+                TensorStorage::<u8>::from_borrowed(
                     buf.as_ptr(),
                     8,
-                    ForeignAllocator,
+                    host_alloc(),
                     MemoryDomain::Host,
                     keep,
                 )
@@ -824,10 +829,10 @@ mod tests {
         let buf = vec![42u8; 4];
         let keep: Arc<dyn core::any::Any + Send + Sync> = Arc::new(buf.clone());
         let s = unsafe {
-            TensorStorage::<u8, ForeignAllocator>::from_borrowed(
+            TensorStorage::<u8>::from_borrowed(
                 buf.as_ptr(),
                 4,
-                ForeignAllocator,
+                host_alloc(),
                 MemoryDomain::Unified { id: 0 },
                 keep,
             )
@@ -889,11 +894,11 @@ mod tests {
             let owner: Box<dyn MemoryResource> = Box::new(counting);
             let ptr = unsafe { NonNull::new_unchecked(owner.as_ptr()) };
 
-            let _storage: TensorStorage<u8, CpuAllocator> = TensorStorage {
+            let _storage: TensorStorage<u8> = TensorStorage {
                 ptr,
                 len: 64,
                 owner,
-                alloc: CpuAllocator,
+                alloc: host_alloc(),
                 _marker: PhantomData,
             };
             // counter == 1 while alive
@@ -911,7 +916,7 @@ mod tests {
         let original_ptr = original.as_ptr();
         let original_cap = original.capacity();
 
-        let storage = TensorStorage::from_vec(original, CpuAllocator);
+        let storage = TensorStorage::from_vec(original, host_alloc());
         let recovered = storage.into_vec();
 
         // Same pointer, same capacity (no copy, no realloc)
@@ -943,11 +948,11 @@ mod tests {
                 .unwrap()
             });
             let storage_ptr = unsafe { NonNull::new_unchecked(ptr as *mut u8) };
-            let _storage: TensorStorage<u8, ForeignAllocator> = TensorStorage {
+            let _storage: TensorStorage<u8> = TensorStorage {
                 ptr: storage_ptr,
                 len,
                 owner,
-                alloc: ForeignAllocator,
+                alloc: host_alloc(),
                 _marker: PhantomData,
             };
             // While alive: same pointer, same bytes.
@@ -965,10 +970,10 @@ mod tests {
         let buf = [1u8, 2, 3, 4];
         let keep: Arc<dyn core::any::Any + Send + Sync> = Arc::new(()); // dummy keepalive
         let s = unsafe {
-            TensorStorage::<u8, ForeignAllocator>::from_borrowed_readonly(
+            TensorStorage::<u8>::from_borrowed_readonly(
                 buf.as_ptr(),
                 buf.len(),
-                ForeignAllocator,
+                host_alloc(),
                 MemoryDomain::Host,
                 keep,
             )
@@ -984,10 +989,10 @@ mod tests {
         let buf = [1u8, 2, 3, 4];
         let keep: Arc<dyn core::any::Any + Send + Sync> = Arc::new(()); // dummy keepalive
         let mut s = unsafe {
-            TensorStorage::<u8, ForeignAllocator>::from_borrowed_readonly(
+            TensorStorage::<u8>::from_borrowed_readonly(
                 buf.as_ptr(),
                 buf.len(),
-                ForeignAllocator,
+                host_alloc(),
                 MemoryDomain::Host,
                 keep,
             )
@@ -1000,10 +1005,10 @@ mod tests {
         let mut buf = [10u8, 20, 30, 40];
         let keep: Arc<dyn core::any::Any + Send + Sync> = Arc::new(42u8); // dummy keepalive
         let mut s = unsafe {
-            TensorStorage::<u8, ForeignAllocator>::from_borrowed(
+            TensorStorage::<u8>::from_borrowed(
                 buf.as_mut_ptr(),
                 buf.len(),
-                ForeignAllocator,
+                host_alloc(),
                 MemoryDomain::Host,
                 keep,
             )
@@ -1017,9 +1022,9 @@ mod tests {
     fn tensor_storage_send_sync_static_check() {
         fn _assert_send<T: Send>() {}
         fn _assert_sync<T: Sync>() {}
-        _assert_send::<TensorStorage<u8, CpuAllocator>>();
-        _assert_sync::<TensorStorage<u8, CpuAllocator>>();
-        _assert_send::<TensorStorage<f32, CpuAllocator>>();
-        _assert_sync::<TensorStorage<f32, CpuAllocator>>();
+        _assert_send::<TensorStorage<u8>>();
+        _assert_sync::<TensorStorage<u8>>();
+        _assert_send::<TensorStorage<f32>>();
+        _assert_sync::<TensorStorage<f32>>();
     }
 }

--- a/crates/kornia-tensor/src/storage.rs
+++ b/crates/kornia-tensor/src/storage.rs
@@ -353,7 +353,10 @@ impl<T> TensorStorage<T> {
         readonly: bool,
     ) -> Self {
         unsafe {
-            let ptr = NonNull::new_unchecked(data as *mut T);
+            // Defensive null check before caching the pointer: `NonNull::new_unchecked`
+            // on a null `data` is UB, and would otherwise reach the `ForeignResource`
+            // null check below only after the invalid `NonNull` was already formed.
+            let ptr = NonNull::new(data as *mut T).expect("from_borrowed: null data pointer");
             let resource_result = if readonly {
                 ForeignResource::new_readonly(data as *mut u8, len_bytes, domain, Some(keepalive))
             } else {

--- a/crates/kornia-tensor/src/storage.rs
+++ b/crates/kornia-tensor/src/storage.rs
@@ -306,20 +306,7 @@ impl<T> TensorStorage<T> {
         domain: MemoryDomain,
         keepalive: std::sync::Arc<dyn core::any::Any + Send + Sync>,
     ) -> Self {
-        unsafe {
-            let ptr = NonNull::new_unchecked(data as *mut T);
-            let owner: Box<dyn MemoryResource> = Box::new(
-                ForeignResource::new(data as *mut u8, len_bytes, domain, Some(keepalive))
-                    .expect("non-null pointer required"),
-            );
-            Self {
-                ptr,
-                len: len_bytes,
-                owner,
-                alloc,
-                _marker: PhantomData,
-            }
-        }
+        unsafe { Self::make_borrowed(data, len_bytes, alloc, domain, keepalive, false) }
     }
 
     /// Creates a borrowed storage view that is read-only.
@@ -354,12 +341,26 @@ impl<T> TensorStorage<T> {
         domain: MemoryDomain,
         keepalive: std::sync::Arc<dyn core::any::Any + Send + Sync>,
     ) -> Self {
+        unsafe { Self::make_borrowed(data, len_bytes, alloc, domain, keepalive, true) }
+    }
+
+    unsafe fn make_borrowed(
+        data: *const T,
+        len_bytes: usize,
+        alloc: AllocHandle,
+        domain: MemoryDomain,
+        keepalive: std::sync::Arc<dyn core::any::Any + Send + Sync>,
+        readonly: bool,
+    ) -> Self {
         unsafe {
             let ptr = NonNull::new_unchecked(data as *mut T);
-            let owner: Box<dyn MemoryResource> = Box::new(
+            let resource_result = if readonly {
                 ForeignResource::new_readonly(data as *mut u8, len_bytes, domain, Some(keepalive))
-                    .expect("non-null pointer required"),
-            );
+            } else {
+                ForeignResource::new(data as *mut u8, len_bytes, domain, Some(keepalive))
+            };
+            let owner: Box<dyn MemoryResource> =
+                Box::new(resource_result.expect("non-null pointer required"));
             Self {
                 ptr,
                 len: len_bytes,
@@ -448,12 +449,6 @@ unsafe impl<T: Sync> Sync for TensorStorage<T> {}
 /// Drop is empty: the `owner: Box<dyn MemoryResource>` field drops itself,
 /// calling the correct deallocation path (HostResource::dealloc, or ForeignResource
 /// dropping its keepalive Arc, etc.) exactly once.
-impl<T> Drop for TensorStorage<T> {
-    fn drop(&mut self) {
-        // Nothing to do — `owner` drops automatically via Box<dyn MemoryResource>.
-    }
-}
-
 /// Clones the storage by creating a new storage with copied data.
 ///
 /// This performs a deep copy of the storage data using the cloned allocator handle.

--- a/crates/kornia-tensor/src/tensor.rs
+++ b/crates/kornia-tensor/src/tensor.rs
@@ -878,8 +878,8 @@ impl<T, const N: usize> Tensor<T, N> {
         }
 
         if self.storage.domain() != other.storage.domain() {
-            return Err(TensorError::DimensionMismatch(format!(
-                "Tensors are on different memory domains: {:?} vs {:?}",
+            return Err(TensorError::UnsupportedOperation(format!(
+                "element-wise op on tensors in different memory domains: {:?} vs {:?}",
                 self.storage.domain(),
                 other.storage.domain()
             )));

--- a/crates/kornia-tensor/src/tensor.rs
+++ b/crates/kornia-tensor/src/tensor.rs
@@ -256,17 +256,7 @@ impl<T, const N: usize> Tensor<T, N> {
     where
         T: Clone,
     {
-        let numel = shape.iter().product::<usize>();
-        if numel != data.len() {
-            return Err(TensorError::InvalidShape(numel));
-        }
-        let storage = TensorStorage::from_vec(data.to_vec(), alloc);
-        let strides = get_strides_from_shape(shape);
-        Ok(Self {
-            storage,
-            shape,
-            strides,
-        })
+        Self::from_shape_vec(shape, data.to_vec(), alloc)
     }
 
     /// Creates a new `Tensor` with the given shape and raw parts.
@@ -803,7 +793,7 @@ impl<T, const N: usize> Tensor<T, N> {
         U: From<T>,
         T: Clone,
     {
-        let mut data: Vec<U> = Vec::with_capacity(self.storage.len());
+        let mut data: Vec<U> = Vec::with_capacity(self.numel());
         self.as_slice().iter().for_each(|x| {
             data.push(U::from(x.clone()));
         });
@@ -852,6 +842,14 @@ impl<T, const N: usize> Tensor<T, N> {
             return Err(TensorError::DimensionMismatch(format!(
                 "Shapes {:?} and {:?} are not compatible for element-wise operations",
                 self.shape, other.shape
+            )));
+        }
+
+        if self.storage.domain() != other.storage.domain() {
+            return Err(TensorError::DimensionMismatch(format!(
+                "Tensors are on different memory domains: {:?} vs {:?}",
+                self.storage.domain(),
+                other.storage.domain()
             )));
         }
 

--- a/crates/kornia-tensor/src/tensor.rs
+++ b/crates/kornia-tensor/src/tensor.rs
@@ -1,7 +1,7 @@
 use thiserror::Error;
 
 use super::{
-    allocator::{CpuAllocator, TensorAllocator, TensorAllocatorError},
+    allocator::{AllocHandle, TensorAllocatorError},
     storage::TensorStorage,
     view::TensorView,
 };
@@ -81,13 +81,12 @@ pub fn get_strides_from_shape<const N: usize>(shape: [usize; N]) -> [usize; N] {
 ///
 /// * `T` - The element type stored in the tensor
 /// * `N` - The number of dimensions (const generic, checked at compile time)
-/// * `A` - The allocator type for memory management
 ///
 /// # Architecture
 ///
 /// The tensor consists of three main components:
 ///
-/// * **Storage** - Owns the actual data in a contiguous memory buffer managed by an allocator
+/// * **Storage** - Owns the actual data in a contiguous memory buffer managed by a runtime allocator handle
 /// * **Shape** - Defines the size of each dimension
 /// * **Strides** - Describes the memory layout for element access
 ///
@@ -99,7 +98,7 @@ pub fn get_strides_from_shape<const N: usize>(shape: [usize; N]) -> [usize; N] {
 ///
 /// # Thread Safety
 ///
-/// Tensors are `Send` and `Sync` when using thread-safe allocators, allowing safe sharing
+/// Tensors are `Send` and `Sync` when `T: Send + Sync`, allowing safe sharing
 /// across thread boundaries.
 ///
 /// # Examples
@@ -107,10 +106,10 @@ pub fn get_strides_from_shape<const N: usize>(shape: [usize; N]) -> [usize; N] {
 /// Creating a tensor from data:
 ///
 /// ```rust
-/// use kornia_tensor::{Tensor, CpuAllocator};
+/// use kornia_tensor::{Tensor, host_alloc};
 ///
 /// let data = vec![1, 2, 3, 4, 5, 6];
-/// let tensor = Tensor::<i32, 2, _>::from_shape_vec([2, 3], data, CpuAllocator).unwrap();
+/// let tensor = Tensor::<i32, 2>::from_shape_vec([2, 3], data, host_alloc()).unwrap();
 ///
 /// assert_eq!(tensor.shape, [2, 3]);
 /// assert_eq!(tensor.strides, [3, 1]); // Row-major layout
@@ -120,27 +119,27 @@ pub fn get_strides_from_shape<const N: usize>(shape: [usize; N]) -> [usize; N] {
 /// Creating tensors with convenience constructors:
 ///
 /// ```rust
-/// use kornia_tensor::{Tensor, CpuAllocator};
+/// use kornia_tensor::{Tensor, host_alloc};
 ///
 /// // All zeros
-/// let zeros = Tensor::<f32, 2, _>::zeros([3, 3], CpuAllocator);
+/// let zeros = Tensor::<f32, 2>::zeros([3, 3], host_alloc());
 ///
 /// // All ones
-/// let ones = Tensor::<f32, 2, _>::from_shape_val([3, 3], 1.0, CpuAllocator);
+/// let ones = Tensor::<f32, 2>::from_shape_val([3, 3], 1.0, host_alloc());
 ///
 /// // Generated with a function
-/// let range = Tensor::<i32, 1, _>::from_shape_fn([10], CpuAllocator, |[i]| i as i32);
+/// let range = Tensor::<i32, 1>::from_shape_fn([10], host_alloc(), |[i]| i as i32);
 /// ```
-pub struct Tensor<T, const N: usize, A: TensorAllocator = CpuAllocator> {
+pub struct Tensor<T, const N: usize> {
     /// The storage of the tensor.
-    pub storage: TensorStorage<T, A>,
+    pub storage: TensorStorage<T>,
     /// The shape of the tensor.
     pub shape: [usize; N],
     /// The strides of the tensor data in memory.
     pub strides: [usize; N],
 }
 
-impl<T, const N: usize, A: TensorAllocator> Tensor<T, N, A> {
+impl<T, const N: usize> Tensor<T, N> {
     /// Get the data of the tensor as a slice.
     ///
     /// # Returns
@@ -197,7 +196,7 @@ impl<T, const N: usize, A: TensorAllocator> Tensor<T, N, A> {
     ///
     /// * `shape` - An array containing the shape of the tensor.
     /// * `data` - A vector containing the data of the tensor.
-    /// * `alloc` - The allocator to use.
+    /// * `alloc` - The allocator handle to use.
     ///
     /// # Returns
     ///
@@ -210,13 +209,17 @@ impl<T, const N: usize, A: TensorAllocator> Tensor<T, N, A> {
     /// # Example
     ///
     /// ```
-    /// use kornia_tensor::{Tensor, CpuAllocator};
+    /// use kornia_tensor::{Tensor, host_alloc};
     ///
     /// let data: Vec<u8> = vec![1, 2, 3, 4];
-    /// let t = Tensor::<u8, 2, CpuAllocator>::from_shape_vec([2, 2], data, CpuAllocator).unwrap();
+    /// let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data, host_alloc()).unwrap();
     /// assert_eq!(t.shape, [2, 2]);
     /// ```
-    pub fn from_shape_vec(shape: [usize; N], data: Vec<T>, alloc: A) -> Result<Self, TensorError> {
+    pub fn from_shape_vec(
+        shape: [usize; N],
+        data: Vec<T>,
+        alloc: AllocHandle,
+    ) -> Result<Self, TensorError> {
         let numel = shape.iter().product::<usize>();
         if numel != data.len() {
             return Err(TensorError::InvalidShape(numel));
@@ -236,7 +239,7 @@ impl<T, const N: usize, A: TensorAllocator> Tensor<T, N, A> {
     ///
     /// * `shape` - An array containing the shape of the tensor.
     /// * `data` - A slice containing the data of the tensor.
-    /// * `alloc` - The allocator to use.
+    /// * `alloc` - The allocator handle to use.
     ///
     /// # Returns
     ///
@@ -245,7 +248,11 @@ impl<T, const N: usize, A: TensorAllocator> Tensor<T, N, A> {
     /// # Errors
     ///
     /// If the number of elements in the data does not match the shape of the tensor, an error is returned.
-    pub fn from_shape_slice(shape: [usize; N], data: &[T], alloc: A) -> Result<Self, TensorError>
+    pub fn from_shape_slice(
+        shape: [usize; N],
+        data: &[T],
+        alloc: AllocHandle,
+    ) -> Result<Self, TensorError>
     where
         T: Clone,
     {
@@ -269,7 +276,7 @@ impl<T, const N: usize, A: TensorAllocator> Tensor<T, N, A> {
     /// * `shape` - An array containing the shape of the tensor.
     /// * `data` - A pointer to the data of the tensor.
     /// * `len` - The length of the data.
-    /// * `alloc` - The allocator to use.
+    /// * `alloc` - The allocator handle to use.
     ///
     /// # Safety
     ///
@@ -278,27 +285,29 @@ impl<T, const N: usize, A: TensorAllocator> Tensor<T, N, A> {
         shape: [usize; N],
         data: *const T,
         len: usize,
-        alloc: A,
+        alloc: AllocHandle,
     ) -> Result<Self, TensorError>
     where
         T: Clone,
     {
-        let storage = TensorStorage::from_raw_parts(data, len, alloc);
-        let strides = get_strides_from_shape(shape);
-        Ok(Self {
-            storage,
-            shape,
-            strides,
-        })
+        unsafe {
+            let storage = TensorStorage::from_raw_parts(data, len, alloc);
+            let strides = get_strides_from_shape(shape);
+            Ok(Self {
+                storage,
+                shape,
+                strides,
+            })
+        }
     }
 
-    /// Creates a new `Tensor` with the given shape and a default value.
     /// Creates a new `Tensor` with the given shape and a default value.
     ///
     /// # Arguments
     ///
     /// * `shape` - An array containing the shape of the tensor.
     /// * `value` - The default value to fill the tensor with.
+    /// * `alloc` - The allocator handle to use.
     ///
     /// # Returns
     ///
@@ -307,18 +316,18 @@ impl<T, const N: usize, A: TensorAllocator> Tensor<T, N, A> {
     /// # Example
     ///
     /// ```
-    /// use kornia_tensor::{Tensor, CpuAllocator};
+    /// use kornia_tensor::{Tensor, host_alloc};
     ///
-    /// let t = Tensor::<u8, 1, CpuAllocator>::from_shape_val([4], 0, CpuAllocator);
+    /// let t = Tensor::<u8, 1>::from_shape_val([4], 0, host_alloc());
     /// assert_eq!(t.as_slice(), vec![0, 0, 0, 0]);
     ///
-    /// let t = Tensor::<u8, 2, CpuAllocator>::from_shape_val([2, 2], 1, CpuAllocator);
+    /// let t = Tensor::<u8, 2>::from_shape_val([2, 2], 1, host_alloc());
     /// assert_eq!(t.as_slice(), vec![1, 1, 1, 1]);
     ///
-    /// let t = Tensor::<u8, 3, CpuAllocator>::from_shape_val([2, 1, 3], 2, CpuAllocator);
+    /// let t = Tensor::<u8, 3>::from_shape_val([2, 1, 3], 2, host_alloc());
     /// assert_eq!(t.as_slice(), vec![2, 2, 2, 2, 2, 2]);
     /// ```
-    pub fn from_shape_val(shape: [usize; N], value: T, alloc: A) -> Self
+    pub fn from_shape_val(shape: [usize; N], value: T, alloc: AllocHandle) -> Self
     where
         T: Clone,
     {
@@ -340,6 +349,7 @@ impl<T, const N: usize, A: TensorAllocator> Tensor<T, N, A> {
     /// # Arguments
     ///
     /// * `shape` - An array containing the shape of the tensor.
+    /// * `alloc` - The allocator handle to use.
     /// * `f` - The function to generate the data.
     ///
     /// # Returns
@@ -349,15 +359,15 @@ impl<T, const N: usize, A: TensorAllocator> Tensor<T, N, A> {
     /// # Example
     ///
     /// ```
-    /// use kornia_tensor::{Tensor, CpuAllocator};
+    /// use kornia_tensor::{Tensor, host_alloc};
     ///
-    /// let t = Tensor::<u8, 1, CpuAllocator>::from_shape_fn([4], CpuAllocator, |[i]| i as u8);
+    /// let t = Tensor::<u8, 1>::from_shape_fn([4], host_alloc(), |[i]| i as u8);
     /// assert_eq!(t.as_slice(), vec![0, 1, 2, 3]);
     ///
-    /// let t = Tensor::<u8, 2, CpuAllocator>::from_shape_fn([2, 2], CpuAllocator, |[i, j]| (i * 2 + j) as u8);
+    /// let t = Tensor::<u8, 2>::from_shape_fn([2, 2], host_alloc(), |[i, j]| (i * 2 + j) as u8);
     /// assert_eq!(t.as_slice(), vec![0, 1, 2, 3]);
     /// ```
-    pub fn from_shape_fn<F>(shape: [usize; N], alloc: A, f: F) -> Self
+    pub fn from_shape_fn<F>(shape: [usize; N], alloc: AllocHandle, f: F) -> Self
     where
         F: Fn([usize; N]) -> T,
     {
@@ -484,11 +494,11 @@ impl<T, const N: usize, A: TensorAllocator> Tensor<T, N, A> {
     /// # Example
     ///
     /// ```
-    /// use kornia_tensor::{Tensor, CpuAllocator};
+    /// use kornia_tensor::{Tensor, host_alloc};
     ///
     /// let data: Vec<u8> = vec![1, 2, 3, 4];
     ///
-    /// let t = Tensor::<u8, 2, CpuAllocator>::from_shape_vec([2, 2], data, CpuAllocator).unwrap();
+    /// let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data, host_alloc()).unwrap();
     /// assert_eq!(*t.get_unchecked([0, 0]), 1);
     /// assert_eq!(*t.get_unchecked([0, 1]), 2);
     /// assert_eq!(*t.get_unchecked([1, 0]), 3);
@@ -516,11 +526,11 @@ impl<T, const N: usize, A: TensorAllocator> Tensor<T, N, A> {
     /// # Example
     ///
     /// ```
-    /// use kornia_tensor::{Tensor, CpuAllocator};
+    /// use kornia_tensor::{Tensor, host_alloc};
     ///
     /// let data: Vec<u8> = vec![1, 2, 3, 4];
     ///
-    /// let t = Tensor::<u8, 2, CpuAllocator>::from_shape_vec([2, 2], data, CpuAllocator).unwrap();
+    /// let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data, host_alloc()).unwrap();
     ///
     /// assert_eq!(t.get([0, 0]), Some(&1));
     /// assert_eq!(t.get([0, 1]), Some(&2));
@@ -551,11 +561,11 @@ impl<T, const N: usize, A: TensorAllocator> Tensor<T, N, A> {
     /// # Example
     ///
     /// ```
-    /// use kornia_tensor::{Tensor, CpuAllocator};
+    /// use kornia_tensor::{Tensor, host_alloc};
     ///
     /// let data: Vec<u8> = vec![1, 2, 3, 4];
     ///
-    /// let t = Tensor::<u8, 1, CpuAllocator>::from_shape_vec([4], data, CpuAllocator).unwrap();
+    /// let t = Tensor::<u8, 1>::from_shape_vec([4], data, host_alloc()).unwrap();
     /// let t2 = t.reshape([2, 2]).unwrap();
     /// assert_eq!(t2.shape, [2, 2]);
     /// assert_eq!(t2.as_slice(), vec![1, 2, 3, 4]);
@@ -565,7 +575,7 @@ impl<T, const N: usize, A: TensorAllocator> Tensor<T, N, A> {
     pub fn reshape<const M: usize>(
         &self,
         shape: [usize; M],
-    ) -> Result<TensorView<'_, T, M, A>, TensorError> {
+    ) -> Result<TensorView<'_, T, M>, TensorError> {
         let numel = shape.iter().product::<usize>();
         if numel != self.numel() {
             return Err(TensorError::DimensionMismatch(format!(
@@ -603,39 +613,16 @@ impl<T, const N: usize, A: TensorAllocator> Tensor<T, N, A> {
     /// Transposing a 2D tensor (matrix):
     ///
     /// ```rust
-    /// use kornia_tensor::{Tensor, CpuAllocator};
+    /// use kornia_tensor::{Tensor, host_alloc};
     ///
     /// let data = vec![1, 2, 3, 4, 5, 6];
-    /// let tensor = Tensor::<i32, 2, _>::from_shape_vec([2, 3], data, CpuAllocator).unwrap();
-    ///
-    /// // Original: [[1, 2, 3],
-    /// //            [4, 5, 6]]
+    /// let tensor = Tensor::<i32, 2>::from_shape_vec([2, 3], data, host_alloc()).unwrap();
     ///
     /// // Transpose by swapping dimensions
     /// let transposed = tensor.permute_axes([1, 0]);
     /// assert_eq!(transposed.shape, [3, 2]);
-    ///
-    /// // Result: [[1, 4],
-    /// //          [2, 5],
-    /// //          [3, 6]]
-    /// assert_eq!(*transposed.get_unchecked([0, 0]), 1);
-    /// assert_eq!(*transposed.get_unchecked([0, 1]), 4);
-    /// assert_eq!(*transposed.get_unchecked([1, 0]), 2);
     /// ```
-    ///
-    /// Reordering dimensions of a 3D tensor (e.g., changing channel order):
-    ///
-    /// ```rust
-    /// use kornia_tensor::{Tensor, CpuAllocator};
-    ///
-    /// // Create a 2x3x4 tensor (batch x height x width)
-    /// let tensor = Tensor::<i32, 3, _>::from_shape_val([2, 3, 4], 1, CpuAllocator);
-    ///
-    /// // Reorder to (batch x width x height)
-    /// let permuted = tensor.permute_axes([0, 2, 1]);
-    /// assert_eq!(permuted.shape, [2, 4, 3]);
-    /// ```
-    pub fn permute_axes(&self, axes: [usize; N]) -> TensorView<'_, T, N, A> {
+    pub fn permute_axes(&self, axes: [usize; N]) -> TensorView<'_, T, N> {
         let mut new_shape = [0; N];
         let mut new_strides = [0; N];
         for (i, &axis) in axes.iter().enumerate() {
@@ -657,7 +644,7 @@ impl<T, const N: usize, A: TensorAllocator> Tensor<T, N, A> {
     /// # Returns
     ///
     /// A `TensorView` instance.
-    pub fn view(&self) -> TensorView<'_, T, N, A> {
+    pub fn view(&self) -> TensorView<'_, T, N> {
         TensorView {
             storage: &self.storage,
             shape: self.shape,
@@ -670,14 +657,13 @@ impl<T, const N: usize, A: TensorAllocator> Tensor<T, N, A> {
     /// # Arguments
     ///
     /// * `shape` - The shape of the tensor.
-    /// * `alloc` - The allocator to use.
+    /// * `alloc` - The allocator handle to use.
     ///
     /// # Returns
-    pub fn zeros(shape: [usize; N], alloc: A) -> Tensor<T, N, A>
+    pub fn zeros(shape: [usize; N], alloc: AllocHandle) -> Tensor<T, N>
     where
         T: Clone + num_traits::Zero,
     {
-        // TODO: add allocator parameter
         Self::from_shape_val(shape, T::zero(), alloc)
     }
 
@@ -694,15 +680,15 @@ impl<T, const N: usize, A: TensorAllocator> Tensor<T, N, A> {
     /// # Example
     ///
     /// ```
-    /// use kornia_tensor::{Tensor, CpuAllocator};
+    /// use kornia_tensor::{Tensor, host_alloc};
     ///
     /// let data: Vec<u8> = vec![1, 2, 3, 4];
-    /// let t = Tensor::<u8, 1, CpuAllocator>::from_shape_vec([4], data, CpuAllocator).unwrap();
+    /// let t = Tensor::<u8, 1>::from_shape_vec([4], data, host_alloc()).unwrap();
     ///
     /// let t2 = t.map(|x| *x + 1);
     /// assert_eq!(t2.as_slice(), vec![2, 3, 4, 5]);
     /// ```
-    pub fn map<U, F>(&self, f: F) -> Tensor<U, N, A>
+    pub fn map<U, F>(&self, f: F) -> Tensor<U, N>
     where
         F: Fn(&T) -> U,
     {
@@ -726,52 +712,6 @@ impl<T, const N: usize, A: TensorAllocator> Tensor<T, N, A> {
     /// # Returns
     ///
     /// `true` if the tensor has contiguous row-major layout, `false` otherwise.
-    ///
-    /// # When is a layout non-standard?
-    ///
-    /// - After dimension permutation (e.g., transpose)
-    /// - After certain slicing operations
-    /// - When strides have been manually modified
-    /// - When the tensor is a non-contiguous view
-    ///
-    /// # Examples
-    ///
-    /// Standard layout:
-    ///
-    /// ```rust
-    /// use kornia_tensor::{Tensor, CpuAllocator};
-    ///
-    /// let tensor = Tensor::<i32, 2, _>::from_shape_val([3, 4], 0, CpuAllocator);
-    /// assert!(tensor.is_standard_layout());
-    /// ```
-    ///
-    /// Non-standard layout after transpose:
-    ///
-    /// ```rust
-    /// use kornia_tensor::{Tensor, CpuAllocator};
-    ///
-    /// let data = vec![1, 2, 3, 4];
-    /// let tensor = Tensor::<i32, 2, _>::from_shape_vec([2, 2], data, CpuAllocator).unwrap();
-    ///
-    /// // After permutation, the memory layout is no longer contiguous
-    /// let mut transposed = tensor.permute_axes([1, 0]).as_contiguous();
-    /// transposed.strides = [1, 2]; // Transpose stride pattern
-    ///
-    /// // This would need to_standard_layout() to become contiguous again
-    /// ```
-    ///
-    /// Detecting non-standard layout:
-    ///
-    /// ```rust
-    /// use kornia_tensor::{Tensor, CpuAllocator};
-    ///
-    /// let data = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-    /// let mut tensor = Tensor::<i32, 3, _>::from_shape_vec([2, 2, 3], data, CpuAllocator).unwrap();
-    ///
-    /// // Manually corrupt the strides
-    /// tensor.strides = [10, 5, 1];
-    /// assert!(!tensor.is_standard_layout());
-    /// ```
     pub fn is_standard_layout(&self) -> bool {
         let mut expected_stride: usize = 1;
         for (&dim, &stride) in self.shape.iter().rev().zip(self.strides.iter().rev()) {
@@ -789,14 +729,9 @@ impl<T, const N: usize, A: TensorAllocator> Tensor<T, N, A> {
     /// tensor with contiguous memory by copying elements in the correct order according to
     /// the current shape and strides.
     ///
-    /// This is essential for:
-    /// - Interfacing with libraries expecting contiguous memory
-    /// - Optimizing performance of certain operations
-    /// - Ensuring consistent memory layout after transformations
-    ///
     /// # Arguments
     ///
-    /// * `alloc` - The allocator to use for the new tensor if reallocation is needed
+    /// * `alloc` - The allocator handle to use for the new tensor if reallocation is needed
     ///
     /// # Returns
     ///
@@ -805,62 +740,7 @@ impl<T, const N: usize, A: TensorAllocator> Tensor<T, N, A> {
     /// # Errors
     ///
     /// Returns [`TensorError::DimensionMismatch`] if the tensor's shape and data are inconsistent.
-    ///
-    /// # Performance
-    ///
-    /// This operation is O(1) if already standard layout (just clones), O(n) otherwise where
-    /// n is the number of elements.
-    ///
-    /// # Examples
-    ///
-    /// Converting after permutation:
-    ///
-    /// ```rust
-    /// use kornia_tensor::{Tensor, CpuAllocator};
-    ///
-    /// let data = vec![1, 2, 3, 4, 5, 6];
-    /// let tensor = Tensor::<i32, 2, _>::from_shape_vec([2, 3], data, CpuAllocator).unwrap();
-    ///
-    /// // Transpose creates non-contiguous layout
-    /// let transposed = tensor.permute_axes([1, 0]);
-    /// let owned = transposed.as_contiguous(); // Now we have an owned tensor
-    ///
-    /// // Convert to standard layout
-    /// let standard = owned.to_standard_layout(CpuAllocator).unwrap();
-    /// assert!(standard.is_standard_layout());
-    /// ```
-    ///
-    /// Fixing corrupted strides:
-    ///
-    /// ```rust
-    /// use kornia_tensor::{Tensor, CpuAllocator};
-    ///
-    /// let data = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-    /// let mut tensor = Tensor::<i32, 3, _>::from_shape_vec([2, 2, 3], data, CpuAllocator).unwrap();
-    ///
-    /// // Simulate non-standard strides
-    /// tensor.strides = [1, 6, 2];
-    /// assert!(!tensor.is_standard_layout());
-    ///
-    /// // Restore standard layout
-    /// let fixed = tensor.to_standard_layout(CpuAllocator).unwrap();
-    /// assert!(fixed.is_standard_layout());
-    /// assert_eq!(fixed.strides, [6, 3, 1]);
-    /// ```
-    ///
-    /// No-op for already standard tensors:
-    ///
-    /// ```rust
-    /// use kornia_tensor::{Tensor, CpuAllocator};
-    ///
-    /// let tensor = Tensor::<i32, 2, _>::from_shape_val([3, 4], 42, CpuAllocator);
-    /// assert!(tensor.is_standard_layout());
-    ///
-    /// // This will just clone since it's already standard
-    /// let standard = tensor.to_standard_layout(CpuAllocator).unwrap();
-    /// assert!(standard.is_standard_layout());
-    /// ```
-    pub fn to_standard_layout(&self, alloc: A) -> Result<Self, TensorError>
+    pub fn to_standard_layout(&self, alloc: AllocHandle) -> Result<Self, TensorError>
     where
         T: Clone + std::fmt::Debug,
     {
@@ -910,15 +790,15 @@ impl<T, const N: usize, A: TensorAllocator> Tensor<T, N, A> {
     /// # Example
     ///
     /// ```
-    /// use kornia_tensor::{Tensor, CpuAllocator};
+    /// use kornia_tensor::{Tensor, host_alloc};
     ///
     /// let data: Vec<u8> = vec![1, 2, 3, 4];
-    /// let t = Tensor::<u8, 1, CpuAllocator>::from_shape_vec([4], data, CpuAllocator).unwrap();
+    /// let t = Tensor::<u8, 1>::from_shape_vec([4], data, host_alloc()).unwrap();
     ///
     /// let t2 = t.cast::<f32>();
     /// assert_eq!(t2.as_slice(), vec![1.0, 2.0, 3.0, 4.0]);
     /// ```
-    pub fn cast<U>(&self) -> Tensor<U, N, CpuAllocator>
+    pub fn cast<U>(&self) -> Tensor<U, N>
     where
         U: From<T>,
         T: Clone,
@@ -927,7 +807,7 @@ impl<T, const N: usize, A: TensorAllocator> Tensor<T, N, A> {
         self.as_slice().iter().for_each(|x| {
             data.push(U::from(x.clone()));
         });
-        let storage = TensorStorage::from_vec(data, CpuAllocator);
+        let storage = TensorStorage::from_vec(data, self.storage.alloc().clone());
         Tensor {
             storage,
             shape: self.shape,
@@ -949,31 +829,22 @@ impl<T, const N: usize, A: TensorAllocator> Tensor<T, N, A> {
     /// # Example
     ///
     /// ```
-    /// use kornia_tensor::{Tensor, CpuAllocator};
+    /// use kornia_tensor::{Tensor, host_alloc};
     ///
     /// let data1: Vec<u8> = vec![1, 2, 3, 4];
-    /// let t1 = Tensor::<u8, 1, CpuAllocator>::from_shape_vec([4], data1, CpuAllocator).unwrap();
+    /// let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1, host_alloc()).unwrap();
     ///
     /// let data2: Vec<u8> = vec![1, 2, 3, 4];
-    /// let t2 = Tensor::<u8, 1, CpuAllocator>::from_shape_vec([4], data2, CpuAllocator).unwrap();
+    /// let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2, host_alloc()).unwrap();
     ///
     /// let t3 = t1.element_wise_op(&t2, |a, b| *a + *b).unwrap();
     /// assert_eq!(t3.as_slice(), vec![2, 4, 6, 8]);
-    ///
-    /// let t4 = t1.element_wise_op(&t2, |a, b| *a - *b).unwrap();
-    /// assert_eq!(t4.as_slice(), vec![0, 0, 0, 0]);
-    ///
-    /// let t5 = t1.element_wise_op(&t2, |a, b| *a * *b).unwrap();
-    /// assert_eq!(t5.as_slice(), vec![1, 4, 9, 16]);
-    ///
-    /// let t6 = t1.element_wise_op(&t2, |a, b| *a / *b).unwrap();
-    /// assert_eq!(t6.as_slice(), vec![1, 1, 1, 1]);
     /// ```
     pub fn element_wise_op<F>(
         &self,
-        other: &Tensor<T, N, CpuAllocator>,
+        other: &Tensor<T, N>,
         op: F,
-    ) -> Result<Tensor<T, N, CpuAllocator>, TensorError>
+    ) -> Result<Tensor<T, N>, TensorError>
     where
         F: Fn(&T, &T) -> T,
     {
@@ -991,7 +862,7 @@ impl<T, const N: usize, A: TensorAllocator> Tensor<T, N, A> {
             .map(|(a, b)| op(a, b))
             .collect();
 
-        let storage = TensorStorage::from_vec(data, CpuAllocator);
+        let storage = TensorStorage::from_vec(data, self.storage.alloc().clone());
 
         Ok(Tensor {
             storage,
@@ -1001,11 +872,7 @@ impl<T, const N: usize, A: TensorAllocator> Tensor<T, N, A> {
     }
 }
 
-impl<T, const N: usize, A> Clone for Tensor<T, N, A>
-where
-    T: Clone,
-    A: TensorAllocator + Clone,
-{
+impl<T: Clone, const N: usize> Clone for Tensor<T, N> {
     fn clone(&self) -> Self {
         Self {
             storage: self.storage.clone(),
@@ -1015,10 +882,9 @@ where
     }
 }
 
-impl<T, const N: usize, A> std::fmt::Display for Tensor<T, N, A>
+impl<T, const N: usize> std::fmt::Display for Tensor<T, N>
 where
     T: std::fmt::Display + std::fmt::LowerExp,
-    A: TensorAllocator,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let width = self
@@ -1094,13 +960,13 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::allocator::CpuAllocator;
+    use crate::allocator::host_alloc;
     use crate::tensor::{Tensor, TensorError};
 
     #[test]
     fn constructor_1d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1];
-        let t = Tensor::<u8, 1, _>::from_shape_vec([1], data, CpuAllocator)?;
+        let t = Tensor::<u8, 1>::from_shape_vec([1], data, host_alloc())?;
         assert_eq!(t.shape, [1]);
         assert_eq!(t.as_slice(), vec![1]);
         assert_eq!(t.strides, [1]);
@@ -1111,7 +977,7 @@ mod tests {
     #[test]
     fn constructor_2d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2];
-        let t = Tensor::<u8, 2, _>::from_shape_vec([1, 2], data, CpuAllocator)?;
+        let t = Tensor::<u8, 2>::from_shape_vec([1, 2], data, host_alloc())?;
         assert_eq!(t.shape, [1, 2]);
         assert_eq!(t.as_slice(), vec![1, 2]);
         assert_eq!(t.strides, [2, 1]);
@@ -1122,7 +988,7 @@ mod tests {
     #[test]
     fn get_1d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 1, _>::from_shape_vec([4], data, CpuAllocator)?;
+        let t = Tensor::<u8, 1>::from_shape_vec([4], data, host_alloc())?;
         assert_eq!(t.get([0]), Some(&1));
         assert_eq!(t.get([1]), Some(&2));
         assert_eq!(t.get([2]), Some(&3));
@@ -1134,7 +1000,7 @@ mod tests {
     #[test]
     fn get_2d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 2, _>::from_shape_vec([2, 2], data, CpuAllocator)?;
+        let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data, host_alloc())?;
         assert_eq!(t.get([0, 0]), Some(&1));
         assert_eq!(t.get([0, 1]), Some(&2));
         assert_eq!(t.get([1, 0]), Some(&3));
@@ -1147,7 +1013,7 @@ mod tests {
     #[test]
     fn get_3d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4, 5, 6];
-        let t = Tensor::<u8, 3, _>::from_shape_vec([2, 1, 3], data, CpuAllocator)?;
+        let t = Tensor::<u8, 3>::from_shape_vec([2, 1, 3], data, host_alloc())?;
         assert_eq!(t.get([0, 0, 0]), Some(&1));
         assert_eq!(t.get([0, 0, 1]), Some(&2));
         assert_eq!(t.get([0, 0, 2]), Some(&3));
@@ -1163,7 +1029,7 @@ mod tests {
     #[test]
     fn get_checked_1d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 1, _>::from_shape_vec([4], data, CpuAllocator)?;
+        let t = Tensor::<u8, 1>::from_shape_vec([4], data, host_alloc())?;
         assert_eq!(*t.get_unchecked([0]), 1);
         assert_eq!(*t.get_unchecked([1]), 2);
         assert_eq!(*t.get_unchecked([2]), 3);
@@ -1174,7 +1040,7 @@ mod tests {
     #[test]
     fn get_checked_2d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 2, _>::from_shape_vec([2, 2], data, CpuAllocator)?;
+        let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data, host_alloc())?;
         assert_eq!(*t.get_unchecked([0, 0]), 1);
         assert_eq!(*t.get_unchecked([0, 1]), 2);
         assert_eq!(*t.get_unchecked([1, 0]), 3);
@@ -1184,7 +1050,7 @@ mod tests {
     #[test]
     fn reshape_1d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 1, _>::from_shape_vec([4], data, CpuAllocator)?;
+        let t = Tensor::<u8, 1>::from_shape_vec([4], data, host_alloc())?;
 
         let view = t.reshape([2, 2])?;
 
@@ -1199,7 +1065,7 @@ mod tests {
     #[test]
     fn reshape_2d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 2, _>::from_shape_vec([2, 2], data, CpuAllocator)?;
+        let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data, host_alloc())?;
         let t2 = t.reshape([4])?;
 
         assert_eq!(t2.shape, [4]);
@@ -1213,7 +1079,7 @@ mod tests {
     #[test]
     fn reshape_get_1d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 1, _>::from_shape_vec([4], data, CpuAllocator)?;
+        let t = Tensor::<u8, 1>::from_shape_vec([4], data, host_alloc())?;
         let view = t.reshape([2, 2])?;
         assert_eq!(*view.get_unchecked([0, 0]), 1);
         assert_eq!(*view.get_unchecked([0, 1]), 2);
@@ -1227,7 +1093,7 @@ mod tests {
     #[test]
     fn permute_axes_1d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 1, _>::from_shape_vec([4], data, CpuAllocator)?;
+        let t = Tensor::<u8, 1>::from_shape_vec([4], data, host_alloc())?;
         let t2 = t.permute_axes([0]);
         assert_eq!(t2.shape, [4]);
         assert_eq!(t2.as_slice(), vec![1, 2, 3, 4]);
@@ -1239,7 +1105,7 @@ mod tests {
     #[test]
     fn permute_axes_2d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 2, _>::from_shape_vec([2, 2], data, CpuAllocator)?;
+        let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data, host_alloc())?;
         let view = t.permute_axes([1, 0]);
         assert_eq!(view.shape, [2, 2]);
         assert_eq!(*view.get_unchecked([0, 0]), 1u8);
@@ -1254,7 +1120,7 @@ mod tests {
     #[test]
     fn contiguous_2d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4, 5, 6];
-        let t = Tensor::<u8, 2, _>::from_shape_vec([2, 3], data, CpuAllocator)?;
+        let t = Tensor::<u8, 2>::from_shape_vec([2, 3], data, host_alloc())?;
 
         let view = t.permute_axes([1, 0]);
 
@@ -1269,14 +1135,14 @@ mod tests {
 
     #[test]
     fn zeros_1d() -> Result<(), TensorError> {
-        let t = Tensor::<u8, 1, _>::zeros([4], CpuAllocator);
+        let t = Tensor::<u8, 1>::zeros([4], host_alloc());
         assert_eq!(t.as_slice(), vec![0, 0, 0, 0]);
         Ok(())
     }
 
     #[test]
     fn zeros_2d() -> Result<(), TensorError> {
-        let t = Tensor::<u8, 2, _>::zeros([2, 2], CpuAllocator);
+        let t = Tensor::<u8, 2>::zeros([2, 2], host_alloc());
         assert_eq!(t.as_slice(), vec![0, 0, 0, 0]);
         Ok(())
     }
@@ -1284,7 +1150,7 @@ mod tests {
     #[test]
     fn map_1d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 1, _>::from_shape_vec([4], data, CpuAllocator)?;
+        let t = Tensor::<u8, 1>::from_shape_vec([4], data, host_alloc())?;
         let t2 = t.map(|x| *x + 1);
         assert_eq!(t2.as_slice(), vec![2, 3, 4, 5]);
         Ok(())
@@ -1293,7 +1159,7 @@ mod tests {
     #[test]
     fn map_2d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 2, _>::from_shape_vec([2, 2], data, CpuAllocator)?;
+        let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data, host_alloc())?;
         let t2 = t.map(|x| *x + 1);
         assert_eq!(t2.as_slice(), vec![2, 3, 4, 5]);
         Ok(())
@@ -1301,21 +1167,21 @@ mod tests {
 
     #[test]
     fn from_shape_val_1d() -> Result<(), TensorError> {
-        let t = Tensor::<u8, 1, _>::from_shape_val([4], 0, CpuAllocator);
+        let t = Tensor::<u8, 1>::from_shape_val([4], 0, host_alloc());
         assert_eq!(t.as_slice(), vec![0, 0, 0, 0]);
         Ok(())
     }
 
     #[test]
     fn from_shape_val_2d() -> Result<(), TensorError> {
-        let t = Tensor::<u8, 2, _>::from_shape_val([2, 2], 1, CpuAllocator);
+        let t = Tensor::<u8, 2>::from_shape_val([2, 2], 1, host_alloc());
         assert_eq!(t.as_slice(), vec![1, 1, 1, 1]);
         Ok(())
     }
 
     #[test]
     fn from_shape_val_3d() -> Result<(), TensorError> {
-        let t = Tensor::<u8, 3, _>::from_shape_val([2, 1, 3], 2, CpuAllocator);
+        let t = Tensor::<u8, 3>::from_shape_val([2, 1, 3], 2, host_alloc());
         assert_eq!(t.as_slice(), vec![2, 2, 2, 2, 2, 2]);
         Ok(())
     }
@@ -1323,7 +1189,7 @@ mod tests {
     #[test]
     fn cast_1d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 1, _>::from_shape_vec([4], data, CpuAllocator)?;
+        let t = Tensor::<u8, 1>::from_shape_vec([4], data, host_alloc())?;
         let t2 = t.cast::<u16>();
         assert_eq!(t2.as_slice(), vec![1, 2, 3, 4]);
         Ok(())
@@ -1332,7 +1198,7 @@ mod tests {
     #[test]
     fn cast_2d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 2, _>::from_shape_vec([2, 2], data, CpuAllocator)?;
+        let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data, host_alloc())?;
         let t2 = t.cast::<u16>();
         assert_eq!(t2.as_slice(), vec![1, 2, 3, 4]);
         Ok(())
@@ -1340,7 +1206,7 @@ mod tests {
 
     #[test]
     fn from_shape_fn_1d() -> Result<(), TensorError> {
-        let alloc = CpuAllocator;
+        let alloc = host_alloc();
         let t = Tensor::from_shape_fn([3, 3], alloc, |[i, j]| ((1 + i) * (1 + j)) as u8);
         assert_eq!(t.as_slice(), vec![1, 2, 3, 2, 4, 6, 3, 6, 9]);
         Ok(())
@@ -1348,7 +1214,7 @@ mod tests {
 
     #[test]
     fn from_shape_fn_2d() -> Result<(), TensorError> {
-        let alloc = CpuAllocator;
+        let alloc = host_alloc();
         let t = Tensor::from_shape_fn([3, 3], alloc, |[i, j]| ((1 + i) * (1 + j)) as f32);
         assert_eq!(
             t.as_slice(),
@@ -1359,7 +1225,7 @@ mod tests {
 
     #[test]
     fn from_shape_fn_3d() -> Result<(), TensorError> {
-        let alloc = CpuAllocator;
+        let alloc = host_alloc();
         let t = Tensor::from_shape_fn([2, 3, 3], alloc, |[x, y, c]| {
             ((1 + x) * (1 + y) * (1 + c)) as i16
         });
@@ -1372,9 +1238,9 @@ mod tests {
 
     #[test]
     fn view_1d() -> Result<(), TensorError> {
-        let alloc = CpuAllocator;
+        let alloc = host_alloc();
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 1, _>::from_shape_vec([4], data, alloc)?;
+        let t = Tensor::<u8, 1>::from_shape_vec([4], data, alloc)?;
         let view = t.view();
 
         // check that the view has the same data
@@ -1389,7 +1255,7 @@ mod tests {
     #[test]
     fn from_slice() -> Result<(), TensorError> {
         let data: [u8; 4] = [1, 2, 3, 4];
-        let t = Tensor::<u8, 2, _>::from_shape_slice([2, 2], &data, CpuAllocator)?;
+        let t = Tensor::<u8, 2>::from_shape_slice([2, 2], &data, host_alloc())?;
 
         assert_eq!(t.shape, [2, 2]);
         assert_eq!(t.as_slice(), &[1, 2, 3, 4]);
@@ -1400,7 +1266,7 @@ mod tests {
     #[test]
     fn display_2d() -> Result<(), TensorError> {
         let data: [u8; 4] = [1, 2, 3, 4];
-        let t = Tensor::<u8, 2, _>::from_shape_slice([2, 2], &data, CpuAllocator)?;
+        let t = Tensor::<u8, 2>::from_shape_slice([2, 2], &data, host_alloc())?;
         let disp = t.to_string();
         let lines = disp.lines().collect::<Vec<_>>();
 
@@ -1414,7 +1280,7 @@ mod tests {
     #[test]
     fn display_3d() -> Result<(), TensorError> {
         let data: [u8; 12] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-        let t = Tensor::<u8, 3, _>::from_shape_slice([2, 3, 2], &data, CpuAllocator)?;
+        let t = Tensor::<u8, 3>::from_shape_slice([2, 3, 2], &data, host_alloc())?;
         let disp = t.to_string();
         let lines = disp.lines().collect::<Vec<_>>();
 
@@ -1433,7 +1299,7 @@ mod tests {
     #[test]
     fn display_float() -> Result<(), TensorError> {
         let data: [f32; 4] = [1.00001, 1.00009, 0.99991, 0.99999];
-        let t = Tensor::<f32, 2, _>::from_shape_slice([2, 2], &data, CpuAllocator)?;
+        let t = Tensor::<f32, 2>::from_shape_slice([2, 2], &data, host_alloc())?;
         let disp = t.to_string();
         let lines = disp.lines().collect::<Vec<_>>();
 
@@ -1447,7 +1313,7 @@ mod tests {
     #[test]
     fn display_big_float() -> Result<(), TensorError> {
         let data: [f32; 4] = [1000.00001, 1.00009, 0.99991, 0.99999];
-        let t = Tensor::<f32, 2, _>::from_shape_slice([2, 2], &data, CpuAllocator)?;
+        let t = Tensor::<f32, 2>::from_shape_slice([2, 2], &data, host_alloc())?;
         let disp = t.to_string();
         let lines = disp.lines().collect::<Vec<_>>();
 
@@ -1461,7 +1327,7 @@ mod tests {
     #[test]
     fn display_big_tensor() -> Result<(), TensorError> {
         let data: [u8; 1000] = [0; 1000];
-        let t = Tensor::<u8, 3, _>::from_shape_slice([10, 10, 10], &data, CpuAllocator)?;
+        let t = Tensor::<u8, 3>::from_shape_slice([10, 10, 10], &data, host_alloc())?;
         let disp = t.to_string();
         let lines = disp.lines().collect::<Vec<_>>();
 
@@ -1498,7 +1364,7 @@ mod tests {
     #[test]
     fn get_index_unchecked_1d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 1, CpuAllocator>::from_shape_vec([4], data, CpuAllocator)?;
+        let t = Tensor::<u8, 1>::from_shape_vec([4], data, host_alloc())?;
         assert_eq!(t.get_index_unchecked(0), [0]);
         assert_eq!(t.get_index_unchecked(1), [1]);
         assert_eq!(t.get_index_unchecked(2), [2]);
@@ -1509,7 +1375,7 @@ mod tests {
     #[test]
     fn get_index_unchecked_2d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 2, CpuAllocator>::from_shape_vec([2, 2], data, CpuAllocator)?;
+        let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data, host_alloc())?;
         assert_eq!(t.get_index_unchecked(0), [0, 0]);
         assert_eq!(t.get_index_unchecked(1), [0, 1]);
         assert_eq!(t.get_index_unchecked(2), [1, 0]);
@@ -1520,7 +1386,7 @@ mod tests {
     #[test]
     fn get_index_unchecked_3d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-        let t = Tensor::<u8, 3, CpuAllocator>::from_shape_vec([2, 2, 3], data, CpuAllocator)?;
+        let t = Tensor::<u8, 3>::from_shape_vec([2, 2, 3], data, host_alloc())?;
         assert_eq!(t.get_index_unchecked(0), [0, 0, 0]);
         assert_eq!(t.get_index_unchecked(1), [0, 0, 1]);
         assert_eq!(t.get_index_unchecked(2), [0, 0, 2]);
@@ -1539,7 +1405,7 @@ mod tests {
     #[test]
     fn get_index_to_offset_and_back() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-        let t = Tensor::<u8, 3, CpuAllocator>::from_shape_vec([2, 2, 3], data, CpuAllocator)?;
+        let t = Tensor::<u8, 3>::from_shape_vec([2, 2, 3], data, host_alloc())?;
         for offset in 0..12 {
             assert_eq!(
                 t.get_iter_offset_unchecked(t.get_index_unchecked(offset)),
@@ -1552,7 +1418,7 @@ mod tests {
     #[test]
     fn get_offset_to_index_and_back() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-        let t = Tensor::<u8, 3, CpuAllocator>::from_shape_vec([2, 2, 3], data, CpuAllocator)?;
+        let t = Tensor::<u8, 3>::from_shape_vec([2, 2, 3], data, host_alloc())?;
         for ind in [
             [0, 0, 0],
             [0, 0, 1],
@@ -1575,7 +1441,7 @@ mod tests {
     #[test]
     fn get_index_1d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 1, CpuAllocator>::from_shape_vec([4], data, CpuAllocator)?;
+        let t = Tensor::<u8, 1>::from_shape_vec([4], data, host_alloc())?;
         assert_eq!(t.get_index(3), Ok([3]));
         assert!(t
             .get_index(4)
@@ -1586,7 +1452,7 @@ mod tests {
     #[test]
     fn get_index_2d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 2, CpuAllocator>::from_shape_vec([2, 2], data, CpuAllocator)?;
+        let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data, host_alloc())?;
         assert_eq!(t.get_index_unchecked(3), [1, 1]);
         assert!(t
             .get_index(4)
@@ -1597,7 +1463,7 @@ mod tests {
     #[test]
     fn get_index_3d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-        let t = Tensor::<u8, 3, CpuAllocator>::from_shape_vec([2, 2, 3], data, CpuAllocator)?;
+        let t = Tensor::<u8, 3>::from_shape_vec([2, 2, 3], data, host_alloc())?;
         assert_eq!(t.get_index_unchecked(11), [1, 1, 2]);
         assert!(t
             .get_index(12)
@@ -1608,7 +1474,7 @@ mod tests {
     #[test]
     fn from_raw_parts() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = unsafe { Tensor::from_raw_parts([2, 2], data.as_ptr(), data.len(), CpuAllocator)? };
+        let t = unsafe { Tensor::from_raw_parts([2, 2], data.as_ptr(), data.len(), host_alloc())? };
         std::mem::forget(data);
         assert_eq!(t.shape, [2, 2]);
         assert_eq!(t.as_slice(), &[1, 2, 3, 4]);
@@ -1618,7 +1484,7 @@ mod tests {
     #[test]
     fn test_from_shape_vec_shape_data_mismatch() {
         // 2*3 = 6 elements expected but only 3 supplied — must return InvalidShape.
-        let result = Tensor::<u8, 2, _>::from_shape_vec([2, 3], vec![1, 2, 3], CpuAllocator);
+        let result = Tensor::<u8, 2>::from_shape_vec([2, 3], vec![1, 2, 3], host_alloc());
         assert!(
             matches!(result, Err(TensorError::InvalidShape(6))),
             "expected Err(TensorError::InvalidShape(6))"
@@ -1629,7 +1495,7 @@ mod tests {
     fn test_reshape_invalid_numel() -> Result<(), TensorError> {
         // 4-element tensor cannot be reshaped to [3, 2] (= 6 elements).
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 1, _>::from_shape_vec([4], data, CpuAllocator)?;
+        let t = Tensor::<u8, 1>::from_shape_vec([4], data, host_alloc())?;
         let result = t.reshape([3, 2]);
         assert!(
             matches!(result, Err(TensorError::DimensionMismatch(_))),
@@ -1641,7 +1507,7 @@ mod tests {
     #[test]
     fn test_zero_sized_tensor_roundtrip() -> Result<(), TensorError> {
         // A 1-D tensor with zero elements must be constructable and report correct metadata.
-        let t = Tensor::<f32, 1, _>::from_shape_vec([0], vec![], CpuAllocator)?;
+        let t = Tensor::<f32, 1>::from_shape_vec([0], vec![], host_alloc())?;
         assert_eq!(t.numel(), 0);
         assert!(t.as_slice().is_empty());
 
@@ -1657,7 +1523,7 @@ mod tests {
     fn test_cast_on_permuted_view() -> Result<(), TensorError> {
         // Build a 2x3 tensor [[1,2,3],[4,5,6]] and permute (transpose) to 3x2.
         let data: Vec<u8> = vec![1, 2, 3, 4, 5, 6];
-        let t = Tensor::<u8, 2, _>::from_shape_vec([2, 3], data, CpuAllocator)?;
+        let t = Tensor::<u8, 2>::from_shape_vec([2, 3], data, host_alloc())?;
 
         // permute_axes returns a TensorView; materialise it before casting.
         let permuted_view = t.permute_axes([1, 0]);
@@ -1680,7 +1546,7 @@ mod tests {
     #[test]
     fn contiguous_tensor_is_standard_layout_true() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-        let t = Tensor::<u8, 3, CpuAllocator>::from_shape_vec([2, 2, 3], data, CpuAllocator)?;
+        let t = Tensor::<u8, 3>::from_shape_vec([2, 2, 3], data, host_alloc())?;
         assert!(t.is_standard_layout());
         Ok(())
     }
@@ -1688,7 +1554,7 @@ mod tests {
     #[test]
     fn broken_stride_is_standard_layout_false() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-        let mut t = Tensor::<u8, 3, CpuAllocator>::from_shape_vec([2, 2, 3], data, CpuAllocator)?;
+        let mut t = Tensor::<u8, 3>::from_shape_vec([2, 2, 3], data, host_alloc())?;
         // arbitrary incorrect stride
         t.strides = [10, 5, 1];
         assert!(!t.is_standard_layout());
@@ -1698,10 +1564,9 @@ mod tests {
     #[test]
     fn contiguous_tensor_roundtrip() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-        let t =
-            Tensor::<u8, 3, CpuAllocator>::from_shape_vec([2, 2, 3], data.clone(), CpuAllocator)?;
+        let t = Tensor::<u8, 3>::from_shape_vec([2, 2, 3], data.clone(), host_alloc())?;
         assert!(t.is_standard_layout());
-        match t.to_standard_layout(CpuAllocator) {
+        match t.to_standard_layout(host_alloc()) {
             Ok(t2) => {
                 assert!(t2.is_standard_layout());
                 assert_eq!(t2.storage.as_slice(), data.as_slice());
@@ -1714,12 +1579,11 @@ mod tests {
     #[test]
     fn non_contiguous_to_standard_layout() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-        let mut t =
-            Tensor::<u8, 3, CpuAllocator>::from_shape_vec([2, 2, 3], data.clone(), CpuAllocator)?;
+        let mut t = Tensor::<u8, 3>::from_shape_vec([2, 2, 3], data.clone(), host_alloc())?;
         // altering strides
         t.strides = [1, 6, 2];
         assert!(!t.is_standard_layout());
-        match t.to_standard_layout(CpuAllocator) {
+        match t.to_standard_layout(host_alloc()) {
             Ok(t2) => {
                 assert!(t2.is_standard_layout());
             }

--- a/crates/kornia-tensor/src/tensor.rs
+++ b/crates/kornia-tensor/src/tensor.rs
@@ -1,7 +1,7 @@
 use thiserror::Error;
 
 use super::{
-    allocator::{AllocHandle, TensorAllocatorError},
+    allocator::{host_alloc, AllocHandle, TensorAllocatorError},
     storage::TensorStorage,
     view::TensorView,
 };
@@ -106,10 +106,10 @@ pub fn get_strides_from_shape<const N: usize>(shape: [usize; N]) -> [usize; N] {
 /// Creating a tensor from data:
 ///
 /// ```rust
-/// use kornia_tensor::{Tensor, host_alloc};
+/// use kornia_tensor::Tensor;
 ///
 /// let data = vec![1, 2, 3, 4, 5, 6];
-/// let tensor = Tensor::<i32, 2>::from_shape_vec([2, 3], data, host_alloc()).unwrap();
+/// let tensor = Tensor::<i32, 2>::from_shape_vec([2, 3], data).unwrap();
 ///
 /// assert_eq!(tensor.shape, [2, 3]);
 /// assert_eq!(tensor.strides, [3, 1]); // Row-major layout
@@ -119,16 +119,16 @@ pub fn get_strides_from_shape<const N: usize>(shape: [usize; N]) -> [usize; N] {
 /// Creating tensors with convenience constructors:
 ///
 /// ```rust
-/// use kornia_tensor::{Tensor, host_alloc};
+/// use kornia_tensor::Tensor;
 ///
 /// // All zeros
-/// let zeros = Tensor::<f32, 2>::zeros([3, 3], host_alloc());
+/// let zeros = Tensor::<f32, 2>::zeros([3, 3]);
 ///
 /// // All ones
-/// let ones = Tensor::<f32, 2>::from_shape_val([3, 3], 1.0, host_alloc());
+/// let ones = Tensor::<f32, 2>::from_shape_val([3, 3], 1.0);
 ///
 /// // Generated with a function
-/// let range = Tensor::<i32, 1>::from_shape_fn([10], host_alloc(), |[i]| i as i32);
+/// let range = Tensor::<i32, 1>::from_shape_fn([10], |[i]| i as i32);
 /// ```
 pub struct Tensor<T, const N: usize> {
     /// The storage of the tensor.
@@ -196,7 +196,6 @@ impl<T, const N: usize> Tensor<T, N> {
     ///
     /// * `shape` - An array containing the shape of the tensor.
     /// * `data` - A vector containing the data of the tensor.
-    /// * `alloc` - The allocator handle to use.
     ///
     /// # Returns
     ///
@@ -209,13 +208,18 @@ impl<T, const N: usize> Tensor<T, N> {
     /// # Example
     ///
     /// ```
-    /// use kornia_tensor::{Tensor, host_alloc};
+    /// use kornia_tensor::Tensor;
     ///
     /// let data: Vec<u8> = vec![1, 2, 3, 4];
-    /// let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data, host_alloc()).unwrap();
+    /// let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data).unwrap();
     /// assert_eq!(t.shape, [2, 2]);
     /// ```
-    pub fn from_shape_vec(
+    pub fn from_shape_vec(shape: [usize; N], data: Vec<T>) -> Result<Self, TensorError> {
+        Self::from_shape_vec_in(shape, data, host_alloc())
+    }
+
+    /// Like [`from_shape_vec`](Self::from_shape_vec) but with an explicit allocator handle.
+    pub fn from_shape_vec_in(
         shape: [usize; N],
         data: Vec<T>,
         alloc: AllocHandle,
@@ -239,7 +243,6 @@ impl<T, const N: usize> Tensor<T, N> {
     ///
     /// * `shape` - An array containing the shape of the tensor.
     /// * `data` - A slice containing the data of the tensor.
-    /// * `alloc` - The allocator handle to use.
     ///
     /// # Returns
     ///
@@ -248,7 +251,15 @@ impl<T, const N: usize> Tensor<T, N> {
     /// # Errors
     ///
     /// If the number of elements in the data does not match the shape of the tensor, an error is returned.
-    pub fn from_shape_slice(
+    pub fn from_shape_slice(shape: [usize; N], data: &[T]) -> Result<Self, TensorError>
+    where
+        T: Clone,
+    {
+        Self::from_shape_slice_in(shape, data, host_alloc())
+    }
+
+    /// Like [`from_shape_slice`](Self::from_shape_slice) but with an explicit allocator handle.
+    pub fn from_shape_slice_in(
         shape: [usize; N],
         data: &[T],
         alloc: AllocHandle,
@@ -256,7 +267,7 @@ impl<T, const N: usize> Tensor<T, N> {
     where
         T: Clone,
     {
-        Self::from_shape_vec(shape, data.to_vec(), alloc)
+        Self::from_shape_vec_in(shape, data.to_vec(), alloc)
     }
 
     /// Creates a new `Tensor` with the given shape and raw parts.
@@ -297,7 +308,6 @@ impl<T, const N: usize> Tensor<T, N> {
     ///
     /// * `shape` - An array containing the shape of the tensor.
     /// * `value` - The default value to fill the tensor with.
-    /// * `alloc` - The allocator handle to use.
     ///
     /// # Returns
     ///
@@ -306,18 +316,26 @@ impl<T, const N: usize> Tensor<T, N> {
     /// # Example
     ///
     /// ```
-    /// use kornia_tensor::{Tensor, host_alloc};
+    /// use kornia_tensor::Tensor;
     ///
-    /// let t = Tensor::<u8, 1>::from_shape_val([4], 0, host_alloc());
+    /// let t = Tensor::<u8, 1>::from_shape_val([4], 0);
     /// assert_eq!(t.as_slice(), vec![0, 0, 0, 0]);
     ///
-    /// let t = Tensor::<u8, 2>::from_shape_val([2, 2], 1, host_alloc());
+    /// let t = Tensor::<u8, 2>::from_shape_val([2, 2], 1);
     /// assert_eq!(t.as_slice(), vec![1, 1, 1, 1]);
     ///
-    /// let t = Tensor::<u8, 3>::from_shape_val([2, 1, 3], 2, host_alloc());
+    /// let t = Tensor::<u8, 3>::from_shape_val([2, 1, 3], 2);
     /// assert_eq!(t.as_slice(), vec![2, 2, 2, 2, 2, 2]);
     /// ```
-    pub fn from_shape_val(shape: [usize; N], value: T, alloc: AllocHandle) -> Self
+    pub fn from_shape_val(shape: [usize; N], value: T) -> Self
+    where
+        T: Clone,
+    {
+        Self::from_shape_val_in(shape, value, host_alloc())
+    }
+
+    /// Like [`from_shape_val`](Self::from_shape_val) but with an explicit allocator handle.
+    pub fn from_shape_val_in(shape: [usize; N], value: T, alloc: AllocHandle) -> Self
     where
         T: Clone,
     {
@@ -339,7 +357,6 @@ impl<T, const N: usize> Tensor<T, N> {
     /// # Arguments
     ///
     /// * `shape` - An array containing the shape of the tensor.
-    /// * `alloc` - The allocator handle to use.
     /// * `f` - The function to generate the data.
     ///
     /// # Returns
@@ -349,15 +366,23 @@ impl<T, const N: usize> Tensor<T, N> {
     /// # Example
     ///
     /// ```
-    /// use kornia_tensor::{Tensor, host_alloc};
+    /// use kornia_tensor::Tensor;
     ///
-    /// let t = Tensor::<u8, 1>::from_shape_fn([4], host_alloc(), |[i]| i as u8);
+    /// let t = Tensor::<u8, 1>::from_shape_fn([4], |[i]| i as u8);
     /// assert_eq!(t.as_slice(), vec![0, 1, 2, 3]);
     ///
-    /// let t = Tensor::<u8, 2>::from_shape_fn([2, 2], host_alloc(), |[i, j]| (i * 2 + j) as u8);
+    /// let t = Tensor::<u8, 2>::from_shape_fn([2, 2], |[i, j]| (i * 2 + j) as u8);
     /// assert_eq!(t.as_slice(), vec![0, 1, 2, 3]);
     /// ```
-    pub fn from_shape_fn<F>(shape: [usize; N], alloc: AllocHandle, f: F) -> Self
+    pub fn from_shape_fn<F>(shape: [usize; N], f: F) -> Self
+    where
+        F: Fn([usize; N]) -> T,
+    {
+        Self::from_shape_fn_in(shape, host_alloc(), f)
+    }
+
+    /// Like [`from_shape_fn`](Self::from_shape_fn) but with an explicit allocator handle.
+    pub fn from_shape_fn_in<F>(shape: [usize; N], alloc: AllocHandle, f: F) -> Self
     where
         F: Fn([usize; N]) -> T,
     {
@@ -484,11 +509,11 @@ impl<T, const N: usize> Tensor<T, N> {
     /// # Example
     ///
     /// ```
-    /// use kornia_tensor::{Tensor, host_alloc};
+    /// use kornia_tensor::Tensor;
     ///
     /// let data: Vec<u8> = vec![1, 2, 3, 4];
     ///
-    /// let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data, host_alloc()).unwrap();
+    /// let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data).unwrap();
     /// assert_eq!(*t.get_unchecked([0, 0]), 1);
     /// assert_eq!(*t.get_unchecked([0, 1]), 2);
     /// assert_eq!(*t.get_unchecked([1, 0]), 3);
@@ -516,11 +541,11 @@ impl<T, const N: usize> Tensor<T, N> {
     /// # Example
     ///
     /// ```
-    /// use kornia_tensor::{Tensor, host_alloc};
+    /// use kornia_tensor::Tensor;
     ///
     /// let data: Vec<u8> = vec![1, 2, 3, 4];
     ///
-    /// let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data, host_alloc()).unwrap();
+    /// let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data).unwrap();
     ///
     /// assert_eq!(t.get([0, 0]), Some(&1));
     /// assert_eq!(t.get([0, 1]), Some(&2));
@@ -551,11 +576,11 @@ impl<T, const N: usize> Tensor<T, N> {
     /// # Example
     ///
     /// ```
-    /// use kornia_tensor::{Tensor, host_alloc};
+    /// use kornia_tensor::Tensor;
     ///
     /// let data: Vec<u8> = vec![1, 2, 3, 4];
     ///
-    /// let t = Tensor::<u8, 1>::from_shape_vec([4], data, host_alloc()).unwrap();
+    /// let t = Tensor::<u8, 1>::from_shape_vec([4], data).unwrap();
     /// let t2 = t.reshape([2, 2]).unwrap();
     /// assert_eq!(t2.shape, [2, 2]);
     /// assert_eq!(t2.as_slice(), vec![1, 2, 3, 4]);
@@ -603,10 +628,10 @@ impl<T, const N: usize> Tensor<T, N> {
     /// Transposing a 2D tensor (matrix):
     ///
     /// ```rust
-    /// use kornia_tensor::{Tensor, host_alloc};
+    /// use kornia_tensor::Tensor;
     ///
     /// let data = vec![1, 2, 3, 4, 5, 6];
-    /// let tensor = Tensor::<i32, 2>::from_shape_vec([2, 3], data, host_alloc()).unwrap();
+    /// let tensor = Tensor::<i32, 2>::from_shape_vec([2, 3], data).unwrap();
     ///
     /// // Transpose by swapping dimensions
     /// let transposed = tensor.permute_axes([1, 0]);
@@ -647,14 +672,21 @@ impl<T, const N: usize> Tensor<T, N> {
     /// # Arguments
     ///
     /// * `shape` - The shape of the tensor.
-    /// * `alloc` - The allocator handle to use.
     ///
     /// # Returns
-    pub fn zeros(shape: [usize; N], alloc: AllocHandle) -> Tensor<T, N>
+    pub fn zeros(shape: [usize; N]) -> Tensor<T, N>
     where
         T: Clone + num_traits::Zero,
     {
-        Self::from_shape_val(shape, T::zero(), alloc)
+        Self::zeros_in(shape, host_alloc())
+    }
+
+    /// Like [`zeros`](Self::zeros) but with an explicit allocator handle.
+    pub fn zeros_in(shape: [usize; N], alloc: AllocHandle) -> Tensor<T, N>
+    where
+        T: Clone + num_traits::Zero,
+    {
+        Self::from_shape_val_in(shape, T::zero(), alloc)
     }
 
     /// Apply a function to each element of the tensor.
@@ -670,10 +702,10 @@ impl<T, const N: usize> Tensor<T, N> {
     /// # Example
     ///
     /// ```
-    /// use kornia_tensor::{Tensor, host_alloc};
+    /// use kornia_tensor::Tensor;
     ///
     /// let data: Vec<u8> = vec![1, 2, 3, 4];
-    /// let t = Tensor::<u8, 1>::from_shape_vec([4], data, host_alloc()).unwrap();
+    /// let t = Tensor::<u8, 1>::from_shape_vec([4], data).unwrap();
     ///
     /// let t2 = t.map(|x| *x + 1);
     /// assert_eq!(t2.as_slice(), vec![2, 3, 4, 5]);
@@ -763,7 +795,7 @@ impl<T, const N: usize> Tensor<T, N> {
             }
         }
 
-        Tensor::from_shape_vec(self.shape, flat, alloc).map_err(|_| {
+        Tensor::from_shape_vec_in(self.shape, flat, alloc).map_err(|_| {
             TensorError::DimensionMismatch(format!(
                 "Cannot construct tensor of shape {:?} with {:?} elements",
                 self.shape, total_elems,
@@ -780,10 +812,10 @@ impl<T, const N: usize> Tensor<T, N> {
     /// # Example
     ///
     /// ```
-    /// use kornia_tensor::{Tensor, host_alloc};
+    /// use kornia_tensor::Tensor;
     ///
     /// let data: Vec<u8> = vec![1, 2, 3, 4];
-    /// let t = Tensor::<u8, 1>::from_shape_vec([4], data, host_alloc()).unwrap();
+    /// let t = Tensor::<u8, 1>::from_shape_vec([4], data).unwrap();
     ///
     /// let t2 = t.cast::<f32>();
     /// assert_eq!(t2.as_slice(), vec![1.0, 2.0, 3.0, 4.0]);
@@ -819,13 +851,13 @@ impl<T, const N: usize> Tensor<T, N> {
     /// # Example
     ///
     /// ```
-    /// use kornia_tensor::{Tensor, host_alloc};
+    /// use kornia_tensor::Tensor;
     ///
     /// let data1: Vec<u8> = vec![1, 2, 3, 4];
-    /// let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1, host_alloc()).unwrap();
+    /// let t1 = Tensor::<u8, 1>::from_shape_vec([4], data1).unwrap();
     ///
     /// let data2: Vec<u8> = vec![1, 2, 3, 4];
-    /// let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2, host_alloc()).unwrap();
+    /// let t2 = Tensor::<u8, 1>::from_shape_vec([4], data2).unwrap();
     ///
     /// let t3 = t1.element_wise_op(&t2, |a, b| *a + *b).unwrap();
     /// assert_eq!(t3.as_slice(), vec![2, 4, 6, 8]);
@@ -964,7 +996,7 @@ mod tests {
     #[test]
     fn constructor_1d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1];
-        let t = Tensor::<u8, 1>::from_shape_vec([1], data, host_alloc())?;
+        let t = Tensor::<u8, 1>::from_shape_vec([1], data)?;
         assert_eq!(t.shape, [1]);
         assert_eq!(t.as_slice(), vec![1]);
         assert_eq!(t.strides, [1]);
@@ -975,7 +1007,7 @@ mod tests {
     #[test]
     fn constructor_2d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2];
-        let t = Tensor::<u8, 2>::from_shape_vec([1, 2], data, host_alloc())?;
+        let t = Tensor::<u8, 2>::from_shape_vec([1, 2], data)?;
         assert_eq!(t.shape, [1, 2]);
         assert_eq!(t.as_slice(), vec![1, 2]);
         assert_eq!(t.strides, [2, 1]);
@@ -986,7 +1018,7 @@ mod tests {
     #[test]
     fn get_1d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 1>::from_shape_vec([4], data, host_alloc())?;
+        let t = Tensor::<u8, 1>::from_shape_vec([4], data)?;
         assert_eq!(t.get([0]), Some(&1));
         assert_eq!(t.get([1]), Some(&2));
         assert_eq!(t.get([2]), Some(&3));
@@ -998,7 +1030,7 @@ mod tests {
     #[test]
     fn get_2d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data, host_alloc())?;
+        let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data)?;
         assert_eq!(t.get([0, 0]), Some(&1));
         assert_eq!(t.get([0, 1]), Some(&2));
         assert_eq!(t.get([1, 0]), Some(&3));
@@ -1011,7 +1043,7 @@ mod tests {
     #[test]
     fn get_3d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4, 5, 6];
-        let t = Tensor::<u8, 3>::from_shape_vec([2, 1, 3], data, host_alloc())?;
+        let t = Tensor::<u8, 3>::from_shape_vec([2, 1, 3], data)?;
         assert_eq!(t.get([0, 0, 0]), Some(&1));
         assert_eq!(t.get([0, 0, 1]), Some(&2));
         assert_eq!(t.get([0, 0, 2]), Some(&3));
@@ -1027,7 +1059,7 @@ mod tests {
     #[test]
     fn get_checked_1d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 1>::from_shape_vec([4], data, host_alloc())?;
+        let t = Tensor::<u8, 1>::from_shape_vec([4], data)?;
         assert_eq!(*t.get_unchecked([0]), 1);
         assert_eq!(*t.get_unchecked([1]), 2);
         assert_eq!(*t.get_unchecked([2]), 3);
@@ -1038,7 +1070,7 @@ mod tests {
     #[test]
     fn get_checked_2d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data, host_alloc())?;
+        let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data)?;
         assert_eq!(*t.get_unchecked([0, 0]), 1);
         assert_eq!(*t.get_unchecked([0, 1]), 2);
         assert_eq!(*t.get_unchecked([1, 0]), 3);
@@ -1048,7 +1080,7 @@ mod tests {
     #[test]
     fn reshape_1d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 1>::from_shape_vec([4], data, host_alloc())?;
+        let t = Tensor::<u8, 1>::from_shape_vec([4], data)?;
 
         let view = t.reshape([2, 2])?;
 
@@ -1063,7 +1095,7 @@ mod tests {
     #[test]
     fn reshape_2d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data, host_alloc())?;
+        let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data)?;
         let t2 = t.reshape([4])?;
 
         assert_eq!(t2.shape, [4]);
@@ -1077,7 +1109,7 @@ mod tests {
     #[test]
     fn reshape_get_1d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 1>::from_shape_vec([4], data, host_alloc())?;
+        let t = Tensor::<u8, 1>::from_shape_vec([4], data)?;
         let view = t.reshape([2, 2])?;
         assert_eq!(*view.get_unchecked([0, 0]), 1);
         assert_eq!(*view.get_unchecked([0, 1]), 2);
@@ -1091,7 +1123,7 @@ mod tests {
     #[test]
     fn permute_axes_1d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 1>::from_shape_vec([4], data, host_alloc())?;
+        let t = Tensor::<u8, 1>::from_shape_vec([4], data)?;
         let t2 = t.permute_axes([0]);
         assert_eq!(t2.shape, [4]);
         assert_eq!(t2.as_slice(), vec![1, 2, 3, 4]);
@@ -1103,7 +1135,7 @@ mod tests {
     #[test]
     fn permute_axes_2d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data, host_alloc())?;
+        let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data)?;
         let view = t.permute_axes([1, 0]);
         assert_eq!(view.shape, [2, 2]);
         assert_eq!(*view.get_unchecked([0, 0]), 1u8);
@@ -1118,7 +1150,7 @@ mod tests {
     #[test]
     fn contiguous_2d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4, 5, 6];
-        let t = Tensor::<u8, 2>::from_shape_vec([2, 3], data, host_alloc())?;
+        let t = Tensor::<u8, 2>::from_shape_vec([2, 3], data)?;
 
         let view = t.permute_axes([1, 0]);
 
@@ -1133,14 +1165,14 @@ mod tests {
 
     #[test]
     fn zeros_1d() -> Result<(), TensorError> {
-        let t = Tensor::<u8, 1>::zeros([4], host_alloc());
+        let t = Tensor::<u8, 1>::zeros([4]);
         assert_eq!(t.as_slice(), vec![0, 0, 0, 0]);
         Ok(())
     }
 
     #[test]
     fn zeros_2d() -> Result<(), TensorError> {
-        let t = Tensor::<u8, 2>::zeros([2, 2], host_alloc());
+        let t = Tensor::<u8, 2>::zeros([2, 2]);
         assert_eq!(t.as_slice(), vec![0, 0, 0, 0]);
         Ok(())
     }
@@ -1148,7 +1180,7 @@ mod tests {
     #[test]
     fn map_1d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 1>::from_shape_vec([4], data, host_alloc())?;
+        let t = Tensor::<u8, 1>::from_shape_vec([4], data)?;
         let t2 = t.map(|x| *x + 1);
         assert_eq!(t2.as_slice(), vec![2, 3, 4, 5]);
         Ok(())
@@ -1157,7 +1189,7 @@ mod tests {
     #[test]
     fn map_2d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data, host_alloc())?;
+        let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data)?;
         let t2 = t.map(|x| *x + 1);
         assert_eq!(t2.as_slice(), vec![2, 3, 4, 5]);
         Ok(())
@@ -1165,21 +1197,21 @@ mod tests {
 
     #[test]
     fn from_shape_val_1d() -> Result<(), TensorError> {
-        let t = Tensor::<u8, 1>::from_shape_val([4], 0, host_alloc());
+        let t = Tensor::<u8, 1>::from_shape_val([4], 0);
         assert_eq!(t.as_slice(), vec![0, 0, 0, 0]);
         Ok(())
     }
 
     #[test]
     fn from_shape_val_2d() -> Result<(), TensorError> {
-        let t = Tensor::<u8, 2>::from_shape_val([2, 2], 1, host_alloc());
+        let t = Tensor::<u8, 2>::from_shape_val([2, 2], 1);
         assert_eq!(t.as_slice(), vec![1, 1, 1, 1]);
         Ok(())
     }
 
     #[test]
     fn from_shape_val_3d() -> Result<(), TensorError> {
-        let t = Tensor::<u8, 3>::from_shape_val([2, 1, 3], 2, host_alloc());
+        let t = Tensor::<u8, 3>::from_shape_val([2, 1, 3], 2);
         assert_eq!(t.as_slice(), vec![2, 2, 2, 2, 2, 2]);
         Ok(())
     }
@@ -1187,7 +1219,7 @@ mod tests {
     #[test]
     fn cast_1d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 1>::from_shape_vec([4], data, host_alloc())?;
+        let t = Tensor::<u8, 1>::from_shape_vec([4], data)?;
         let t2 = t.cast::<u16>();
         assert_eq!(t2.as_slice(), vec![1, 2, 3, 4]);
         Ok(())
@@ -1196,7 +1228,7 @@ mod tests {
     #[test]
     fn cast_2d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data, host_alloc())?;
+        let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data)?;
         let t2 = t.cast::<u16>();
         assert_eq!(t2.as_slice(), vec![1, 2, 3, 4]);
         Ok(())
@@ -1205,7 +1237,7 @@ mod tests {
     #[test]
     fn from_shape_fn_1d() -> Result<(), TensorError> {
         let alloc = host_alloc();
-        let t = Tensor::from_shape_fn([3, 3], alloc, |[i, j]| ((1 + i) * (1 + j)) as u8);
+        let t = Tensor::from_shape_fn_in([3, 3], alloc, |[i, j]| ((1 + i) * (1 + j)) as u8);
         assert_eq!(t.as_slice(), vec![1, 2, 3, 2, 4, 6, 3, 6, 9]);
         Ok(())
     }
@@ -1213,7 +1245,7 @@ mod tests {
     #[test]
     fn from_shape_fn_2d() -> Result<(), TensorError> {
         let alloc = host_alloc();
-        let t = Tensor::from_shape_fn([3, 3], alloc, |[i, j]| ((1 + i) * (1 + j)) as f32);
+        let t = Tensor::from_shape_fn_in([3, 3], alloc, |[i, j]| ((1 + i) * (1 + j)) as f32);
         assert_eq!(
             t.as_slice(),
             vec![1.0, 2.0, 3.0, 2.0, 4.0, 6.0, 3.0, 6.0, 9.0]
@@ -1224,7 +1256,7 @@ mod tests {
     #[test]
     fn from_shape_fn_3d() -> Result<(), TensorError> {
         let alloc = host_alloc();
-        let t = Tensor::from_shape_fn([2, 3, 3], alloc, |[x, y, c]| {
+        let t = Tensor::from_shape_fn_in([2, 3, 3], alloc, |[x, y, c]| {
             ((1 + x) * (1 + y) * (1 + c)) as i16
         });
         assert_eq!(
@@ -1238,7 +1270,7 @@ mod tests {
     fn view_1d() -> Result<(), TensorError> {
         let alloc = host_alloc();
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 1>::from_shape_vec([4], data, alloc)?;
+        let t = Tensor::<u8, 1>::from_shape_vec_in([4], data, alloc)?;
         let view = t.view();
 
         // check that the view has the same data
@@ -1253,7 +1285,7 @@ mod tests {
     #[test]
     fn from_slice() -> Result<(), TensorError> {
         let data: [u8; 4] = [1, 2, 3, 4];
-        let t = Tensor::<u8, 2>::from_shape_slice([2, 2], &data, host_alloc())?;
+        let t = Tensor::<u8, 2>::from_shape_slice([2, 2], &data)?;
 
         assert_eq!(t.shape, [2, 2]);
         assert_eq!(t.as_slice(), &[1, 2, 3, 4]);
@@ -1264,7 +1296,7 @@ mod tests {
     #[test]
     fn display_2d() -> Result<(), TensorError> {
         let data: [u8; 4] = [1, 2, 3, 4];
-        let t = Tensor::<u8, 2>::from_shape_slice([2, 2], &data, host_alloc())?;
+        let t = Tensor::<u8, 2>::from_shape_slice([2, 2], &data)?;
         let disp = t.to_string();
         let lines = disp.lines().collect::<Vec<_>>();
 
@@ -1278,7 +1310,7 @@ mod tests {
     #[test]
     fn display_3d() -> Result<(), TensorError> {
         let data: [u8; 12] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-        let t = Tensor::<u8, 3>::from_shape_slice([2, 3, 2], &data, host_alloc())?;
+        let t = Tensor::<u8, 3>::from_shape_slice([2, 3, 2], &data)?;
         let disp = t.to_string();
         let lines = disp.lines().collect::<Vec<_>>();
 
@@ -1297,7 +1329,7 @@ mod tests {
     #[test]
     fn display_float() -> Result<(), TensorError> {
         let data: [f32; 4] = [1.00001, 1.00009, 0.99991, 0.99999];
-        let t = Tensor::<f32, 2>::from_shape_slice([2, 2], &data, host_alloc())?;
+        let t = Tensor::<f32, 2>::from_shape_slice([2, 2], &data)?;
         let disp = t.to_string();
         let lines = disp.lines().collect::<Vec<_>>();
 
@@ -1311,7 +1343,7 @@ mod tests {
     #[test]
     fn display_big_float() -> Result<(), TensorError> {
         let data: [f32; 4] = [1000.00001, 1.00009, 0.99991, 0.99999];
-        let t = Tensor::<f32, 2>::from_shape_slice([2, 2], &data, host_alloc())?;
+        let t = Tensor::<f32, 2>::from_shape_slice([2, 2], &data)?;
         let disp = t.to_string();
         let lines = disp.lines().collect::<Vec<_>>();
 
@@ -1325,7 +1357,7 @@ mod tests {
     #[test]
     fn display_big_tensor() -> Result<(), TensorError> {
         let data: [u8; 1000] = [0; 1000];
-        let t = Tensor::<u8, 3>::from_shape_slice([10, 10, 10], &data, host_alloc())?;
+        let t = Tensor::<u8, 3>::from_shape_slice([10, 10, 10], &data)?;
         let disp = t.to_string();
         let lines = disp.lines().collect::<Vec<_>>();
 
@@ -1362,7 +1394,7 @@ mod tests {
     #[test]
     fn get_index_unchecked_1d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 1>::from_shape_vec([4], data, host_alloc())?;
+        let t = Tensor::<u8, 1>::from_shape_vec([4], data)?;
         assert_eq!(t.get_index_unchecked(0), [0]);
         assert_eq!(t.get_index_unchecked(1), [1]);
         assert_eq!(t.get_index_unchecked(2), [2]);
@@ -1373,7 +1405,7 @@ mod tests {
     #[test]
     fn get_index_unchecked_2d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data, host_alloc())?;
+        let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data)?;
         assert_eq!(t.get_index_unchecked(0), [0, 0]);
         assert_eq!(t.get_index_unchecked(1), [0, 1]);
         assert_eq!(t.get_index_unchecked(2), [1, 0]);
@@ -1384,7 +1416,7 @@ mod tests {
     #[test]
     fn get_index_unchecked_3d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-        let t = Tensor::<u8, 3>::from_shape_vec([2, 2, 3], data, host_alloc())?;
+        let t = Tensor::<u8, 3>::from_shape_vec([2, 2, 3], data)?;
         assert_eq!(t.get_index_unchecked(0), [0, 0, 0]);
         assert_eq!(t.get_index_unchecked(1), [0, 0, 1]);
         assert_eq!(t.get_index_unchecked(2), [0, 0, 2]);
@@ -1403,7 +1435,7 @@ mod tests {
     #[test]
     fn get_index_to_offset_and_back() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-        let t = Tensor::<u8, 3>::from_shape_vec([2, 2, 3], data, host_alloc())?;
+        let t = Tensor::<u8, 3>::from_shape_vec([2, 2, 3], data)?;
         for offset in 0..12 {
             assert_eq!(
                 t.get_iter_offset_unchecked(t.get_index_unchecked(offset)),
@@ -1416,7 +1448,7 @@ mod tests {
     #[test]
     fn get_offset_to_index_and_back() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-        let t = Tensor::<u8, 3>::from_shape_vec([2, 2, 3], data, host_alloc())?;
+        let t = Tensor::<u8, 3>::from_shape_vec([2, 2, 3], data)?;
         for ind in [
             [0, 0, 0],
             [0, 0, 1],
@@ -1439,7 +1471,7 @@ mod tests {
     #[test]
     fn get_index_1d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 1>::from_shape_vec([4], data, host_alloc())?;
+        let t = Tensor::<u8, 1>::from_shape_vec([4], data)?;
         assert_eq!(t.get_index(3), Ok([3]));
         assert!(t
             .get_index(4)
@@ -1450,7 +1482,7 @@ mod tests {
     #[test]
     fn get_index_2d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data, host_alloc())?;
+        let t = Tensor::<u8, 2>::from_shape_vec([2, 2], data)?;
         assert_eq!(t.get_index_unchecked(3), [1, 1]);
         assert!(t
             .get_index(4)
@@ -1461,7 +1493,7 @@ mod tests {
     #[test]
     fn get_index_3d() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-        let t = Tensor::<u8, 3>::from_shape_vec([2, 2, 3], data, host_alloc())?;
+        let t = Tensor::<u8, 3>::from_shape_vec([2, 2, 3], data)?;
         assert_eq!(t.get_index_unchecked(11), [1, 1, 2]);
         assert!(t
             .get_index(12)
@@ -1482,7 +1514,7 @@ mod tests {
     #[test]
     fn test_from_shape_vec_shape_data_mismatch() {
         // 2*3 = 6 elements expected but only 3 supplied — must return InvalidShape.
-        let result = Tensor::<u8, 2>::from_shape_vec([2, 3], vec![1, 2, 3], host_alloc());
+        let result = Tensor::<u8, 2>::from_shape_vec([2, 3], vec![1, 2, 3]);
         assert!(
             matches!(result, Err(TensorError::InvalidShape(6))),
             "expected Err(TensorError::InvalidShape(6))"
@@ -1493,7 +1525,7 @@ mod tests {
     fn test_reshape_invalid_numel() -> Result<(), TensorError> {
         // 4-element tensor cannot be reshaped to [3, 2] (= 6 elements).
         let data: Vec<u8> = vec![1, 2, 3, 4];
-        let t = Tensor::<u8, 1>::from_shape_vec([4], data, host_alloc())?;
+        let t = Tensor::<u8, 1>::from_shape_vec([4], data)?;
         let result = t.reshape([3, 2]);
         assert!(
             matches!(result, Err(TensorError::DimensionMismatch(_))),
@@ -1505,7 +1537,7 @@ mod tests {
     #[test]
     fn test_zero_sized_tensor_roundtrip() -> Result<(), TensorError> {
         // A 1-D tensor with zero elements must be constructable and report correct metadata.
-        let t = Tensor::<f32, 1>::from_shape_vec([0], vec![], host_alloc())?;
+        let t = Tensor::<f32, 1>::from_shape_vec([0], vec![])?;
         assert_eq!(t.numel(), 0);
         assert!(t.as_slice().is_empty());
 
@@ -1521,7 +1553,7 @@ mod tests {
     fn test_cast_on_permuted_view() -> Result<(), TensorError> {
         // Build a 2x3 tensor [[1,2,3],[4,5,6]] and permute (transpose) to 3x2.
         let data: Vec<u8> = vec![1, 2, 3, 4, 5, 6];
-        let t = Tensor::<u8, 2>::from_shape_vec([2, 3], data, host_alloc())?;
+        let t = Tensor::<u8, 2>::from_shape_vec([2, 3], data)?;
 
         // permute_axes returns a TensorView; materialise it before casting.
         let permuted_view = t.permute_axes([1, 0]);
@@ -1544,7 +1576,7 @@ mod tests {
     #[test]
     fn contiguous_tensor_is_standard_layout_true() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-        let t = Tensor::<u8, 3>::from_shape_vec([2, 2, 3], data, host_alloc())?;
+        let t = Tensor::<u8, 3>::from_shape_vec([2, 2, 3], data)?;
         assert!(t.is_standard_layout());
         Ok(())
     }
@@ -1552,7 +1584,7 @@ mod tests {
     #[test]
     fn broken_stride_is_standard_layout_false() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-        let mut t = Tensor::<u8, 3>::from_shape_vec([2, 2, 3], data, host_alloc())?;
+        let mut t = Tensor::<u8, 3>::from_shape_vec([2, 2, 3], data)?;
         // arbitrary incorrect stride
         t.strides = [10, 5, 1];
         assert!(!t.is_standard_layout());
@@ -1562,7 +1594,7 @@ mod tests {
     #[test]
     fn contiguous_tensor_roundtrip() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-        let t = Tensor::<u8, 3>::from_shape_vec([2, 2, 3], data.clone(), host_alloc())?;
+        let t = Tensor::<u8, 3>::from_shape_vec([2, 2, 3], data.clone())?;
         assert!(t.is_standard_layout());
         match t.to_standard_layout(host_alloc()) {
             Ok(t2) => {
@@ -1577,7 +1609,7 @@ mod tests {
     #[test]
     fn non_contiguous_to_standard_layout() -> Result<(), TensorError> {
         let data: Vec<u8> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-        let mut t = Tensor::<u8, 3>::from_shape_vec([2, 2, 3], data.clone(), host_alloc())?;
+        let mut t = Tensor::<u8, 3>::from_shape_vec([2, 2, 3], data.clone())?;
         // altering strides
         t.strides = [1, 6, 2];
         assert!(!t.is_standard_layout());

--- a/crates/kornia-tensor/src/view.rs
+++ b/crates/kornia-tensor/src/view.rs
@@ -23,10 +23,10 @@ use rayon::prelude::*;
 /// Creating a view through reshaping:
 ///
 /// ```rust
-/// use kornia_tensor::{Tensor, host_alloc};
+/// use kornia_tensor::Tensor;
 ///
 /// let data = vec![1, 2, 3, 4, 5, 6];
-/// let tensor = Tensor::<i32, 1>::from_shape_vec([6], data, host_alloc()).unwrap();
+/// let tensor = Tensor::<i32, 1>::from_shape_vec([6], data).unwrap();
 ///
 /// // Create a 2x3 view of the 1D tensor
 /// let view = tensor.reshape([2, 3]).unwrap();
@@ -38,10 +38,10 @@ use rayon::prelude::*;
 /// Converting a view to a contiguous tensor:
 ///
 /// ```rust
-/// use kornia_tensor::{Tensor, host_alloc};
+/// use kornia_tensor::Tensor;
 ///
 /// let data = vec![1, 2, 3, 4];
-/// let tensor = Tensor::<i32, 2>::from_shape_vec([2, 2], data, host_alloc()).unwrap();
+/// let tensor = Tensor::<i32, 2>::from_shape_vec([2, 2], data).unwrap();
 ///
 /// // Permute creates a non-contiguous view
 /// let view = tensor.permute_axes([1, 0]);
@@ -119,10 +119,10 @@ impl<T: Send, const N: usize> TensorView<'_, T, N> {
     /// # Examples
     ///
     /// ```rust
-    /// use kornia_tensor::{Tensor, host_alloc};
+    /// use kornia_tensor::Tensor;
     ///
     /// let data = vec![1, 2, 3, 4, 5, 6];
-    /// let tensor = Tensor::<i32, 1>::from_shape_vec([6], data, host_alloc()).unwrap();
+    /// let tensor = Tensor::<i32, 1>::from_shape_vec([6], data).unwrap();
     /// let view = tensor.reshape([2, 3]).unwrap();
     ///
     /// assert_eq!(*view.get_unchecked([0, 0]), 1);
@@ -151,10 +151,10 @@ impl<T: Send, const N: usize> TensorView<'_, T, N> {
     /// # Examples
     ///
     /// ```rust
-    /// use kornia_tensor::{Tensor, host_alloc};
+    /// use kornia_tensor::Tensor;
     ///
     /// let data = vec![1, 2, 3, 4, 5, 6];
-    /// let tensor = Tensor::<i32, 2>::from_shape_vec([2, 3], data, host_alloc()).unwrap();
+    /// let tensor = Tensor::<i32, 2>::from_shape_vec([2, 3], data).unwrap();
     ///
     /// // Transpose by permuting axes
     /// let transposed = tensor.permute_axes([1, 0]);

--- a/crates/kornia-tensor/src/view.rs
+++ b/crates/kornia-tensor/src/view.rs
@@ -1,6 +1,4 @@
-use crate::{
-    get_strides_from_shape, storage::TensorStorage, CpuAllocator, Tensor, TensorAllocator,
-};
+use crate::{get_strides_from_shape, storage::TensorStorage, Tensor};
 use rayon::prelude::*;
 
 /// A non-owning view into tensor data.
@@ -25,10 +23,10 @@ use rayon::prelude::*;
 /// Creating a view through reshaping:
 ///
 /// ```rust
-/// use kornia_tensor::{Tensor, CpuAllocator};
+/// use kornia_tensor::{Tensor, host_alloc};
 ///
 /// let data = vec![1, 2, 3, 4, 5, 6];
-/// let tensor = Tensor::<i32, 1, _>::from_shape_vec([6], data, CpuAllocator).unwrap();
+/// let tensor = Tensor::<i32, 1>::from_shape_vec([6], data, host_alloc()).unwrap();
 ///
 /// // Create a 2x3 view of the 1D tensor
 /// let view = tensor.reshape([2, 3]).unwrap();
@@ -40,10 +38,10 @@ use rayon::prelude::*;
 /// Converting a view to a contiguous tensor:
 ///
 /// ```rust
-/// use kornia_tensor::{Tensor, CpuAllocator};
+/// use kornia_tensor::{Tensor, host_alloc};
 ///
 /// let data = vec![1, 2, 3, 4];
-/// let tensor = Tensor::<i32, 2, _>::from_shape_vec([2, 2], data, CpuAllocator).unwrap();
+/// let tensor = Tensor::<i32, 2>::from_shape_vec([2, 2], data, host_alloc()).unwrap();
 ///
 /// // Permute creates a non-contiguous view
 /// let view = tensor.permute_axes([1, 0]);
@@ -52,9 +50,9 @@ use rayon::prelude::*;
 /// let contiguous = view.as_contiguous();
 /// assert_eq!(contiguous.as_slice(), &[1, 3, 2, 4]);
 /// ```
-pub struct TensorView<'a, T, const N: usize, A: TensorAllocator> {
+pub struct TensorView<'a, T, const N: usize> {
     /// Reference to the storage held by another tensor.
-    pub storage: &'a TensorStorage<T, A>,
+    pub storage: &'a TensorStorage<T>,
 
     /// The shape of the tensor view.
     pub shape: [usize; N],
@@ -63,7 +61,7 @@ pub struct TensorView<'a, T, const N: usize, A: TensorAllocator> {
     pub strides: [usize; N],
 }
 
-impl<T: Send, const N: usize, A: TensorAllocator> TensorView<'_, T, N, A> {
+impl<T: Send, const N: usize> TensorView<'_, T, N> {
     /// Returns a slice view of the underlying storage.
     ///
     /// Note: This returns the entire underlying storage slice, not just the elements
@@ -121,10 +119,10 @@ impl<T: Send, const N: usize, A: TensorAllocator> TensorView<'_, T, N, A> {
     /// # Examples
     ///
     /// ```rust
-    /// use kornia_tensor::{Tensor, CpuAllocator};
+    /// use kornia_tensor::{Tensor, host_alloc};
     ///
     /// let data = vec![1, 2, 3, 4, 5, 6];
-    /// let tensor = Tensor::<i32, 1, _>::from_shape_vec([6], data, CpuAllocator).unwrap();
+    /// let tensor = Tensor::<i32, 1>::from_shape_vec([6], data, host_alloc()).unwrap();
     /// let view = tensor.reshape([2, 3]).unwrap();
     ///
     /// assert_eq!(*view.get_unchecked([0, 0]), 1);
@@ -148,15 +146,15 @@ impl<T: Send, const N: usize, A: TensorAllocator> TensorView<'_, T, N, A> {
     /// # Returns
     ///
     /// A new [`Tensor`] instance with contiguous memory containing the same logical
-    /// data as this view, allocated using [`CpuAllocator`].
+    /// data as this view, allocated using [`host_alloc`](crate::allocator::host_alloc).
     ///
     /// # Examples
     ///
     /// ```rust
-    /// use kornia_tensor::{Tensor, CpuAllocator};
+    /// use kornia_tensor::{Tensor, host_alloc};
     ///
     /// let data = vec![1, 2, 3, 4, 5, 6];
-    /// let tensor = Tensor::<i32, 2, _>::from_shape_vec([2, 3], data, CpuAllocator).unwrap();
+    /// let tensor = Tensor::<i32, 2>::from_shape_vec([2, 3], data, host_alloc()).unwrap();
     ///
     /// // Transpose by permuting axes
     /// let transposed = tensor.permute_axes([1, 0]);
@@ -165,7 +163,7 @@ impl<T: Send, const N: usize, A: TensorAllocator> TensorView<'_, T, N, A> {
     /// let contiguous = transposed.as_contiguous();
     /// assert_eq!(contiguous.as_slice(), &[1, 4, 2, 5, 3, 6]);
     /// ```
-    pub fn as_contiguous(&self) -> Tensor<T, N, CpuAllocator>
+    pub fn as_contiguous(&self) -> Tensor<T, N>
     where
         T: Clone + Sync,
     {
@@ -181,7 +179,7 @@ impl<T: Send, const N: usize, A: TensorAllocator> TensorView<'_, T, N, A> {
 
         let strides = get_strides_from_shape(self.shape);
         Tensor {
-            storage: TensorStorage::from_vec(data, CpuAllocator),
+            storage: TensorStorage::from_vec(data, self.storage.alloc().clone()),
             shape: self.shape,
             strides,
         }
@@ -201,14 +199,14 @@ impl<T: Send, const N: usize, A: TensorAllocator> TensorView<'_, T, N, A> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::allocator::{CpuAllocator, TensorAllocatorError};
+    use crate::allocator::{host_alloc, TensorAllocatorError};
 
     #[test]
     fn test_tensor_view_from_vec() -> Result<(), TensorAllocatorError> {
         let vec = vec![1, 2, 3, 4, 5, 6, 7, 8];
-        let storage = TensorStorage::from_vec(vec, CpuAllocator);
+        let storage = TensorStorage::from_vec(vec, host_alloc());
 
-        let view = TensorView::<u8, 1, _> {
+        let view = TensorView::<u8, 1> {
             storage: &storage,
             shape: [8],
             strides: [1],
@@ -245,9 +243,9 @@ mod tests {
     #[test]
     fn test_flat_index_to_multi_index_2d() {
         let vec: Vec<u8> = (0..12).collect();
-        let storage = TensorStorage::from_vec(vec, CpuAllocator);
+        let storage = TensorStorage::from_vec(vec, host_alloc());
 
-        let view = TensorView::<u8, 2, _> {
+        let view = TensorView::<u8, 2> {
             storage: &storage,
             shape: [3, 4],
             strides: [4, 1],

--- a/crates/kornia-vlm/src/paligemma/mod.rs
+++ b/crates/kornia-vlm/src/paligemma/mod.rs
@@ -89,7 +89,7 @@ impl Paligemma {
         use crate::device::get_device_and_dtype;
         let (device, dtype) = get_device_and_dtype();
         let (model, tokenizer) = Self::load_model(dtype, &device)?;
-        let img_buf = Image::from_size_val([224, 224].into(), 0, kornia_tensor::host_alloc())?;
+        let img_buf = Image::from_size_val([224, 224].into(), 0)?;
         let pipeline = TextGeneration::new(model, tokenizer, device, config.into());
 
         Ok(Self {

--- a/crates/kornia-vlm/src/paligemma/mod.rs
+++ b/crates/kornia-vlm/src/paligemma/mod.rs
@@ -5,10 +5,7 @@ use candle_core::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::models::paligemma::{Config, Model};
 use hf_hub::{api::sync::Api, Repo, RepoType};
-use kornia_image::{
-    allocator::{CpuAllocator, ImageAllocator},
-    Image,
-};
+use kornia_image::Image;
 use kornia_imgproc::{interpolation::InterpolationMode, resize::resize_fast_rgb};
 use model::{TextGeneration, TextGenerationConfig};
 use tokenizers::Tokenizer;
@@ -76,7 +73,7 @@ impl Default for PaligemmaConfig {
 /// NOTE: to run the model with Cuda, you need to pass the `--features cuda` flag to the `cargo run` command.
 pub struct Paligemma {
     pipeline: TextGeneration,
-    img_buf: Image<u8, 3, CpuAllocator>,
+    img_buf: Image<u8, 3>,
     dtype: DType,
 }
 
@@ -92,7 +89,7 @@ impl Paligemma {
         use crate::device::get_device_and_dtype;
         let (device, dtype) = get_device_and_dtype();
         let (model, tokenizer) = Self::load_model(dtype, &device)?;
-        let img_buf = Image::from_size_val([224, 224].into(), 0, CpuAllocator)?;
+        let img_buf = Image::from_size_val([224, 224].into(), 0, kornia_tensor::host_alloc())?;
         let pipeline = TextGeneration::new(model, tokenizer, device, config.into());
 
         Ok(Self {
@@ -114,9 +111,9 @@ impl Paligemma {
     /// # Returns
     ///
     /// * `caption` - The generated caption
-    pub fn inference<A: ImageAllocator>(
+    pub fn inference(
         &mut self,
-        image: &Image<u8, 3, A>,
+        image: &Image<u8, 3>,
         prompt: &str,
         sample_len: usize,
         stdout_debug: bool,

--- a/crates/kornia-vlm/src/smolvlm/mod.rs
+++ b/crates/kornia-vlm/src/smolvlm/mod.rs
@@ -18,12 +18,12 @@ use crate::{
 use candle_core::{DType, Device, IndexOp, Tensor};
 use candle_transformers::generation::{LogitsProcessor, Sampling};
 use hf_hub::api::sync::Api;
-use kornia_image::{allocator::ImageAllocator, Image};
+use kornia_image::Image;
 use log::debug;
 use preprocessor::get_prompt_split_image;
 use tokenizers::Tokenizer;
 
-pub struct SmolVlm<A: ImageAllocator> {
+pub struct SmolVlm {
     model: SmolModel,
     tokenizer: Tokenizer,
     image_token_tensor: Tensor,
@@ -34,11 +34,11 @@ pub struct SmolVlm<A: ImageAllocator> {
     index_pos: usize,        // index of the next token to be processed
     first_prompt: bool,      // whether this is the first prompt
     token_history: Vec<u32>, // stores the history of generated tokens
-    preprocessor: SmolVlmImagePreprocessor<A>,
+    preprocessor: SmolVlmImagePreprocessor,
     response: String,
 }
 
-impl<A: ImageAllocator> SmolVlm<A> {
+impl SmolVlm {
     /// Create a new SmolVlm model
     ///
     /// # Arguments
@@ -100,9 +100,8 @@ impl<A: ImageAllocator> SmolVlm<A> {
     pub fn inference(
         &mut self,
         prompt: &str, // TODO: make it structured
-        image: Option<Image<u8, 3, A>>,
+        image: Option<Image<u8, 3>>,
         sample_len: usize, // per prompt
-        alloc: A,
     ) -> Result<String, SmolVlmError> {
         let mut full_prompt = if self.first_prompt {
             self.first_prompt = false;
@@ -126,7 +125,7 @@ impl<A: ImageAllocator> SmolVlm<A> {
             vec![]
         };
 
-        let response = self.inference_raw(&full_prompt, images, sample_len, alloc, false)?;
+        let response = self.inference_raw(&full_prompt, images, sample_len, false)?;
 
         Ok(response)
     }
@@ -146,9 +145,8 @@ impl<A: ImageAllocator> SmolVlm<A> {
     pub fn inference_raw(
         &mut self,
         full_prompt: &str,
-        images: Vec<Image<u8, 3, A>>,
+        images: Vec<Image<u8, 3>>,
         sample_len: usize, // per prompt
-        alloc: A,
         debug: bool,
     ) -> Result<String, SmolVlmError> {
         if debug {
@@ -174,8 +172,7 @@ impl<A: ImageAllocator> SmolVlm<A> {
         let mut processed_images = vec![];
         for ((start, _), image) in image_tags_pos.iter().zip(images.into_iter()) {
             let (img_patches, mask_patches, size) =
-                self.preprocessor
-                    .preprocess(&image, &self.device, alloc.clone())?;
+                self.preprocessor.preprocess(&image, &self.device)?;
             processed_images.push((img_patches, mask_patches));
 
             let img_token = get_prompt_split_image(81, size);

--- a/crates/kornia-vlm/src/smolvlm/preprocessor.rs
+++ b/crates/kornia-vlm/src/smolvlm/preprocessor.rs
@@ -154,7 +154,6 @@ impl SmolVlmImagePreprocessor {
                         height: new_height,
                     },
                     0,
-                    kornia_tensor::host_alloc(),
                 )?);
             }
 
@@ -198,7 +197,6 @@ impl SmolVlmImagePreprocessor {
                     height: new_height as usize,
                 },
                 0,
-                kornia_tensor::host_alloc(),
             )?);
         }
 
@@ -213,7 +211,6 @@ impl SmolVlmImagePreprocessor {
                     height: new_height as usize,
                 },
                 255,
-                kornia_tensor::host_alloc(),
             )?);
         }
 
@@ -393,7 +390,6 @@ mod tests {
                 height: 64,
             },
             128, // gray value
-            kornia_tensor::host_alloc(),
         )?;
 
         let device = Device::Cpu;
@@ -430,7 +426,6 @@ mod tests {
                 height: 200,
             },
             0,
-            kornia_tensor::host_alloc(),
         )?;
 
         // Test no resize needed
@@ -492,7 +487,6 @@ mod tests {
                 height: 4,
             },
             img_data.clone(),
-            kornia_tensor::host_alloc(),
         )?;
 
         let device = Device::Cpu;

--- a/crates/kornia-vlm/src/smolvlm/preprocessor.rs
+++ b/crates/kornia-vlm/src/smolvlm/preprocessor.rs
@@ -1,6 +1,6 @@
 use crate::smolvlm::utils::SmolVlmError;
 use candle_core::{DType, Device, Shape, Tensor};
-use kornia_image::{allocator::ImageAllocator, Image, ImageSize};
+use kornia_image::{Image, ImageSize};
 use kornia_imgproc::{interpolation::InterpolationMode, resize::resize_fast_rgb};
 use log::info;
 
@@ -9,19 +9,19 @@ const MEAN: [f32; 3] = [0.5, 0.5, 0.5];
 const STD: [f32; 3] = [0.5, 0.5, 0.5];
 
 /// Image preprocessor for SmolVLM model
-pub struct SmolVlmImagePreprocessor<A: ImageAllocator> {
+pub struct SmolVlmImagePreprocessor {
     max_size: u32,
     outer_patch_size: u32,
 
     // buffers for resizing images
-    buf_resize: Option<Image<u8, 3, A>>,
-    buf_global_resize: Option<Image<u8, 3, A>>,
+    buf_resize: Option<Image<u8, 3>>,
+    buf_global_resize: Option<Image<u8, 3>>,
 
     // buffers for padding images
-    buf_padded_img: Option<Image<u8, 3, A>>,
-    buf_padded_mask: Option<Image<u8, 1, A>>,
-    buf_global_padded_img: Option<Image<u8, 3, A>>,
-    buf_global_padded_mask: Option<Image<u8, 1, A>>,
+    buf_padded_img: Option<Image<u8, 3>>,
+    buf_padded_mask: Option<Image<u8, 1>>,
+    buf_global_padded_img: Option<Image<u8, 3>>,
+    buf_global_padded_mask: Option<Image<u8, 1>>,
 
     // buffers for tensors
     buf_mask_tensor: Tensor,
@@ -29,7 +29,7 @@ pub struct SmolVlmImagePreprocessor<A: ImageAllocator> {
     buf_std_tensor: Tensor,
 }
 
-impl<A: ImageAllocator> SmolVlmImagePreprocessor<A> {
+impl SmolVlmImagePreprocessor {
     /// Create a new SmolVLM image preprocessor
     pub fn new(
         max_size: u32,
@@ -54,9 +54,8 @@ impl<A: ImageAllocator> SmolVlmImagePreprocessor<A> {
     /// Preprocess an image for SmolVLM model inference
     pub fn preprocess(
         &mut self,
-        img: &Image<u8, 3, A>,
+        img: &Image<u8, 3>,
         device: &Device,
-        alloc: A,
     ) -> Result<(Tensor, Tensor, ImageSize), SmolVlmError> {
         {
             info!(
@@ -66,18 +65,13 @@ impl<A: ImageAllocator> SmolVlmImagePreprocessor<A> {
                 self.max_size
             );
 
-            let img_resized = Self::resize_image_with_buffer(
-                img,
-                &mut self.buf_resize,
-                self.max_size,
-                alloc.clone(),
-            )?;
+            let img_resized =
+                Self::resize_image_with_buffer(img, &mut self.buf_resize, self.max_size)?;
             Self::pad_image_in_place(
                 img_resized,
                 &mut self.buf_padded_img,
                 &mut self.buf_padded_mask,
                 self.outer_patch_size,
-                alloc.clone(),
             )?;
         }
 
@@ -93,14 +87,12 @@ impl<A: ImageAllocator> SmolVlmImagePreprocessor<A> {
                 img,
                 &mut self.buf_global_resize,
                 self.outer_patch_size,
-                alloc.clone(),
             )?;
             Self::pad_image_in_place(
                 global_resized,
                 &mut self.buf_global_padded_img,
                 &mut self.buf_global_padded_mask,
                 self.outer_patch_size,
-                alloc.clone(),
             )?;
         }
 
@@ -137,11 +129,10 @@ impl<A: ImageAllocator> SmolVlmImagePreprocessor<A> {
 
     /// Single resize function that takes buffer by value and returns it (lazy init)
     fn resize_image_with_buffer<'a>(
-        img: &'a Image<u8, 3, A>,
-        buffer: &'a mut Option<Image<u8, 3, A>>,
+        img: &'a Image<u8, 3>,
+        buffer: &'a mut Option<Image<u8, 3>>,
         target_size: u32,
-        alloc: A,
-    ) -> Result<&'a Image<u8, 3, A>, SmolVlmError> {
+    ) -> Result<&'a Image<u8, 3>, SmolVlmError> {
         let (width, height) = (img.width() as u32, img.height() as u32);
         let longest_edge = width.max(height);
 
@@ -157,13 +148,13 @@ impl<A: ImageAllocator> SmolVlmImagePreprocessor<A> {
                 .is_none_or(|buf| buf.width() != new_width || buf.height() != new_height);
 
             if needs_resize {
-                *buffer = Some(Image::<u8, 3, A>::from_size_val(
+                *buffer = Some(Image::<u8, 3>::from_size_val(
                     ImageSize {
                         width: new_width,
                         height: new_height,
                     },
                     0,
-                    alloc,
+                    kornia_tensor::host_alloc(),
                 )?);
             }
 
@@ -179,11 +170,10 @@ impl<A: ImageAllocator> SmolVlmImagePreprocessor<A> {
     /// Pad image to be multiples of outer_patch_size and create corresponding mask
     /// Returns references to the internal buffers to avoid copying
     fn pad_image_in_place(
-        img: &Image<u8, 3, A>,
-        img_buffer: &mut Option<Image<u8, 3, A>>,
-        mask_buffer: &mut Option<Image<u8, 1, A>>,
+        img: &Image<u8, 3>,
+        img_buffer: &mut Option<Image<u8, 3>>,
+        mask_buffer: &mut Option<Image<u8, 1>>,
         outer_patch_size: u32,
-        alloc: A,
     ) -> Result<(), SmolVlmError> {
         let (width, height) = (img.width(), img.height());
 
@@ -202,13 +192,13 @@ impl<A: ImageAllocator> SmolVlmImagePreprocessor<A> {
         });
 
         if needs_resize {
-            *img_buffer = Some(Image::<u8, 3, A>::from_size_val(
+            *img_buffer = Some(Image::<u8, 3>::from_size_val(
                 ImageSize {
                     width: new_width as usize,
                     height: new_height as usize,
                 },
                 0,
-                alloc.clone(),
+                kornia_tensor::host_alloc(),
             )?);
         }
 
@@ -217,13 +207,13 @@ impl<A: ImageAllocator> SmolVlmImagePreprocessor<A> {
         });
 
         if needs_mask_resize {
-            *mask_buffer = Some(Image::<u8, 1, A>::from_size_val(
+            *mask_buffer = Some(Image::<u8, 1>::from_size_val(
                 ImageSize {
                     width: new_width as usize,
                     height: new_height as usize,
                 },
                 255,
-                alloc.clone(),
+                kornia_tensor::host_alloc(),
             )?);
         }
 
@@ -251,7 +241,7 @@ impl<A: ImageAllocator> SmolVlmImagePreprocessor<A> {
     /// Convert image to normalized tensor
     fn image_to_normalized_tensor(
         &self,
-        img: Image<u8, 3, A>, // Take ownership
+        img: Image<u8, 3>, // Take ownership
         device: &Device,
     ) -> Result<Tensor, SmolVlmError> {
         let (width, height) = (img.width(), img.height());
@@ -274,7 +264,7 @@ impl<A: ImageAllocator> SmolVlmImagePreprocessor<A> {
     /// Convert mask to tensor
     fn mask_to_tensor(
         &mut self,
-        mask: Image<u8, 1, A>, // Take ownership of the mask
+        mask: Image<u8, 1>, // Take ownership of the mask
         device: &Device,
     ) -> Result<Tensor, SmolVlmError> {
         let (width, height) = (mask.width(), mask.height());
@@ -393,25 +383,23 @@ pub fn get_prompt_split_image(img_seq_len: usize, size: ImageSize) -> String {
 mod tests {
     use super::*;
     use candle_core::Device;
-    use kornia_image::allocator::CpuAllocator;
 
     #[test]
     fn test_smolvlm_preprocessor_basic() -> Result<(), SmolVlmError> {
         // Create a simple test image (64x64, RGB)
-        let img = Image::<u8, 3, CpuAllocator>::from_size_val(
+        let img = Image::<u8, 3>::from_size_val(
             ImageSize {
                 width: 64,
                 height: 64,
             },
             128, // gray value
-            CpuAllocator,
+            kornia_tensor::host_alloc(),
         )?;
 
         let device = Device::Cpu;
         let mut preprocessor = SmolVlmImagePreprocessor::new(512, 32, &device)?;
 
-        let (img_patches, mask_patches, size) =
-            preprocessor.preprocess(&img, &device, CpuAllocator)?;
+        let (img_patches, mask_patches, size) = preprocessor.preprocess(&img, &device)?;
 
         // Check that we got the expected dimensions
         assert_eq!(img_patches.dims().len(), 4); // [patches, channels, height, width]
@@ -436,13 +424,13 @@ mod tests {
 
     #[test]
     fn test_resize_image_to_fit() -> Result<(), SmolVlmError> {
-        let img = Image::<u8, 3, CpuAllocator>::from_size_val(
+        let img = Image::<u8, 3>::from_size_val(
             ImageSize {
                 width: 100,
                 height: 200,
             },
             0,
-            CpuAllocator,
+            kornia_tensor::host_alloc(),
         )?;
 
         // Test no resize needed
@@ -451,7 +439,7 @@ mod tests {
             &img,
             &mut buffer,
             300,
-            CpuAllocator,
+            kornia_tensor::host_alloc(),
         )?;
         assert_eq!(result.width(), 100);
         assert_eq!(result.height(), 200);
@@ -462,7 +450,7 @@ mod tests {
             &img,
             &mut buffer,
             100,
-            CpuAllocator,
+            kornia_tensor::host_alloc(),
         )?;
         assert_eq!(result.width(), 50); // scaled down proportionally
         assert_eq!(result.height(), 100); // longest edge = 100
@@ -508,13 +496,13 @@ mod tests {
             img_data[offset + 2] = (x * 10) as u8; // B: 0, 10, 20, 30, 40, 50
         }
 
-        let img = Image::<u8, 3, CpuAllocator>::new(
+        let img = Image::<u8, 3>::new(
             ImageSize {
                 width: 6,
                 height: 4,
             },
             img_data.clone(),
-            CpuAllocator,
+            kornia_tensor::host_alloc(),
         )?;
 
         let device = Device::Cpu;
@@ -528,7 +516,7 @@ mod tests {
             &mut img_buffer,
             &mut mask_buffer,
             4,
-            CpuAllocator,
+            kornia_tensor::host_alloc(),
         )?;
 
         let padded_img_data = img_buffer
@@ -556,8 +544,7 @@ mod tests {
         }
 
         // Now test the full preprocessing pipeline
-        let (img_patches, mask_patches, size) =
-            preprocessor.preprocess(&img, &device, CpuAllocator)?;
+        let (img_patches, mask_patches, size) = preprocessor.preprocess(&img, &device)?;
 
         // Verify basic structure
         assert_eq!(img_patches.dims().len(), 4); // [patches, channels, height, width]

--- a/crates/kornia-vlm/src/smolvlm/preprocessor.rs
+++ b/crates/kornia-vlm/src/smolvlm/preprocessor.rs
@@ -435,23 +435,13 @@ mod tests {
 
         // Test no resize needed
         let mut buffer = None;
-        let result = SmolVlmImagePreprocessor::resize_image_with_buffer(
-            &img,
-            &mut buffer,
-            300,
-            kornia_tensor::host_alloc(),
-        )?;
+        let result = SmolVlmImagePreprocessor::resize_image_with_buffer(&img, &mut buffer, 300)?;
         assert_eq!(result.width(), 100);
         assert_eq!(result.height(), 200);
 
         // Test resize needed
         let mut buffer = None;
-        let result = SmolVlmImagePreprocessor::resize_image_with_buffer(
-            &img,
-            &mut buffer,
-            100,
-            kornia_tensor::host_alloc(),
-        )?;
+        let result = SmolVlmImagePreprocessor::resize_image_with_buffer(&img, &mut buffer, 100)?;
         assert_eq!(result.width(), 50); // scaled down proportionally
         assert_eq!(result.height(), 100); // longest edge = 100
 
@@ -511,13 +501,7 @@ mod tests {
         // First, test just the padding to verify it works correctly
         let mut img_buffer = None;
         let mut mask_buffer = None;
-        SmolVlmImagePreprocessor::pad_image_in_place(
-            &img,
-            &mut img_buffer,
-            &mut mask_buffer,
-            4,
-            kornia_tensor::host_alloc(),
-        )?;
+        SmolVlmImagePreprocessor::pad_image_in_place(&img, &mut img_buffer, &mut mask_buffer, 4)?;
 
         let padded_img_data = img_buffer
             .as_ref()

--- a/crates/kornia-vlm/src/smolvlm2/image_processor.rs
+++ b/crates/kornia-vlm/src/smolvlm2/image_processor.rs
@@ -1,6 +1,6 @@
 use crate::smolvlm2::{text_processor::TextProcessor, SmolVlm2Error};
 use candle_core::{DType, Device, Shape, Tensor};
-use kornia_image::{allocator::ImageAllocator, Image, ImageSize};
+use kornia_image::{Image, ImageSize};
 use kornia_imgproc::{interpolation::InterpolationMode, resize::resize_fast_rgb};
 use log::trace;
 
@@ -14,18 +14,18 @@ pub struct ImageProcessorConfig {
 }
 
 /// Image preprocessor for SmolVLM model
-pub struct ImageProcessor<A: ImageAllocator> {
+pub struct ImageProcessor {
     config: ImageProcessorConfig,
 
     // buffers for resizing images
-    buf_resize: Option<Image<u8, 3, A>>,
-    buf_global_resize: Option<Image<u8, 3, A>>,
+    buf_resize: Option<Image<u8, 3>>,
+    buf_global_resize: Option<Image<u8, 3>>,
 
     // buffers for padding images
-    buf_padded_img: Option<Image<u8, 3, A>>,
-    buf_padded_mask: Option<Image<u8, 1, A>>,
-    buf_global_padded_img: Option<Image<u8, 3, A>>,
-    buf_global_padded_mask: Option<Image<u8, 1, A>>,
+    buf_padded_img: Option<Image<u8, 3>>,
+    buf_padded_mask: Option<Image<u8, 1>>,
+    buf_global_padded_img: Option<Image<u8, 3>>,
+    buf_global_padded_mask: Option<Image<u8, 1>>,
 
     // buffers for tensors
     buf_mask_tensor: Tensor,
@@ -38,7 +38,7 @@ pub struct ImageProcessor<A: ImageAllocator> {
     image_token_tensor: Option<Tensor>,
 }
 
-impl<A: ImageAllocator> ImageProcessor<A> {
+impl ImageProcessor {
     /// Create a new SmolVLM image preprocessor
     pub fn new(
         config: ImageProcessorConfig,
@@ -46,13 +46,12 @@ impl<A: ImageAllocator> ImageProcessor<A> {
         device: &Device,
         txt_processor: &TextProcessor,
     ) -> Result<Self, SmolVlm2Error> {
-        let image_token_tensor = if let Err(SmolVlm2Error::MissingTokenizer) =
-            txt_processor.encode(config.image_token)
-        {
-            None
-        } else {
-            let image_token = txt_processor.encode(config.image_token)?;
-            Some(Tensor::from_slice(&[image_token], &[1], device)?)
+        let image_token_tensor = match txt_processor.encode(config.image_token) {
+            Err(SmolVlm2Error::MissingTokenizer) => None,
+            _ => {
+                let image_token = txt_processor.encode(config.image_token)?;
+                Some(Tensor::from_slice(&[image_token], &[1], device)?)
+            }
         };
         Ok(Self {
             buf_resize: None,
@@ -82,10 +81,9 @@ impl<A: ImageAllocator> ImageProcessor<A> {
     pub fn binding_images_to_prompt(
         &mut self,
         prompt: &mut String,
-        images: Vec<Image<u8, 3, A>>,
+        images: Vec<Image<u8, 3>>,
         dtype: DType,
         device: &Device,
-        alloc: A,
     ) -> Result<(), SmolVlm2Error> {
         let cloned_prompt = prompt.clone();
         let image_tags_pos = cloned_prompt
@@ -101,8 +99,7 @@ impl<A: ImageAllocator> ImageProcessor<A> {
         }
 
         for ((start, _), image) in image_tags_pos.iter().zip(images.into_iter()) {
-            let (img_patches, mask_patches, size) =
-                self.preprocess(&image, dtype, device, alloc.clone())?;
+            let (img_patches, mask_patches, size) = self.preprocess(&image, dtype, device)?;
             self.processed_images.push((img_patches, mask_patches));
 
             let img_token = get_prompt_split_image(81, size);
@@ -136,10 +133,9 @@ impl<A: ImageAllocator> ImageProcessor<A> {
     /// Preprocess an image for SmolVLM model inference
     pub fn preprocess(
         &mut self,
-        img: &Image<u8, 3, A>,
+        img: &Image<u8, 3>,
         dtype: DType,
         device: &Device,
-        alloc: A,
     ) -> Result<(Tensor, Tensor, ImageSize), SmolVlm2Error> {
         {
             trace!(
@@ -153,14 +149,12 @@ impl<A: ImageAllocator> ImageProcessor<A> {
                 img,
                 &mut self.buf_resize,
                 self.config.size_longest_edge,
-                alloc.clone(),
             )?;
             Self::pad_image_in_place(
                 img_resized,
                 &mut self.buf_padded_img,
                 &mut self.buf_padded_mask,
                 self.config.max_image_size_longest_edge,
-                alloc.clone(),
             )?;
         }
 
@@ -176,14 +170,12 @@ impl<A: ImageAllocator> ImageProcessor<A> {
                 img,
                 &mut self.buf_global_resize,
                 self.config.max_image_size_longest_edge,
-                alloc.clone(),
             )?;
             Self::pad_image_in_place(
                 global_resized,
                 &mut self.buf_global_padded_img,
                 &mut self.buf_global_padded_mask,
                 self.config.max_image_size_longest_edge,
-                alloc.clone(),
             )?;
         }
 
@@ -220,11 +212,10 @@ impl<A: ImageAllocator> ImageProcessor<A> {
 
     /// Single resize function that takes buffer by value and returns it (lazy init)
     fn resize_image_with_buffer<'a>(
-        img: &'a Image<u8, 3, A>,
-        buffer: &'a mut Option<Image<u8, 3, A>>,
+        img: &'a Image<u8, 3>,
+        buffer: &'a mut Option<Image<u8, 3>>,
         target_size: u32,
-        alloc: A,
-    ) -> Result<&'a Image<u8, 3, A>, SmolVlm2Error> {
+    ) -> Result<&'a Image<u8, 3>, SmolVlm2Error> {
         let (width, height) = (img.width() as u32, img.height() as u32);
         let longest_edge = width.max(height);
 
@@ -240,13 +231,13 @@ impl<A: ImageAllocator> ImageProcessor<A> {
                 .is_none_or(|buf| buf.width() != new_width || buf.height() != new_height);
 
             if needs_resize {
-                *buffer = Some(Image::<u8, 3, A>::from_size_val(
+                *buffer = Some(Image::<u8, 3>::from_size_val(
                     ImageSize {
                         width: new_width,
                         height: new_height,
                     },
                     0,
-                    alloc,
+                    kornia_tensor::host_alloc(),
                 )?);
             }
 
@@ -262,11 +253,10 @@ impl<A: ImageAllocator> ImageProcessor<A> {
     /// Pad image to be multiples of outer_patch_size and create corresponding mask
     /// Returns references to the internal buffers to avoid copying
     fn pad_image_in_place(
-        img: &Image<u8, 3, A>,
-        img_buffer: &mut Option<Image<u8, 3, A>>,
-        mask_buffer: &mut Option<Image<u8, 1, A>>,
+        img: &Image<u8, 3>,
+        img_buffer: &mut Option<Image<u8, 3>>,
+        mask_buffer: &mut Option<Image<u8, 1>>,
         outer_patch_size: u32,
-        alloc: A,
     ) -> Result<(), SmolVlm2Error> {
         let (width, height) = (img.width(), img.height());
 
@@ -285,13 +275,13 @@ impl<A: ImageAllocator> ImageProcessor<A> {
         });
 
         if needs_resize {
-            *img_buffer = Some(Image::<u8, 3, A>::from_size_val(
+            *img_buffer = Some(Image::<u8, 3>::from_size_val(
                 ImageSize {
                     width: new_width as usize,
                     height: new_height as usize,
                 },
                 0,
-                alloc.clone(),
+                kornia_tensor::host_alloc(),
             )?);
         }
 
@@ -300,13 +290,13 @@ impl<A: ImageAllocator> ImageProcessor<A> {
         });
 
         if needs_mask_resize {
-            *mask_buffer = Some(Image::<u8, 1, A>::from_size_val(
+            *mask_buffer = Some(Image::<u8, 1>::from_size_val(
                 ImageSize {
                     width: new_width as usize,
                     height: new_height as usize,
                 },
                 255,
-                alloc.clone(),
+                kornia_tensor::host_alloc(),
             )?);
         }
 
@@ -334,7 +324,7 @@ impl<A: ImageAllocator> ImageProcessor<A> {
     /// Convert image to normalized tensor
     fn image_to_normalized_tensor(
         &self,
-        img: Image<u8, 3, A>, // Take ownership
+        img: Image<u8, 3>, // Take ownership
         dtype: DType,
         device: &Device,
     ) -> Result<Tensor, SmolVlm2Error> {
@@ -358,7 +348,7 @@ impl<A: ImageAllocator> ImageProcessor<A> {
     /// Convert mask to tensor
     fn mask_to_tensor(
         &mut self,
-        mask: Image<u8, 1, A>, // Take ownership of the mask
+        mask: Image<u8, 1>, // Take ownership of the mask
         dtype: DType,
         device: &Device,
     ) -> Result<Tensor, SmolVlm2Error> {
@@ -478,18 +468,17 @@ pub fn get_prompt_split_image(img_seq_len: usize, size: ImageSize) -> String {
 mod tests {
     use super::*;
     use candle_core::Device;
-    use kornia_image::allocator::CpuAllocator;
 
     #[test]
     fn test_smolvlm_preprocessor_basic() -> Result<(), SmolVlm2Error> {
         // Create a simple test image (64x64, RGB)
-        let img = Image::<u8, 3, CpuAllocator>::from_size_val(
+        let img = Image::<u8, 3>::from_size_val(
             ImageSize {
                 width: 64,
                 height: 64,
             },
             128, // gray value
-            CpuAllocator,
+            kornia_tensor::host_alloc(),
         )?;
 
         let device = Device::Cpu;
@@ -508,7 +497,7 @@ mod tests {
         )?;
 
         let (img_patches, mask_patches, size) =
-            preprocessor.preprocess(&img, DType::F32, &device, CpuAllocator)?;
+            preprocessor.preprocess(&img, DType::F32, &device, kornia_tensor::host_alloc())?;
 
         // Check that we got the expected dimensions
         assert_eq!(img_patches.dims().len(), 4); // [patches, channels, height, width]
@@ -533,26 +522,34 @@ mod tests {
 
     #[test]
     fn test_resize_image_to_fit() -> Result<(), SmolVlm2Error> {
-        let img = Image::<u8, 3, CpuAllocator>::from_size_val(
+        let img = Image::<u8, 3>::from_size_val(
             ImageSize {
                 width: 100,
                 height: 200,
             },
             0,
-            CpuAllocator,
+            kornia_tensor::host_alloc(),
         )?;
 
         // Test no resize needed
         let mut buffer = None;
-        let result =
-            ImageProcessor::resize_image_with_buffer(&img, &mut buffer, 300, CpuAllocator)?;
+        let result = ImageProcessor::resize_image_with_buffer(
+            &img,
+            &mut buffer,
+            300,
+            kornia_tensor::host_alloc(),
+        )?;
         assert_eq!(result.width(), 100);
         assert_eq!(result.height(), 200);
 
         // Test resize needed
         let mut buffer = None;
-        let result =
-            ImageProcessor::resize_image_with_buffer(&img, &mut buffer, 100, CpuAllocator)?;
+        let result = ImageProcessor::resize_image_with_buffer(
+            &img,
+            &mut buffer,
+            100,
+            kornia_tensor::host_alloc(),
+        )?;
         assert_eq!(result.width(), 50); // scaled down proportionally
         assert_eq!(result.height(), 100); // longest edge = 100
 
@@ -597,13 +594,13 @@ mod tests {
             img_data[offset + 2] = (x * 10) as u8; // B: 0, 10, 20, 30, 40, 50
         }
 
-        let img = Image::<u8, 3, CpuAllocator>::new(
+        let img = Image::<u8, 3>::new(
             ImageSize {
                 width: 6,
                 height: 4,
             },
             img_data.clone(),
-            CpuAllocator,
+            kornia_tensor::host_alloc(),
         )?;
 
         let device = Device::Cpu;
@@ -629,7 +626,7 @@ mod tests {
             &mut img_buffer,
             &mut mask_buffer,
             4,
-            CpuAllocator,
+            kornia_tensor::host_alloc(),
         )?;
 
         let padded_img_data = img_buffer
@@ -658,7 +655,7 @@ mod tests {
 
         // Now test the full preprocessing pipeline
         let (img_patches, mask_patches, size) =
-            preprocessor.preprocess(&img, DType::F32, &device, CpuAllocator)?;
+            preprocessor.preprocess(&img, DType::F32, &device, kornia_tensor::host_alloc())?;
 
         // Verify basic structure
         assert_eq!(img_patches.dims().len(), 4); // [patches, channels, height, width]

--- a/crates/kornia-vlm/src/smolvlm2/image_processor.rs
+++ b/crates/kornia-vlm/src/smolvlm2/image_processor.rs
@@ -497,7 +497,7 @@ mod tests {
         )?;
 
         let (img_patches, mask_patches, size) =
-            preprocessor.preprocess(&img, DType::F32, &device, kornia_tensor::host_alloc())?;
+            preprocessor.preprocess(&img, DType::F32, &device)?;
 
         // Check that we got the expected dimensions
         assert_eq!(img_patches.dims().len(), 4); // [patches, channels, height, width]
@@ -533,23 +533,13 @@ mod tests {
 
         // Test no resize needed
         let mut buffer = None;
-        let result = ImageProcessor::resize_image_with_buffer(
-            &img,
-            &mut buffer,
-            300,
-            kornia_tensor::host_alloc(),
-        )?;
+        let result = ImageProcessor::resize_image_with_buffer(&img, &mut buffer, 300)?;
         assert_eq!(result.width(), 100);
         assert_eq!(result.height(), 200);
 
         // Test resize needed
         let mut buffer = None;
-        let result = ImageProcessor::resize_image_with_buffer(
-            &img,
-            &mut buffer,
-            100,
-            kornia_tensor::host_alloc(),
-        )?;
+        let result = ImageProcessor::resize_image_with_buffer(&img, &mut buffer, 100)?;
         assert_eq!(result.width(), 50); // scaled down proportionally
         assert_eq!(result.height(), 100); // longest edge = 100
 
@@ -621,13 +611,7 @@ mod tests {
         // First, test just the padding to verify it works correctly
         let mut img_buffer = None;
         let mut mask_buffer = None;
-        ImageProcessor::pad_image_in_place(
-            &img,
-            &mut img_buffer,
-            &mut mask_buffer,
-            4,
-            kornia_tensor::host_alloc(),
-        )?;
+        ImageProcessor::pad_image_in_place(&img, &mut img_buffer, &mut mask_buffer, 4)?;
 
         let padded_img_data = img_buffer
             .as_ref()
@@ -655,7 +639,7 @@ mod tests {
 
         // Now test the full preprocessing pipeline
         let (img_patches, mask_patches, size) =
-            preprocessor.preprocess(&img, DType::F32, &device, kornia_tensor::host_alloc())?;
+            preprocessor.preprocess(&img, DType::F32, &device)?;
 
         // Verify basic structure
         assert_eq!(img_patches.dims().len(), 4); // [patches, channels, height, width]

--- a/crates/kornia-vlm/src/smolvlm2/image_processor.rs
+++ b/crates/kornia-vlm/src/smolvlm2/image_processor.rs
@@ -237,7 +237,6 @@ impl ImageProcessor {
                         height: new_height,
                     },
                     0,
-                    kornia_tensor::host_alloc(),
                 )?);
             }
 
@@ -281,7 +280,6 @@ impl ImageProcessor {
                     height: new_height as usize,
                 },
                 0,
-                kornia_tensor::host_alloc(),
             )?);
         }
 
@@ -296,7 +294,6 @@ impl ImageProcessor {
                     height: new_height as usize,
                 },
                 255,
-                kornia_tensor::host_alloc(),
             )?);
         }
 
@@ -478,7 +475,6 @@ mod tests {
                 height: 64,
             },
             128, // gray value
-            kornia_tensor::host_alloc(),
         )?;
 
         let device = Device::Cpu;
@@ -528,7 +524,6 @@ mod tests {
                 height: 200,
             },
             0,
-            kornia_tensor::host_alloc(),
         )?;
 
         // Test no resize needed
@@ -590,7 +585,6 @@ mod tests {
                 height: 4,
             },
             img_data.clone(),
-            kornia_tensor::host_alloc(),
         )?;
 
         let device = Device::Cpu;

--- a/crates/kornia-vlm/src/smolvlm2/mod.rs
+++ b/crates/kornia-vlm/src/smolvlm2/mod.rs
@@ -10,7 +10,6 @@ use std::time::Instant;
 use candle_core::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
 use hf_hub::api::sync::Api;
-use kornia_image::allocator::ImageAllocator;
 
 use crate::context::InferenceContext;
 use crate::smolvlm2::image_processor::{ImageProcessor, ImageProcessorConfig};
@@ -116,12 +115,12 @@ impl Default for SmolVlm2Config {
     }
 }
 
-pub enum InputMedia<'v, const N: usize, A: ImageAllocator> {
-    Images(Vec<Image<u8, 3, A>>),
-    Video(Vec<&'v mut VideoSample<N, A>>),
+pub enum InputMedia<'v, const N: usize> {
+    Images(Vec<Image<u8, 3>>),
+    Video(Vec<&'v mut VideoSample<N>>),
 }
 
-pub struct SmolVlm2<const N: usize, A: ImageAllocator> {
+pub struct SmolVlm2<const N: usize> {
     model: model::Model,
     config: SmolVlm2Config,
     device: Device,
@@ -129,14 +128,14 @@ pub struct SmolVlm2<const N: usize, A: ImageAllocator> {
     index_pos: usize, // index of the next token to be processed
 
     txt_processor: TextProcessor,
-    img_processor: ImageProcessor<A>,
+    img_processor: ImageProcessor,
     vid_processor: VideoProcessor<N>,
     response: String,
 
     buf_single_zero_tensor: Tensor, // buffer for a single zero tensor
 }
 
-impl<const N: usize, A: ImageAllocator> SmolVlm2<N, A> {
+impl<const N: usize> SmolVlm2<N> {
     const MODEL_IDENTIFIER: &'static str = "HuggingFaceTB/SmolVLM2-2.2B-Instruct";
     const IMG_PROCESSOR_CONFIG: ImageProcessorConfig = ImageProcessorConfig {
         size_longest_edge: 1536,
@@ -203,7 +202,7 @@ impl<const N: usize, A: ImageAllocator> SmolVlm2<N, A> {
     ///     "/path/to/model-00001-of-00002.safetensors",
     ///     "/path/to/model-00002-of-00002.safetensors",
     /// ];
-    /// let model = SmolVlm2::<32, kornia_tensor::CpuAllocator>::from_safetensors(weights, SmolVlm2Config::default()).unwrap();
+    /// let model = SmolVlm2::<32, kornia_tensor::kornia_tensor::host_alloc()>::from_safetensors(weights, SmolVlm2Config::default()).unwrap();
     /// ```
     pub fn from_safetensors<P: Into<std::path::PathBuf>>(
         weights_paths: Vec<P>,
@@ -225,7 +224,7 @@ impl<const N: usize, A: ImageAllocator> SmolVlm2<N, A> {
     /// ```no_run
     /// use kornia_vlm::smolvlm2::{SmolVlm2, SmolVlm2Config};
     ///
-    /// let model = SmolVlm2::<32, kornia_tensor::CpuAllocator>::from_single_safetensor(
+    /// let model = SmolVlm2::<32, kornia_tensor::kornia_tensor::host_alloc()>::from_single_safetensor(
     ///     "/path/to/model.safetensors",
     ///     SmolVlm2Config::default()
     /// ).unwrap();
@@ -248,7 +247,7 @@ impl<const N: usize, A: ImageAllocator> SmolVlm2<N, A> {
     /// Run inference with prompt formatting and media input.
     /// # Arguments
     /// * `prompt` - Vector of `Message` representing the conversation history and user prompt.
-    /// * `media` - Input media (images, video, or none) as `InputMedia<A>`.
+    /// * `media` - Input media (images, video, or none) as `InputMedia`.
     /// * `sample_len` - Maximum number of tokens to generate.
     /// * `alloc` - Image allocator for image/video processing.
     /// # Returns
@@ -256,21 +255,20 @@ impl<const N: usize, A: ImageAllocator> SmolVlm2<N, A> {
     pub fn inference(
         &mut self,
         prompt: Vec<text_processor::Message>,
-        media: Option<InputMedia<N, A>>,
+        media: Option<InputMedia<N>>,
         sample_len: usize,
-        alloc: A,
     ) -> Result<String, SmolVlm2Error> {
         let full_prompt = self
             .txt_processor
             .reformat_with_additional_prompts(prompt, true)?;
-        let response = self.inference_raw(&full_prompt, media, sample_len, alloc)?;
+        let response = self.inference_raw(&full_prompt, media, sample_len)?;
         Ok(response)
     }
 
     /// Run inference with a pre-formatted prompt and media input.
     /// # Arguments
     /// * `full_prompt` - The fully formatted prompt string (should include any required tags for media).
-    /// * `media` - Input media (images, video, or none) as `InputMedia<A>`.
+    /// * `media` - Input media (images, video, or none) as `InputMedia`.
     /// * `sample_len` - Maximum number of tokens to generate.
     /// * `alloc` - Image allocator for image/video processing.
     /// # Returns
@@ -278,9 +276,8 @@ impl<const N: usize, A: ImageAllocator> SmolVlm2<N, A> {
     pub fn inference_raw(
         &mut self,
         full_prompt: &str,
-        media: Option<InputMedia<N, A>>,
+        media: Option<InputMedia<N>>,
         sample_len: usize,
-        alloc: A,
     ) -> Result<String, SmolVlm2Error> {
         if self.config.debug {
             std::io::stdout().flush()?;
@@ -309,7 +306,6 @@ impl<const N: usize, A: ImageAllocator> SmolVlm2<N, A> {
                         images,
                         self.dtype,
                         &self.device,
-                        alloc,
                     )?;
                 }
                 InputMedia::Video(videos) => {
@@ -326,7 +322,6 @@ impl<const N: usize, A: ImageAllocator> SmolVlm2<N, A> {
                         videos,
                         self.dtype,
                         &self.device,
-                        alloc,
                     )?;
 
                     use_video = true;
@@ -416,7 +411,7 @@ impl<const N: usize, A: ImageAllocator> SmolVlm2<N, A> {
         (
             model::Model,
             TextProcessor,
-            ImageProcessor<A>,
+            ImageProcessor,
             VideoProcessor<N>,
         ),
         SmolVlm2Error,
@@ -458,7 +453,7 @@ mod tests {
     use std::path::Path;
 
     use kornia_io::{jpeg::read_image_jpeg_rgb8, png::read_image_png_rgb8};
-    use kornia_tensor::CpuAllocator;
+    use kornia_tensor::host_alloc;
 
     use super::*;
 
@@ -502,7 +497,7 @@ mod tests {
                 }],
                 Some(InputMedia::Images(vec![image.into_inner()])),
                 sample_len,
-                CpuAllocator,
+                kornia_tensor::host_alloc(),
             )
             .expect("Inference failed");
     }

--- a/crates/kornia-vlm/src/smolvlm2/mod.rs
+++ b/crates/kornia-vlm/src/smolvlm2/mod.rs
@@ -202,7 +202,7 @@ impl<const N: usize> SmolVlm2<N> {
     ///     "/path/to/model-00001-of-00002.safetensors",
     ///     "/path/to/model-00002-of-00002.safetensors",
     /// ];
-    /// let model = SmolVlm2::<32, kornia_tensor::kornia_tensor::host_alloc()>::from_safetensors(weights, SmolVlm2Config::default()).unwrap();
+    /// let model = SmolVlm2::<32>::from_safetensors(weights, SmolVlm2Config::default()).unwrap();
     /// ```
     pub fn from_safetensors<P: Into<std::path::PathBuf>>(
         weights_paths: Vec<P>,
@@ -224,7 +224,7 @@ impl<const N: usize> SmolVlm2<N> {
     /// ```no_run
     /// use kornia_vlm::smolvlm2::{SmolVlm2, SmolVlm2Config};
     ///
-    /// let model = SmolVlm2::<32, kornia_tensor::kornia_tensor::host_alloc()>::from_single_safetensor(
+    /// let model = SmolVlm2::<32>::from_single_safetensor(
     ///     "/path/to/model.safetensors",
     ///     SmolVlm2Config::default()
     /// ).unwrap();

--- a/crates/kornia-vlm/src/smolvlm2/mod.rs
+++ b/crates/kornia-vlm/src/smolvlm2/mod.rs
@@ -453,7 +453,6 @@ mod tests {
     use std::path::Path;
 
     use kornia_io::{jpeg::read_image_jpeg_rgb8, png::read_image_png_rgb8};
-    use kornia_tensor::host_alloc;
 
     use super::*;
 
@@ -479,7 +478,7 @@ mod tests {
             debug: true,
             ..Default::default()
         };
-        let mut model = SmolVlm2::<32, _>::new(config).unwrap();
+        let mut model = SmolVlm2::<32>::new(config).unwrap();
 
         let prompt = "Describe the image.";
         let sample_len = 500;
@@ -497,7 +496,6 @@ mod tests {
                 }],
                 Some(InputMedia::Images(vec![image.into_inner()])),
                 sample_len,
-                kornia_tensor::host_alloc(),
             )
             .expect("Inference failed");
     }

--- a/crates/kornia-vlm/src/smolvlm2/video_processor.rs
+++ b/crates/kornia-vlm/src/smolvlm2/video_processor.rs
@@ -256,7 +256,7 @@ impl<const N: usize> VideoProcessor<N> {
         new_size: ImageSize,
         interpolation: InterpolationMode,
     ) -> Result<(), VideoError> {
-        let mut buf = Image::<u8, 3>::from_size_val(new_size, 0, kornia_tensor::host_alloc())?;
+        let mut buf = Image::<u8, 3>::from_size_val(new_size, 0)?;
         resize_fast_rgb(frame, &mut buf, interpolation)?;
         *frame = buf;
         Ok(())
@@ -289,8 +289,7 @@ impl<const N: usize> VideoProcessor<N> {
         // Pad each frame spatially if needed
         let size = frame.size();
         if size.width < padded_size.width || size.height < padded_size.height {
-            let mut padded =
-                Image::<u8, 3>::from_size_val(padded_size, fill, kornia_tensor::host_alloc())?;
+            let mut padded = Image::<u8, 3>::from_size_val(padded_size, fill)?;
             let img_slice = frame.as_slice();
             let padded_img_slice = padded.as_slice_mut();
             let width = size.width;

--- a/crates/kornia-vlm/src/smolvlm2/video_processor.rs
+++ b/crates/kornia-vlm/src/smolvlm2/video_processor.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use candle_core::{DType, Device, Tensor};
-use kornia_image::{allocator::ImageAllocator, Image, ImageSize};
+use kornia_image::{Image, ImageSize};
 use kornia_imgproc::{interpolation::InterpolationMode, resize::resize_fast_rgb};
 use num2words::Num2Words;
 
@@ -44,13 +44,12 @@ impl<const N: usize> VideoProcessor<N> {
         dtype: DType,
         txt_processor: &TextProcessor,
     ) -> Result<Self, SmolVlm2Error> {
-        let image_token_tensor = if let Err(SmolVlm2Error::MissingTokenizer) =
-            txt_processor.encode(config.image_token)
-        {
-            None
-        } else {
-            let image_token = txt_processor.encode(config.image_token)?;
-            Some(Tensor::from_slice(&[image_token], &[1], device)?)
+        let image_token_tensor = match txt_processor.encode(config.image_token) {
+            Err(SmolVlm2Error::MissingTokenizer) => None,
+            _ => {
+                let image_token = txt_processor.encode(config.image_token)?;
+                Some(Tensor::from_slice(&[image_token], &[1], device)?)
+            }
         };
 
         // Create normalization tensors once
@@ -72,13 +71,12 @@ impl<const N: usize> VideoProcessor<N> {
         })
     }
 
-    pub fn binding_videos_to_prompt<A: ImageAllocator>(
+    pub fn binding_videos_to_prompt(
         &mut self,
         prompt: &mut String,
-        videos: Vec<&mut VideoSample<N, A>>,
+        videos: Vec<&mut VideoSample<N>>,
         dtype: DType,
         device: &Device,
-        alloc: A,
     ) -> Result<(), SmolVlm2Error> {
         let cloned_prompt = prompt.clone();
         let video_tags_pos = cloned_prompt
@@ -102,7 +100,7 @@ impl<const N: usize> VideoProcessor<N> {
         let mut video_metadatas = vec![];
         for video in videos.into_iter() {
             video_metadatas.push(video.metadata().clone());
-            let img_patches = self.preprocess(video, device, dtype, alloc.clone())?;
+            let img_patches = self.preprocess(video, device, dtype)?;
             self.processed_videos
                 .push((img_patches, Tensor::zeros(&[0], dtype, device)?));
         }
@@ -135,12 +133,11 @@ impl<const N: usize> VideoProcessor<N> {
 
     /// Preprocess a video for SmolVLM2 model inference
     /// We assume images are RGB.
-    pub fn preprocess<A: ImageAllocator>(
+    pub fn preprocess(
         &mut self,
-        video: &mut VideoSample<N, A>,
+        video: &mut VideoSample<N>,
         device: &Device,
         dtype: DType,
-        alloc: A,
     ) -> Result<Tensor, SmolVlm2Error> {
         let new_size = get_resize_output_image_size(
             video.frames()[0].size(),
@@ -148,7 +145,7 @@ impl<const N: usize> VideoProcessor<N> {
         );
 
         video.process_frames(|frame| {
-            Self::resize(frame, new_size, InterpolationMode::Bicubic, alloc.clone())?;
+            Self::resize(frame, new_size, InterpolationMode::Bicubic)?;
             Self::resize(
                 frame,
                 ImageSize {
@@ -156,7 +153,6 @@ impl<const N: usize> VideoProcessor<N> {
                     height: self.config.video_size_longest_edge,
                 },
                 InterpolationMode::Bicubic,
-                alloc.clone(),
             )?;
 
             // pad
@@ -165,7 +161,7 @@ impl<const N: usize> VideoProcessor<N> {
                 height: self.config.video_size_longest_edge,
             };
             // TODO: masking
-            Self::pad(frame, padded_size, 0, alloc.clone())?;
+            Self::pad(frame, padded_size, 0)?;
 
             Ok(())
         })?;
@@ -255,13 +251,12 @@ impl<const N: usize> VideoProcessor<N> {
     /// # Returns
     ///
     /// * `Result<(), VideoError>` - Ok if successful, VideoError if resizing fails
-    pub fn resize<A: ImageAllocator>(
-        frame: &mut Image<u8, 3, A>,
+    pub fn resize(
+        frame: &mut Image<u8, 3>,
         new_size: ImageSize,
         interpolation: InterpolationMode,
-        alloc: A,
     ) -> Result<(), VideoError> {
-        let mut buf = Image::<u8, 3, A>::from_size_val(new_size, 0, alloc.clone())?;
+        let mut buf = Image::<u8, 3>::from_size_val(new_size, 0, kornia_tensor::host_alloc())?;
         resize_fast_rgb(frame, &mut buf, interpolation)?;
         *frame = buf;
         Ok(())
@@ -286,16 +281,16 @@ impl<const N: usize> VideoProcessor<N> {
     /// # Returns
     ///
     /// * `Result<(), VideoError>` - Ok if successful, VideoError if padding fails
-    pub fn pad<A: ImageAllocator>(
-        frame: &mut Image<u8, 3, A>,
+    pub fn pad(
+        frame: &mut Image<u8, 3>,
         padded_size: ImageSize,
         fill: u8,
-        alloc: A,
     ) -> Result<(), VideoError> {
         // Pad each frame spatially if needed
         let size = frame.size();
         if size.width < padded_size.width || size.height < padded_size.height {
-            let mut padded = Image::<u8, 3, A>::from_size_val(padded_size, fill, alloc.clone())?;
+            let mut padded =
+                Image::<u8, 3>::from_size_val(padded_size, fill, kornia_tensor::host_alloc())?;
             let img_slice = frame.as_slice();
             let padded_img_slice = padded.as_slice_mut();
             let width = size.width;

--- a/crates/kornia-vlm/src/video.rs
+++ b/crates/kornia-vlm/src/video.rs
@@ -129,9 +129,8 @@ impl<const N: usize> VideoSample<N> {
     ///
     /// ```no_run
     /// use kornia_vlm::video::VideoSample;
-    /// use kornia_tensor::kornia_tensor::host_alloc();
     /// use kornia_image::Image;
-    /// let mut video = VideoSample::<32, kornia_tensor::host_alloc()>::default();
+    /// let mut video = VideoSample::<32>::default();
     /// // Apply some processing to each frame
     /// video.process_frames(|frame| {
     ///     // Example: modify frame data (e.g., apply a filter)
@@ -190,10 +189,9 @@ impl<const N: usize> VideoSample<N> {
     ///
     /// ```no_run
     /// use kornia_vlm::video::VideoSample;
-    /// use kornia_tensor::kornia_tensor::host_alloc();
     /// use kornia_image::Image;
     /// use candle_core::Device;
-    /// let video = VideoSample::<32, kornia_tensor::host_alloc()>::default();
+    /// let video = VideoSample::<32>::default();
     /// let device = Device::Cpu;
     /// let tensor = video.into_tensor(candle_core::DType::F32, &device).unwrap();
     /// println!("Tensor shape: {:?}", tensor.dims()); // [N, 3, H, W]
@@ -232,8 +230,7 @@ impl<const N: usize> VideoSample<N> {
     ///
     /// ```no_run
     /// use kornia_vlm::video::VideoSample;
-    /// use kornia_tensor::kornia_tensor::host_alloc();
-    /// let video = VideoSample::<32, kornia_tensor::host_alloc()>::default();
+    /// let video = VideoSample::<32>::default();
     /// let metadata = video.metadata();
     /// if let Some(fps) = metadata.fps {
     ///     println!("Video FPS: {}", fps);

--- a/crates/kornia-vlm/src/video.rs
+++ b/crates/kornia-vlm/src/video.rs
@@ -3,7 +3,7 @@ use candle_core::Device;
 use candle_core::Shape;
 use candle_core::Tensor;
 use circular_buffer::CircularBuffer;
-use kornia_image::{allocator::ImageAllocator, Image};
+use kornia_image::Image;
 use thiserror::Error;
 
 /// Errors that can occur during video processing operations.
@@ -60,9 +60,9 @@ pub struct VideoMetadata<const N: usize> {
 ///
 /// * `A` - The image allocator type used for frame storage
 #[derive(Clone, Default)]
-pub struct VideoSample<const N: usize, A: ImageAllocator> {
+pub struct VideoSample<const N: usize> {
     /// Circular buffer of image frames that make up the video.
-    frames: CircularBuffer<N, Image<u8, 3, A>>,
+    frames: CircularBuffer<N, Image<u8, 3>>,
 
     /// Metadata containing timing and video information.
     meta: VideoMetadata<N>,
@@ -75,7 +75,7 @@ pub struct VideoSample<const N: usize, A: ImageAllocator> {
     processed: CircularBuffer<N, bool>,
 }
 
-impl<const N: usize, A: ImageAllocator + Clone> VideoSample<N, A> {
+impl<const N: usize> VideoSample<N> {
     /// Create a new Video instance with frames and timestamps.
     ///
     /// # Arguments
@@ -104,7 +104,7 @@ impl<const N: usize, A: ImageAllocator + Clone> VideoSample<N, A> {
     ///
     /// * `frame` - The image frame to add
     /// * `timestamp` - Timestamp of the frame in seconds
-    pub fn add_frame(&mut self, frame: Image<u8, 3, A>, timestamp: u32) {
+    pub fn add_frame(&mut self, frame: Image<u8, 3>, timestamp: u32) {
         self.frames.push_back(frame);
         self.processed.push_back(false);
         self.meta.timestamps.push_back(timestamp);
@@ -129,9 +129,9 @@ impl<const N: usize, A: ImageAllocator + Clone> VideoSample<N, A> {
     ///
     /// ```no_run
     /// use kornia_vlm::video::VideoSample;
-    /// use kornia_tensor::CpuAllocator;
+    /// use kornia_tensor::kornia_tensor::host_alloc();
     /// use kornia_image::Image;
-    /// let mut video = VideoSample::<32, CpuAllocator>::default();
+    /// let mut video = VideoSample::<32, kornia_tensor::host_alloc()>::default();
     /// // Apply some processing to each frame
     /// video.process_frames(|frame| {
     ///     // Example: modify frame data (e.g., apply a filter)
@@ -142,7 +142,7 @@ impl<const N: usize, A: ImageAllocator + Clone> VideoSample<N, A> {
     /// ```
     pub fn process_frames<F>(&mut self, mut processor: F) -> Result<(), VideoError>
     where
-        F: FnMut(&mut Image<u8, 3, A>) -> Result<(), VideoError>,
+        F: FnMut(&mut Image<u8, 3>) -> Result<(), VideoError>,
     {
         for (frame, processed) in self.frames.iter_mut().zip(self.processed.iter_mut()) {
             if *processed {
@@ -159,7 +159,7 @@ impl<const N: usize, A: ImageAllocator + Clone> VideoSample<N, A> {
     /// # Returns
     ///
     /// A reference to the frames vector
-    pub fn frames(&self) -> &CircularBuffer<N, Image<u8, 3, A>> {
+    pub fn frames(&self) -> &CircularBuffer<N, Image<u8, 3>> {
         &self.frames
     }
 
@@ -190,10 +190,10 @@ impl<const N: usize, A: ImageAllocator + Clone> VideoSample<N, A> {
     ///
     /// ```no_run
     /// use kornia_vlm::video::VideoSample;
-    /// use kornia_tensor::CpuAllocator;
+    /// use kornia_tensor::kornia_tensor::host_alloc();
     /// use kornia_image::Image;
     /// use candle_core::Device;
-    /// let video = VideoSample::<32, CpuAllocator>::default();
+    /// let video = VideoSample::<32, kornia_tensor::host_alloc()>::default();
     /// let device = Device::Cpu;
     /// let tensor = video.into_tensor(candle_core::DType::F32, &device).unwrap();
     /// println!("Tensor shape: {:?}", tensor.dims()); // [N, 3, H, W]
@@ -232,8 +232,8 @@ impl<const N: usize, A: ImageAllocator + Clone> VideoSample<N, A> {
     ///
     /// ```no_run
     /// use kornia_vlm::video::VideoSample;
-    /// use kornia_tensor::CpuAllocator;
-    /// let video = VideoSample::<32, CpuAllocator>::default();
+    /// use kornia_tensor::kornia_tensor::host_alloc();
+    /// let video = VideoSample::<32, kornia_tensor::host_alloc()>::default();
     /// let metadata = video.metadata();
     /// if let Some(fps) = metadata.fps {
     ///     println!("Video FPS: {}", fps);

--- a/crates/kornia/README.md
+++ b/crates/kornia/README.md
@@ -49,18 +49,18 @@ kornia = { version = "0.1.0", features = ["image", "io", "imgproc"] }
 The `prelude` module provides easy access to common types and traits.
 
 ```rust
-use kornia::image::{Image, ImageSize, allocator::CpuAllocator};
+use kornia::image::{allocator::host_alloc, Image, ImageSize, InterpolationMode};
 use kornia::io::functional as F;
-use kornia::imgproc::resize::{resize_fast_rgb, InterpolationMode};
+use kornia::imgproc::resize::resize_fast_rgb;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // 1. Read an image
-    let image = F::read_image_any_rgb8("tests/data/dog.jpeg")?;
+    let image = F::read_image_any_rgb8("../../tests/data/dog.jpeg")?;
     println!("Loaded image: {:?}", image.size());
 
     // 2. Resize it
     let new_size = ImageSize { width: 128, height: 128 };
-    let mut resized = Image::from_size_val(new_size, 0, CpuAllocator)?;
+    let mut resized = Image::from_size_val(new_size, 0, host_alloc())?;
 
     resize_fast_rgb(&image, &mut resized, InterpolationMode::Bilinear)?;
 

--- a/crates/kornia/README.md
+++ b/crates/kornia/README.md
@@ -60,7 +60,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // 2. Resize it
     let new_size = ImageSize { width: 128, height: 128 };
-    let mut resized = Image::from_size_val(new_size, 0, host_alloc())?;
+    let mut resized = Image::from_size_val(new_size, 0)?;
 
     resize_fast_rgb(&image, &mut resized, InterpolationMode::Bilinear)?;
 

--- a/examples/apriltag/src/main.rs
+++ b/examples/apriltag/src/main.rs
@@ -57,8 +57,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let img = read_image_any_rgb8(args.path)?;
 
-    let mut grayscale_img =
-        Image::from_size_val(img.size(), 0, kornia::image::allocator::host_alloc())?;
+    let mut grayscale_img = Image::from_size_val(img.size(), 0)?;
     gray_from_rgb_u8(&img, &mut grayscale_img)?;
 
     let mut config = DecodeTagsConfig::new(args.kind)?;

--- a/examples/apriltag/src/main.rs
+++ b/examples/apriltag/src/main.rs
@@ -1,9 +1,5 @@
 use argh::FromArgs;
-use kornia::{
-    image::{allocator::CpuAllocator, Image},
-    imgproc::color::gray_from_rgb_u8,
-    io::functional::read_image_any_rgb8,
-};
+use kornia::{image::Image, imgproc::color::gray_from_rgb_u8, io::functional::read_image_any_rgb8};
 use kornia_apriltag::{family::TagFamilyKind, AprilTagDecoder, DecodeTagsConfig};
 
 /// Detects AprilTags in an image
@@ -61,7 +57,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let img = read_image_any_rgb8(args.path)?;
 
-    let mut grayscale_img = Image::from_size_val(img.size(), 0, CpuAllocator)?;
+    let mut grayscale_img =
+        Image::from_size_val(img.size(), 0, kornia::image::allocator::host_alloc())?;
     gray_from_rgb_u8(&img, &mut grayscale_img)?;
 
     let mut config = DecodeTagsConfig::new(args.kind)?;

--- a/examples/binarize/src/main.rs
+++ b/examples/binarize/src/main.rs
@@ -19,24 +19,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let image = F::read_image_any_rgb8(args.image_path)?;
 
     // binarize the image as u8
-    let mut bin =
-        Image::<u8, 3>::from_size_val(image.size(), 0, kornia::image::allocator::host_alloc())?;
+    let mut bin = Image::<u8, 3>::from_size_val(image.size(), 0)?;
     imgproc::threshold::threshold_binary(&image, &mut bin, 127, 255)?;
 
     // normalize the image between 0 and 1
     let image_f32 = image.into_inner().cast_and_scale::<f32>(1.0 / 255.0)?;
 
     // convert to grayscale as floating point
-    let mut gray = Image::<f32, 1>::from_size_val(
-        image_f32.size(),
-        0.0,
-        kornia::image::allocator::host_alloc(),
-    )?;
+    let mut gray = Image::<f32, 1>::from_size_val(image_f32.size(), 0.0)?;
     imgproc::color::gray_from_rgb(&image_f32, &mut gray)?;
 
     // binarize the gray image as floating point
-    let mut gray_bin =
-        Image::<f32, 1>::from_size_val(gray.size(), 0.0, kornia::image::allocator::host_alloc())?;
+    let mut gray_bin = Image::<f32, 1>::from_size_val(gray.size(), 0.0)?;
     imgproc::threshold::threshold_binary(&gray, &mut gray_bin, 0.5, 1.0)?;
 
     // create a Rerun recording stream

--- a/examples/binarize/src/main.rs
+++ b/examples/binarize/src/main.rs
@@ -1,5 +1,4 @@
 use argh::FromArgs;
-use kornia::image::allocator::host_alloc;
 use std::path::PathBuf;
 
 use kornia::io::functional as F;

--- a/examples/binarize/src/main.rs
+++ b/examples/binarize/src/main.rs
@@ -1,5 +1,5 @@
 use argh::FromArgs;
-use kornia::tensor::CpuAllocator;
+use kornia::image::allocator::host_alloc;
 use std::path::PathBuf;
 
 use kornia::io::functional as F;
@@ -20,18 +20,24 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let image = F::read_image_any_rgb8(args.image_path)?;
 
     // binarize the image as u8
-    let mut bin = Image::<u8, 3, _>::from_size_val(image.size(), 0, CpuAllocator)?;
+    let mut bin =
+        Image::<u8, 3>::from_size_val(image.size(), 0, kornia::image::allocator::host_alloc())?;
     imgproc::threshold::threshold_binary(&image, &mut bin, 127, 255)?;
 
     // normalize the image between 0 and 1
     let image_f32 = image.into_inner().cast_and_scale::<f32>(1.0 / 255.0)?;
 
     // convert to grayscale as floating point
-    let mut gray = Image::<f32, 1, _>::from_size_val(image_f32.size(), 0.0, CpuAllocator)?;
+    let mut gray = Image::<f32, 1>::from_size_val(
+        image_f32.size(),
+        0.0,
+        kornia::image::allocator::host_alloc(),
+    )?;
     imgproc::color::gray_from_rgb(&image_f32, &mut gray)?;
 
     // binarize the gray image as floating point
-    let mut gray_bin = Image::<f32, 1, _>::from_size_val(gray.size(), 0.0, CpuAllocator)?;
+    let mut gray_bin =
+        Image::<f32, 1>::from_size_val(gray.size(), 0.0, kornia::image::allocator::host_alloc())?;
     imgproc::threshold::threshold_binary(&gray, &mut gray_bin, 0.5, 1.0)?;
 
     // create a Rerun recording stream

--- a/examples/color_detector/src/main.rs
+++ b/examples/color_detector/src/main.rs
@@ -1,5 +1,5 @@
 use argh::FromArgs;
-use kornia::tensor::CpuAllocator;
+use kornia::image::allocator::host_alloc;
 use std::path::PathBuf;
 
 use kornia::image::{ops, Image};
@@ -21,19 +21,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rgb = F::read_image_any_rgb8(args.image_path)?;
 
     // cast the image to f32
-    let mut rgb_f32 = Image::<f32, 3, _>::from_size_val(rgb.size(), 0.0, CpuAllocator)?;
+    let mut rgb_f32 =
+        Image::<f32, 3>::from_size_val(rgb.size(), 0.0, kornia::image::allocator::host_alloc())?;
     ops::cast_and_scale(&rgb, &mut rgb_f32, 1.0)?;
 
     // binarize the image as u8
-    let mut hsv = Image::<f32, 3, _>::from_size_val(rgb.size(), 0.0, CpuAllocator)?;
+    let mut hsv =
+        Image::<f32, 3>::from_size_val(rgb.size(), 0.0, kornia::image::allocator::host_alloc())?;
     imgproc::color::hsv_from_rgb(&rgb_f32, &mut hsv)?; // convert to u8 (0-255)
 
     // create the mask for the green color
-    let mut mask = Image::<u8, 1, _>::from_size_val(hsv.size(), 0, CpuAllocator)?;
+    let mut mask =
+        Image::<u8, 1>::from_size_val(hsv.size(), 0, kornia::image::allocator::host_alloc())?;
     imgproc::threshold::in_range(&hsv, &mut mask, &[40.0, 110.0, 50.0], &[90.0, 255.0, 255.0])?;
 
     // apply the mask to the image
-    let mut out = Image::<u8, 3, _>::from_size_val(mask.size(), 0, CpuAllocator)?;
+    let mut out =
+        Image::<u8, 3>::from_size_val(mask.size(), 0, kornia::image::allocator::host_alloc())?;
     imgproc::core::bitwise_and(&rgb, &rgb, &mut out, &mask)?;
 
     // create a Rerun recording stream

--- a/examples/color_detector/src/main.rs
+++ b/examples/color_detector/src/main.rs
@@ -1,5 +1,4 @@
 use argh::FromArgs;
-use kornia::image::allocator::host_alloc;
 use std::path::PathBuf;
 
 use kornia::image::{ops, Image};

--- a/examples/color_detector/src/main.rs
+++ b/examples/color_detector/src/main.rs
@@ -20,23 +20,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rgb = F::read_image_any_rgb8(args.image_path)?;
 
     // cast the image to f32
-    let mut rgb_f32 =
-        Image::<f32, 3>::from_size_val(rgb.size(), 0.0, kornia::image::allocator::host_alloc())?;
+    let mut rgb_f32 = Image::<f32, 3>::from_size_val(rgb.size(), 0.0)?;
     ops::cast_and_scale(&rgb, &mut rgb_f32, 1.0)?;
 
     // binarize the image as u8
-    let mut hsv =
-        Image::<f32, 3>::from_size_val(rgb.size(), 0.0, kornia::image::allocator::host_alloc())?;
+    let mut hsv = Image::<f32, 3>::from_size_val(rgb.size(), 0.0)?;
     imgproc::color::hsv_from_rgb(&rgb_f32, &mut hsv)?; // convert to u8 (0-255)
 
     // create the mask for the green color
-    let mut mask =
-        Image::<u8, 1>::from_size_val(hsv.size(), 0, kornia::image::allocator::host_alloc())?;
+    let mut mask = Image::<u8, 1>::from_size_val(hsv.size(), 0)?;
     imgproc::threshold::in_range(&hsv, &mut mask, &[40.0, 110.0, 50.0], &[90.0, 255.0, 255.0])?;
 
     // apply the mask to the image
-    let mut out =
-        Image::<u8, 3>::from_size_val(mask.size(), 0, kornia::image::allocator::host_alloc())?;
+    let mut out = Image::<u8, 3>::from_size_val(mask.size(), 0)?;
     imgproc::core::bitwise_and(&rgb, &rgb, &mut out, &mask)?;
 
     // create a Rerun recording stream

--- a/examples/color_spaces/README.md
+++ b/examples/color_spaces/README.md
@@ -4,7 +4,7 @@ This example demonstrates the modern, type-safe color space API in kornia-rs.
 
 ## Features
 
-- **Explicit Types**: Use `Rgb8`, `Gray8`, `Bgr8` instead of generic `Image<u8, 3, _>`
+- **Explicit Types**: Use `Rgb8`, `Gray8`, `Bgr8` instead of generic `Image<u8, 3>`
 - **Compile-Time Safety**: Can't mix RGB with BGR accidentally
 - **Clean API**: `rgb.convert(&mut gray)?` instead of function calls
 - **Zero-Cost**: `#[repr(transparent)]` wrappers with Deref
@@ -27,7 +27,6 @@ let rgb = F::read_image_any_rgb8("dog.jpeg")?;
 let rgb = Rgb8::from_size_vec(
     ImageSize { width: 640, height: 480 },
     vec![128; 640 * 480 * 3],
-    CpuAllocator
 )?;
 ```
 

--- a/examples/color_spaces/src/main.rs
+++ b/examples/color_spaces/src/main.rs
@@ -1,4 +1,3 @@
-use kornia_image::allocator::CpuAllocator;
 use kornia_image::{color_spaces::Rgb8, ImageSize};
 use kornia_imgproc::color::{ConvertColor, Gray8};
 use kornia_io::functional as F;
@@ -11,12 +10,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("✓ Loaded RGB8 image: {}x{}", rgb.width(), rgb.height());
 
     // Convert to grayscale with type safety
-    let mut gray = Gray8::from_size_val(rgb.size(), 0, CpuAllocator)?;
+    let mut gray = Gray8::from_size_val(rgb.size(), 0, kornia_image::allocator::host_alloc())?;
     rgb.convert(&mut gray)?;
     println!("✓ Converted to Gray8: {}x{}", gray.width(), gray.height());
 
     // Convert back to RGB
-    let mut rgb_back = Rgb8::from_size_val(gray.size(), 0, CpuAllocator)?;
+    let mut rgb_back = Rgb8::from_size_val(gray.size(), 0, kornia_image::allocator::host_alloc())?;
     gray.convert(&mut rgb_back)?;
     println!("✓ Converted back to RGB8");
 
@@ -32,12 +31,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             0, 0, 255, // Blue
             128, 128, 128, // Gray
         ],
-        CpuAllocator,
+        kornia_image::allocator::host_alloc(),
     )?;
     println!("\n✓ Created 2x2 RGB8 image from scratch");
 
     // Type-safe conversions work seamlessly
-    let mut small_gray = Gray8::from_size_val(small_rgb.size(), 0, CpuAllocator)?;
+    let mut small_gray =
+        Gray8::from_size_val(small_rgb.size(), 0, kornia_image::allocator::host_alloc())?;
     small_rgb.convert(&mut small_gray)?;
 
     println!("✓ Converted to grayscale: {:?}", small_gray.as_slice());

--- a/examples/color_spaces/src/main.rs
+++ b/examples/color_spaces/src/main.rs
@@ -10,12 +10,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("✓ Loaded RGB8 image: {}x{}", rgb.width(), rgb.height());
 
     // Convert to grayscale with type safety
-    let mut gray = Gray8::from_size_val(rgb.size(), 0, kornia_image::allocator::host_alloc())?;
+    let mut gray = Gray8::from_size_val(rgb.size(), 0)?;
     rgb.convert(&mut gray)?;
     println!("✓ Converted to Gray8: {}x{}", gray.width(), gray.height());
 
     // Convert back to RGB
-    let mut rgb_back = Rgb8::from_size_val(gray.size(), 0, kornia_image::allocator::host_alloc())?;
+    let mut rgb_back = Rgb8::from_size_val(gray.size(), 0)?;
     gray.convert(&mut rgb_back)?;
     println!("✓ Converted back to RGB8");
 
@@ -31,13 +31,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             0, 0, 255, // Blue
             128, 128, 128, // Gray
         ],
-        kornia_image::allocator::host_alloc(),
     )?;
     println!("\n✓ Created 2x2 RGB8 image from scratch");
 
     // Type-safe conversions work seamlessly
-    let mut small_gray =
-        Gray8::from_size_val(small_rgb.size(), 0, kornia_image::allocator::host_alloc())?;
+    let mut small_gray = Gray8::from_size_val(small_rgb.size(), 0)?;
     small_rgb.convert(&mut small_gray)?;
 
     println!("✓ Converted to grayscale: {:?}", small_gray.as_slice());

--- a/examples/contours/src/main.rs
+++ b/examples/contours/src/main.rs
@@ -1,9 +1,9 @@
 use argh::FromArgs;
 
 use kornia::{
+    image::allocator::host_alloc,
     image::{ops, Image},
     imgproc::{color, contours, threshold},
-    tensor::CpuAllocator,
 };
 
 #[derive(FromArgs)]
@@ -60,22 +60,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let img = kornia::io::functional::read_image_any_rgb8(&args.image)?;
     let size = img.size();
 
-    let mut img_f32 = Image::from_size_val(size, 0f32, CpuAllocator)?;
-    let mut gray = Image::from_size_val(size, 0f32, CpuAllocator)?;
+    let mut img_f32 = Image::from_size_val(size, 0f32, kornia::image::allocator::host_alloc())?;
+    let mut gray = Image::from_size_val(size, 0f32, kornia::image::allocator::host_alloc())?;
 
     // convert to gray scale
     ops::cast_and_scale(&img, &mut img_f32, 1.0 / 255.0)?;
     color::gray_from_rgb(&img_f32, &mut gray)?;
 
     // convert to binary image
-    let mut binary_f32 = Image::from_size_val(size, 0f32, CpuAllocator)?;
+    let mut binary_f32 = Image::from_size_val(size, 0f32, kornia::image::allocator::host_alloc())?;
     threshold::threshold_binary(
         &gray,
         &mut binary_f32,
         args.threshold as f32 / 255.0,
         1.0f32,
     )?;
-    let mut binary = Image::from_size_val(size, 0u8, CpuAllocator)?;
+    let mut binary = Image::from_size_val(size, 0u8, kornia::image::allocator::host_alloc())?;
     ops::cast_and_scale(&binary_f32, &mut binary, 1)?;
 
     // find contours

--- a/examples/contours/src/main.rs
+++ b/examples/contours/src/main.rs
@@ -1,7 +1,6 @@
 use argh::FromArgs;
 
 use kornia::{
-    image::allocator::host_alloc,
     image::{ops, Image},
     imgproc::{color, contours, threshold},
 };

--- a/examples/contours/src/main.rs
+++ b/examples/contours/src/main.rs
@@ -59,22 +59,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let img = kornia::io::functional::read_image_any_rgb8(&args.image)?;
     let size = img.size();
 
-    let mut img_f32 = Image::from_size_val(size, 0f32, kornia::image::allocator::host_alloc())?;
-    let mut gray = Image::from_size_val(size, 0f32, kornia::image::allocator::host_alloc())?;
+    let mut img_f32 = Image::from_size_val(size, 0f32)?;
+    let mut gray = Image::from_size_val(size, 0f32)?;
 
     // convert to gray scale
     ops::cast_and_scale(&img, &mut img_f32, 1.0 / 255.0)?;
     color::gray_from_rgb(&img_f32, &mut gray)?;
 
     // convert to binary image
-    let mut binary_f32 = Image::from_size_val(size, 0f32, kornia::image::allocator::host_alloc())?;
+    let mut binary_f32 = Image::from_size_val(size, 0f32)?;
     threshold::threshold_binary(
         &gray,
         &mut binary_f32,
         args.threshold as f32 / 255.0,
         1.0f32,
     )?;
-    let mut binary = Image::from_size_val(size, 0u8, kornia::image::allocator::host_alloc())?;
+    let mut binary = Image::from_size_val(size, 0u8)?;
     ops::cast_and_scale(&binary_f32, &mut binary, 1)?;
 
     // find contours

--- a/examples/copper/src/tasks/cu_image.rs
+++ b/examples/copper/src/tasks/cu_image.rs
@@ -22,14 +22,7 @@ impl std::fmt::Debug for ImageRgb8Msg {
 // TODO: implement Image::empty()
 impl Default for ImageRgb8Msg {
     fn default() -> Self {
-        Self(
-            ImageRgb8::new(
-                [0, 0].into(),
-                vec![],
-                kornia::image::allocator::host_alloc(),
-            )
-            .unwrap(),
-        )
+        Self(ImageRgb8::new([0, 0].into(), vec![]).unwrap())
     }
 }
 
@@ -54,12 +47,8 @@ impl<C> bincode::de::Decode<C> for ImageRgb8Msg {
         let rows = bincode::Decode::decode(decoder)?;
         let cols = bincode::Decode::decode(decoder)?;
         let data = bincode::Decode::decode(decoder)?;
-        let image = ImageRgb8::new(
-            [rows, cols].into(),
-            data,
-            kornia::image::allocator::host_alloc(),
-        )
-        .map_err(|e| bincode::error::DecodeError::OtherString(e.to_string()))?;
+        let image = ImageRgb8::new([rows, cols].into(), data)
+            .map_err(|e| bincode::error::DecodeError::OtherString(e.to_string()))?;
         Ok(Self(image))
     }
 }
@@ -83,14 +72,7 @@ impl std::fmt::Debug for ImageGray8Msg {
 
 impl Default for ImageGray8Msg {
     fn default() -> Self {
-        Self(
-            ImageGray8::new(
-                [0, 0].into(),
-                vec![],
-                kornia::image::allocator::host_alloc(),
-            )
-            .unwrap(),
-        )
+        Self(ImageGray8::new([0, 0].into(), vec![]).unwrap())
     }
 }
 
@@ -113,12 +95,8 @@ impl<C> bincode::de::Decode<C> for ImageGray8Msg {
         let rows = bincode::Decode::decode(decoder)?;
         let cols = bincode::Decode::decode(decoder)?;
         let data = bincode::Decode::decode(decoder)?;
-        let image = ImageGray8::new(
-            [rows, cols].into(),
-            data,
-            kornia::image::allocator::host_alloc(),
-        )
-        .map_err(|e| bincode::error::DecodeError::OtherString(e.to_string()))?;
+        let image = ImageGray8::new([rows, cols].into(), data)
+            .map_err(|e| bincode::error::DecodeError::OtherString(e.to_string()))?;
         Ok(Self(image))
     }
 }

--- a/examples/copper/src/tasks/cu_image.rs
+++ b/examples/copper/src/tasks/cu_image.rs
@@ -1,7 +1,5 @@
-use kornia::io::stream::ForeignAllocator;
-
-type ImageRgb8 = kornia::image::Image<u8, 3, ForeignAllocator>;
-type ImageGray8 = kornia::image::Image<u8, 1, ForeignAllocator>;
+type ImageRgb8 = kornia::image::Image<u8, 3>;
+type ImageGray8 = kornia::image::Image<u8, 1>;
 
 #[derive(Clone)]
 pub struct ImageRgb8Msg(pub ImageRgb8);
@@ -24,7 +22,14 @@ impl std::fmt::Debug for ImageRgb8Msg {
 // TODO: implement Image::empty()
 impl Default for ImageRgb8Msg {
     fn default() -> Self {
-        Self(ImageRgb8::new([0, 0].into(), vec![], ForeignAllocator).unwrap())
+        Self(
+            ImageRgb8::new(
+                [0, 0].into(),
+                vec![],
+                kornia::image::allocator::host_alloc(),
+            )
+            .unwrap(),
+        )
     }
 }
 
@@ -49,8 +54,12 @@ impl<C> bincode::de::Decode<C> for ImageRgb8Msg {
         let rows = bincode::Decode::decode(decoder)?;
         let cols = bincode::Decode::decode(decoder)?;
         let data = bincode::Decode::decode(decoder)?;
-        let image = ImageRgb8::new([rows, cols].into(), data, ForeignAllocator)
-            .map_err(|e| bincode::error::DecodeError::OtherString(e.to_string()))?;
+        let image = ImageRgb8::new(
+            [rows, cols].into(),
+            data,
+            kornia::image::allocator::host_alloc(),
+        )
+        .map_err(|e| bincode::error::DecodeError::OtherString(e.to_string()))?;
         Ok(Self(image))
     }
 }
@@ -74,7 +83,14 @@ impl std::fmt::Debug for ImageGray8Msg {
 
 impl Default for ImageGray8Msg {
     fn default() -> Self {
-        Self(ImageGray8::new([0, 0].into(), vec![], ForeignAllocator).unwrap())
+        Self(
+            ImageGray8::new(
+                [0, 0].into(),
+                vec![],
+                kornia::image::allocator::host_alloc(),
+            )
+            .unwrap(),
+        )
     }
 }
 
@@ -97,8 +113,12 @@ impl<C> bincode::de::Decode<C> for ImageGray8Msg {
         let rows = bincode::Decode::decode(decoder)?;
         let cols = bincode::Decode::decode(decoder)?;
         let data = bincode::Decode::decode(decoder)?;
-        let image = ImageGray8::new([rows, cols].into(), data, ForeignAllocator)
-            .map_err(|e| bincode::error::DecodeError::OtherString(e.to_string()))?;
+        let image = ImageGray8::new(
+            [rows, cols].into(),
+            data,
+            kornia::image::allocator::host_alloc(),
+        )
+        .map_err(|e| bincode::error::DecodeError::OtherString(e.to_string()))?;
         Ok(Self(image))
     }
 }

--- a/examples/copper/src/tasks/sobel.rs
+++ b/examples/copper/src/tasks/sobel.rs
@@ -1,5 +1,5 @@
 use cu29::prelude::*;
-use kornia::{image::Image, imgproc, io::stream::ForeignAllocator};
+use kornia::{image::allocator::host_alloc, image::Image, imgproc};
 
 use super::cu_image::{ImageGray8Msg, ImageRgb8Msg};
 
@@ -42,7 +42,7 @@ impl<'cl> CuTask<'cl> for Sobel {
             .map(|&x| x as f32)
             .map_err(|e| CuError::new_with_cause("Failed to cast image to f32", e))?;
 
-        let mut img_sobel = Image::from_size_val(img.size(), 0.0f32, ForeignAllocator)
+        let mut img_sobel = Image::from_size_val(img.size(), 0.0f32, host_alloc())
             .map_err(|e| CuError::new_with_cause("Failed to create image", e))?;
 
         imgproc::filter::sobel(&img, &mut img_sobel, 3)

--- a/examples/copper/src/tasks/sobel.rs
+++ b/examples/copper/src/tasks/sobel.rs
@@ -1,5 +1,5 @@
 use cu29::prelude::*;
-use kornia::{image::allocator::host_alloc, image::Image, imgproc};
+use kornia::{image::Image, imgproc};
 
 use super::cu_image::{ImageGray8Msg, ImageRgb8Msg};
 
@@ -42,7 +42,7 @@ impl<'cl> CuTask<'cl> for Sobel {
             .map(|&x| x as f32)
             .map_err(|e| CuError::new_with_cause("Failed to cast image to f32", e))?;
 
-        let mut img_sobel = Image::from_size_val(img.size(), 0.0f32, host_alloc())
+        let mut img_sobel = Image::from_size_val(img.size(), 0.0f32)
             .map_err(|e| CuError::new_with_cause("Failed to create image", e))?;
 
         imgproc::filter::sobel(&img, &mut img_sobel, 3)

--- a/examples/cuda_imgproc/src/main.rs
+++ b/examples/cuda_imgproc/src/main.rs
@@ -19,7 +19,7 @@ use kornia_image::color_spaces::Gray8;
 use kornia_image::image::ImageSize;
 use kornia_io::functional::read_image_any_rgb8;
 use kornia_io::png::write_image_png_gray8;
-use kornia_tensor::{zeros_cuda, CpuAllocator, CudaKernel, Tensor};
+use kornia_tensor::{zeros_cuda, CudaKernel, Tensor};
 
 // BT.601 RGB→gray CUDA kernel (u8 interleaved RGB → u8 planar gray).
 // `src` is the flat h*w*3 byte buffer; `dst` is the flat h*w gray buffer.
@@ -47,7 +47,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Loading image: {path}");
 
     // Load an RGB8 image from disk via kornia-io. `Rgb8` derefs/owns an
-    // `Image<u8, 3, CpuAllocator>`, which is a newtype over `Tensor3<u8, _>`.
+    // `Image<u8, 3>`, which is a newtype over `Tensor3<u8, _>`.
     let rgb = read_image_any_rgb8(&path)?;
     let (h, w) = (rgb.rows(), rgb.cols());
     let npix = h * w;
@@ -59,7 +59,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ── Eased device path: everything stays a kornia Tensor ──────────────────
     // Upload the RGB image directly — `to_cuda` copies the contiguous
     // h*w*3 bytes to a device tensor (no manual host flatten / Vec copy).
-    let dev_rgb: Tensor<u8, 3, _> = rgb.to_cuda(&stream)?;
+    let dev_rgb: Tensor<u8, 3> = rgb.to_cuda(&stream)?;
     // Allocate the device output as a zero-filled device tensor (no raw CudaSlice).
     let mut dev_gray = zeros_cuda::<u8, 1>([npix], &stream)?;
 
@@ -92,7 +92,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             height: h,
         },
         gray_slice.to_vec(),
-        CpuAllocator,
+        kornia_image::allocator::host_alloc(),
     )?;
     let out_path = "/tmp/cuda_imgproc_output.png";
     write_image_png_gray8(out_path, &gray_img)?;

--- a/examples/fast_detector/src/main.rs
+++ b/examples/fast_detector/src/main.rs
@@ -37,15 +37,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let img_rgb8 = F::read_image_any_rgb8(args.image_path)?;
 
     // convert to grayscale
-    let mut img_gray8 =
-        Image::from_size_val(img_rgb8.size(), 0u8, kornia::image::allocator::host_alloc())?;
+    let mut img_gray8 = Image::from_size_val(img_rgb8.size(), 0u8)?;
     imgproc::color::gray_from_rgb_u8(&img_rgb8, &mut img_gray8)?;
 
-    let mut img_grayf32 = Image::from_size_val(
-        img_gray8.size(),
-        0.0,
-        kornia::image::allocator::host_alloc(),
-    )?;
+    let mut img_grayf32 = Image::from_size_val(img_gray8.size(), 0.0)?;
     img_gray8
         .as_slice()
         .iter()

--- a/examples/fast_detector/src/main.rs
+++ b/examples/fast_detector/src/main.rs
@@ -5,7 +5,6 @@ use kornia::{
     image::Image,
     imgproc::{self, features::FastDetector},
     io::functional as F,
-    tensor::CpuAllocator,
 };
 
 /// Detect FAST features on an image.
@@ -38,10 +37,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let img_rgb8 = F::read_image_any_rgb8(args.image_path)?;
 
     // convert to grayscale
-    let mut img_gray8 = Image::from_size_val(img_rgb8.size(), 0u8, CpuAllocator)?;
+    let mut img_gray8 =
+        Image::from_size_val(img_rgb8.size(), 0u8, kornia::image::allocator::host_alloc())?;
     imgproc::color::gray_from_rgb_u8(&img_rgb8, &mut img_gray8)?;
 
-    let mut img_grayf32 = Image::from_size_val(img_gray8.size(), 0.0, CpuAllocator)?;
+    let mut img_grayf32 = Image::from_size_val(
+        img_gray8.size(),
+        0.0,
+        kornia::image::allocator::host_alloc(),
+    )?;
     img_gray8
         .as_slice()
         .iter()

--- a/examples/features/src/main.rs
+++ b/examples/features/src/main.rs
@@ -2,10 +2,10 @@ use argh::FromArgs;
 use std::path::PathBuf;
 
 use kornia::{
+    image::allocator::host_alloc,
     image::{ops, Image},
     imgproc,
     io::functional as F,
-    tensor::CpuAllocator,
 };
 
 #[derive(FromArgs)]
@@ -24,12 +24,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let size = img_rgb.size();
 
     // preallocate images
-    let mut img_f32 = Image::from_size_val(size, 0f32, CpuAllocator)?;
-    let mut gray = Image::from_size_val(size, 0f32, CpuAllocator)?;
-    let mut gftt_response = Image::from_size_val(size, 0f32, CpuAllocator)?;
-    let mut hessian_response = Image::from_size_val(size, 0f32, CpuAllocator)?;
-    let mut gftt_corners = Image::from_size_val(size, 0f32, CpuAllocator)?;
-    let mut hessian_corners = Image::from_size_val(size, 0f32, CpuAllocator)?;
+    let mut img_f32 = Image::from_size_val(size, 0f32, kornia::image::allocator::host_alloc())?;
+    let mut gray = Image::from_size_val(size, 0f32, kornia::image::allocator::host_alloc())?;
+    let mut gftt_response =
+        Image::from_size_val(size, 0f32, kornia::image::allocator::host_alloc())?;
+    let mut hessian_response =
+        Image::from_size_val(size, 0f32, kornia::image::allocator::host_alloc())?;
+    let mut gftt_corners =
+        Image::from_size_val(size, 0f32, kornia::image::allocator::host_alloc())?;
+    let mut hessian_corners =
+        Image::from_size_val(size, 0f32, kornia::image::allocator::host_alloc())?;
 
     // convert to gray scale
     ops::cast_and_scale(&img_rgb, &mut img_f32, 1.0 / 255.0)?;

--- a/examples/features/src/main.rs
+++ b/examples/features/src/main.rs
@@ -23,16 +23,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let size = img_rgb.size();
 
     // preallocate images
-    let mut img_f32 = Image::from_size_val(size, 0f32, kornia::image::allocator::host_alloc())?;
-    let mut gray = Image::from_size_val(size, 0f32, kornia::image::allocator::host_alloc())?;
-    let mut gftt_response =
-        Image::from_size_val(size, 0f32, kornia::image::allocator::host_alloc())?;
-    let mut hessian_response =
-        Image::from_size_val(size, 0f32, kornia::image::allocator::host_alloc())?;
-    let mut gftt_corners =
-        Image::from_size_val(size, 0f32, kornia::image::allocator::host_alloc())?;
-    let mut hessian_corners =
-        Image::from_size_val(size, 0f32, kornia::image::allocator::host_alloc())?;
+    let mut img_f32 = Image::from_size_val(size, 0f32)?;
+    let mut gray = Image::from_size_val(size, 0f32)?;
+    let mut gftt_response = Image::from_size_val(size, 0f32)?;
+    let mut hessian_response = Image::from_size_val(size, 0f32)?;
+    let mut gftt_corners = Image::from_size_val(size, 0f32)?;
+    let mut hessian_corners = Image::from_size_val(size, 0f32)?;
 
     // convert to gray scale
     ops::cast_and_scale(&img_rgb, &mut img_f32, 1.0 / 255.0)?;

--- a/examples/features/src/main.rs
+++ b/examples/features/src/main.rs
@@ -2,7 +2,6 @@ use argh::FromArgs;
 use std::path::PathBuf;
 
 use kornia::{
-    image::allocator::host_alloc,
     image::{ops, Image},
     imgproc,
     io::functional as F,

--- a/examples/filters/src/main.rs
+++ b/examples/filters/src/main.rs
@@ -62,9 +62,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     })?;
 
     // preallocate images
-    let mut img_f32 = Image::from_size_val(size, 0f32, kornia::image::allocator::host_alloc())?;
-    let mut img_f32_filtered =
-        Image::from_size_val(size, 0f32, kornia::image::allocator::host_alloc())?;
+    let mut img_f32 = Image::from_size_val(size, 0f32)?;
+    let mut img_f32_filtered = Image::from_size_val(size, 0f32)?;
     // start grabbing frames from the camera
     while !cancel_token.load(Ordering::SeqCst) {
         let Some(img) = webcam.grab_rgb8()? else {
@@ -89,8 +88,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 )?;
             }
             "sobel" => {
-                let mut img_f32_filtered_sobel =
-                    Image::from_size_val(size, 0f32, kornia::image::allocator::host_alloc())?;
+                let mut img_f32_filtered_sobel = Image::from_size_val(size, 0f32)?;
                 imgproc::filter::sobel(&img_f32, &mut img_f32_filtered_sobel, args.kx)?;
 
                 // we need to normalize the sobel filter to 0-1

--- a/examples/filters/src/main.rs
+++ b/examples/filters/src/main.rs
@@ -5,7 +5,6 @@ use std::sync::{
 };
 
 use kornia::{
-    image::allocator::host_alloc,
     image::{ops, Image},
     imgproc,
     io::stream::V4L2CameraConfig,

--- a/examples/filters/src/main.rs
+++ b/examples/filters/src/main.rs
@@ -5,10 +5,10 @@ use std::sync::{
 };
 
 use kornia::{
+    image::allocator::host_alloc,
     image::{ops, Image},
     imgproc,
     io::stream::V4L2CameraConfig,
-    tensor::CpuAllocator,
 };
 
 #[derive(FromArgs)]
@@ -63,8 +63,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     })?;
 
     // preallocate images
-    let mut img_f32 = Image::from_size_val(size, 0f32, CpuAllocator)?;
-    let mut img_f32_filtered = Image::from_size_val(size, 0f32, CpuAllocator)?;
+    let mut img_f32 = Image::from_size_val(size, 0f32, kornia::image::allocator::host_alloc())?;
+    let mut img_f32_filtered =
+        Image::from_size_val(size, 0f32, kornia::image::allocator::host_alloc())?;
     // start grabbing frames from the camera
     while !cancel_token.load(Ordering::SeqCst) {
         let Some(img) = webcam.grab_rgb8()? else {
@@ -89,7 +90,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 )?;
             }
             "sobel" => {
-                let mut img_f32_filtered_sobel = Image::from_size_val(size, 0f32, CpuAllocator)?;
+                let mut img_f32_filtered_sobel =
+                    Image::from_size_val(size, 0f32, kornia::image::allocator::host_alloc())?;
                 imgproc::filter::sobel(&img_f32, &mut img_f32_filtered_sobel, args.kx)?;
 
                 // we need to normalize the sobel filter to 0-1

--- a/examples/hiroz-nodes/src/compute_node.rs
+++ b/examples/hiroz-nodes/src/compute_node.rs
@@ -79,7 +79,7 @@ impl ComputeNode {
                     let img = match Image::<u8, 3>::new(ImageSize {
                         width: msg.width as usize,
                         height: msg.height as usize,
-                    }, msg.data, kornia_image::allocator::host_alloc()) {
+                    }, msg.data) {
                         Ok(img) => img,
                         Err(e) => {
                             log::warn!("skipping malformed frame: {e}");

--- a/examples/hiroz-nodes/src/compute_node.rs
+++ b/examples/hiroz-nodes/src/compute_node.rs
@@ -4,7 +4,7 @@ use crate::protos::{Header, ImageStats, RawImage};
 use hiroz::{
     context::ZContext, msg::ProtobufSerdes, node::ZNode, pubsub::ZPub, Builder, Result as ZResult,
 };
-use kornia_image::{allocator::CpuAllocator, Image, ImageSize};
+use kornia_image::{Image, ImageSize};
 use prost::Message;
 use std::sync::Arc;
 use zenoh::Wait;
@@ -76,10 +76,10 @@ impl ComputeNode {
                     let msg = RawImage::decode(bytes.as_ref())?;
 
                     // convert to image kornia
-                    let img = match Image::<u8, 3, CpuAllocator>::new(ImageSize {
+                    let img = match Image::<u8, 3>::new(ImageSize {
                         width: msg.width as usize,
                         height: msg.height as usize,
-                    }, msg.data, CpuAllocator) {
+                    }, msg.data, kornia_image::allocator::host_alloc()) {
                         Ok(img) => img,
                         Err(e) => {
                             log::warn!("skipping malformed frame: {e}");

--- a/examples/hiroz-nodes/src/decoder_node.rs
+++ b/examples/hiroz-nodes/src/decoder_node.rs
@@ -81,11 +81,7 @@ impl DecoderNode {
         let layout = decode_image_jpeg_layout(&msg.data)?;
         assert_eq!(layout.channels, 3);
 
-        let mut image = Image::<u8, 3>::from_size_val(
-            layout.image_size,
-            0,
-            kornia_image::allocator::host_alloc(),
-        )?;
+        let mut image = Image::<u8, 3>::from_size_val(layout.image_size, 0)?;
         decode_image_jpeg_rgb8(&msg.data, &mut image)?;
 
         let sequence = self.sequence;

--- a/examples/hiroz-nodes/src/decoder_node.rs
+++ b/examples/hiroz-nodes/src/decoder_node.rs
@@ -4,7 +4,7 @@ use crate::protos::{CompressedImage, Header, RawImage};
 use hiroz::{
     context::ZContext, msg::ProtobufSerdes, node::ZNode, pubsub::ZSub, Builder, Result as ZResult,
 };
-use kornia_image::{allocator::CpuAllocator, Image};
+use kornia_image::Image;
 use kornia_io::jpeg::{decode_image_jpeg_layout, decode_image_jpeg_rgb8};
 use prost::Message;
 use std::sync::Arc;
@@ -81,8 +81,11 @@ impl DecoderNode {
         let layout = decode_image_jpeg_layout(&msg.data)?;
         assert_eq!(layout.channels, 3);
 
-        let mut image =
-            Image::<u8, 3, CpuAllocator>::from_size_val(layout.image_size, 0, CpuAllocator)?;
+        let mut image = Image::<u8, 3>::from_size_val(
+            layout.image_size,
+            0,
+            kornia_image::allocator::host_alloc(),
+        )?;
         decode_image_jpeg_rgb8(&msg.data, &mut image)?;
 
         let sequence = self.sequence;

--- a/examples/image_api/README.md
+++ b/examples/image_api/README.md
@@ -58,11 +58,10 @@ Example 3: Error handling (wrong data size)
 ### 1. Creating Images from Fill Values
 
 ```rust
-use kornia_image::{Image, ImageSize, allocator::CpuAllocator};
+use kornia_image::{Image, ImageSize};
 
 let size = ImageSize { width: 640, height: 480 };
-let alloc = CpuAllocator::default();
-let img = Image::<u8, 3, _>::from_size_val(size, 128, alloc)?;
+let img = Image::<u8, 3>::from_size_val(size, 128)?;
 ```
 
 ### 2. Creating Images from Data Vectors
@@ -70,14 +69,13 @@ let img = Image::<u8, 3, _>::from_size_val(size, 128, alloc)?;
 ```rust
 let data = vec![0u8; 100];
 let size = ImageSize { width: 10, height: 10 };
-let alloc = CpuAllocator::default();
-let img = Image::<u8, 1, _>::new(size, data, alloc)?;
+let img = Image::<u8, 1>::new(size, data)?;
 ```
 
 ### 3. Zero-Copy Data Access
 
 ```rust
-let img = Image::<u8, 3, _>::from_size_val(size, 42, alloc)?;
+let img = Image::<u8, 3>::from_size_val(size, 42)?;
 let data = img.as_slice();  // &[u8] - zero copy!
 let pixel = data[0];
 ```
@@ -85,7 +83,7 @@ let pixel = data[0];
 ### 4. Owned Copy of Data
 
 ```rust
-let img = Image::<f32, 3, _>::from_size_val(size, 0.5, alloc)?;
+let img = Image::<f32, 3>::from_size_val(size, 0.5)?;
 let owned_copy = img.to_vec();  // Vec<f32>
 // Can modify independently of original
 ```
@@ -95,9 +93,8 @@ let owned_copy = img.to_vec();  // Vec<f32>
 ```rust
 let data = vec![0u8; 100];  // Wrong size
 let size = ImageSize { width: 10, height: 10 };
-let alloc = CpuAllocator::default();
 
-match Image::<u8, 3, _>::new(size, data, alloc) {
+match Image::<u8, 3>::new(size, data) {
     Ok(img) => println!("Created image"),
     Err(ImageError::InvalidChannelShape(got, expected)) => {
         println!("Error: got {} bytes, expected {}", got, expected);
@@ -109,7 +106,7 @@ match Image::<u8, 3, _>::new(size, data, alloc) {
 ### 6. Pixel-Level Access
 
 ```rust
-let mut img = Image::<u8, 3, _>::from_size_val(size, 0, alloc)?;
+let mut img = Image::<u8, 3>::from_size_val(size, 0)?;
 
 // Set individual pixels
 img.set_pixel(0, 0, 0, 255)?;  // Red channel at (0, 0)
@@ -125,13 +122,13 @@ let b = img.get_pixel(0, 0, 2)?;
 ### 7. Channel Operations
 
 ```rust
-let img = Image::<u8, 3, _>::from_size_val(size, 128, alloc)?;
+let img = Image::<u8, 3>::from_size_val(size, 128)?;
 
 // Extract single channel
-let red_channel = img.channel(0)?;  // Returns Image<u8, 1, _>
+let red_channel = img.channel(0)?;  // Returns Image<u8, 1>
 
 // Split into all channels
-let channels = img.split_channels()?;  // Vec<Image<u8, 1, _>>
+let channels = img.split_channels()?;  // Vec<Image<u8, 1>>
 for ch in channels {
     println!("Channel data: {:?}", ch.as_slice());
 }
@@ -140,7 +137,7 @@ for ch in channels {
 ### 8. Image Properties
 
 ```rust
-let img = Image::<u8, 3, _>::from_size_val(size, 0, alloc)?;
+let img = Image::<u8, 3>::from_size_val(size, 0)?;
 
 let width = img.width();      // usize
 let height = img.height();    // usize
@@ -152,25 +149,27 @@ let num_ch = img.num_channels();  // Returns 3
 
 ## Supported Image Types
 
-The `Image<T, C, A>` type is generic over:
+The `Image<T, C>` type is generic over:
 - `T`: Data type (u8, u16, f32, f64, etc.)
 - `C`: Number of channels (1, 3, 4, etc.)
-- `A`: Allocator (typically `CpuAllocator`)
+
+The allocator is **not** a type parameter — it is a runtime handle on the backing storage
+(host by default). Memory domain (Host / Device / Unified) is also runtime.
 
 | Type | Description | Example |
 |------|-------------|---------|
-| `Image<u8, 1, A>` | Grayscale 8-bit | `Image::<u8, 1, _>::from_size_val(...)` |
-| `Image<u8, 3, A>` | RGB 8-bit | `Image::<u8, 3, _>::from_size_val(...)` |
-| `Image<u8, 4, A>` | RGBA 8-bit | `Image::<u8, 4, _>::from_size_val(...)` |
-| `Image<f32, 1, A>` | Grayscale float | `Image::<f32, 1, _>::from_size_val(...)` |
-| `Image<f32, 3, A>` | RGB float | `Image::<f32, 3, _>::from_size_val(...)` |
-| `Image<f32, 4, A>` | RGBA float | `Image::<f32, 4, _>::from_size_val(...)` |
+| `Image<u8, 1>` | Grayscale 8-bit | `Image::<u8, 1>::from_size_val(...)` |
+| `Image<u8, 3>` | RGB 8-bit | `Image::<u8, 3>::from_size_val(...)` |
+| `Image<u8, 4>` | RGBA 8-bit | `Image::<u8, 4>::from_size_val(...)` |
+| `Image<f32, 1>` | Grayscale float | `Image::<f32, 1>::from_size_val(...)` |
+| `Image<f32, 3>` | RGB float | `Image::<f32, 3>::from_size_val(...)` |
+| `Image<f32, 4>` | RGBA float | `Image::<f32, 4>::from_size_val(...)` |
 
 ## Memory Management
 
 - **Ownership**: Images own their data via `Tensor3`
 - **Zero-copy**: `as_slice()` returns `&[T]` reference to internal data
-- **Allocators**: Support custom allocators (default: `CpuAllocator`)
+- **Allocators**: Runtime handle (host by default); `new_in`/`from_size_val_in` accept a custom one
 - **RAII**: Automatic cleanup when image goes out of scope
 
 ## Data Layout

--- a/examples/image_api/src/main.rs
+++ b/examples/image_api/src/main.rs
@@ -23,7 +23,7 @@ fn example_create_from_value() -> Result<(), ImageError> {
         width: 640,
         height: 480,
     };
-    let img = Image::<u8, 3>::from_size_val(size, 128, kornia_image::allocator::host_alloc())?;
+    let img = Image::<u8, 3>::from_size_val(size, 128)?;
 
     println!("✓ Created {}x{}x{} image", img.width(), img.height(), 3);
     println!("  Fill value: {}", img.as_slice()[0]);
@@ -47,7 +47,7 @@ fn example_create_from_data() -> Result<(), ImageError> {
         width: 10,
         height: 10,
     };
-    let img = Image::<u8, 1>::new(size, data, kornia_image::allocator::host_alloc())?;
+    let img = Image::<u8, 1>::new(size, data)?;
 
     println!(
         "✓ Created {}x{} grayscale image from data",
@@ -72,7 +72,7 @@ fn example_error_handling() {
         height: 10,
     };
 
-    match Image::<u8, 3>::new(size, data, kornia_image::allocator::host_alloc()) {
+    match Image::<u8, 3>::new(size, data) {
         Ok(_) => println!("✓ Created image (should not reach here)"),
         Err(e) => {
             println!("✓ Caught expected error:");
@@ -91,7 +91,7 @@ fn example_zero_copy_access() -> Result<(), ImageError> {
         width: 5,
         height: 5,
     };
-    let img = Image::<u8, 3>::from_size_val(size, 42, kornia_image::allocator::host_alloc())?;
+    let img = Image::<u8, 3>::from_size_val(size, 42)?;
 
     // Zero-copy access to underlying data
     let data = img.as_slice(); // &[u8] - zero copy!
@@ -122,7 +122,7 @@ fn example_owned_copy() -> Result<(), ImageError> {
         width: 3,
         height: 3,
     };
-    let img = Image::<f32, 3>::from_size_val(size, 0.5, kornia_image::allocator::host_alloc())?;
+    let img = Image::<f32, 3>::from_size_val(size, 0.5)?;
 
     // Zero-copy view
     let data_view = img.as_slice();
@@ -148,17 +148,14 @@ fn example_different_types() -> Result<(), ImageError> {
     };
 
     // U8 images (8-bit unsigned)
-    let _gray_u8 = Image::<u8, 1>::from_size_val(size, 255, kornia_image::allocator::host_alloc())?;
-    let _rgb_u8 = Image::<u8, 3>::from_size_val(size, 128, kornia_image::allocator::host_alloc())?;
-    let _rgba_u8 = Image::<u8, 4>::from_size_val(size, 64, kornia_image::allocator::host_alloc())?;
+    let _gray_u8 = Image::<u8, 1>::from_size_val(size, 255)?;
+    let _rgb_u8 = Image::<u8, 3>::from_size_val(size, 128)?;
+    let _rgba_u8 = Image::<u8, 4>::from_size_val(size, 64)?;
 
     // F32 images (32-bit float, common for ML/processing)
-    let _gray_f32 =
-        Image::<f32, 1>::from_size_val(size, 1.0, kornia_image::allocator::host_alloc())?;
-    let _rgb_f32 =
-        Image::<f32, 3>::from_size_val(size, 0.5, kornia_image::allocator::host_alloc())?;
-    let _rgba_f32 =
-        Image::<f32, 4>::from_size_val(size, 0.25, kornia_image::allocator::host_alloc())?;
+    let _gray_f32 = Image::<f32, 1>::from_size_val(size, 1.0)?;
+    let _rgb_f32 = Image::<f32, 3>::from_size_val(size, 0.5)?;
+    let _rgba_f32 = Image::<f32, 4>::from_size_val(size, 0.25)?;
 
     println!("✓ Created 6 different image types:");
     println!("  U8:  Grayscale (C1), RGB (C3), RGBA (C4)");
@@ -182,7 +179,7 @@ fn example_pixel_access() -> Result<(), ImageError> {
         width: 5,
         height: 5,
     };
-    let mut img = Image::<u8, 3>::from_size_val(size, 0, kornia_image::allocator::host_alloc())?;
+    let mut img = Image::<u8, 3>::from_size_val(size, 0)?;
 
     // Set individual pixels
     img.set_pixel(0, 0, 0, 255)?; // Red channel at (0, 0)
@@ -224,7 +221,7 @@ fn example_image_from_slice() -> Result<(), ImageError> {
     };
 
     // Create image from slice (copies data)
-    let img = Image::<u8, 3>::from_size_slice(size, &data, kornia_image::allocator::host_alloc())?;
+    let img = Image::<u8, 3>::from_size_slice(size, &data)?;
 
     println!(
         "✓ Created {}x{}x{} image from slice",
@@ -256,7 +253,7 @@ fn example_channel_operations() -> Result<(), ImageError> {
         data.push(64); // B
     }
 
-    let img = Image::<u8, 3>::new(size, data, kornia_image::allocator::host_alloc())?;
+    let img = Image::<u8, 3>::new(size, data)?;
 
     // Extract single channel
     let red_channel = img.channel(0)?;

--- a/examples/image_api/src/main.rs
+++ b/examples/image_api/src/main.rs
@@ -8,7 +8,7 @@
 //!
 //! Run with: cargo run --example image_api
 
-use kornia_image::{allocator::CpuAllocator, Image, ImageError, ImageSize};
+use kornia_image::{Image, ImageError, ImageSize};
 
 fn print_separator() {
     println!("================================================");
@@ -23,8 +23,7 @@ fn example_create_from_value() -> Result<(), ImageError> {
         width: 640,
         height: 480,
     };
-    let alloc = CpuAllocator;
-    let img = Image::<u8, 3, _>::from_size_val(size, 128, alloc)?;
+    let img = Image::<u8, 3>::from_size_val(size, 128, kornia_image::allocator::host_alloc())?;
 
     println!("✓ Created {}x{}x{} image", img.width(), img.height(), 3);
     println!("  Fill value: {}", img.as_slice()[0]);
@@ -48,8 +47,7 @@ fn example_create_from_data() -> Result<(), ImageError> {
         width: 10,
         height: 10,
     };
-    let alloc = CpuAllocator;
-    let img = Image::<u8, 1, _>::new(size, data, alloc)?;
+    let img = Image::<u8, 1>::new(size, data, kornia_image::allocator::host_alloc())?;
 
     println!(
         "✓ Created {}x{} grayscale image from data",
@@ -73,9 +71,8 @@ fn example_error_handling() {
         width: 10,
         height: 10,
     };
-    let alloc = CpuAllocator;
 
-    match Image::<u8, 3, _>::new(size, data, alloc) {
+    match Image::<u8, 3>::new(size, data, kornia_image::allocator::host_alloc()) {
         Ok(_) => println!("✓ Created image (should not reach here)"),
         Err(e) => {
             println!("✓ Caught expected error:");
@@ -94,8 +91,7 @@ fn example_zero_copy_access() -> Result<(), ImageError> {
         width: 5,
         height: 5,
     };
-    let alloc = CpuAllocator;
-    let img = Image::<u8, 3, _>::from_size_val(size, 42, alloc)?;
+    let img = Image::<u8, 3>::from_size_val(size, 42, kornia_image::allocator::host_alloc())?;
 
     // Zero-copy access to underlying data
     let data = img.as_slice(); // &[u8] - zero copy!
@@ -126,8 +122,7 @@ fn example_owned_copy() -> Result<(), ImageError> {
         width: 3,
         height: 3,
     };
-    let alloc = CpuAllocator;
-    let img = Image::<f32, 3, _>::from_size_val(size, 0.5, alloc)?;
+    let img = Image::<f32, 3>::from_size_val(size, 0.5, kornia_image::allocator::host_alloc())?;
 
     // Zero-copy view
     let data_view = img.as_slice();
@@ -151,17 +146,19 @@ fn example_different_types() -> Result<(), ImageError> {
         width: 100,
         height: 100,
     };
-    let alloc = CpuAllocator;
 
     // U8 images (8-bit unsigned)
-    let _gray_u8 = Image::<u8, 1, _>::from_size_val(size, 255, alloc.clone())?;
-    let _rgb_u8 = Image::<u8, 3, _>::from_size_val(size, 128, alloc.clone())?;
-    let _rgba_u8 = Image::<u8, 4, _>::from_size_val(size, 64, alloc.clone())?;
+    let _gray_u8 = Image::<u8, 1>::from_size_val(size, 255, kornia_image::allocator::host_alloc())?;
+    let _rgb_u8 = Image::<u8, 3>::from_size_val(size, 128, kornia_image::allocator::host_alloc())?;
+    let _rgba_u8 = Image::<u8, 4>::from_size_val(size, 64, kornia_image::allocator::host_alloc())?;
 
     // F32 images (32-bit float, common for ML/processing)
-    let _gray_f32 = Image::<f32, 1, _>::from_size_val(size, 1.0, alloc.clone())?;
-    let _rgb_f32 = Image::<f32, 3, _>::from_size_val(size, 0.5, alloc.clone())?;
-    let _rgba_f32 = Image::<f32, 4, _>::from_size_val(size, 0.25, alloc)?;
+    let _gray_f32 =
+        Image::<f32, 1>::from_size_val(size, 1.0, kornia_image::allocator::host_alloc())?;
+    let _rgb_f32 =
+        Image::<f32, 3>::from_size_val(size, 0.5, kornia_image::allocator::host_alloc())?;
+    let _rgba_f32 =
+        Image::<f32, 4>::from_size_val(size, 0.25, kornia_image::allocator::host_alloc())?;
 
     println!("✓ Created 6 different image types:");
     println!("  U8:  Grayscale (C1), RGB (C3), RGBA (C4)");
@@ -185,8 +182,7 @@ fn example_pixel_access() -> Result<(), ImageError> {
         width: 5,
         height: 5,
     };
-    let alloc = CpuAllocator;
-    let mut img = Image::<u8, 3, _>::from_size_val(size, 0, alloc)?;
+    let mut img = Image::<u8, 3>::from_size_val(size, 0, kornia_image::allocator::host_alloc())?;
 
     // Set individual pixels
     img.set_pixel(0, 0, 0, 255)?; // Red channel at (0, 0)
@@ -226,10 +222,9 @@ fn example_image_from_slice() -> Result<(), ImageError> {
         width: 10,
         height: 10,
     };
-    let alloc = CpuAllocator;
 
     // Create image from slice (copies data)
-    let img = Image::<u8, 3, _>::from_size_slice(size, &data, alloc)?;
+    let img = Image::<u8, 3>::from_size_slice(size, &data, kornia_image::allocator::host_alloc())?;
 
     println!(
         "✓ Created {}x{}x{} image from slice",
@@ -252,7 +247,6 @@ fn example_channel_operations() -> Result<(), ImageError> {
         width: 10,
         height: 10,
     };
-    let alloc = CpuAllocator;
 
     // Create RGB image with different values per channel
     let mut data = Vec::with_capacity(10 * 10 * 3);
@@ -262,7 +256,7 @@ fn example_channel_operations() -> Result<(), ImageError> {
         data.push(64); // B
     }
 
-    let img = Image::<u8, 3, _>::new(size, data, alloc)?;
+    let img = Image::<u8, 3>::new(size, data, kornia_image::allocator::host_alloc())?;
 
     // Extract single channel
     let red_channel = img.channel(0)?;

--- a/examples/imgproc/src/main.rs
+++ b/examples/imgproc/src/main.rs
@@ -22,13 +22,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let image = F::read_image_any_rgb8(args.image_path)?;
 
     // convert the image to grayscale
-    let mut gray =
-        Image::<u8, 1>::from_size_val(image.size(), 0, kornia::image::allocator::host_alloc())?;
+    let mut gray = Image::<u8, 1>::from_size_val(image.size(), 0)?;
     imgproc::color::gray_from_rgb_u8(&image, &mut gray)?;
 
     // convert to float
-    let mut gray_f32 =
-        Image::<f32, 1>::from_size_val(gray.size(), 0.0, kornia::image::allocator::host_alloc())?;
+    let mut gray_f32 = Image::<f32, 1>::from_size_val(gray.size(), 0.0)?;
     ops::cast_and_scale(&gray, &mut gray_f32, 1.0 / 255.0)?;
 
     let new_size = ImageSize {
@@ -36,8 +34,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         height: 128,
     };
 
-    let mut gray_resize =
-        Image::<f32, 1>::from_size_val(new_size, 0.0, kornia::image::allocator::host_alloc())?;
+    let mut gray_resize = Image::<f32, 1>::from_size_val(new_size, 0.0)?;
     imgproc::resize::resize_native(
         &gray_f32,
         &mut gray_resize,

--- a/examples/imgproc/src/main.rs
+++ b/examples/imgproc/src/main.rs
@@ -1,5 +1,5 @@
 use argh::FromArgs;
-use kornia::tensor::CpuAllocator;
+use kornia::image::allocator::host_alloc;
 use std::path::PathBuf;
 
 use kornia::io::functional as F;
@@ -23,11 +23,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let image = F::read_image_any_rgb8(args.image_path)?;
 
     // convert the image to grayscale
-    let mut gray = Image::<u8, 1, _>::from_size_val(image.size(), 0, CpuAllocator)?;
+    let mut gray =
+        Image::<u8, 1>::from_size_val(image.size(), 0, kornia::image::allocator::host_alloc())?;
     imgproc::color::gray_from_rgb_u8(&image, &mut gray)?;
 
     // convert to float
-    let mut gray_f32 = Image::<f32, 1, _>::from_size_val(gray.size(), 0.0, CpuAllocator)?;
+    let mut gray_f32 =
+        Image::<f32, 1>::from_size_val(gray.size(), 0.0, kornia::image::allocator::host_alloc())?;
     ops::cast_and_scale(&gray, &mut gray_f32, 1.0 / 255.0)?;
 
     let new_size = ImageSize {
@@ -35,7 +37,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         height: 128,
     };
 
-    let mut gray_resize = Image::<f32, 1, _>::from_size_val(new_size, 0.0, CpuAllocator)?;
+    let mut gray_resize =
+        Image::<f32, 1>::from_size_val(new_size, 0.0, kornia::image::allocator::host_alloc())?;
     imgproc::resize::resize_native(
         &gray_f32,
         &mut gray_resize,

--- a/examples/imgproc/src/main.rs
+++ b/examples/imgproc/src/main.rs
@@ -1,5 +1,4 @@
 use argh::FromArgs;
-use kornia::image::allocator::host_alloc;
 use std::path::PathBuf;
 
 use kornia::io::functional as F;

--- a/examples/metrics/src/main.rs
+++ b/examples/metrics/src/main.rs
@@ -1,5 +1,4 @@
 use argh::FromArgs;
-use kornia::image::allocator::host_alloc;
 use std::path::PathBuf;
 
 use kornia::io::functional as F;

--- a/examples/metrics/src/main.rs
+++ b/examples/metrics/src/main.rs
@@ -1,5 +1,5 @@
 use argh::FromArgs;
-use kornia::tensor::CpuAllocator;
+use kornia::image::allocator::host_alloc;
 use std::path::PathBuf;
 
 use kornia::io::functional as F;
@@ -24,11 +24,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let image = F::read_image_any_rgb8(args.image_path)?;
 
     // convert the image to f32 and scale it
-    let mut image_f32 = Image::<f32, 3, _>::from_size_val(image.size(), 0.0, CpuAllocator)?;
+    let mut image_f32 =
+        Image::<f32, 3>::from_size_val(image.size(), 0.0, kornia::image::allocator::host_alloc())?;
     ops::cast_and_scale(&image, &mut image_f32, 1.0 / 255.0)?;
 
     // modify the image to see the changes
-    let mut image_dirty = Image::<f32, 3, _>::from_size_val(image.size(), 0.0, CpuAllocator)?;
+    let mut image_dirty =
+        Image::<f32, 3>::from_size_val(image.size(), 0.0, kornia::image::allocator::host_alloc())?;
     imgproc::flip::horizontal_flip(&image_f32, &mut image_dirty)?;
 
     // compute the mean squared error (mse) between the original and the modified image

--- a/examples/metrics/src/main.rs
+++ b/examples/metrics/src/main.rs
@@ -23,13 +23,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let image = F::read_image_any_rgb8(args.image_path)?;
 
     // convert the image to f32 and scale it
-    let mut image_f32 =
-        Image::<f32, 3>::from_size_val(image.size(), 0.0, kornia::image::allocator::host_alloc())?;
+    let mut image_f32 = Image::<f32, 3>::from_size_val(image.size(), 0.0)?;
     ops::cast_and_scale(&image, &mut image_f32, 1.0 / 255.0)?;
 
     // modify the image to see the changes
-    let mut image_dirty =
-        Image::<f32, 3>::from_size_val(image.size(), 0.0, kornia::image::allocator::host_alloc())?;
+    let mut image_dirty = Image::<f32, 3>::from_size_val(image.size(), 0.0)?;
     imgproc::flip::horizontal_flip(&image_f32, &mut image_dirty)?;
 
     // compute the mean squared error (mse) between the original and the modified image

--- a/examples/morphology/src/main.rs
+++ b/examples/morphology/src/main.rs
@@ -2,7 +2,6 @@ use argh::FromArgs;
 use std::path::PathBuf;
 
 use kornia::{
-    image::allocator::host_alloc,
     image::{Image, ImageSize},
     imgproc::{color, morphology, padding, threshold},
     io::functional as F,
@@ -32,21 +31,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let size = gray.size();
     let (width, height) = (size.width, size.height);
 
-    let mut gray_single = Image::<u8, 1>::new(
-        ImageSize { width, height },
-        vec![0u8; width * height],
-        host_alloc(),
-    )?;
+    let mut gray_single =
+        Image::<u8, 1>::new(ImageSize { width, height }, vec![0u8; width * height])?;
 
     // rgb to grayscale
     color::gray_from_rgb_u8(&gray, &mut gray_single)?;
 
     // apply threshold to create binary image
-    let mut binary = Image::<u8, 1>::new(
-        ImageSize { width, height },
-        vec![0u8; width * height],
-        host_alloc(),
-    )?;
+    let mut binary = Image::<u8, 1>::new(ImageSize { width, height }, vec![0u8; width * height])?;
     threshold::threshold_binary(&gray_single, &mut binary, 128u8, 255u8)?;
 
     let kernel_shape = match args.kernel_shape.as_str() {
@@ -63,29 +55,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     let kernel = morphology::Kernel::new(kernel_shape);
 
-    let mut dilated = Image::<u8, 1>::new(
-        ImageSize { width, height },
-        vec![0u8; width * height],
-        host_alloc(),
-    )?;
+    let mut dilated = Image::<u8, 1>::new(ImageSize { width, height }, vec![0u8; width * height])?;
 
-    let mut eroded = Image::<u8, 1>::new(
-        ImageSize { width, height },
-        vec![0u8; width * height],
-        host_alloc(),
-    )?;
+    let mut eroded = Image::<u8, 1>::new(ImageSize { width, height }, vec![0u8; width * height])?;
 
-    let mut opened = Image::<u8, 1>::new(
-        ImageSize { width, height },
-        vec![0u8; width * height],
-        host_alloc(),
-    )?;
+    let mut opened = Image::<u8, 1>::new(ImageSize { width, height }, vec![0u8; width * height])?;
 
-    let mut closed = Image::<u8, 1>::new(
-        ImageSize { width, height },
-        vec![0u8; width * height],
-        host_alloc(),
-    )?;
+    let mut closed = Image::<u8, 1>::new(ImageSize { width, height }, vec![0u8; width * height])?;
 
     // apply all morphological operations
     morphology::dilate(
@@ -124,46 +100,28 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("Kornia Morphology").spawn()?;
 
     // convert all images to rgb
-    let mut gray_rgb = Image::<u8, 3>::new(
-        ImageSize { width, height },
-        vec![0u8; width * height * 3],
-        host_alloc(),
-    )?;
+    let mut gray_rgb =
+        Image::<u8, 3>::new(ImageSize { width, height }, vec![0u8; width * height * 3])?;
     color::rgb_from_gray(&gray_single, &mut gray_rgb)?;
 
-    let mut binary_rgb = Image::<u8, 3>::new(
-        ImageSize { width, height },
-        vec![0u8; width * height * 3],
-        host_alloc(),
-    )?;
+    let mut binary_rgb =
+        Image::<u8, 3>::new(ImageSize { width, height }, vec![0u8; width * height * 3])?;
     color::rgb_from_gray(&binary, &mut binary_rgb)?;
 
-    let mut dilated_rgb = Image::<u8, 3>::new(
-        ImageSize { width, height },
-        vec![0u8; width * height * 3],
-        host_alloc(),
-    )?;
+    let mut dilated_rgb =
+        Image::<u8, 3>::new(ImageSize { width, height }, vec![0u8; width * height * 3])?;
     color::rgb_from_gray(&dilated, &mut dilated_rgb)?;
 
-    let mut eroded_rgb = Image::<u8, 3>::new(
-        ImageSize { width, height },
-        vec![0u8; width * height * 3],
-        host_alloc(),
-    )?;
+    let mut eroded_rgb =
+        Image::<u8, 3>::new(ImageSize { width, height }, vec![0u8; width * height * 3])?;
     color::rgb_from_gray(&eroded, &mut eroded_rgb)?;
 
-    let mut opened_rgb = Image::<u8, 3>::new(
-        ImageSize { width, height },
-        vec![0u8; width * height * 3],
-        host_alloc(),
-    )?;
+    let mut opened_rgb =
+        Image::<u8, 3>::new(ImageSize { width, height }, vec![0u8; width * height * 3])?;
     color::rgb_from_gray(&opened, &mut opened_rgb)?;
 
-    let mut closed_rgb = Image::<u8, 3>::new(
-        ImageSize { width, height },
-        vec![0u8; width * height * 3],
-        host_alloc(),
-    )?;
+    let mut closed_rgb =
+        Image::<u8, 3>::new(ImageSize { width, height }, vec![0u8; width * height * 3])?;
     color::rgb_from_gray(&closed, &mut closed_rgb)?;
 
     // log all images

--- a/examples/morphology/src/main.rs
+++ b/examples/morphology/src/main.rs
@@ -2,10 +2,10 @@ use argh::FromArgs;
 use std::path::PathBuf;
 
 use kornia::{
+    image::allocator::host_alloc,
     image::{Image, ImageSize},
     imgproc::{color, morphology, padding, threshold},
     io::functional as F,
-    tensor::CpuAllocator,
 };
 
 #[derive(FromArgs)]
@@ -32,20 +32,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let size = gray.size();
     let (width, height) = (size.width, size.height);
 
-    let mut gray_single = Image::<u8, 1, CpuAllocator>::new(
+    let mut gray_single = Image::<u8, 1>::new(
         ImageSize { width, height },
         vec![0u8; width * height],
-        CpuAllocator,
+        host_alloc(),
     )?;
 
     // rgb to grayscale
     color::gray_from_rgb_u8(&gray, &mut gray_single)?;
 
     // apply threshold to create binary image
-    let mut binary = Image::<u8, 1, CpuAllocator>::new(
+    let mut binary = Image::<u8, 1>::new(
         ImageSize { width, height },
         vec![0u8; width * height],
-        CpuAllocator,
+        host_alloc(),
     )?;
     threshold::threshold_binary(&gray_single, &mut binary, 128u8, 255u8)?;
 
@@ -63,28 +63,28 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     let kernel = morphology::Kernel::new(kernel_shape);
 
-    let mut dilated = Image::<u8, 1, CpuAllocator>::new(
+    let mut dilated = Image::<u8, 1>::new(
         ImageSize { width, height },
         vec![0u8; width * height],
-        CpuAllocator,
+        host_alloc(),
     )?;
 
-    let mut eroded = Image::<u8, 1, CpuAllocator>::new(
+    let mut eroded = Image::<u8, 1>::new(
         ImageSize { width, height },
         vec![0u8; width * height],
-        CpuAllocator,
+        host_alloc(),
     )?;
 
-    let mut opened = Image::<u8, 1, CpuAllocator>::new(
+    let mut opened = Image::<u8, 1>::new(
         ImageSize { width, height },
         vec![0u8; width * height],
-        CpuAllocator,
+        host_alloc(),
     )?;
 
-    let mut closed = Image::<u8, 1, CpuAllocator>::new(
+    let mut closed = Image::<u8, 1>::new(
         ImageSize { width, height },
         vec![0u8; width * height],
-        CpuAllocator,
+        host_alloc(),
     )?;
 
     // apply all morphological operations
@@ -124,45 +124,45 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("Kornia Morphology").spawn()?;
 
     // convert all images to rgb
-    let mut gray_rgb = Image::<u8, 3, CpuAllocator>::new(
+    let mut gray_rgb = Image::<u8, 3>::new(
         ImageSize { width, height },
         vec![0u8; width * height * 3],
-        CpuAllocator,
+        host_alloc(),
     )?;
     color::rgb_from_gray(&gray_single, &mut gray_rgb)?;
 
-    let mut binary_rgb = Image::<u8, 3, CpuAllocator>::new(
+    let mut binary_rgb = Image::<u8, 3>::new(
         ImageSize { width, height },
         vec![0u8; width * height * 3],
-        CpuAllocator,
+        host_alloc(),
     )?;
     color::rgb_from_gray(&binary, &mut binary_rgb)?;
 
-    let mut dilated_rgb = Image::<u8, 3, CpuAllocator>::new(
+    let mut dilated_rgb = Image::<u8, 3>::new(
         ImageSize { width, height },
         vec![0u8; width * height * 3],
-        CpuAllocator,
+        host_alloc(),
     )?;
     color::rgb_from_gray(&dilated, &mut dilated_rgb)?;
 
-    let mut eroded_rgb = Image::<u8, 3, CpuAllocator>::new(
+    let mut eroded_rgb = Image::<u8, 3>::new(
         ImageSize { width, height },
         vec![0u8; width * height * 3],
-        CpuAllocator,
+        host_alloc(),
     )?;
     color::rgb_from_gray(&eroded, &mut eroded_rgb)?;
 
-    let mut opened_rgb = Image::<u8, 3, CpuAllocator>::new(
+    let mut opened_rgb = Image::<u8, 3>::new(
         ImageSize { width, height },
         vec![0u8; width * height * 3],
-        CpuAllocator,
+        host_alloc(),
     )?;
     color::rgb_from_gray(&opened, &mut opened_rgb)?;
 
-    let mut closed_rgb = Image::<u8, 3, CpuAllocator>::new(
+    let mut closed_rgb = Image::<u8, 3>::new(
         ImageSize { width, height },
         vec![0u8; width * height * 3],
-        CpuAllocator,
+        host_alloc(),
     )?;
     color::rgb_from_gray(&closed, &mut closed_rgb)?;
 

--- a/examples/normalize/src/main.rs
+++ b/examples/normalize/src/main.rs
@@ -1,5 +1,4 @@
 use argh::FromArgs;
-use kornia::image::allocator::host_alloc;
 use std::path::PathBuf;
 
 use kornia::io::functional as F;
@@ -23,7 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let image_f32 = image.clone().cast::<f32>()?;
 
     // normalize the image between 0 and 255
-    let mut image_f32_norm = Image::from_size_val(image_f32.size(), 0.0, host_alloc())?;
+    let mut image_f32_norm = Image::from_size_val(image_f32.size(), 0.0)?;
     imgproc::normalize::normalize_mean_std(
         &image_f32,
         &mut image_f32_norm,

--- a/examples/normalize/src/main.rs
+++ b/examples/normalize/src/main.rs
@@ -1,5 +1,5 @@
 use argh::FromArgs;
-use kornia::tensor::CpuAllocator;
+use kornia::image::allocator::host_alloc;
 use std::path::PathBuf;
 
 use kornia::io::functional as F;
@@ -23,7 +23,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let image_f32 = image.clone().cast::<f32>()?;
 
     // normalize the image between 0 and 255
-    let mut image_f32_norm = Image::from_size_val(image_f32.size(), 0.0, CpuAllocator)?;
+    let mut image_f32_norm = Image::from_size_val(image_f32.size(), 0.0, host_alloc())?;
     imgproc::normalize::normalize_mean_std(
         &image_f32,
         &mut image_f32_norm,

--- a/examples/normalize_ii/src/main.rs
+++ b/examples/normalize_ii/src/main.rs
@@ -22,19 +22,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let image_f32 = image.into_inner().cast_and_scale::<f32>(1.0 / 255.0)?;
 
     // convert to grayscale
-    let mut gray = Image::<f32, 1>::from_size_val(
-        image_f32.size(),
-        0.0,
-        kornia::image::allocator::host_alloc(),
-    )?;
+    let mut gray = Image::<f32, 1>::from_size_val(image_f32.size(), 0.0)?;
     imgproc::color::gray_from_rgb(&image_f32, &mut gray)?;
 
     // normalize the image each channel
-    let mut image_norm = Image::<f32, 3>::from_size_val(
-        image_f32.size(),
-        0.0,
-        kornia::image::allocator::host_alloc(),
-    )?;
+    let mut image_norm = Image::<f32, 3>::from_size_val(image_f32.size(), 0.0)?;
     imgproc::normalize::normalize_mean_std(
         &image_f32,
         &mut image_norm,
@@ -43,12 +35,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     // normalize the grayscale image
-    let mut gray_norm =
-        Image::<f32, 1>::from_size_val(gray.size(), 0.0, kornia::image::allocator::host_alloc())?;
+    let mut gray_norm = Image::<f32, 1>::from_size_val(gray.size(), 0.0)?;
     imgproc::normalize::normalize_mean_std(&gray, &mut gray_norm, &[0.5], &[0.5])?;
 
     // alternative way to normalize the image between 0 and 255
-    // let mut gray_norm_min_max = Image::<f32, 1>::from_size_val(gray.size(), 0.0, kornia::image::allocator::host_alloc())?;
+    // let mut gray_norm_min_max = Image::<f32, 1>::from_size_val(gray.size(), 0.0)?;
     // imgproc::normalize::normalize_min_max(&gray, &mut gray_norm_min_max, 0.0, 255.0)?;
 
     let (min, max) = imgproc::normalize::find_min_max(&gray)?;

--- a/examples/normalize_ii/src/main.rs
+++ b/examples/normalize_ii/src/main.rs
@@ -1,5 +1,4 @@
 use argh::FromArgs;
-use kornia::tensor::CpuAllocator;
 use std::path::PathBuf;
 
 use kornia::io::functional as F;
@@ -23,11 +22,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let image_f32 = image.into_inner().cast_and_scale::<f32>(1.0 / 255.0)?;
 
     // convert to grayscale
-    let mut gray = Image::<f32, 1, _>::from_size_val(image_f32.size(), 0.0, CpuAllocator)?;
+    let mut gray = Image::<f32, 1>::from_size_val(
+        image_f32.size(),
+        0.0,
+        kornia::image::allocator::host_alloc(),
+    )?;
     imgproc::color::gray_from_rgb(&image_f32, &mut gray)?;
 
     // normalize the image each channel
-    let mut image_norm = Image::<f32, 3, _>::from_size_val(image_f32.size(), 0.0, CpuAllocator)?;
+    let mut image_norm = Image::<f32, 3>::from_size_val(
+        image_f32.size(),
+        0.0,
+        kornia::image::allocator::host_alloc(),
+    )?;
     imgproc::normalize::normalize_mean_std(
         &image_f32,
         &mut image_norm,
@@ -36,11 +43,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     // normalize the grayscale image
-    let mut gray_norm = Image::<f32, 1, _>::from_size_val(gray.size(), 0.0, CpuAllocator)?;
+    let mut gray_norm =
+        Image::<f32, 1>::from_size_val(gray.size(), 0.0, kornia::image::allocator::host_alloc())?;
     imgproc::normalize::normalize_mean_std(&gray, &mut gray_norm, &[0.5], &[0.5])?;
 
     // alternative way to normalize the image between 0 and 255
-    // let mut gray_norm_min_max = Image::<f32, 1>::from_size_val(gray.size(), 0.0)?;
+    // let mut gray_norm_min_max = Image::<f32, 1>::from_size_val(gray.size(), 0.0, kornia::image::allocator::host_alloc())?;
     // imgproc::normalize::normalize_min_max(&gray, &mut gray_norm_min_max, 0.0, 255.0)?;
 
     let (min, max) = imgproc::normalize::find_min_max(&gray)?;

--- a/examples/onnx/src/main.rs
+++ b/examples/onnx/src/main.rs
@@ -59,8 +59,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .commit_from_file(&args.onnx_model_path)?;
 
     // cast and scale the image to f32
-    let mut image_hwc_f32 =
-        Image::from_size_val(image.size(), 0.0f32, kornia_tensor::host_alloc())?;
+    let mut image_hwc_f32 = Image::from_size_val(image.size(), 0.0f32)?;
     kornia::image::ops::cast_and_scale(&image, &mut image_hwc_f32, 1.0 / 255.0)?;
 
     // convert to HWC -> CHW
@@ -75,7 +74,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             image_chw.shape[2],
         ],
         image_chw.into_vec(),
-        kornia_tensor::host_alloc(),
     )?;
 
     // make the ort tensor
@@ -122,7 +120,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             out_shape[2] as usize,
         ],
         out_ort.to_vec(),
-        kornia_tensor::host_alloc(),
     )?;
 
     println!("out_tensor: {:?}", out_tensor.shape);

--- a/examples/onnx/src/main.rs
+++ b/examples/onnx/src/main.rs
@@ -1,5 +1,5 @@
 use argh::FromArgs;
-use kornia_tensor::{CpuAllocator, Tensor};
+use kornia_tensor::Tensor;
 use std::path::PathBuf;
 use std::time::Instant;
 
@@ -59,7 +59,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .commit_from_file(&args.onnx_model_path)?;
 
     // cast and scale the image to f32
-    let mut image_hwc_f32 = Image::from_size_val(image.size(), 0.0f32, CpuAllocator)?;
+    let mut image_hwc_f32 =
+        Image::from_size_val(image.size(), 0.0f32, kornia_tensor::host_alloc())?;
     kornia::image::ops::cast_and_scale(&image, &mut image_hwc_f32, 1.0 / 255.0)?;
 
     // convert to HWC -> CHW
@@ -74,7 +75,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             image_chw.shape[2],
         ],
         image_chw.into_vec(),
-        CpuAllocator,
+        kornia_tensor::host_alloc(),
     )?;
 
     // make the ort tensor
@@ -114,14 +115,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (out_shape, out_ort) = outputs["output"].try_extract_tensor::<f32>()?;
     println!("out_shape: {out_shape:?}");
 
-    let out_tensor = Tensor::<f32, 3, CpuAllocator>::from_shape_vec(
+    let out_tensor = Tensor::<f32, 3>::from_shape_vec(
         [
             out_shape[0] as usize,
             out_shape[1] as usize,
             out_shape[2] as usize,
         ],
         out_ort.to_vec(),
-        CpuAllocator,
+        kornia_tensor::host_alloc(),
     )?;
 
     println!("out_tensor: {:?}", out_tensor.shape);

--- a/examples/orb_detector/src/main.rs
+++ b/examples/orb_detector/src/main.rs
@@ -4,7 +4,6 @@ mod linux {
     use std::path::PathBuf;
 
     use kornia::{
-        image::allocator::host_alloc,
         image::{Image, ImageSize},
         imgproc::{
             self,
@@ -41,12 +40,9 @@ mod linux {
             ..Default::default()
         })?;
 
-        let mut webcam_frame =
-            Image::from_size_val(webcam_size, 0, kornia::image::allocator::host_alloc())?;
-        let mut webcam_frame_gray =
-            Image::from_size_val(webcam_size, 0, kornia::image::allocator::host_alloc())?;
-        let mut webcam_frame_grayf32 =
-            Image::from_size_val(webcam_size, 0.0, kornia::image::allocator::host_alloc())?;
+        let mut webcam_frame = Image::from_size_val(webcam_size, 0)?;
+        let mut webcam_frame_gray = Image::from_size_val(webcam_size, 0)?;
+        let mut webcam_frame_grayf32 = Image::from_size_val(webcam_size, 0.0)?;
 
         let webcam_orb_detector = OrbDetector::new();
 
@@ -55,10 +51,8 @@ mod linux {
         // read the image
         let img_rgb = read_image_any_rgb8(args.image_path)?;
 
-        let mut img_gray =
-            Image::from_size_val(img_rgb.size(), 0, kornia::image::allocator::host_alloc())?;
-        let mut img_grayf32 =
-            Image::from_size_val(img_rgb.size(), 0.0, kornia::image::allocator::host_alloc())?;
+        let mut img_gray = Image::from_size_val(img_rgb.size(), 0)?;
+        let mut img_grayf32 = Image::from_size_val(img_rgb.size(), 0.0)?;
         gray_from_rgb_u8(&img_rgb, &mut img_gray)?;
         u8_to_f32_image(&img_gray, &mut img_grayf32);
 
@@ -68,7 +62,6 @@ mod linux {
                 height: webcam_size.height.max(img_rgb.height()),
             },
             0,
-            host_alloc(),
         )?;
 
         let img_orb_detector = OrbDetector::new();

--- a/examples/orb_detector/src/main.rs
+++ b/examples/orb_detector/src/main.rs
@@ -4,6 +4,7 @@ mod linux {
     use std::path::PathBuf;
 
     use kornia::{
+        image::allocator::host_alloc,
         image::{Image, ImageSize},
         imgproc::{
             self,
@@ -11,7 +12,6 @@ mod linux {
             features::{match_descriptors, OrbDetector},
         },
         io::{functional::read_image_any_rgb8, jpeg},
-        tensor::CpuAllocator,
     };
 
     use kornia::io::v4l::{PixelFormat, V4LCameraConfig, V4lVideoCapture};
@@ -41,9 +41,12 @@ mod linux {
             ..Default::default()
         })?;
 
-        let mut webcam_frame = Image::from_size_val(webcam_size, 0, CpuAllocator)?;
-        let mut webcam_frame_gray = Image::from_size_val(webcam_size, 0, CpuAllocator)?;
-        let mut webcam_frame_grayf32 = Image::from_size_val(webcam_size, 0.0, CpuAllocator)?;
+        let mut webcam_frame =
+            Image::from_size_val(webcam_size, 0, kornia::image::allocator::host_alloc())?;
+        let mut webcam_frame_gray =
+            Image::from_size_val(webcam_size, 0, kornia::image::allocator::host_alloc())?;
+        let mut webcam_frame_grayf32 =
+            Image::from_size_val(webcam_size, 0.0, kornia::image::allocator::host_alloc())?;
 
         let webcam_orb_detector = OrbDetector::new();
 
@@ -52,8 +55,10 @@ mod linux {
         // read the image
         let img_rgb = read_image_any_rgb8(args.image_path)?;
 
-        let mut img_gray = Image::from_size_val(img_rgb.size(), 0, CpuAllocator)?;
-        let mut img_grayf32 = Image::from_size_val(img_rgb.size(), 0.0, CpuAllocator)?;
+        let mut img_gray =
+            Image::from_size_val(img_rgb.size(), 0, kornia::image::allocator::host_alloc())?;
+        let mut img_grayf32 =
+            Image::from_size_val(img_rgb.size(), 0.0, kornia::image::allocator::host_alloc())?;
         gray_from_rgb_u8(&img_rgb, &mut img_gray)?;
         u8_to_f32_image(&img_gray, &mut img_grayf32);
 
@@ -63,7 +68,7 @@ mod linux {
                 height: webcam_size.height.max(img_rgb.height()),
             },
             0,
-            CpuAllocator,
+            host_alloc(),
         )?;
 
         let img_orb_detector = OrbDetector::new();
@@ -162,11 +167,7 @@ mod linux {
         }
     }
 
-    fn join_images_inplace(
-        image1: &Image<u8, 1, CpuAllocator>,
-        image2: &Image<u8, 1, CpuAllocator>,
-        out: &mut Image<u8, 1, CpuAllocator>,
-    ) {
+    fn join_images_inplace(image1: &Image<u8, 1>, image2: &Image<u8, 1>, out: &mut Image<u8, 1>) {
         let width1 = image1.width();
         let width2 = image2.width();
         let height = image1.height();
@@ -197,7 +198,7 @@ mod linux {
         }
     }
 
-    fn u8_to_f32_image(src: &Image<u8, 1, CpuAllocator>, dst: &mut Image<f32, 1, CpuAllocator>) {
+    fn u8_to_f32_image(src: &Image<u8, 1>, dst: &mut Image<f32, 1>) {
         src.as_slice()
             .iter()
             .zip(dst.as_slice_mut())

--- a/examples/rotate/src/main.rs
+++ b/examples/rotate/src/main.rs
@@ -33,11 +33,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let scale = i as f32 / 360.0;
         let rotation_matrix = imgproc::warp::get_rotation_matrix2d(center, angle, scale);
 
-        let mut output = Image::<f32, 3>::from_size_val(
-            image.size(),
-            0.0,
-            kornia::image::allocator::host_alloc(),
-        )?;
+        let mut output = Image::<f32, 3>::from_size_val(image.size(), 0.0)?;
         let mut output_norm = output.clone();
 
         imgproc::warp::warp_affine(

--- a/examples/rotate/src/main.rs
+++ b/examples/rotate/src/main.rs
@@ -1,5 +1,4 @@
 use argh::FromArgs;
-use kornia::tensor::CpuAllocator;
 use std::path::PathBuf;
 
 use kornia::io::functional as F;
@@ -34,7 +33,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let scale = i as f32 / 360.0;
         let rotation_matrix = imgproc::warp::get_rotation_matrix2d(center, angle, scale);
 
-        let mut output = Image::<f32, 3, _>::from_size_val(image.size(), 0.0, CpuAllocator)?;
+        let mut output = Image::<f32, 3>::from_size_val(
+            image.size(),
+            0.0,
+            kornia::image::allocator::host_alloc(),
+        )?;
         let mut output_norm = output.clone();
 
         imgproc::warp::warp_affine(

--- a/examples/rtspcam/src/main.rs
+++ b/examples/rtspcam/src/main.rs
@@ -87,12 +87,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         // initialize images lazily
         let img_f32_ref = img_f32.get_or_insert_with(|| {
-            Image::<f32, 3>::from_size_val(img.size(), 0.0, kornia::image::allocator::host_alloc())
-                .expect("Failed to create image")
+            Image::<f32, 3>::from_size_val(img.size(), 0.0).expect("Failed to create image")
         });
         let gray_ref = gray.get_or_insert_with(|| {
-            Image::<f32, 1>::from_size_val(img.size(), 0.0, kornia::image::allocator::host_alloc())
-                .expect("Failed to create image")
+            Image::<f32, 1>::from_size_val(img.size(), 0.0).expect("Failed to create image")
         });
 
         // cast the image to floating point and convert to grayscale

--- a/examples/rtspcam/src/main.rs
+++ b/examples/rtspcam/src/main.rs
@@ -1,9 +1,9 @@
 use argh::FromArgs;
 use kornia::{
+    image::allocator::host_alloc,
     image::{ops, Image},
     imgproc,
     io::{fps_counter::FpsCounter, stream::RTSPCameraConfig},
-    tensor::CpuAllocator,
 };
 use std::sync::{
     atomic::{AtomicBool, Ordering},
@@ -88,11 +88,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         // initialize images lazily
         let img_f32_ref = img_f32.get_or_insert_with(|| {
-            Image::<f32, 3, _>::from_size_val(img.size(), 0.0, CpuAllocator)
+            Image::<f32, 3>::from_size_val(img.size(), 0.0, kornia::image::allocator::host_alloc())
                 .expect("Failed to create image")
         });
         let gray_ref = gray.get_or_insert_with(|| {
-            Image::<f32, 1, _>::from_size_val(img.size(), 0.0, CpuAllocator)
+            Image::<f32, 1>::from_size_val(img.size(), 0.0, kornia::image::allocator::host_alloc())
                 .expect("Failed to create image")
         });
 

--- a/examples/rtspcam/src/main.rs
+++ b/examples/rtspcam/src/main.rs
@@ -1,6 +1,5 @@
 use argh::FromArgs;
 use kornia::{
-    image::allocator::host_alloc,
     image::{ops, Image},
     imgproc,
     io::{fps_counter::FpsCounter, stream::RTSPCameraConfig},

--- a/examples/smol_vlm/src/main.rs
+++ b/examples/smol_vlm/src/main.rs
@@ -1,5 +1,4 @@
 use argh::FromArgs;
-use kornia_tensor::CpuAllocator;
 use kornia_vlm::smolvlm::{utils::SmolVlmConfig, SmolVlm};
 
 use kornia_io::{jpeg::read_image_jpeg_rgb8, png::read_image_png_rgb8};
@@ -47,7 +46,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &args.text_prompt,
         image.map(|i| i.into_inner()),
         args.sample_length,
-        CpuAllocator,
     )?;
 
     Ok(())

--- a/examples/smol_vlm2/src/demo.rs
+++ b/examples/smol_vlm2/src/demo.rs
@@ -11,7 +11,6 @@ pub fn run_video_demo(
     prompt: &str,
     max_tokens: usize,
 ) {
-    use kornia_tensor::host_alloc;
     use kornia_vlm::smolvlm2::{InputMedia, Line, Message, Role, SmolVlm2, SmolVlm2Config};
 
     use crate::video::{from_video_path, VideoSamplingMethod};
@@ -59,7 +58,6 @@ pub fn run_video_demo(
             messages,
             Some(InputMedia::Video(vec![&mut video])),
             max_tokens,
-            kornia_image::allocator::host_alloc(),
         )
         .unwrap_or_else(|e| format!("Model error: {:?}", e));
 
@@ -69,7 +67,6 @@ pub fn run_video_demo(
 #[cfg(test)]
 mod tests {
     use kornia_io::{jpeg::read_image_jpeg_rgb8, png::read_image_png_rgb8};
-    use kornia_tensor::host_alloc;
     use kornia_vlm::smolvlm2::{InputMedia, Line, Message, Role, SmolVlm2, SmolVlm2Config};
     use std::path::Path;
 
@@ -132,7 +129,6 @@ mod tests {
                         }],
                         Some(InputMedia::Images(vec![image.clone()])),
                         sample_len,
-                        kornia_image::allocator::host_alloc(),
                     )
                     .unwrap_or_else(|e| format!("Inference failed: {:?}", e));
                 let duration = start_time.elapsed();
@@ -203,11 +199,8 @@ mod tests {
 
                         use crate::video::{from_video_path, VideoSamplingMethod};
                         let start_load = std::time::Instant::now();
-                        let video_result = from_video_path::<32, _>(
-                            video_path,
-                            VideoSamplingMethod::FirstN(32),
-                            kornia_image::allocator::host_alloc(),
-                        );
+                        let video_result =
+                            from_video_path::<32, _>(video_path, VideoSamplingMethod::FirstN(32));
                         let load_duration = start_load.elapsed();
                         let load_secs = load_duration.as_secs_f64();
                         load_times.push(load_secs);
@@ -239,7 +232,6 @@ mod tests {
                                         messages,
                                         Some(InputMedia::Video(vec![&mut video])),
                                         500,
-                                        kornia_image::allocator::host_alloc(),
                                     )
                                     .unwrap_or_else(|e| format!("Model error: {:?}", e));
                                 let infer_duration = start_infer.elapsed();
@@ -335,7 +327,6 @@ mod tests {
                 }],
                 Some(InputMedia::Images(vec![image.into_inner()])),
                 sample_len,
-                kornia_image::allocator::host_alloc(),
             )
             .unwrap_or_else(|e| format!("Inference failed: {:?}", e));
 

--- a/examples/smol_vlm2/src/demo.rs
+++ b/examples/smol_vlm2/src/demo.rs
@@ -11,7 +11,7 @@ pub fn run_video_demo(
     prompt: &str,
     max_tokens: usize,
 ) {
-    use kornia_tensor::CpuAllocator;
+    use kornia_tensor::host_alloc;
     use kornia_vlm::smolvlm2::{InputMedia, Line, Message, Role, SmolVlm2, SmolVlm2Config};
 
     use crate::video::{from_video_path, VideoSamplingMethod};
@@ -24,7 +24,7 @@ pub fn run_video_demo(
         _ => VideoSamplingMethod::Uniform(sample_frames),
     };
 
-    let video = from_video_path::<32, _, CpuAllocator>(video_path, sampling_method, CpuAllocator);
+    let video = from_video_path::<32, _>(video_path, sampling_method);
     let mut video = match video {
         Ok(v) => v,
         Err(e) => {
@@ -40,8 +40,7 @@ pub fn run_video_demo(
         debug: true,
         ..Default::default()
     };
-    let mut model =
-        SmolVlm2::<32, CpuAllocator>::new(config).expect("Failed to create SmolVLM2 model");
+    let mut model = SmolVlm2::<32>::new(config).expect("Failed to create SmolVLM2 model");
 
     // Prepare prompt
     let messages = vec![Message {
@@ -60,7 +59,7 @@ pub fn run_video_demo(
             messages,
             Some(InputMedia::Video(vec![&mut video])),
             max_tokens,
-            CpuAllocator,
+            kornia_image::allocator::host_alloc(),
         )
         .unwrap_or_else(|e| format!("Model error: {:?}", e));
 
@@ -70,7 +69,7 @@ pub fn run_video_demo(
 #[cfg(test)]
 mod tests {
     use kornia_io::{jpeg::read_image_jpeg_rgb8, png::read_image_png_rgb8};
-    use kornia_tensor::CpuAllocator;
+    use kornia_tensor::host_alloc;
     use kornia_vlm::smolvlm2::{InputMedia, Line, Message, Role, SmolVlm2, SmolVlm2Config};
     use std::path::Path;
 
@@ -106,7 +105,7 @@ mod tests {
             debug: true,
             ..Default::default()
         };
-        let mut model = SmolVlm2::<32, CpuAllocator>::new(config).unwrap();
+        let mut model = SmolVlm2::<32>::new(config).unwrap();
         let sample_len = 500;
 
         let mut inference_times = Vec::new();
@@ -133,7 +132,7 @@ mod tests {
                         }],
                         Some(InputMedia::Images(vec![image.clone()])),
                         sample_len,
-                        CpuAllocator,
+                        kornia_image::allocator::host_alloc(),
                     )
                     .unwrap_or_else(|e| format!("Inference failed: {:?}", e));
                 let duration = start_time.elapsed();
@@ -190,8 +189,8 @@ mod tests {
                     debug: true,
                     ..Default::default()
                 };
-                let mut model = SmolVlm2::<32, CpuAllocator>::new(config)
-                    .expect("Failed to create SmolVLM2 model");
+                let mut model =
+                    SmolVlm2::<32>::new(config).expect("Failed to create SmolVLM2 model");
 
                 for (i, prompt) in video_prompts.iter().enumerate() {
                     model.clear_context().unwrap();
@@ -204,10 +203,10 @@ mod tests {
 
                         use crate::video::{from_video_path, VideoSamplingMethod};
                         let start_load = std::time::Instant::now();
-                        let video_result = from_video_path::<32, _, CpuAllocator>(
+                        let video_result = from_video_path::<32, _>(
                             video_path,
                             VideoSamplingMethod::FirstN(32),
-                            CpuAllocator,
+                            kornia_image::allocator::host_alloc(),
                         );
                         let load_duration = start_load.elapsed();
                         let load_secs = load_duration.as_secs_f64();
@@ -240,7 +239,7 @@ mod tests {
                                         messages,
                                         Some(InputMedia::Video(vec![&mut video])),
                                         500,
-                                        CpuAllocator,
+                                        kornia_image::allocator::host_alloc(),
                                     )
                                     .unwrap_or_else(|e| format!("Model error: {:?}", e));
                                 let infer_duration = start_infer.elapsed();
@@ -318,7 +317,7 @@ mod tests {
             debug: true,
             ..Default::default()
         };
-        let mut model = SmolVlm2::<32, CpuAllocator>::new(config).unwrap();
+        let mut model = SmolVlm2::<32>::new(config).unwrap();
 
         let prompt = "Describe the image.";
         let sample_len = 500;
@@ -336,7 +335,7 @@ mod tests {
                 }],
                 Some(InputMedia::Images(vec![image.into_inner()])),
                 sample_len,
-                CpuAllocator,
+                kornia_image::allocator::host_alloc(),
             )
             .unwrap_or_else(|e| format!("Inference failed: {:?}", e));
 

--- a/examples/smol_vlm2/src/video.rs
+++ b/examples/smol_vlm2/src/video.rs
@@ -18,12 +18,10 @@
 /// # #[cfg(feature = "gstreamer")]
 /// # {
 /// use kornia_vlm::video::{Video, VideoSamplingMethod};
-/// use kornia_tensor::host_alloc;
 ///
 /// let video = Video::from_video_path(
 ///     "video.mp4",
 ///     VideoSamplingMethod::Uniform(30),
-///     kornia_image::allocator::host_alloc(),
 /// ).unwrap();
 /// # }
 /// ```
@@ -132,12 +130,8 @@ pub fn from_video_path<const N: usize, P: AsRef<std::path::Path>>(
                 let size = gst_image.size();
                 let gst_data = gst_image.as_slice();
 
-                let img = Image::<u8, 3>::from_size_slice(
-                    size,
-                    gst_data,
-                    kornia_image::allocator::host_alloc(),
-                )
-                .map_err(VideoError::KorniaImage)?;
+                let img = Image::<u8, 3>::from_size_slice(size, gst_data)
+                    .map_err(VideoError::KorniaImage)?;
 
                 // Get current position for timestamp - using frame index as fallback
                 let current_pos = video_reader

--- a/examples/smol_vlm2/src/video.rs
+++ b/examples/smol_vlm2/src/video.rs
@@ -18,12 +18,12 @@
 /// # #[cfg(feature = "gstreamer")]
 /// # {
 /// use kornia_vlm::video::{Video, VideoSamplingMethod};
-/// use kornia_tensor::CpuAllocator;
+/// use kornia_tensor::host_alloc;
 ///
 /// let video = Video::from_video_path(
 ///     "video.mp4",
 ///     VideoSamplingMethod::Uniform(30),
-///     CpuAllocator,
+///     kornia_image::allocator::host_alloc(),
 /// ).unwrap();
 /// # }
 /// ```
@@ -31,8 +31,6 @@
 use kornia_io::gstreamer::{video::ImageFormat as IoImageFormat, video::VideoReader};
 use kornia_vlm::video::VideoError;
 use kornia_vlm::video::VideoSample;
-
-use kornia_image::allocator::ImageAllocator;
 
 /// Video sampling strategies for extracting frames from a video.
 ///
@@ -68,20 +66,18 @@ pub enum VideoSamplingMethod {
 
 #[cfg(not(feature = "gstreamer"))]
 #[allow(dead_code)]
-pub fn from_video_path<P: AsRef<std::path::Path>, A: ImageAllocator>(
+pub fn from_video_path<P: AsRef<std::path::Path>>(
     _path: P,
     _sampling: VideoSamplingMethod,
-    _allocator: A,
-) -> Result<VideoSample<32, A>, VideoError> {
+) -> Result<VideoSample<32>, VideoError> {
     panic!("This function requires the 'gstreamer' feature to be enabled.");
 }
 
 #[cfg(feature = "gstreamer")]
-pub fn from_video_path<const N: usize, P: AsRef<std::path::Path>, A: ImageAllocator>(
+pub fn from_video_path<const N: usize, P: AsRef<std::path::Path>>(
     path: P,
     sampling: VideoSamplingMethod,
-    allocator: A,
-) -> Result<VideoSample<N, A>, VideoError> {
+) -> Result<VideoSample<N>, VideoError> {
     let mut video_reader = VideoReader::new(&path, IoImageFormat::Rgb8).map_err(|e| {
         VideoError::VideoReaderCreation(format!("Path: {:?}, Error: {:?}", path.as_ref(), e))
     })?;
@@ -132,12 +128,16 @@ pub fn from_video_path<const N: usize, P: AsRef<std::path::Path>, A: ImageAlloca
 
                 consecutive_no_frames = 0; // Reset counter when we get a frame
 
-                // Convert ForeignAllocator image to target allocator
+                // Convert kornia_image::allocator::host_alloc() image to target allocator
                 let size = gst_image.size();
                 let gst_data = gst_image.as_slice();
 
-                let img = Image::<u8, 3, A>::from_size_slice(size, gst_data, allocator.clone())
-                    .map_err(VideoError::KorniaImage)?;
+                let img = Image::<u8, 3>::from_size_slice(
+                    size,
+                    gst_data,
+                    kornia_image::allocator::host_alloc(),
+                )
+                .map_err(VideoError::KorniaImage)?;
 
                 // Get current position for timestamp - using frame index as fallback
                 let current_pos = video_reader

--- a/examples/smol_vlm2_video/src/video_demo.rs
+++ b/examples/smol_vlm2_video/src/video_demo.rs
@@ -1,4 +1,5 @@
 use kornia::{
+    image::allocator::host_alloc,
     image::{color_spaces::Rgb8, ImageSize},
     imgproc::{self, color::YuvToRgbMode},
     io::{
@@ -6,7 +7,6 @@ use kornia::{
         jpeg,
         v4l::{camera_control, PixelFormat, V4LCameraConfig, V4lVideoCapture},
     },
-    tensor::CpuAllocator,
 };
 use kornia_vlm::smolvlm2::{InputMedia, Line, Message, Role, SmolVlm2, SmolVlm2Config};
 use kornia_vlm::video::VideoSample;
@@ -78,7 +78,7 @@ pub fn video_demo(args: &crate::Args) -> Result<(), Box<dyn std::error::Error>> 
     let mut fps_counter = FpsCounter::new();
 
     // Pre-allocate RGB image buffer outside the loop
-    let mut rgb_image = Rgb8::from_size_val(img_size, 0, CpuAllocator)?;
+    let mut rgb_image = Rgb8::from_size_val(img_size, 0, host_alloc())?;
 
     let prompt = &args.prompt as &str;
     let mut smolvlm2 = SmolVlm2::new(SmolVlm2Config::default())?;
@@ -86,7 +86,7 @@ pub fn video_demo(args: &crate::Args) -> Result<(), Box<dyn std::error::Error>> 
     // === Video Understanding Implementation ===
     // This implementation uses Line::Video and InputMedia::Video for proper video understanding:
     //    - Uses Line::Video in message content
-    //    - Passes entire Video<CpuAllocator> via InputMedia::Video
+    //    - Passes entire Video<kornia_image::allocator::host_alloc()> via InputMedia::Video
     //    - Leverages SmolVLM2's native video processing for temporal analysis
     //    - Provides holistic understanding of motion and temporal relationships
     //
@@ -96,7 +96,7 @@ pub fn video_demo(args: &crate::Args) -> Result<(), Box<dyn std::error::Error>> 
     // Create a video object to manage frames with a rolling buffer
     const MAX_FRAMES_IN_BUFFER: usize = 32; // After around keeping 50 frames, CUDA OOM for 24gb GPU
     let mut frame_idx = 0;
-    let mut video_buffer = VideoSample::<MAX_FRAMES_IN_BUFFER, CpuAllocator>::new();
+    let mut video_buffer = VideoSample::<MAX_FRAMES_IN_BUFFER>::new();
 
     while !cancel_token.load(Ordering::SeqCst) {
         let Some(frame) = webcam.grab_frame()? else {
@@ -142,7 +142,6 @@ pub fn video_demo(args: &crate::Args) -> Result<(), Box<dyn std::error::Error>> 
             vec![video_message],
             Some(InputMedia::Video(vec![&mut video_buffer])),
             20,
-            CpuAllocator,
         )?;
 
         // Log the frame to rerun

--- a/examples/smol_vlm2_video/src/video_demo.rs
+++ b/examples/smol_vlm2_video/src/video_demo.rs
@@ -1,5 +1,4 @@
 use kornia::{
-    image::allocator::host_alloc,
     image::{color_spaces::Rgb8, ImageSize},
     imgproc::{self, color::YuvToRgbMode},
     io::{
@@ -78,7 +77,7 @@ pub fn video_demo(args: &crate::Args) -> Result<(), Box<dyn std::error::Error>> 
     let mut fps_counter = FpsCounter::new();
 
     // Pre-allocate RGB image buffer outside the loop
-    let mut rgb_image = Rgb8::from_size_val(img_size, 0, host_alloc())?;
+    let mut rgb_image = Rgb8::from_size_val(img_size, 0)?;
 
     let prompt = &args.prompt as &str;
     let mut smolvlm2 = SmolVlm2::new(SmolVlm2Config::default())?;

--- a/examples/smol_vlm2_video/src/video_demo.rs
+++ b/examples/smol_vlm2_video/src/video_demo.rs
@@ -86,7 +86,7 @@ pub fn video_demo(args: &crate::Args) -> Result<(), Box<dyn std::error::Error>> 
     // === Video Understanding Implementation ===
     // This implementation uses Line::Video and InputMedia::Video for proper video understanding:
     //    - Uses Line::Video in message content
-    //    - Passes entire Video<kornia_image::allocator::host_alloc()> via InputMedia::Video
+    //    - Passes entire VideoSample via InputMedia::Video
     //    - Leverages SmolVLM2's native video processing for temporal analysis
     //    - Provides holistic understanding of motion and temporal relationships
     //

--- a/examples/smol_vlm2_video/src/video_file_demo.rs
+++ b/examples/smol_vlm2_video/src/video_file_demo.rs
@@ -24,7 +24,7 @@ use std::error::Error;
 /// - **Real-time Logging**: Streams results to Rerun for visualization
 ///
 /// ## Video Buffer Management:
-/// - Creates a `Video<kornia_image::allocator::host_alloc()>` object to manage frame history
+/// - Creates a `VideoSample` object to manage frame history
 /// - Adds new frames with timestamps for temporal tracking
 /// - Automatically removes old frames when buffer exceeds `max_frames_in_buffer`
 /// - Passes entire video buffer to SmolVLM2 for holistic video analysis

--- a/examples/smol_vlm2_video/src/video_file_demo.rs
+++ b/examples/smol_vlm2_video/src/video_file_demo.rs
@@ -3,8 +3,8 @@ use gstreamer::prelude::*;
 use gstreamer_app as gst_app;
 use gstreamer_video as gst_video;
 use kornia::{
+    image::allocator::host_alloc,
     image::{Image, ImageSize},
-    tensor::CpuAllocator,
 };
 use kornia_vlm::smolvlm2::{InputMedia, Line, Message, Role, SmolVlm2, SmolVlm2Config};
 use kornia_vlm::video::VideoSample;
@@ -27,7 +27,7 @@ use std::error::Error;
 /// - **Real-time Logging**: Streams results to Rerun for visualization
 ///
 /// ## Video Buffer Management:
-/// - Creates a `Video<CpuAllocator>` object to manage frame history
+/// - Creates a `Video<kornia_image::allocator::host_alloc()>` object to manage frame history
 /// - Adds new frames with timestamps for temporal tracking
 /// - Automatically removes old frames when buffer exceeds `max_frames_in_buffer`
 /// - Passes entire video buffer to SmolVLM2 for holistic video analysis
@@ -76,7 +76,7 @@ pub fn video_file_demo(args: &Args) -> Result<(), Box<dyn Error>> {
     const MAX_FRAMES_IN_BUFFER: usize = 32;
 
     // Keeping around 50 frames caused CUDA OOM on a 24GB GPU, so we use 32 as a safety margin.
-    let mut video_buffer = VideoSample::<MAX_FRAMES_IN_BUFFER, CpuAllocator>::new();
+    let mut video_buffer = VideoSample::<MAX_FRAMES_IN_BUFFER>::new();
 
     // FPS tracking variables
     let mut last_frame_time = std::time::Instant::now();
@@ -89,7 +89,11 @@ pub fn video_file_demo(args: &Args) -> Result<(), Box<dyn Error>> {
         let height = s.height() as usize;
         let img_size = ImageSize { width, height };
         let rgb_slice = map.as_ref();
-        let image = Image::<u8, 3, CpuAllocator>::new(img_size, rgb_slice.to_vec(), CpuAllocator)?;
+        let image = Image::<u8, 3>::new(
+            img_size,
+            rgb_slice.to_vec(),
+            kornia::image::allocator::host_alloc(),
+        )?;
 
         video_buffer.add_frame(image, frame_idx);
 
@@ -111,7 +115,6 @@ pub fn video_file_demo(args: &Args) -> Result<(), Box<dyn Error>> {
             vec![video_message],
             Some(InputMedia::Video(vec![&mut video_buffer])),
             20,
-            CpuAllocator,
         )?;
 
         // Log image and text to rerun (all using rgb_slice for image)

--- a/examples/smol_vlm2_video/src/video_file_demo.rs
+++ b/examples/smol_vlm2_video/src/video_file_demo.rs
@@ -86,11 +86,7 @@ pub fn video_file_demo(args: &Args) -> Result<(), Box<dyn Error>> {
         let height = s.height() as usize;
         let img_size = ImageSize { width, height };
         let rgb_slice = map.as_ref();
-        let image = Image::<u8, 3>::new(
-            img_size,
-            rgb_slice.to_vec(),
-            kornia::image::allocator::host_alloc(),
-        )?;
+        let image = Image::<u8, 3>::new(img_size, rgb_slice.to_vec())?;
 
         video_buffer.add_frame(image, frame_idx);
 

--- a/examples/smol_vlm2_video/src/video_file_demo.rs
+++ b/examples/smol_vlm2_video/src/video_file_demo.rs
@@ -2,10 +2,7 @@ use gstreamer as gst;
 use gstreamer::prelude::*;
 use gstreamer_app as gst_app;
 use gstreamer_video as gst_video;
-use kornia::{
-    image::allocator::host_alloc,
-    image::{Image, ImageSize},
-};
+use kornia::image::{Image, ImageSize};
 use kornia_vlm::smolvlm2::{InputMedia, Line, Message, Role, SmolVlm2, SmolVlm2Config};
 use kornia_vlm::video::VideoSample;
 

--- a/examples/smol_vlm_convo/src/model_state.rs
+++ b/examples/smol_vlm_convo/src/model_state.rs
@@ -3,11 +3,10 @@ use std::sync::mpsc;
 use std::thread::{self, JoinHandle};
 
 use kornia_image::Image;
-use kornia_tensor::CpuAllocator;
 pub enum ModelRequest {
     Inference {
         prompt: String,
-        image: Option<Image<u8, 3, CpuAllocator>>,
+        image: Option<Image<u8, 3>>,
         response_tx: mpsc::Sender<ModelResponse>,
     },
     SetTemperature(f64),
@@ -47,7 +46,7 @@ impl ModelStateHandle {
                         response_tx,
                     }) => {
                         // No streaming: send only the full response at once
-                        let result = model.inference(&prompt, image, sample_len, CpuAllocator);
+                        let result = model.inference(&prompt, image, sample_len);
                         match result {
                             Ok(full) => {
                                 let _ = response_tx.send(ModelResponse::StreamChunk(full));

--- a/examples/smol_vlm_video/src/video_demo.rs
+++ b/examples/smol_vlm_video/src/video_demo.rs
@@ -1,4 +1,5 @@
 use kornia::{
+    image::allocator::host_alloc,
     image::{color_spaces::Rgb8, ImageSize},
     imgproc::{self, color::YuvToRgbMode},
     io::{
@@ -6,7 +7,6 @@ use kornia::{
         jpeg,
         v4l::{camera_control, PixelFormat, V4LCameraConfig, V4lVideoCapture},
     },
-    tensor::CpuAllocator,
 };
 use kornia_vlm::smolvlm::{utils::SmolVlmConfig, SmolVlm};
 use std::sync::{
@@ -76,7 +76,7 @@ pub fn video_demo(args: &crate::Args) -> Result<(), Box<dyn std::error::Error>> 
     let mut fps_counter = FpsCounter::new();
 
     // Pre-allocate RGB image buffer outside the loop
-    let mut rgb_image = Rgb8::from_size_val(img_size, 0, CpuAllocator)?;
+    let mut rgb_image = Rgb8::from_size_val(img_size, 0, host_alloc())?;
 
     let prompt = &args.prompt as &str;
     let mut smolvlm = SmolVlm::new(SmolVlmConfig::default())?;
@@ -105,7 +105,7 @@ pub fn video_demo(args: &crate::Args) -> Result<(), Box<dyn std::error::Error>> 
         }
 
         smolvlm.clear_context()?;
-        let response = smolvlm.inference(prompt, Some(rgb_image.clone()), 20, CpuAllocator)?;
+        let response = smolvlm.inference(prompt, Some(rgb_image.clone()), 20)?;
 
         // Log the frame to rerun
         rec.log(

--- a/examples/smol_vlm_video/src/video_demo.rs
+++ b/examples/smol_vlm_video/src/video_demo.rs
@@ -1,5 +1,4 @@
 use kornia::{
-    image::allocator::host_alloc,
     image::{color_spaces::Rgb8, ImageSize},
     imgproc::{self, color::YuvToRgbMode},
     io::{
@@ -76,7 +75,7 @@ pub fn video_demo(args: &crate::Args) -> Result<(), Box<dyn std::error::Error>> 
     let mut fps_counter = FpsCounter::new();
 
     // Pre-allocate RGB image buffer outside the loop
-    let mut rgb_image = Rgb8::from_size_val(img_size, 0, host_alloc())?;
+    let mut rgb_image = Rgb8::from_size_val(img_size, 0)?;
 
     let prompt = &args.prompt as &str;
     let mut smolvlm = SmolVlm::new(SmolVlmConfig::default())?;

--- a/examples/smol_vlm_video/src/video_file_demo.rs
+++ b/examples/smol_vlm_video/src/video_file_demo.rs
@@ -2,10 +2,7 @@ use gstreamer as gst;
 use gstreamer::prelude::*;
 use gstreamer_app as gst_app;
 use gstreamer_video as gst_video;
-use kornia::{
-    image::allocator::host_alloc,
-    image::{Image, ImageSize},
-};
+use kornia::image::{Image, ImageSize};
 use kornia_vlm::smolvlm::{utils::SmolVlmConfig, SmolVlm};
 
 use crate::Args;
@@ -50,7 +47,7 @@ pub fn video_file_demo(args: &Args) -> Result<(), Box<dyn Error>> {
         let height = s.height() as usize;
         let img_size = ImageSize { width, height };
         let rgb_slice = map.as_ref();
-        let image = Image::<u8, 3>::new(img_size, rgb_slice.to_vec(), host_alloc())?;
+        let image = Image::<u8, 3>::new(img_size, rgb_slice.to_vec())?;
         smolvlm.clear_context()?;
         let response = smolvlm.inference(prompt, Some(image.clone()), 20)?;
 

--- a/examples/smol_vlm_video/src/video_file_demo.rs
+++ b/examples/smol_vlm_video/src/video_file_demo.rs
@@ -3,8 +3,8 @@ use gstreamer::prelude::*;
 use gstreamer_app as gst_app;
 use gstreamer_video as gst_video;
 use kornia::{
+    image::allocator::host_alloc,
     image::{Image, ImageSize},
-    tensor::CpuAllocator,
 };
 use kornia_vlm::smolvlm::{utils::SmolVlmConfig, SmolVlm};
 
@@ -50,9 +50,13 @@ pub fn video_file_demo(args: &Args) -> Result<(), Box<dyn Error>> {
         let height = s.height() as usize;
         let img_size = ImageSize { width, height };
         let rgb_slice = map.as_ref();
-        let image = Image::<u8, 3, CpuAllocator>::new(img_size, rgb_slice.to_vec(), CpuAllocator)?;
+        let image = Image::<u8, 3>::new(
+            img_size,
+            rgb_slice.to_vec(),
+            kornia::image::allocator::host_alloc(),
+        )?;
         smolvlm.clear_context()?;
-        let response = smolvlm.inference(prompt, Some(image.clone()), 20, CpuAllocator)?;
+        let response = smolvlm.inference(prompt, Some(image.clone()), 20)?;
 
         // Log image and text to rerun (all using rgb_slice for image)
         rec.log(

--- a/examples/smol_vlm_video/src/video_file_demo.rs
+++ b/examples/smol_vlm_video/src/video_file_demo.rs
@@ -50,11 +50,7 @@ pub fn video_file_demo(args: &Args) -> Result<(), Box<dyn Error>> {
         let height = s.height() as usize;
         let img_size = ImageSize { width, height };
         let rgb_slice = map.as_ref();
-        let image = Image::<u8, 3>::new(
-            img_size,
-            rgb_slice.to_vec(),
-            kornia::image::allocator::host_alloc(),
-        )?;
+        let image = Image::<u8, 3>::new(img_size, rgb_slice.to_vec(), host_alloc())?;
         smolvlm.clear_context()?;
         let response = smolvlm.inference(prompt, Some(image.clone()), 20)?;
 

--- a/examples/undistort_image/src/main.rs
+++ b/examples/undistort_image/src/main.rs
@@ -2,6 +2,7 @@ use argh::FromArgs;
 use std::path::PathBuf;
 
 use kornia::{
+    image::allocator::host_alloc,
     image::{Image, ImageSize},
     imgproc::{
         self,
@@ -11,7 +12,6 @@ use kornia::{
         },
     },
     io::functional as F,
-    tensor::CpuAllocator,
 };
 
 #[derive(FromArgs)]
@@ -67,7 +67,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     // apply the remap
-    let mut img_undistorted = Image::from_size_val(img.size(), 0.0, CpuAllocator)?;
+    let mut img_undistorted =
+        Image::from_size_val(img.size(), 0.0, kornia::image::allocator::host_alloc())?;
     imgproc::interpolation::remap(
         &img.clone().cast_and_scale(1.0 / 255.0)?,
         &mut img_undistorted,

--- a/examples/undistort_image/src/main.rs
+++ b/examples/undistort_image/src/main.rs
@@ -66,8 +66,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     // apply the remap
-    let mut img_undistorted =
-        Image::from_size_val(img.size(), 0.0, kornia::image::allocator::host_alloc())?;
+    let mut img_undistorted = Image::from_size_val(img.size(), 0.0)?;
     imgproc::interpolation::remap(
         &img.clone().cast_and_scale(1.0 / 255.0)?,
         &mut img_undistorted,

--- a/examples/undistort_image/src/main.rs
+++ b/examples/undistort_image/src/main.rs
@@ -2,7 +2,6 @@ use argh::FromArgs;
 use std::path::PathBuf;
 
 use kornia::{
-    image::allocator::host_alloc,
     image::{Image, ImageSize},
     imgproc::{
         self,

--- a/examples/undistort_points_image/src/main.rs
+++ b/examples/undistort_points_image/src/main.rs
@@ -8,7 +8,7 @@ use kornia::{
         CameraIntrinsic,
     },
     io::functional as F,
-    tensor::{host_alloc, Tensor},
+    tensor::Tensor,
 };
 
 #[derive(FromArgs)]
@@ -59,8 +59,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // undistort all points
-    let src = Tensor::<f64, 2>::from_shape_vec([num_pixels, 2], distorted_points, host_alloc())?;
-    let mut dst = Tensor::<f64, 2>::from_shape_val([num_pixels, 2], 0.0, host_alloc());
+    let src = Tensor::<f64, 2>::from_shape_vec([num_pixels, 2], distorted_points)?;
+    let mut dst = Tensor::<f64, 2>::from_shape_val([num_pixels, 2], 0.0);
 
     let criteria = TermCriteria {
         max_iter: 20,
@@ -80,8 +80,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // bilinear splatting (distorted is mapped on undistorted)
     let img_f32 = img_u8.cast::<f32>()?;
-    let mut img_undistorted =
-        Image::<f32, 3>::from_size_val(size, 0.0, kornia::image::allocator::host_alloc())?;
+    let mut img_undistorted = Image::<f32, 3>::from_size_val(size, 0.0)?;
     let mut weight_map = vec![0.0f32; num_pixels];
 
     let dst_slice = dst.as_slice();

--- a/examples/undistort_points_image/src/main.rs
+++ b/examples/undistort_points_image/src/main.rs
@@ -8,7 +8,7 @@ use kornia::{
         CameraIntrinsic,
     },
     io::functional as F,
-    tensor::{CpuAllocator, Tensor},
+    tensor::{host_alloc, Tensor},
 };
 
 #[derive(FromArgs)]
@@ -59,8 +59,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // undistort all points
-    let src = Tensor::<f64, 2, _>::from_shape_vec([num_pixels, 2], distorted_points, CpuAllocator)?;
-    let mut dst = Tensor::<f64, 2, _>::from_shape_val([num_pixels, 2], 0.0, CpuAllocator);
+    let src = Tensor::<f64, 2>::from_shape_vec([num_pixels, 2], distorted_points, host_alloc())?;
+    let mut dst = Tensor::<f64, 2>::from_shape_val([num_pixels, 2], 0.0, host_alloc());
 
     let criteria = TermCriteria {
         max_iter: 20,
@@ -80,7 +80,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // bilinear splatting (distorted is mapped on undistorted)
     let img_f32 = img_u8.cast::<f32>()?;
-    let mut img_undistorted = Image::<f32, 3, _>::from_size_val(size, 0.0, CpuAllocator)?;
+    let mut img_undistorted =
+        Image::<f32, 3>::from_size_val(size, 0.0, kornia::image::allocator::host_alloc())?;
     let mut weight_map = vec![0.0f32; num_pixels];
 
     let dst_slice = dst.as_slice();

--- a/examples/v4l/src/v4l.rs
+++ b/examples/v4l/src/v4l.rs
@@ -1,6 +1,5 @@
 use argh::FromArgs;
 use kornia::{
-    image::allocator::host_alloc,
     image::{color_spaces::Rgb8, ImageSize},
     imgproc::{self, color::YuvToRgbMode},
     io::{
@@ -80,7 +79,7 @@ pub fn v4l_demo() -> Result<(), Box<dyn std::error::Error>> {
     let mut fps_counter = FpsCounter::new();
 
     // Pre-allocate RGB image buffer outside the loop
-    let mut rgb_image = Rgb8::from_size_val(img_size, 0, host_alloc())?;
+    let mut rgb_image = Rgb8::from_size_val(img_size, 0)?;
 
     while !cancel_token.load(Ordering::SeqCst) {
         let Some(frame) = webcam.grab_frame()? else {

--- a/examples/v4l/src/v4l.rs
+++ b/examples/v4l/src/v4l.rs
@@ -1,5 +1,6 @@
 use argh::FromArgs;
 use kornia::{
+    image::allocator::host_alloc,
     image::{color_spaces::Rgb8, ImageSize},
     imgproc::{self, color::YuvToRgbMode},
     io::{
@@ -7,7 +8,6 @@ use kornia::{
         jpeg,
         v4l::{camera_control, PixelFormat, V4LCameraConfig, V4lVideoCapture},
     },
-    tensor::CpuAllocator,
 };
 use std::sync::{
     atomic::{AtomicBool, Ordering},
@@ -80,7 +80,7 @@ pub fn v4l_demo() -> Result<(), Box<dyn std::error::Error>> {
     let mut fps_counter = FpsCounter::new();
 
     // Pre-allocate RGB image buffer outside the loop
-    let mut rgb_image = Rgb8::from_size_val(img_size, 0, CpuAllocator)?;
+    let mut rgb_image = Rgb8::from_size_val(img_size, 0, host_alloc())?;
 
     while !cancel_token.load(Ordering::SeqCst) {
         let Some(frame) = webcam.grab_frame()? else {

--- a/examples/video_player/src/lib.rs
+++ b/examples/video_player/src/lib.rs
@@ -1,6 +1,6 @@
 use eframe::egui::{self, CentralPanel, Grid, TextEdit};
 use humanize_duration::{prelude::*, Truncate};
-use kornia::image::allocator::CpuAllocator;
+use kornia::image::allocator::host_alloc;
 use kornia::image::{Image, ImageSize};
 use kornia::imgproc::resize::resize_fast_rgb;
 use kornia::io::stream::video::{ImageFormat, SeekFlags, VideoReader};
@@ -18,7 +18,7 @@ pub struct MyApp {
 }
 
 struct TextureStore {
-    image: Image<u8, 3, CpuAllocator>,
+    image: Image<u8, 3>,
     texture_handle: egui::TextureHandle,
 }
 
@@ -311,8 +311,8 @@ fn render_image(app: &mut MyApp, ui: &mut eframe::egui::Ui) {
                         ts.texture_handle
                             .set(color_image, egui::TextureOptions::default());
                     } else {
-                        let mut dst: Image<u8, 3, CpuAllocator> =
-                            Image::from_size_val(new_image_size, 0, CpuAllocator)
+                        let mut dst: Image<u8, 3> =
+                            Image::from_size_val(new_image_size, 0, host_alloc())
                                 .expect("Failed to create Image");
                         resize_fast_rgb(
                             &image_frame,
@@ -356,7 +356,7 @@ fn render_image(app: &mut MyApp, ui: &mut eframe::egui::Ui) {
                         let owned = Image::from_size_slice(
                             image_frame.size(),
                             image_frame.as_slice(),
-                            CpuAllocator,
+                            host_alloc(),
                         )
                         .expect("Failed to copy frame to owned buffer");
                         *texture_store = Some(TextureStore {

--- a/examples/video_player/src/lib.rs
+++ b/examples/video_player/src/lib.rs
@@ -1,6 +1,5 @@
 use eframe::egui::{self, CentralPanel, Grid, TextEdit};
 use humanize_duration::{prelude::*, Truncate};
-use kornia::image::allocator::host_alloc;
 use kornia::image::{Image, ImageSize};
 use kornia::imgproc::resize::resize_fast_rgb;
 use kornia::io::stream::video::{ImageFormat, SeekFlags, VideoReader};
@@ -311,9 +310,8 @@ fn render_image(app: &mut MyApp, ui: &mut eframe::egui::Ui) {
                         ts.texture_handle
                             .set(color_image, egui::TextureOptions::default());
                     } else {
-                        let mut dst: Image<u8, 3> =
-                            Image::from_size_val(new_image_size, 0, host_alloc())
-                                .expect("Failed to create Image");
+                        let mut dst: Image<u8, 3> = Image::from_size_val(new_image_size, 0)
+                            .expect("Failed to create Image");
                         resize_fast_rgb(
                             &image_frame,
                             &mut dst,
@@ -353,12 +351,9 @@ fn render_image(app: &mut MyApp, ui: &mut eframe::egui::Ui) {
                             egui::TextureOptions::default(),
                         );
 
-                        let owned = Image::from_size_slice(
-                            image_frame.size(),
-                            image_frame.as_slice(),
-                            host_alloc(),
-                        )
-                        .expect("Failed to copy frame to owned buffer");
+                        let owned =
+                            Image::from_size_slice(image_frame.size(), image_frame.as_slice())
+                                .expect("Failed to copy frame to owned buffer");
                         *texture_store = Some(TextureStore {
                             image: owned,
                             texture_handle: texture,

--- a/kornia-cpp/src/lib.rs
+++ b/kornia-cpp/src/lib.rs
@@ -190,7 +190,6 @@ mod ffi {
     }
 }
 
-use kornia_image::allocator::CpuAllocator;
 use kornia_image::ImageError;
 use kornia_io::jpeg;
 
@@ -228,7 +227,7 @@ impl From<ffi::ImageSize> for kornia_image::ImageSize {
 /// Args: (TypeName, fn_prefix, dtype, channels)
 macro_rules! define_image_type {
     ($wrapper:ident, $prefix:ident, $dtype:ty, $ch:expr) => {
-        pub struct $wrapper(kornia_image::Image<$dtype, $ch, CpuAllocator>);
+        pub struct $wrapper(kornia_image::Image<$dtype, $ch>);
 
         ::paste::paste! {
             // Accessor functions
@@ -241,8 +240,7 @@ macro_rules! define_image_type {
             // Constructor: from size and fill value
             fn [<$prefix _new>](width: usize, height: usize, value: $dtype) -> Result<Box<$wrapper>, ImageError> {
                 let size = kornia_image::ImageSize { width, height };
-                let alloc = CpuAllocator::default();
-                let image = kornia_image::Image::<$dtype, $ch, CpuAllocator>::from_size_val(size, value, alloc)?;
+                                let image = kornia_image::Image::<$dtype, $ch>::from_size_val(size, value, kornia_image::allocator::host_alloc())?;
                 Ok(Box::new($wrapper(image)))
             }
 
@@ -253,8 +251,7 @@ macro_rules! define_image_type {
                 if data.len() != expected_len {
                     return Err(ImageError::InvalidChannelShape(data.len(), expected_len));
                 }
-                let alloc = CpuAllocator::default();
-                let image = kornia_image::Image::<$dtype, $ch, CpuAllocator>::from_size_slice(size, data, alloc)?;
+                                let image = kornia_image::Image::<$dtype, $ch>::from_size_slice(size, data, kornia_image::allocator::host_alloc())?;
                 Ok(Box::new($wrapper(image)))
             }
         }
@@ -332,10 +329,10 @@ fn decode_image_jpeg_rgb8(jpeg_bytes: &[u8]) -> Result<Box<ImageU8C3>, Box<dyn s
     }
 
     // Create output image
-    let mut image = kornia_image::Image::<u8, 3, CpuAllocator>::from_size_val(
+    let mut image = kornia_image::Image::<u8, 3>::from_size_val(
         layout.image_size,
         0,
-        CpuAllocator,
+        kornia_image::allocator::host_alloc(),
     )?;
 
     // Decode into it (zero-copy from slice)

--- a/kornia-cpp/src/lib.rs
+++ b/kornia-cpp/src/lib.rs
@@ -240,7 +240,7 @@ macro_rules! define_image_type {
             // Constructor: from size and fill value
             fn [<$prefix _new>](width: usize, height: usize, value: $dtype) -> Result<Box<$wrapper>, ImageError> {
                 let size = kornia_image::ImageSize { width, height };
-                                let image = kornia_image::Image::<$dtype, $ch>::from_size_val(size, value, kornia_image::allocator::host_alloc())?;
+                                let image = kornia_image::Image::<$dtype, $ch>::from_size_val(size, value)?;
                 Ok(Box::new($wrapper(image)))
             }
 
@@ -251,7 +251,7 @@ macro_rules! define_image_type {
                 if data.len() != expected_len {
                     return Err(ImageError::InvalidChannelShape(data.len(), expected_len));
                 }
-                                let image = kornia_image::Image::<$dtype, $ch>::from_size_slice(size, data, kornia_image::allocator::host_alloc())?;
+                                let image = kornia_image::Image::<$dtype, $ch>::from_size_slice(size, data)?;
                 Ok(Box::new($wrapper(image)))
             }
         }
@@ -329,11 +329,7 @@ fn decode_image_jpeg_rgb8(jpeg_bytes: &[u8]) -> Result<Box<ImageU8C3>, Box<dyn s
     }
 
     // Create output image
-    let mut image = kornia_image::Image::<u8, 3>::from_size_val(
-        layout.image_size,
-        0,
-        kornia_image::allocator::host_alloc(),
-    )?;
+    let mut image = kornia_image::Image::<u8, 3>::from_size_val(layout.image_size, 0)?;
 
     // Decode into it (zero-copy from slice)
     jpeg::decode_image_jpeg_rgb8(jpeg_bytes, &mut image)?;

--- a/kornia-py/benchmarks.md
+++ b/kornia-py/benchmarks.md
@@ -263,7 +263,7 @@ kornia-py is a **pure-CPU, NEON-optimized image pipeline** with zero-copy numpy 
 - ORB at 1080p runs end-to-end in 10.65 ms, competitive with VPI CUDA's 11.77 ms (cached-src, 4 ms/call lower than the unfair uncached measurement) — the CPU path stays in the same ballpark as the GPU kernel with zero device overhead.
 - FAST-9 beats both VPI CPU (5–8×) and VPI CUDA (6–9×) at both sizes because CUDA launch cost dominates a sub-ms kernel.
 
-**Design choices driving the numbers:** NEON kernels wherever bandwidth or arithmetic density justifies them (see `Techniques used` table); rayon parallelism at the strip/row level on every multi-pass kernel; `ForeignAllocator` wrapping the numpy buffer so PyO3 never copies in or out; hand-dispatched fast paths for common shapes (exact-2× bilinear up/down, binomial 5×5 Gaussian, 32-byte BRIEF descriptor).
+**Design choices driving the numbers:** NEON kernels wherever bandwidth or arithmetic density justifies them (see `Techniques used` table); rayon parallelism at the strip/row level on every multi-pass kernel; a borrowed `ForeignResource` wrapping the numpy buffer so PyO3 never copies in or out; hand-dispatched fast paths for common shapes (exact-2× bilinear up/down, binomial 5×5 Gaussian, 32-byte BRIEF descriptor).
 
 ### ORB benchmarking honesty note
 
@@ -311,7 +311,7 @@ An earlier revision of this file reported VPI CUDA at 15.45 ms for 1080p ORB. Th
 | NEON 4-wide reciprocal (`vrecpeq_f32` + 1 NR) | Warp Perspective | Amortizes per-pixel `nx/nd` divide across 4 lanes; ~17-bit precision |
 | Analytical branch-free valid-range | Warp Perspective | 4 linear-constraint intersections give safe `[x_lo, x_hi)` per row; no per-pixel bounds check in hot path |
 | Per-arch kernel dispatch (`warp/kernels.rs`) | Affine + Perspective | `_scalar` reference + `_neon` behind `cfg`; stable seam for future AVX / WASM-SIMD / SVE |
-| Zero-copy `ForeignAllocator` | All ops | Wrap numpy pointer, no memcpy |
+| Zero-copy `ForeignResource` | All ops | Wrap numpy pointer, no memcpy |
 | Direct PyArray output | All ops | Write into numpy buffer, skip intermediate Vec |
 
 ## NEON kernel locations (upstream in `kornia-imgproc`)

--- a/kornia-py/src/augmentations.rs
+++ b/kornia-py/src/augmentations.rs
@@ -484,6 +484,7 @@ impl PyColorJitter {
 
         self.last_params = Some(Self::params_to_dict(py, b, c, s, h, &order)?);
 
+        img.backing.ensure_host()?;
         img.require_u8("ColorJitter")?;
         let (height, width, channels) = img.shape_hwc();
         let src = img.u8_elems();

--- a/kornia-py/src/backing.rs
+++ b/kornia-py/src/backing.rs
@@ -239,10 +239,22 @@ impl Backing {
 ///
 /// Caller guarantees `b`'s buffer holds at least H*W*C elements of T and
 /// stays alive for the returned Image's lifetime (the Image borrows it).
+///
+/// # Panics
+///
+/// Panics if `b` is not host-accessible. This wraps the pointer in a
+/// `MemoryDomain::Host` Image (whose `as_slice` would then *not* panic), so a device
+/// backing reaching here would be a silent host-deref of device memory. The assert
+/// turns that latent UB into a panic; callers must gate with [`Backing::ensure_host`].
 pub unsafe fn borrow_image<T: Clone, const C: usize>(
     b: &Backing,
     shape: [usize; 3],
 ) -> Result<Image<T, C>, ImageError> {
+    assert!(
+        b.is_host(),
+        "borrow_image on a non-host backing (device_type={}); gate with ensure_host() first",
+        b.device().0
+    );
     let (h, w, c) = (shape[0], shape[1], shape[2]);
     if c != C {
         return Err(ImageError::InvalidChannelShape(c, C));

--- a/kornia-py/src/backing.rs
+++ b/kornia-py/src/backing.rs
@@ -2,7 +2,7 @@
 use std::alloc::{alloc, alloc_zeroed, dealloc, Layout};
 use std::ptr::NonNull;
 
-use dlpack_rs::ffi::{DLDataType, K_DL_FLOAT, K_DL_UINT};
+use dlpack_rs::ffi::{DLDataType, K_DL_CPU, K_DL_FLOAT, K_DL_UINT};
 use dlpack_rs::safe::{dtype_f32, dtype_u16, dtype_u8};
 use kornia_image::allocator::host_alloc;
 use kornia_image::{Image, ImageError, ImageSize};
@@ -172,6 +172,10 @@ pub enum Backing {
         ptr: NonNull<u8>,
         keep: BorrowGuard,
         readonly: bool,
+        /// DLPack device of the borrowed buffer as `(device_type, device_id)`.
+        /// Host buffers (numpy / PEP-3118) use `(K_DL_CPU, 0)`; a DLPack import
+        /// carries the source tensor's real device (e.g. `(K_DL_CUDA, id)`).
+        device: (i32, i32),
     },
 }
 // SAFETY: Owned is Send+Sync; Borrowed holds Send keep-alives and a raw ptr with exclusive logical ownership.
@@ -189,6 +193,42 @@ impl Backing {
         match self {
             Backing::Owned(_) => false,
             Backing::Borrowed { readonly, .. } => *readonly,
+        }
+    }
+
+    /// DLPack device of this backing as `(device_type, device_id)`.
+    ///
+    /// Owned buffers are always host CPU. Borrowed buffers carry the device
+    /// captured at construction (host for numpy / PEP-3118 borrows, or the
+    /// source tensor's device for a zero-copy DLPack import).
+    pub fn device(&self) -> (i32, i32) {
+        match self {
+            Backing::Owned(_) => (K_DL_CPU as i32, 0),
+            Backing::Borrowed { device, .. } => *device,
+        }
+    }
+
+    /// `true` if the backing lives in host (CPU) memory and is safe to
+    /// dereference from Rust.
+    pub fn is_host(&self) -> bool {
+        self.device().0 == K_DL_CPU as i32
+    }
+
+    /// Guard for host-only operations: returns an error if the backing is on a
+    /// non-CPU device, where any host dereference would be undefined behaviour.
+    ///
+    /// Call this at the start of every method that reads or writes the buffer on
+    /// the host (numpy export, pixel compute, encode/save, buffer protocol).
+    pub fn ensure_host(&self) -> pyo3::PyResult<()> {
+        if self.is_host() {
+            Ok(())
+        } else {
+            Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "operation requires a host (CPU) image; this image is on device \
+                 (device_type={}); transfer it to host first (e.g. call .cpu() on \
+                 the source tensor) before this operation",
+                self.device().0
+            )))
         }
     }
 }

--- a/kornia-py/src/backing.rs
+++ b/kornia-py/src/backing.rs
@@ -4,7 +4,8 @@ use std::ptr::NonNull;
 
 use dlpack_rs::ffi::{DLDataType, K_DL_FLOAT, K_DL_UINT};
 use dlpack_rs::safe::{dtype_f32, dtype_u16, dtype_u8};
-use kornia_image::{allocator::ForeignAllocator, Image, ImageError, ImageSize};
+use kornia_image::allocator::host_alloc;
+use kornia_image::{Image, ImageError, ImageSize};
 use pyo3::prelude::*;
 
 const ALIGN: usize = 64;
@@ -201,7 +202,7 @@ impl Backing {
 pub unsafe fn borrow_image<T: Clone, const C: usize>(
     b: &Backing,
     shape: [usize; 3],
-) -> Result<Image<T, C, ForeignAllocator>, ImageError> {
+) -> Result<Image<T, C>, ImageError> {
     let (h, w, c) = (shape[0], shape[1], shape[2]);
     if c != C {
         return Err(ImageError::InvalidChannelShape(c, C));
@@ -213,7 +214,7 @@ pub unsafe fn borrow_image<T: Clone, const C: usize>(
         },
         b.data_ptr() as *const T,
         h * w * c * std::mem::size_of::<T>(),
-        ForeignAllocator,
+        host_alloc(),
     )
 }
 

--- a/kornia-py/src/dlpack.rs
+++ b/kornia-py/src/dlpack.rs
@@ -10,9 +10,9 @@
 use std::ffi::c_void;
 
 use dlpack_rs::{
-    ffi::{DLDataType, DLDevice, K_DL_CPU},
+    ffi::{DLDataType, DLDevice},
     pyo3_glue::IntoDLPack,
-    safe::{cpu_device, TensorInfo},
+    safe::TensorInfo,
 };
 use pyo3::prelude::*;
 
@@ -50,6 +50,9 @@ pub struct ImageExport {
     pub shape: Vec<i64>,
     /// DLPack data-type descriptor.
     pub dtype: DLDataType,
+    /// DLPack device as `(device_type, device_id)`. Carries the image's own
+    /// device so a zero-copy export reports the correct device (CPU or CUDA).
+    pub device: (i32, i32),
 }
 
 impl Drop for ImageExport {
@@ -79,7 +82,11 @@ unsafe impl Send for ImageExport {}
 
 impl IntoDLPack for ImageExport {
     fn tensor_info(&self) -> TensorInfo {
-        TensorInfo::contiguous(self.data, cpu_device(), self.dtype, self.shape.clone())
+        let device = DLDevice {
+            device_type: self.device.0 as u32,
+            device_id: self.device.1,
+        };
+        TensorInfo::contiguous(self.data, device, self.dtype, self.shape.clone())
     }
 }
 
@@ -99,21 +106,4 @@ pub fn dtype_to_dl(dtype: Dtype) -> DLDataType {
 /// Delegates to [`Dtype::from_dldatatype`] — canonical mapping lives in `backing.rs`.
 pub fn dl_to_dtype(dt: DLDataType) -> PyResult<Dtype> {
     Dtype::from_dldatatype(dt)
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Helper: device validation
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// Assert the device is CPU, or raise `NotImplementedError`.
-pub fn require_cpu(device: DLDevice) -> PyResult<()> {
-    if device.device_type != K_DL_CPU {
-        Err(pyo3::exceptions::PyNotImplementedError::new_err(format!(
-            "from_dlpack: only CPU (device_type={K_DL_CPU}) tensors are supported; \
-             got device_type={}. GPU/CUDA support is a future extension.",
-            device.device_type,
-        )))
-    } else {
-        Ok(())
-    }
 }

--- a/kornia-py/src/dlpack.rs
+++ b/kornia-py/src/dlpack.rs
@@ -107,3 +107,24 @@ pub fn dtype_to_dl(dtype: Dtype) -> DLDataType {
 pub fn dl_to_dtype(dt: DLDataType) -> PyResult<Dtype> {
     Dtype::from_dldatatype(dt)
 }
+
+/// Validate a producer-supplied DLPack rank before it is used as a slice length.
+///
+/// `ndim` comes from an untrusted `__dlpack__` producer. A negative value casts to
+/// `usize::MAX` (so `slice::from_raw_parts(shape, ndim)` is instant UB) and an
+/// oversized one reads out of bounds. Only 2D/3D images are supported, so we bound
+/// `ndim` to `2..=3` (capping any slice to ≤3 elements) and reject a null `shape`
+/// pointer, before any slice is constructed from `shape`/`strides`.
+pub fn validate_dlpack_rank(ndim: i32, shape: *const i64) -> PyResult<()> {
+    if !(2..=3).contains(&ndim) {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "from_dlpack: expected a 2D or 3D tensor, got ndim={ndim}"
+        )));
+    }
+    if shape.is_null() {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "from_dlpack: null shape pointer",
+        ));
+    }
+    Ok(())
+}

--- a/kornia-py/src/enhance.rs
+++ b/kornia-py/src/enhance.rs
@@ -1,7 +1,7 @@
 use pyo3::prelude::*;
 
 use crate::image::{alloc_output_pyarray, numpy_to_f32_image, to_pyerr, PyImage};
-use kornia_image::{allocator::CpuAllocator, Image, ImageError};
+use kornia_image::{Image, ImageError};
 use kornia_imgproc::enhance;
 
 #[pyfunction]
@@ -19,7 +19,8 @@ pub fn add_weighted(
     let (mut dst_u8, out) = unsafe { alloc_output_pyarray::<3>(py, size)? };
 
     py.detach(|| -> Result<(), ImageError> {
-        let mut dst_f32 = Image::from_size_val(size, 0.0f32, CpuAllocator)?;
+        let mut dst_f32 =
+            Image::from_size_val(size, 0.0f32, kornia_image::allocator::host_alloc())?;
         enhance::add_weighted(&image1, alpha, &image2, beta, gamma, &mut dst_f32)?;
         dst_u8
             .as_slice_mut()

--- a/kornia-py/src/enhance.rs
+++ b/kornia-py/src/enhance.rs
@@ -19,8 +19,7 @@ pub fn add_weighted(
     let (mut dst_u8, out) = unsafe { alloc_output_pyarray::<3>(py, size)? };
 
     py.detach(|| -> Result<(), ImageError> {
-        let mut dst_f32 =
-            Image::from_size_val(size, 0.0f32, kornia_image::allocator::host_alloc())?;
+        let mut dst_f32 = Image::from_size_val(size, 0.0f32)?;
         enhance::add_weighted(&image1, alpha, &image2, beta, gamma, &mut dst_f32)?;
         dst_u8
             .as_slice_mut()

--- a/kornia-py/src/image.rs
+++ b/kornia-py/src/image.rs
@@ -2,10 +2,7 @@ use numpy::{PyArray, PyArray3, PyArrayMethods, PyUntypedArrayMethods};
 use pyo3::PyTypeInfo;
 
 use crate::backing;
-use kornia_image::{
-    allocator::{CpuAllocator, ForeignAllocator},
-    ColorSpace, Image, ImageError, ImageLayout, ImageSize, PixelFormat,
-};
+use kornia_image::{ColorSpace, Image, ImageError, ImageLayout, ImageSize, PixelFormat};
 use pyo3::prelude::*;
 
 pub type PyImage = Py<PyArray3<u8>>;
@@ -230,7 +227,7 @@ pub(crate) fn to_pyerr(e: impl std::fmt::Display) -> PyErr {
 pub(crate) unsafe fn numpy_as_image<const C: usize>(
     py: Python<'_>,
     image: &Py<PyArray3<u8>>,
-) -> PyResult<Image<u8, C, ForeignAllocator>> {
+) -> PyResult<Image<u8, C>> {
     let arr = image.bind(py);
     if !arr.is_c_contiguous() {
         return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
@@ -249,8 +246,13 @@ pub(crate) unsafe fn numpy_as_image<const C: usize>(
         width: w,
         height: h,
     };
-    Image::from_raw_parts(size, arr.data() as *const u8, h * w * C, ForeignAllocator)
-        .map_err(to_pyerr)
+    Image::from_raw_parts(
+        size,
+        arr.data() as *const u8,
+        h * w * C,
+        kornia_image::allocator::host_alloc(),
+    )
+    .map_err(to_pyerr)
 }
 
 /// Zero-copy wrap a numpy u16 array as a Rust Image for reading.
@@ -259,7 +261,7 @@ pub(crate) unsafe fn numpy_as_image<const C: usize>(
 pub(crate) unsafe fn numpy_as_image_u16<const C: usize>(
     py: Python<'_>,
     image: &Py<PyArray3<u16>>,
-) -> PyResult<Image<u16, C, ForeignAllocator>> {
+) -> PyResult<Image<u16, C>> {
     let arr = image.bind(py);
     if !arr.is_c_contiguous() {
         return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
@@ -279,8 +281,13 @@ pub(crate) unsafe fn numpy_as_image_u16<const C: usize>(
         height: h,
     };
     let len_bytes = h * w * C * std::mem::size_of::<u16>();
-    Image::from_raw_parts(size, arr.data() as *const u16, len_bytes, ForeignAllocator)
-        .map_err(to_pyerr)
+    Image::from_raw_parts(
+        size,
+        arr.data() as *const u16,
+        len_bytes,
+        kornia_image::allocator::host_alloc(),
+    )
+    .map_err(to_pyerr)
 }
 
 /// Zero-copy wrap a numpy f32 array as a Rust Image for reading.
@@ -289,7 +296,7 @@ pub(crate) unsafe fn numpy_as_image_u16<const C: usize>(
 pub(crate) unsafe fn numpy_as_image_f32<const C: usize>(
     py: Python<'_>,
     image: &Py<PyArray3<f32>>,
-) -> PyResult<Image<f32, C, ForeignAllocator>> {
+) -> PyResult<Image<f32, C>> {
     let arr = image.bind(py);
     if !arr.is_c_contiguous() {
         return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
@@ -309,11 +316,16 @@ pub(crate) unsafe fn numpy_as_image_f32<const C: usize>(
         height: h,
     };
     let len_bytes = h * w * C * std::mem::size_of::<f32>();
-    Image::from_raw_parts(size, arr.data() as *const f32, len_bytes, ForeignAllocator)
-        .map_err(to_pyerr)
+    Image::from_raw_parts(
+        size,
+        arr.data() as *const f32,
+        len_bytes,
+        kornia_image::allocator::host_alloc(),
+    )
+    .map_err(to_pyerr)
 }
 
-pub(crate) type AllocOutput<T, const C: usize, P> = (Image<T, C, ForeignAllocator>, Py<P>);
+pub(crate) type AllocOutput<T, const C: usize, P> = (Image<T, C>, Py<P>);
 
 pub(crate) unsafe fn alloc_output_pyarray<const C: usize>(
     py: Python<'_>,
@@ -321,8 +333,13 @@ pub(crate) unsafe fn alloc_output_pyarray<const C: usize>(
 ) -> PyResult<AllocOutput<u8, C, PyArray3<u8>>> {
     let arr = PyArray::<u8, _>::new(py, [size.height, size.width, C], false);
     let len = size.height * size.width * C;
-    let img = Image::from_raw_parts(size, arr.data() as *const u8, len, ForeignAllocator)
-        .map_err(to_pyerr)?;
+    let img = Image::from_raw_parts(
+        size,
+        arr.data() as *const u8,
+        len,
+        kornia_image::allocator::host_alloc(),
+    )
+    .map_err(to_pyerr)?;
     Ok((img, arr.unbind()))
 }
 
@@ -332,8 +349,13 @@ pub(crate) unsafe fn alloc_output_pyarray_u16<const C: usize>(
 ) -> PyResult<AllocOutput<u16, C, PyArray3<u16>>> {
     let arr = PyArray::<u16, _>::new(py, [size.height, size.width, C], false);
     let len = size.height * size.width * C * std::mem::size_of::<u16>();
-    let img = Image::from_raw_parts(size, arr.data() as *const u16, len, ForeignAllocator)
-        .map_err(to_pyerr)?;
+    let img = Image::from_raw_parts(
+        size,
+        arr.data() as *const u16,
+        len,
+        kornia_image::allocator::host_alloc(),
+    )
+    .map_err(to_pyerr)?;
     Ok((img, arr.unbind()))
 }
 
@@ -343,21 +365,26 @@ pub(crate) unsafe fn alloc_output_pyarray_f32<const C: usize>(
 ) -> PyResult<AllocOutput<f32, C, PyArray3<f32>>> {
     let arr = PyArray::<f32, _>::new(py, [size.height, size.width, C], false);
     let len = size.height * size.width * C * std::mem::size_of::<f32>();
-    let img = Image::from_raw_parts(size, arr.data() as *const f32, len, ForeignAllocator)
-        .map_err(to_pyerr)?;
+    let img = Image::from_raw_parts(
+        size,
+        arr.data() as *const f32,
+        len,
+        kornia_image::allocator::host_alloc(),
+    )
+    .map_err(to_pyerr)?;
     Ok((img, arr.unbind()))
 }
 
-/// Copy numpy u8 data into a CpuAllocator f32 Image (for Category B ops needing f32).
+/// Copy numpy u8 data into a kornia_image::allocator::host_alloc() f32 Image (for Category B ops needing f32).
 ///
 /// Uses zero-copy read via numpy_as_image, then a single u8→f32 collect.
 pub(crate) fn numpy_to_f32_image<const C: usize>(
     py: Python<'_>,
     image: &Py<PyArray3<u8>>,
-) -> PyResult<Image<f32, C, CpuAllocator>> {
+) -> PyResult<Image<f32, C>> {
     let src = unsafe { numpy_as_image::<C>(py, image)? };
     let f32_data: Vec<f32> = src.as_slice().iter().map(|&v| v as f32).collect();
-    Image::new(src.size(), f32_data, CpuAllocator).map_err(to_pyerr)
+    Image::new(src.size(), f32_data, kornia_image::allocator::host_alloc()).map_err(to_pyerr)
 }
 
 /// Get raw u8 data and dimensions from a PyArray3.
@@ -1253,7 +1280,7 @@ impl PyImageApi {
     /// The returned Image borrows self's buffer; self must outlive it.
     pub(crate) unsafe fn borrow_self<T: Clone, const C: usize>(
         &self,
-    ) -> Result<Image<T, C, ForeignAllocator>, ImageError> {
+    ) -> Result<Image<T, C>, ImageError> {
         unsafe { backing::borrow_image::<T, C>(&self.backing, self.shape) }
     }
 
@@ -1266,15 +1293,15 @@ impl PyImageApi {
         f: F,
     ) -> PyResult<Self>
     where
-        F: FnOnce(&mut Image<u8, CO, ForeignAllocator>) -> Result<(), ImageError> + Send,
+        F: FnOnce(&mut Image<u8, CO>) -> Result<(), ImageError> + Send,
     {
         let (mut bytes, size) = backing::alloc_output_owned::<CO>(backing::Dtype::U8, out_size)?;
         let mut dst = unsafe {
-            Image::<u8, CO, ForeignAllocator>::from_raw_parts(
+            Image::<u8, CO>::from_raw_parts(
                 size,
                 bytes.as_mut_ptr(),
                 size.width * size.height * CO * std::mem::size_of::<u8>(),
-                ForeignAllocator,
+                kornia_image::allocator::host_alloc(),
             )
             .map_err(to_pyerr)?
         };
@@ -1296,15 +1323,15 @@ impl PyImageApi {
         f: F,
     ) -> PyResult<Self>
     where
-        F: FnOnce(&mut Image<f32, CO, ForeignAllocator>) -> Result<(), ImageError> + Send,
+        F: FnOnce(&mut Image<f32, CO>) -> Result<(), ImageError> + Send,
     {
         let (mut bytes, size) = backing::alloc_output_owned::<CO>(backing::Dtype::F32, out_size)?;
         let mut dst = unsafe {
-            Image::<f32, CO, ForeignAllocator>::from_raw_parts(
+            Image::<f32, CO>::from_raw_parts(
                 size,
                 bytes.as_mut_ptr() as *const f32,
                 size.width * size.height * CO * std::mem::size_of::<f32>(),
-                ForeignAllocator,
+                kornia_image::allocator::host_alloc(),
             )
             .map_err(to_pyerr)?
         };
@@ -1461,11 +1488,11 @@ impl PyImageApi {
             // buffer is wrapped/read, so the uninitialized alloc is fully covered.
             let mut bytes = backing::AlignedBytes::uninit(n);
             let mut dst = unsafe {
-                Image::<u8, 3, ForeignAllocator>::from_raw_parts(
+                Image::<u8, 3>::from_raw_parts(
                     out_size,
                     bytes.as_mut_ptr(),
                     n,
-                    ForeignAllocator,
+                    kornia_image::allocator::host_alloc(),
                 )
                 .map_err(to_pyerr)?
             };

--- a/kornia-py/src/image.rs
+++ b/kornia-py/src/image.rs
@@ -1263,6 +1263,8 @@ impl PyImageApi {
                 buffer: None,
             },
             readonly: !writeable,
+            // numpy borrows are always host memory.
+            device: (dlpack_rs::ffi::K_DL_CPU as i32, 0),
         };
         Ok(Self {
             backing,
@@ -1431,6 +1433,8 @@ impl PyImageApi {
     fn numpy_view_of(slf: Bound<'_, Self>) -> PyResult<Py<PyAny>> {
         let py = slf.py();
         let me = slf.borrow();
+        // Host guard: numpy views dereference the buffer on the host.
+        me.backing.ensure_host()?;
         // Borrowed numpy: return the original ndarray for true identity — but ONLY
         // when the kept object actually IS a numpy ndarray (the `from_numpy` borrow).
         // For other producers kept by `from_dlpack` (e.g. a torch tensor), do NOT
@@ -1469,6 +1473,8 @@ impl PyImageApi {
         width: usize,
         height: usize,
     ) -> PyResult<Self> {
+        // Host guard: crop copies pixel bytes on the host.
+        self.backing.ensure_host()?;
         let [src_h, src_w, c] = self.shape;
         if y + height > src_h || x + width > src_w {
             return Err(value_err(format!(
@@ -1592,6 +1598,8 @@ impl PyImageApi {
         compress_level: Option<u8>,
         #[cfg_attr(not(feature = "turbojpeg"), allow(unused_variables))] subsampling: Option<&str>,
     ) -> PyResult<Vec<u8>> {
+        // Host guard: encoding reads pixel bytes on the host.
+        self.backing.ensure_host()?;
         let c = self.nchannels();
         let is_u16 = self.is_u16();
         let is_f32 = self.is_f32();
@@ -2367,6 +2375,7 @@ impl PyImageApi {
     /// row-major; element width matches ``dtype`` (``uint8`` -> 1 byte/elem,
     /// ``uint16`` -> 2 bytes little-endian native).
     fn tobytes<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, pyo3::types::PyBytes>> {
+        self.backing.ensure_host()?;
         Ok(pyo3::types::PyBytes::new(py, self.raw_bytes()))
     }
 
@@ -2385,6 +2394,7 @@ impl PyImageApi {
 
     /// Return a deep copy of this image (owned, independent storage).
     pub fn copy(&self, py: Python<'_>) -> PyResult<Self> {
+        self.backing.ensure_host()?;
         Ok(self.clone_handle(py))
     }
 
@@ -2399,6 +2409,7 @@ impl PyImageApi {
         height: usize,
         interpolation: &str,
     ) -> PyResult<Self> {
+        self.backing.ensure_host()?;
         self.require_u8("resize")?;
         let [src_h, src_w, c] = self.shape;
         if c == 3 {
@@ -2436,6 +2447,7 @@ impl PyImageApi {
         mean: [f32; 3],
         std: [f32; 3],
     ) -> PyResult<Self> {
+        self.backing.ensure_host()?;
         self.require_u8("resize_normalize_to_tensor")?;
         let [src_h, src_w, c] = self.shape;
         if c != 3 {
@@ -2486,6 +2498,7 @@ impl PyImageApi {
 
     /// Flip image horizontally. Supports 8-bit, 16-bit, and float32 Images.
     pub fn flip_horizontal(&self, py: Python<'_>) -> PyResult<Self> {
+        self.backing.ensure_host()?;
         let [h, w, c] = self.shape;
         if self.dtype == backing::Dtype::U8 && c == 3 {
             let src = unsafe { self.borrow_self::<u8, 3>().map_err(to_pyerr)? };
@@ -2502,6 +2515,7 @@ impl PyImageApi {
 
     /// Flip image vertically. Supports 8-bit, 16-bit, and float32 Images.
     pub fn flip_vertical(&self, py: Python<'_>) -> PyResult<Self> {
+        self.backing.ensure_host()?;
         let [h, w, c] = self.shape;
         if self.dtype == backing::Dtype::U8 && c == 3 {
             let src = unsafe { self.borrow_self::<u8, 3>().map_err(to_pyerr)? };
@@ -2560,6 +2574,7 @@ impl PyImageApi {
     /// Apply Gaussian blur. 8-bit only.
     #[pyo3(signature = (kernel_size=3, sigma=1.0))]
     fn gaussian_blur(&self, py: Python<'_>, kernel_size: usize, sigma: f32) -> PyResult<Self> {
+        self.backing.ensure_host()?;
         self.require_u8("gaussian_blur")?;
         if self.nchannels() == 3 {
             let src = unsafe { self.borrow_self::<u8, 3>().map_err(to_pyerr)? };
@@ -2579,6 +2594,7 @@ impl PyImageApi {
     /// Apply box blur. 8-bit only.
     #[pyo3(signature = (kernel_size=3))]
     fn box_blur(&self, py: Python<'_>, kernel_size: usize) -> PyResult<Self> {
+        self.backing.ensure_host()?;
         self.require_u8("box_blur")?;
         if self.nchannels() == 3 {
             let src = unsafe { self.borrow_self::<u8, 3>().map_err(to_pyerr)? };
@@ -2592,6 +2608,7 @@ impl PyImageApi {
 
     /// Adjust brightness. Factor is additive in [0,1] range. 8-bit only.
     pub fn adjust_brightness(&self, py: Python<'_>, factor: f32) -> PyResult<Self> {
+        self.backing.ensure_host()?;
         self.require_u8("adjust_brightness")?;
         let [h, w, c] = self.shape;
         Ok(self.wrap_u8_result(
@@ -2602,6 +2619,7 @@ impl PyImageApi {
 
     /// Adjust contrast. factor=1.0 is identity, >1 increases contrast. 8-bit only.
     pub fn adjust_contrast(&self, py: Python<'_>, factor: f64) -> PyResult<Self> {
+        self.backing.ensure_host()?;
         self.require_u8("adjust_contrast")?;
         let [h, w, c] = self.shape;
         Ok(self.wrap_u8_result(
@@ -2612,6 +2630,7 @@ impl PyImageApi {
 
     /// Adjust saturation. factor=1.0 is identity, 0.0 is grayscale. 8-bit only.
     pub fn adjust_saturation(&self, py: Python<'_>, factor: f64) -> PyResult<Self> {
+        self.backing.ensure_host()?;
         self.require_u8("adjust_saturation")?;
         let [h, w, c] = self.shape;
         if c != 3 {
@@ -2625,6 +2644,7 @@ impl PyImageApi {
 
     /// Adjust hue. factor is in [-0.5, 0.5], fraction of hue wheel. 8-bit only.
     pub fn adjust_hue(&self, py: Python<'_>, factor: f64) -> PyResult<Self> {
+        self.backing.ensure_host()?;
         self.require_u8("adjust_hue")?;
         let [h, w, c] = self.shape;
         if c != 3 || factor == 0.0 {
@@ -2644,6 +2664,7 @@ impl PyImageApi {
         std: (f32, f32, f32),
     ) -> PyResult<Py<PyAny>> {
         let me = slf.borrow();
+        me.backing.ensure_host()?;
         me.require_u8("normalize")?;
         let [h, w, c] = me.shape;
         let src = me.u8_elems();
@@ -2690,6 +2711,7 @@ impl PyImageApi {
     /// 8-bit and 16-bit dtypes scale the integer range proportionally
     /// (×257 / ÷257) so that pure white / pure black map correctly.
     fn convert(&self, py: Python<'_>, mode: &str) -> PyResult<Self> {
+        self.backing.ensure_host()?;
         if mode == self.mode {
             return self.copy(py);
         }
@@ -2738,6 +2760,7 @@ impl PyImageApi {
 
     /// Convert RGB image to grayscale (1 channel). 8-bit only.
     fn to_grayscale(&self, py: Python<'_>) -> PyResult<Self> {
+        self.backing.ensure_host()?;
         self.require_u8("to_grayscale")?;
         let [h, w, c] = self.shape;
         if c == 1 {
@@ -2764,6 +2787,7 @@ impl PyImageApi {
 
     /// Convert grayscale to RGB (3 channels). 8-bit only.
     fn to_rgb(&self, py: Python<'_>) -> PyResult<Self> {
+        self.backing.ensure_host()?;
         self.require_u8("to_rgb")?;
         let c = self.nchannels();
         if c == 3 {
@@ -2793,6 +2817,7 @@ impl PyImageApi {
     /// unchanged (cloned handle). Required before converting to f32-only spaces
     /// (HSV, Lab, Luv, XYZ, LinearRgb, YCbCr, Yuv).
     fn to_float(&self, py: Python<'_>) -> PyResult<Self> {
+        self.backing.ensure_host()?;
         match self.dtype {
             backing::Dtype::F32 => Ok(self.clone_handle(py)),
             backing::Dtype::U8 => {
@@ -2820,6 +2845,7 @@ impl PyImageApi {
     /// Cast f32 [0,1] -> u8 by multiplying by 255 (saturating round). u8 input
     /// is returned unchanged (cloned handle).
     fn to_uint8(&self, py: Python<'_>) -> PyResult<Self> {
+        self.backing.ensure_host()?;
         match self.dtype {
             backing::Dtype::U8 => Ok(self.clone_handle(py)),
             backing::Dtype::F32 => {
@@ -2847,6 +2873,7 @@ impl PyImageApi {
     /// Convert to another color space, returning a new tagged Image. Strict
     /// dtype: f32-only spaces require a float image (call `to_float()` first).
     fn cvt_color(&self, py: Python<'_>, to: crate::color_space::PyColorSpace) -> PyResult<Self> {
+        self.backing.ensure_host()?;
         use kornia_image::ColorSpace as CS;
         let from = self.color_space;
         let to: CS = to.into();
@@ -2904,6 +2931,7 @@ impl PyImageApi {
     ///
     /// On aarch64 the LUT lookup is NEON-accelerated (16 px/iter).
     fn colormap(&self, py: Python<'_>, colormap: &str) -> PyResult<Self> {
+        self.backing.ensure_host()?;
         self.require_u8("colormap")?;
         let c = self.nchannels();
         if c != 1 {
@@ -2927,6 +2955,7 @@ impl PyImageApi {
     ///  - ±90°/±270° with H == W: transpose+flip (shape preserved)
     /// Non-exact or non-square 90°/270°: general bilinear warp.
     pub fn rotate(&self, py: Python<'_>, angle: f64) -> PyResult<Self> {
+        self.backing.ensure_host()?;
         self.require_u8("rotate")?;
         let [h, w, c] = self.shape;
 
@@ -3000,13 +3029,26 @@ impl PyImageApi {
         {
             return false;
         }
+        // Device images cannot be byte-compared on the host (dereferencing device
+        // memory is UB). Equal only if they alias the same device buffer.
+        if !self.backing.is_host() || !other.backing.is_host() {
+            return self.backing.device() == other.backing.device()
+                && self.backing.data_ptr() == other.backing.data_ptr();
+        }
         self.raw_bytes() == other.raw_bytes()
     }
 
     fn __hash__(&self) -> u64 {
         use std::hash::{Hash, Hasher};
         let mut h = std::collections::hash_map::DefaultHasher::new();
-        self.raw_bytes().hash(&mut h);
+        // Device images cannot be byte-hashed on the host; hash the device +
+        // buffer address instead of dereferencing device memory.
+        if self.backing.is_host() {
+            self.raw_bytes().hash(&mut h);
+        } else {
+            self.backing.device().hash(&mut h);
+            (self.backing.data_ptr() as usize).hash(&mut h);
+        }
         self.mode.hash(&mut h);
         (self.dtype as u8).hash(&mut h);
         self.shape.hash(&mut h);
@@ -3048,6 +3090,9 @@ impl PyImageApi {
         if view.is_null() {
             return Err(pyo3::exceptions::PyBufferError::new_err("null view"));
         }
+        // Host guard: the PEP-3118 buffer exposes the backing pointer for host
+        // access; refuse to hand out a device pointer as a host buffer.
+        slf.backing.ensure_host()?;
         let readonly = slf.backing.readonly();
         if (flags & pyo3::ffi::PyBUF_WRITABLE) == pyo3::ffi::PyBUF_WRITABLE && readonly {
             return Err(pyo3::exceptions::PyBufferError::new_err(
@@ -3137,8 +3182,16 @@ impl PyImageApi {
     /// A `Py<PyAny>` handle to the Image is stored in the `ImageExport`
     /// keep-alive, keeping the buffer alive until the consumer's deleter runs.
     ///
-    /// All other keyword arguments (`stream`, `dl_device`, `copy`) are accepted
-    /// and ignored; this implementation is CPU-only.
+    /// Zero-copy pass-through export: the tensor carries the image's own device
+    /// (CPU or, for a DLPack-imported device image, e.g. CUDA).
+    ///
+    /// Keyword arguments:
+    /// - `stream`: ignored. This is a zero-copy pass-through that performs no
+    ///   compute or synchronization, so for device tensors the consumer is
+    ///   responsible for any stream synchronization on its side.
+    /// - `dl_device`: a cross-device request is rejected; only an explicit
+    ///   request matching the image's own device is honoured.
+    /// - `copy`: `copy=True` is not supported.
     #[pyo3(signature = (*, stream=None, max_version=None, dl_device=None, copy=None))]
     fn __dlpack__(
         slf: Bound<'_, Self>,
@@ -3148,15 +3201,20 @@ impl PyImageApi {
         dl_device: Option<Py<PyAny>>,
         copy: Option<bool>,
     ) -> PyResult<Py<PyAny>> {
-        let _ = stream; // CPU: no stream concept
-                        // Validate dl_device: only CPU (kDLCPU=1, id=0) is supported.
+        // stream is intentionally ignored: zero-copy pass-through does no compute
+        // or sync, so stream synchronization is the consumer's responsibility.
+        let _ = stream;
+        let own_device = slf.borrow().backing.device();
+        // Validate dl_device: only a request matching the image's own device is
+        // honoured. Cross-device export would require a host/device copy, which
+        // this zero-copy path does not perform.
         if let Some(ref dev) = dl_device {
             let (dev_type, dev_id): (i32, i32) = dev.extract(py)?;
-            use dlpack_rs::ffi::K_DL_CPU;
-            if dev_type != K_DL_CPU as i32 || dev_id != 0 {
+            if (dev_type, dev_id) != own_device {
                 return Err(pyo3::exceptions::PyBufferError::new_err(format!(
-                    "__dlpack__: only CPU device (kDLCPU=1, id=0) is supported; \
-                     got ({dev_type}, {dev_id})"
+                    "__dlpack__: cross-device export not supported; image is on \
+                     device ({}, {}) but ({dev_type}, {dev_id}) was requested",
+                    own_device.0, own_device.1
                 )));
             }
         }
@@ -3183,6 +3241,7 @@ impl PyImageApi {
             data,
             shape,
             dtype: dt,
+            device: own_device,
         };
         use dlpack_rs::pyo3_glue::IntoDLPack;
         // If the consumer supports DLPack v1.0+, return a versioned capsule.
@@ -3201,9 +3260,12 @@ impl PyImageApi {
         Ok(capsule.into_any().unbind())
     }
 
-    /// Return the DLPack device tuple for this image: `(kDLCPU=1, device_id=0)`.
+    /// Return the DLPack device tuple `(device_type, device_id)` for this image.
+    ///
+    /// Host images report `(kDLCPU=1, 0)`; a DLPack-imported device image reports
+    /// its source device (e.g. `(kDLCUDA=2, id)`).
     fn __dlpack_device__(&self) -> (i32, i32) {
-        (dlpack_rs::ffi::K_DL_CPU as i32, 0)
+        self.backing.device()
     }
 
     /// Zero-copy ingest of a PEP-3118 buffer (ROS2 bytearray / memoryview).
@@ -3271,6 +3333,8 @@ impl PyImageApi {
                 ptr,
                 keep,
                 readonly,
+                // PEP-3118 buffers are host memory.
+                device: (dlpack_rs::ffi::K_DL_CPU as i32, 0),
             },
             dtype: dt,
             shape: [height, width, channels],
@@ -3285,10 +3349,15 @@ impl PyImageApi {
     /// Import a DLPack tensor as a zero-copy Image (static method).
     ///
     /// Accepts any Python object that implements `__dlpack__()`: numpy arrays
-    /// (>= 1.22), PyTorch tensors, CuPy arrays (CPU only), etc.
+    /// (>= 1.22), PyTorch tensors (CPU or CUDA), CuPy arrays, etc.
+    ///
+    /// Device pass-through: CPU tensors import as host images; non-CPU tensors
+    /// (e.g. CUDA) import as device images that carry their source device. The
+    /// device buffer is never dereferenced on the host — host-only operations
+    /// (numpy export, pixel compute, save) raise `ValueError` on a device image.
+    /// A device image can be re-exported via `__dlpack__`, preserving its device.
     ///
     /// Validation:
-    /// - Device must be CPU (`kDLCPU = 1`); raises `NotImplementedError` otherwise.
     /// - Tensor must be C-contiguous; raises `ValueError` otherwise.
     /// - `ndim` must be 3 (`(H, W, C)`) or 2 (`(H, W)` → treated as `(H, W, 1)`).
     /// - dtype must be `uint8`, `uint16`, or `float32`; raises `ValueError` otherwise.
@@ -3408,8 +3477,12 @@ impl PyImageApi {
                 )));
             };
 
-        // 4. Validate device.
-        crate::dlpack::require_cpu(device)?;
+        // 4. Capture the source device for zero-copy pass-through interop.
+        //    CPU tensors stay host-accessible; non-CPU (e.g. CUDA) tensors are
+        //    imported as device images: their buffer is never dereferenced on the
+        //    host (host ops are gated by `Backing::ensure_host`), and `__dlpack__`
+        //    re-exports them carrying this same device.
+        let src_device = (device.device_type as i32, device.device_id);
 
         // 5. Validate contiguity (strides == None, or compact row-major).
         if let Some(strides) = raw_strides {
@@ -3546,6 +3619,7 @@ impl PyImageApi {
                     buffer: None,
                 },
                 readonly,
+                device: src_device,
             },
             dtype,
             shape: [h, w, c],

--- a/kornia-py/src/image.rs
+++ b/kornia-py/src/image.rs
@@ -384,7 +384,7 @@ pub(crate) fn numpy_to_f32_image<const C: usize>(
 ) -> PyResult<Image<f32, C>> {
     let src = unsafe { numpy_as_image::<C>(py, image)? };
     let f32_data: Vec<f32> = src.as_slice().iter().map(|&v| v as f32).collect();
-    Image::new(src.size(), f32_data, kornia_image::allocator::host_alloc()).map_err(to_pyerr)
+    Image::new(src.size(), f32_data).map_err(to_pyerr)
 }
 
 /// Get raw u8 data and dimensions from a PyArray3.

--- a/kornia-py/src/image.rs
+++ b/kornia-py/src/image.rs
@@ -2481,10 +2481,12 @@ impl PyImageApi {
         ))
     }
 
-    /// Host address (as an int) of the underlying contiguous data buffer.
+    /// Address (as an int) of the underlying contiguous data buffer.
     ///
-    /// Stable for the lifetime of this `Image`; hand it (with `.shape` / `.nbytes`)
-    /// to an external library for a host→device copy without going through numpy.
+    /// For a host image this is a host pointer; for a device (e.g. DLPack-imported CUDA)
+    /// image it is the **device** pointer in that device's address space — check
+    /// `__dlpack_device__()` to learn which. Stable for the lifetime of this `Image`; hand
+    /// it (with `.shape` / `.nbytes`) to an external library without going through numpy.
     #[getter]
     fn data_ptr(&self) -> usize {
         self.backing.data_ptr() as usize
@@ -3432,6 +3434,10 @@ impl PyImageApi {
                 let nn = capsule.pointer_checked(Some(NAME_DL))?;
                 let mt = unsafe { &*(nn.as_ptr() as *const DLManagedTensor) };
                 let t = &mt.dl_tensor;
+                // SECURITY: `ndim` is producer-controlled. Validate it (and the shape
+                // pointer) BEFORE using it as a slice length — a negative `ndim` casts
+                // to `usize::MAX` (instant UB) and an oversized one reads out of bounds.
+                crate::dlpack::validate_dlpack_rank(t.ndim, t.shape)?;
                 let sh = unsafe { std::slice::from_raw_parts(t.shape, t.ndim as usize) };
                 let st = if t.strides.is_null() {
                     None
@@ -3452,6 +3458,8 @@ impl PyImageApi {
                 let nn = capsule.pointer_checked(Some(NAME_DLV))?;
                 let mt = unsafe { &*(nn.as_ptr() as *const DLManagedTensorVersioned) };
                 let t = &mt.dl_tensor;
+                // SECURITY: see note in the `NAME_DL` branch — validate before slicing.
+                crate::dlpack::validate_dlpack_rank(t.ndim, t.shape)?;
                 let sh = unsafe { std::slice::from_raw_parts(t.shape, t.ndim as usize) };
                 let st = if t.strides.is_null() {
                     None
@@ -3535,6 +3543,19 @@ impl PyImageApi {
                 c
             )));
         }
+
+        // 8b. SECURITY: reject shapes whose host byte-extent would overflow `usize`.
+        //     `Backing::Borrowed` stores no length; `raw_bytes`/`u8_elems` recompute it
+        //     later with unchecked multiplication, so an overflowing product would wrap
+        //     to a small length over a larger (or smaller) real buffer. Check it once here.
+        h.checked_mul(w)
+            .and_then(|hw| hw.checked_mul(c))
+            .and_then(|hwc| hwc.checked_mul(dtype.itemsize()))
+            .ok_or_else(|| {
+                pyo3::exceptions::PyValueError::new_err(
+                    "from_dlpack: image dimensions overflow usize",
+                )
+            })?;
 
         // 9. Compute effective data pointer (with byte_offset).
         //    Null check must happen BEFORE adding byte_offset: null+nonzero produces a

--- a/kornia-py/src/normalize.rs
+++ b/kornia-py/src/normalize.rs
@@ -16,8 +16,7 @@ pub fn normalize_mean_std(
     let (mut out_img, out) = unsafe { alloc_output_pyarray_f32::<3>(py, size)? };
 
     py.detach(|| -> Result<(), ImageError> {
-        let mut dst_f32 =
-            Image::from_size_val(size, 0.0f32, kornia_image::allocator::host_alloc())?;
+        let mut dst_f32 = Image::from_size_val(size, 0.0f32)?;
         normalize::normalize_mean_std(&src_f32, &mut dst_f32, &mean, &std)?;
         out_img
             .as_slice_mut()

--- a/kornia-py/src/normalize.rs
+++ b/kornia-py/src/normalize.rs
@@ -1,7 +1,7 @@
 use pyo3::prelude::*;
 
 use crate::image::{alloc_output_pyarray_f32, numpy_to_f32_image, to_pyerr, PyImage, PyImageF32};
-use kornia_image::{allocator::CpuAllocator, Image, ImageError};
+use kornia_image::{Image, ImageError};
 use kornia_imgproc::normalize;
 
 #[pyfunction]
@@ -16,7 +16,8 @@ pub fn normalize_mean_std(
     let (mut out_img, out) = unsafe { alloc_output_pyarray_f32::<3>(py, size)? };
 
     py.detach(|| -> Result<(), ImageError> {
-        let mut dst_f32 = Image::from_size_val(size, 0.0f32, CpuAllocator)?;
+        let mut dst_f32 =
+            Image::from_size_val(size, 0.0f32, kornia_image::allocator::host_alloc())?;
         normalize::normalize_mean_std(&src_f32, &mut dst_f32, &mean, &std)?;
         out_img
             .as_slice_mut()

--- a/kornia-py/src/orb.rs
+++ b/kornia-py/src/orb.rs
@@ -1,7 +1,7 @@
 use numpy::{PyArray, PyArray1, PyArray2, PyArray3, PyArrayMethods, PyUntypedArrayMethods};
 use pyo3::prelude::*;
 
-use kornia_image::{allocator::CpuAllocator, Image, ImageSize};
+use kornia_image::{Image, ImageSize};
 use kornia_imgproc::{
     color::gray_from_rgb_u8,
     features::{fast_detect_rows_u8, OrbDetector},
@@ -161,7 +161,7 @@ pub fn fast_detect(
 fn image_to_gray_u8(
     py: Python<'_>,
     image: Bound<'_, pyo3::types::PyAny>,
-) -> PyResult<Image<u8, 1, CpuAllocator>> {
+) -> PyResult<Image<u8, 1>> {
     if let Ok(arr) = image.cast::<PyArray2<u8>>() {
         if !arr.is_c_contiguous() {
             return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
@@ -175,7 +175,8 @@ fn image_to_gray_u8(
             width: w,
             height: h,
         };
-        return Image::from_size_slice(size, slice, CpuAllocator).map_err(to_pyerr);
+        return Image::from_size_slice(size, slice, kornia_image::allocator::host_alloc())
+            .map_err(to_pyerr);
     }
 
     if let Ok(arr) = image.cast::<PyArray3<u8>>() {
@@ -198,8 +199,10 @@ fn image_to_gray_u8(
         };
         let rgb_slice = unsafe { std::slice::from_raw_parts(arr.data(), h * w * 3) };
         let rgb_img =
-            Image::<u8, 3, _>::from_size_slice(size, rgb_slice, CpuAllocator).map_err(to_pyerr)?;
-        let mut gray = Image::from_size_val(size, 0u8, CpuAllocator).map_err(to_pyerr)?;
+            Image::<u8, 3>::from_size_slice(size, rgb_slice, kornia_image::allocator::host_alloc())
+                .map_err(to_pyerr)?;
+        let mut gray = Image::from_size_val(size, 0u8, kornia_image::allocator::host_alloc())
+            .map_err(to_pyerr)?;
         py.detach(|| gray_from_rgb_u8(&rgb_img, &mut gray))
             .map_err(to_pyerr)?;
         return Ok(gray);

--- a/kornia-py/src/orb.rs
+++ b/kornia-py/src/orb.rs
@@ -175,8 +175,7 @@ fn image_to_gray_u8(
             width: w,
             height: h,
         };
-        return Image::from_size_slice(size, slice, kornia_image::allocator::host_alloc())
-            .map_err(to_pyerr);
+        return Image::from_size_slice(size, slice).map_err(to_pyerr);
     }
 
     if let Ok(arr) = image.cast::<PyArray3<u8>>() {
@@ -198,11 +197,8 @@ fn image_to_gray_u8(
             height: h,
         };
         let rgb_slice = unsafe { std::slice::from_raw_parts(arr.data(), h * w * 3) };
-        let rgb_img =
-            Image::<u8, 3>::from_size_slice(size, rgb_slice, kornia_image::allocator::host_alloc())
-                .map_err(to_pyerr)?;
-        let mut gray = Image::from_size_val(size, 0u8, kornia_image::allocator::host_alloc())
-            .map_err(to_pyerr)?;
+        let rgb_img = Image::<u8, 3>::from_size_slice(size, rgb_slice).map_err(to_pyerr)?;
+        let mut gray = Image::from_size_val(size, 0u8).map_err(to_pyerr)?;
         py.detach(|| gray_from_rgb_u8(&rgb_img, &mut gray))
             .map_err(to_pyerr)?;
         return Ok(gray);

--- a/kornia-py/src/warp.rs
+++ b/kornia-py/src/warp.rs
@@ -2,7 +2,7 @@ use numpy::PyUntypedArrayMethods;
 use pyo3::prelude::*;
 
 use crate::image::{alloc_output_pyarray, numpy_as_image, parse_interpolation, to_pyerr, PyImage};
-use kornia_image::{allocator::ForeignAllocator, Image, ImageError, ImageSize};
+use kornia_image::{Image, ImageError, ImageSize};
 use kornia_imgproc::warp;
 
 fn warp_dispatch<const C: usize, F>(
@@ -14,11 +14,7 @@ fn warp_dispatch<const C: usize, F>(
     op: F,
 ) -> PyResult<PyImage>
 where
-    F: Send
-        + FnOnce(
-            &Image<u8, C, ForeignAllocator>,
-            &mut Image<u8, C, ForeignAllocator>,
-        ) -> Result<(), ImageError>,
+    F: Send + FnOnce(&Image<u8, C>, &mut Image<u8, C>) -> Result<(), ImageError>,
 {
     let new_size = ImageSize {
         height: new_size.0,

--- a/kornia-py/tests/test_dlpack.py
+++ b/kornia-py/tests/test_dlpack.py
@@ -119,14 +119,59 @@ def test_dlpack_import_shape():
     assert img.width == 5
 
 
-def test_dlpack_import_rejects_non_cpu():
-    """Importing a non-CPU tensor must raise NotImplementedError."""
+def test_dlpack_cuda_device_passthrough():
+    """A CUDA tensor imports as a *device* image (zero-copy pass-through):
+
+    - import succeeds (no longer rejected),
+    - ``__dlpack_device__`` reports kDLCUDA (device_type == 2),
+    - host operations (e.g. ``.numpy()``) raise rather than dereference device memory,
+    - it re-exports back to a CUDA torch tensor sharing the same device buffer.
+    """
     torch = pytest.importorskip("torch")
     if not torch.cuda.is_available():
-        pytest.skip("CUDA not available — skipping non-CPU device rejection test")
-    t = torch.zeros((4, 4, 3), dtype=torch.uint8, device="cuda")
-    with pytest.raises((NotImplementedError, Exception)):
-        Image.from_dlpack(t)
+        pytest.skip("CUDA not available — skipping device pass-through test")
+
+    t = torch.arange(4 * 5 * 3, dtype=torch.uint8, device="cuda").reshape(4, 5, 3)
+    img = Image.from_dlpack(t)
+
+    # kDLCUDA == 2; device id matches the source.
+    dev_type, dev_id = img.__dlpack_device__()
+    assert dev_type == 2, f"expected kDLCUDA (2), got {dev_type}"
+    assert dev_id in (t.device.index, 0)
+
+    # Host ops must refuse a device image (no host deref of device memory).
+    with pytest.raises(Exception):
+        img.numpy()
+    with pytest.raises(Exception):
+        img.tobytes()
+
+    # Re-export back to torch: still CUDA, same underlying device pointer (zero-copy).
+    t2 = torch.from_dlpack(img)
+    assert t2.is_cuda
+    assert t2.data_ptr() == t.data_ptr(), "device re-export is not zero-copy"
+
+
+def test_dlpack_host_image_rejects_cross_device_export_request():
+    """Requesting a non-CPU export device from a host image must be rejected."""
+    arr = np.ascontiguousarray(np.zeros((7, 5, 3), np.uint8))
+    img = Image.from_numpy(arr, copy=True)
+    # __dlpack__(dl_device=(kDLCUDA, 0)) on a host image must not silently succeed.
+    with pytest.raises(Exception):
+        img.__dlpack__(dl_device=(2, 0))
+
+
+def test_dlpack_import_rejects_bad_rank():
+    """from_dlpack must reject non-2D/3D tensors.
+
+    Exercises the `validate_dlpack_rank` guard that bounds the producer-supplied
+    `ndim` before it is used as a slice length (a negative/oversized `ndim` would
+    otherwise be UB / an out-of-bounds read). 1D and 4D numpy arrays are honest
+    producers that still drive the rank check — no GPU required.
+    """
+    for shape in [(10,), (2, 2, 2, 2), (1, 2, 3, 4, 5)]:
+        arr = np.ascontiguousarray(np.zeros(shape, np.uint8))
+        with pytest.raises((ValueError, Exception)):
+            Image.from_dlpack(arr)
 
 
 def test_dlpack_import_rejects_unsupported_dtype():


### PR DESCRIPTION
## Summary

Removes the compile-time `A: TensorAllocator` generic from `TensorStorage<T,A>`, `Tensor<T,N,A>`, and `Image<T,C,A>`, replacing it with a runtime `AllocHandle = Arc<dyn TensorAllocator>` carried by the storage. Adds the std-style `_in` constructor convention so the common host case needs **no** allocator argument.

### Motivation — three real blockers
- **DLPack device import** was walled off by a `require_cpu` / `A == CpuAllocator` compile-time guard.
- **Heterogeneous collections** (`Vec<Image<u8,3>>` mixing CPU + GPU) were impossible with distinct `A` types.
- **`cast` / `element_wise_op` / `as_contiguous`** silently hardcoded `CpuAllocator` output, dropping device provenance.

## Design

**Runtime handle, not a type param**
- `AllocHandle = Arc<dyn TensorAllocator>`. `TensorAllocator` is object-safe (one non-generic method, `Send + Sync`, no `Clone` supertrait), so the handle needs no separate shim.
- Hot path untouched: `as_ptr`/`as_slice`/indexing read a cached `NonNull<T>`; the `Arc` is only touched on construction/drop.
- Memory safety moves from compile-time to a runtime domain gate: `as_slice`/`as_mut_slice` assert host-accessibility (panic on `Device`), matching candle/tch.

**Host-default constructors (`_in` convention, mirrors `Vec::new` / `Vec::new_in`)**
```rust
let t = Tensor::<f32, 2>::from_shape_vec([2, 3], data)?;          // host, zero boilerplate
let t = Tensor::<f32, 2>::from_shape_vec_in([2, 3], data, alloc)?; // explicit/custom allocator
let img = Image::<u8, 3>::new(size, data)?;                        // host default
let dev: Tensor<u8, 3> = cpu.to_cuda(&stream)?;                    // device stays stream-based
```
- Converted to default + `_in`: `Tensor::{from_shape_vec, from_shape_slice, from_shape_val, from_shape_fn, zeros}`, `Image::{new, from_size_val, from_size_slice}`, and the typed color-space ctors (`from_size_vec`, `from_size_val`).
- Low-level / non-host paths keep an explicit allocator: `from_vec`, `from_resource`, `from_borrowed[_readonly]`, `from_raw_parts`, all CUDA/DLPack constructors.
- ~142 `host_alloc()` boilerplate call sites collapsed to the default form.

**CUDA / foreign memory**
- CUDA ctors (`to_cuda`, `zeros_cuda`, `from_cudaslice`) take a `&CudaStream` and build the `CudaAllocator` handle internally — the stream is the meaningful input, not a handle.
- Foreign buffers (numpy, GStreamer, DLPack) are adopted via `ForeignResource` in `owner: Box<dyn MemoryResource>`; the old `ForeignAllocator` type tag is removed.

## Cleanups folded in
- Deleted `AllocDyn` (object-safe shim no longer needed after dropping the `Clone` supertrait) → `AllocHandle = Arc<dyn TensorAllocator>`.
- `host_alloc()`: `OnceLock` + `get_or_init` → `LazyLock` (process-global `Arc<CpuAllocator>`, O(1) clone).
- Removed `ForeignAllocator` and `ImageAllocator`; `kornia_image::allocator` slimmed to a `host_alloc`/`AllocHandle`/`CpuAllocator` re-export shim for backward compat.
- `as_contiguous`/`cast`/`element_wise_op` propagate the source tensor's handle; `element_wise_op` adds an explicit domain-mismatch check.
- Misc review fixes: `from_shape_slice` delegates to `from_shape_vec`; `from_borrowed`/`from_borrowed_readonly` share a private helper; `Tensor::cast` capacity fixed (elements, not bytes); dropped a no-op `Drop`.

## Scope
178 files: `kornia-tensor`, `kornia-image`, `kornia-imgproc`, `kornia-3d`, `kornia-apriltag`, `kornia-tensor-ops`, `kornia-vlm`, `kornia-io`, `kornia-py`, `kornia-cpp`, examples and benches. The apriltag changes here are mechanical migration fallout (kornia-apriltag is load-bearing for kornia-py); detector work lives on a separate branch.

## Test plan
- [x] `cargo build --workspace --all-targets`
- [x] `cargo clippy --workspace --no-deps --all-targets --features ci -- -D warnings`
- [x] `cargo test --workspace --doc`
- [x] `cargo fmt --all --check`
- [x] CI: 27/27 green (Linux x86_64/aarch64, macOS, Windows, all C++, py3.8–3.14t, wheels)

🤖 Generated with [Claude Code](https://claude.com/claude-code)