### PR TITLE
refactor(apriltag): migrate to allocator-less Image<T,C> API

### DIFF
--- a/crates/kornia-apriltag/benches/bench_decoding.rs
+++ b/crates/kornia-apriltag/benches/bench_decoding.rs
@@ -1,7 +1,7 @@
 use apriltag::DetectorBuilder;
 use criterion::{criterion_group, criterion_main, Criterion};
 use kornia_apriltag::{family::TagFamilyKind, AprilTagDecoder, DecodeTagsConfig};
-use kornia_image::{allocator::CpuAllocator, Image};
+use kornia_image::{allocator::host_alloc, Image};
 use kornia_imgproc::color::gray_from_rgb_u8;
 use kornia_io::jpeg::read_image_jpeg_rgb8;
 use std::path::PathBuf;
@@ -12,7 +12,7 @@ fn bench_decoding(c: &mut Criterion) {
 
     // Kornia
     let img = read_image_jpeg_rgb8(img_path).unwrap();
-    let mut gray_img = Image::from_size_val(img.size(), 0, CpuAllocator).unwrap();
+    let mut gray_img = Image::from_size_val(img.size(), 0, host_alloc()).unwrap();
     gray_from_rgb_u8(&img, &mut gray_img).unwrap();
 
     let kornia_detector_config = DecodeTagsConfig::new(vec![TagFamilyKind::Tag36H11]).unwrap();

--- a/crates/kornia-apriltag/src/decoder.rs
+++ b/crates/kornia-apriltag/src/decoder.rs
@@ -7,7 +7,7 @@ use crate::{
     utils::value_for_pixel,
 };
 use kornia_algebra::Mat3F32;
-use kornia_image::{allocator::ImageAllocator, Image};
+use kornia_image::Image;
 
 /// Represents a model for grayscale interpolation using a quadratic surface.
 /// The model fits a function of the form f(x, y) = c.x*x + c.y*y + c.z.
@@ -345,8 +345,8 @@ impl SharpeningBuffer {
 /// # Returns
 ///
 /// Returns a vector of `Detection` containing information about each successfully decoded tag.
-pub fn decode_tags<A: ImageAllocator>(
-    src: &Image<u8, 1, A>,
+pub fn decode_tags(
+    src: &Image<u8, 1>,
     quads: &mut [Quad],
     tag_families: &mut [(TagFamilyKind, TagFamily)],
     refine_edges_enabled: bool,
@@ -421,7 +421,7 @@ pub fn decode_tags<A: ImageAllocator>(
 /// * `src` - Reference to the grayscale source image.
 /// * `quad` - Mutable reference to the quadrilateral to refine.
 // TODO: Consider moving this somewhere in kornia-imgproc.
-fn refine_edges<A: ImageAllocator>(src: &Image<u8, 1, A>, quad: &mut Quad) {
+fn refine_edges(src: &Image<u8, 1>, quad: &mut Quad) {
     let src_slice = src.as_slice();
     let mut lines: [[f32; 4]; 4] = Default::default();
 
@@ -596,8 +596,8 @@ fn refine_edges<A: ImageAllocator>(src: &Image<u8, 1, A>, quad: &mut Quad) {
 /// # Returns
 ///
 /// Returns `Some(f32)` containing the decision margin if decoding is successful, or `None` otherwise.
-fn quad_decode<A: ImageAllocator>(
-    src: &Image<u8, 1, A>,
+fn quad_decode(
+    src: &Image<u8, 1>,
     tag_family: &mut TagFamily,
     quad: &Quad,
     decode_sharpening: f32,
@@ -930,7 +930,7 @@ mod tests {
         utils::Pixel,
     };
     use kornia_algebra::Vec2F32;
-    use kornia_image::allocator::CpuAllocator;
+    use kornia_image::allocator::host_alloc;
     use kornia_io::png::read_image_png_mono8;
 
     const EPSILON: f32 = 0.0001;
@@ -941,7 +941,11 @@ mod tests {
         config.downscale_factor = 1;
         let src = read_image_png_mono8("../../tests/data/apriltag.png")?;
 
-        let mut bin = Image::from_size_val(src.size(), Pixel::Skip, CpuAllocator)?;
+        let mut bin = Image::from_size_val(
+            src.size(),
+            Pixel::Skip,
+            kornia_image::allocator::host_alloc(),
+        )?;
         let mut tile_min_max = TileMinMax::new(bin.size(), 4);
         let mut uf = UnionFind::new(bin.as_slice().len());
         let mut clusters = HashMap::new();

--- a/crates/kornia-apriltag/src/iter.rs
+++ b/crates/kornia-apriltag/src/iter.rs
@@ -2,7 +2,7 @@ use crate::{
     errors::AprilTagError,
     utils::{find_total_tiles, Point2d},
 };
-use kornia_image::{allocator::ImageAllocator, Image, ImageSize};
+use kornia_image::{Image, ImageSize};
 
 /// A lightweight, zero-allocation view into a rectangular sub-region of image data.
 ///
@@ -188,8 +188,8 @@ impl<'a, T> TileIterator<'a, T> {
     ///
     /// Returns a `TileIterator` that yields non-overlapping tiles of the specified size from the image.
     /// Tiles at the image edges may be smaller if the image dimensions are not multiples of the tile size.
-    pub fn from_image<const C: usize, A: ImageAllocator>(
-        img: &'a Image<T, C, A>,
+    pub fn from_image<const C: usize>(
+        img: &'a Image<T, C>,
         tile_size: usize,
     ) -> Result<Self, AprilTagError> {
         let img_size = img.size();
@@ -292,18 +292,18 @@ impl<'a, T> Iterator for TileIterator<'a, T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kornia_image::{allocator::CpuAllocator, Image, ImageSize};
+    use kornia_image::{Image, ImageSize};
 
     #[test]
     fn test_tile_iterator_basic() -> Result<(), Box<dyn std::error::Error>> {
         let data = vec![127u8; 100];
-        let image: Image<_, 1, _> = Image::new(
+        let image: Image<_, 1> = Image::new(
             ImageSize {
                 width: 25,
                 height: 4,
             },
             data,
-            CpuAllocator,
+            kornia_image::allocator::host_alloc(),
         )?;
 
         let tile_iter = TileIterator::from_image(&image, 4)?;
@@ -340,19 +340,19 @@ mod tests {
             26, 27, 28, 29, 30,
             31, 32, 33, 34, 35,
         ];
-        let img: Image<_, 1, _> = Image::new(
+        let img: Image<_, 1> = Image::new(
             ImageSize {
                 width: 5,
                 height: 7,
             },
             data,
-            CpuAllocator,
+            kornia_image::allocator::host_alloc(),
         )?;
 
         let mut iter = TileIterator::from_image(&img, 2)?;
 
         macro_rules! test_iter_next {
-            ($variant:ident, $x:expr, $y:expr, $index:expr, $full_index:expr, $rows:expr) => {
+            ($variant:ident, $x:expr_2021, $y:expr_2021, $index:expr_2021, $full_index:expr_2021, $rows:expr_2021) => {
                 let next = iter
                     .next()
                     .ok_or("Failed to get the next value from iterator")?;
@@ -396,13 +396,13 @@ mod tests {
 
     #[test]
     fn test_invalid_image() -> Result<(), Box<dyn std::error::Error>> {
-        let img: Image<_, 1, _> = Image::from_size_val(
+        let img: Image<_, 1> = Image::from_size_val(
             ImageSize {
                 width: 3,
                 height: 4,
             },
             0,
-            CpuAllocator,
+            kornia_image::allocator::host_alloc(),
         )?;
 
         let tile_iterator = TileIterator::from_image(&img, 4);

--- a/crates/kornia-apriltag/src/lib.rs
+++ b/crates/kornia-apriltag/src/lib.rs
@@ -3,10 +3,7 @@
 
 use std::collections::HashMap;
 
-use kornia_image::{
-    allocator::{CpuAllocator, ImageAllocator},
-    Image, ImageSize,
-};
+use kornia_image::{Image, ImageSize};
 use kornia_imgproc::resize::resize_fast_mono;
 
 use crate::{
@@ -144,8 +141,8 @@ impl DecodeTagsConfig {
 pub struct AprilTagDecoder {
     config: DecodeTagsConfig,
     cached_families: Vec<(TagFamilyKind, TagFamily)>,
-    downscale_img: Option<Image<u8, 1, CpuAllocator>>,
-    bin_img: Image<Pixel, 1, CpuAllocator>,
+    downscale_img: Option<Image<u8, 1>>,
+    bin_img: Image<Pixel, 1>,
     tile_min_max: TileMinMax,
     uf: UnionFind,
     clusters: HashMap<(usize, usize), Vec<GradientInfo>>,
@@ -189,7 +186,11 @@ impl AprilTagDecoder {
 
             (
                 new_size,
-                Some(Image::from_size_val(new_size, 0, CpuAllocator)?),
+                Some(Image::from_size_val(
+                    new_size,
+                    0,
+                    kornia_image::allocator::host_alloc(),
+                )?),
             )
         };
 
@@ -204,7 +205,8 @@ impl AprilTagDecoder {
             })
             .collect();
 
-        let bin_img = Image::from_size_val(img_size, Pixel::Skip, CpuAllocator)?;
+        let bin_img =
+            Image::from_size_val(img_size, Pixel::Skip, kornia_image::allocator::host_alloc())?;
         let tile_min_max = TileMinMax::new(img_size, 4);
         let uf = UnionFind::new(img_size.width * img_size.height);
 
@@ -234,10 +236,7 @@ impl AprilTagDecoder {
     ///
     /// If you are running this method multiple times on the same decoder instance,
     /// you should call [`AprilTagDecoder::clear`] between runs to reset internal state.
-    pub fn decode<A: ImageAllocator>(
-        &mut self,
-        src: &Image<u8, 1, A>,
-    ) -> Result<Vec<Detection>, AprilTagError> {
+    pub fn decode(&mut self, src: &Image<u8, 1>) -> Result<Vec<Detection>, AprilTagError> {
         if let Some(downscale_img) = self.downscale_img.as_mut() {
             resize_fast_mono(
                 src,

--- a/crates/kornia-apriltag/src/quad.rs
+++ b/crates/kornia-apriltag/src/quad.rs
@@ -4,7 +4,7 @@ use crate::{
     DecodeTagsConfig,
 };
 use kornia_algebra::{Mat3F32, Vec3F32};
-use kornia_image::{allocator::ImageAllocator, Image};
+use kornia_image::Image;
 use kornia_imgproc::filter::kernels::gaussian_kernel_1d;
 use std::{
     collections::HashMap,
@@ -118,8 +118,8 @@ impl Quad {
 ///
 /// A vector of detected `Quad` structures.
 // TODO: Support multiple tag families
-pub fn fit_quads<A: ImageAllocator>(
-    src: &Image<Pixel, 1, A>,
+pub fn fit_quads(
+    src: &Image<Pixel, 1>,
     clusters: &mut HashMap<(usize, usize), Vec<GradientInfo>>,
     config: &DecodeTagsConfig,
 ) -> Vec<Quad> {
@@ -175,8 +175,8 @@ pub fn fit_quads<A: ImageAllocator>(
 /// # Returns
 ///
 /// An `Option<Quad>` containing the detected quadrilateral if successful, or `None` otherwise.
-fn fit_single_quad<A: ImageAllocator>(
-    src: &Image<Pixel, 1, A>,
+fn fit_single_quad(
+    src: &Image<Pixel, 1>,
     cluster: &mut [GradientInfo],
     min_tag_width: usize,
     normal_border: bool,
@@ -406,8 +406,8 @@ struct LineFit {
 /// # Returns
 ///
 /// A vector of `LineFit` structures containing prefix sums for each point.
-fn compute_line_fit_prefix_sums<A: ImageAllocator>(
-    src: &Image<Pixel, 1, A>,
+fn compute_line_fit_prefix_sums(
+    src: &Image<Pixel, 1>,
     gradient_infos: &[GradientInfo],
 ) -> Vec<LineFit> {
     let src_slice = src.as_slice();
@@ -787,7 +787,7 @@ fn fit_line(
 
 #[cfg(test)]
 mod tests {
-    use kornia_image::allocator::CpuAllocator;
+    use kornia_image::allocator::host_alloc;
     use kornia_io::png::read_image_png_mono8;
 
     use crate::{
@@ -806,7 +806,11 @@ mod tests {
     fn test_fit_quads() -> Result<(), Box<dyn std::error::Error>> {
         let src = read_image_png_mono8("../../tests/data/apriltag.png")?;
 
-        let mut bin = Image::from_size_val(src.size(), Pixel::Skip, CpuAllocator)?;
+        let mut bin = Image::from_size_val(
+            src.size(),
+            Pixel::Skip,
+            kornia_image::allocator::host_alloc(),
+        )?;
         let mut tile_min_max = TileMinMax::new(src.size(), 4);
         let mut uf = UnionFind::new(src.as_slice().len());
         let mut clusters = HashMap::new();
@@ -898,7 +902,11 @@ mod tests {
     #[test]
     fn test_quad_segment_maxima() -> Result<(), Box<dyn std::error::Error>> {
         let src = read_image_png_mono8("../../tests/data/apriltag.png")?;
-        let mut bin = Image::from_size_val(src.size(), Pixel::Skip, CpuAllocator)?;
+        let mut bin = Image::from_size_val(
+            src.size(),
+            Pixel::Skip,
+            kornia_image::allocator::host_alloc(),
+        )?;
         let mut tile_min_max = TileMinMax::new(src.size(), 4);
         let mut uf = UnionFind::new(src.as_slice().len());
         let mut clusters = HashMap::new();
@@ -1049,7 +1057,12 @@ mod tests {
             width: 4,
             height: 4,
         };
-        let img = Image::<Pixel, 1, _>::from_size_val(size, Pixel::White, CpuAllocator).unwrap();
+        let img = Image::<Pixel, 1>::from_size_val(
+            size,
+            Pixel::White,
+            kornia_image::allocator::host_alloc(),
+        )
+        .unwrap();
 
         // Test 1: Single point
         let gradient_infos = vec![GradientInfo {

--- a/crates/kornia-apriltag/src/segmentation.rs
+++ b/crates/kornia-apriltag/src/segmentation.rs
@@ -5,7 +5,7 @@ use crate::{
     union_find::UnionFind,
     utils::{Pixel, Point2d},
 };
-use kornia_image::{allocator::ImageAllocator, Image};
+use kornia_image::Image;
 
 /// Finds connected components in a binary image using union-find.
 ///
@@ -18,8 +18,8 @@ use kornia_image::{allocator::ImageAllocator, Image};
 /// # Returns
 ///
 /// * `Result<(), AprilTagError>` - Returns `Ok(())` if successful, or an error if the union-find size is invalid.
-pub fn find_connected_components<A: ImageAllocator>(
-    src: &Image<Pixel, 1, A>,
+pub fn find_connected_components(
+    src: &Image<Pixel, 1>,
     uf: &mut UnionFind,
 ) -> Result<(), AprilTagError> {
     let src_size = src.size();
@@ -150,8 +150,8 @@ impl Pixel {
 /// * `uf` - Mutable reference to a [`UnionFind`] structure for tracking connected components.
 /// * `clusters` - Mutable reference to a map where the gradient information between component pairs will be stored.
 ///   Make sure to call [`HashMap::clear`] if you are using this function multiple times with the same `clusters`
-pub fn find_gradient_clusters<A: ImageAllocator>(
-    src: &Image<Pixel, 1, A>,
+pub fn find_gradient_clusters(
+    src: &Image<Pixel, 1>,
     uf: &mut UnionFind,
     clusters: &mut HashMap<(usize, usize), Vec<GradientInfo>>,
 ) {
@@ -237,7 +237,7 @@ pub fn find_gradient_clusters<A: ImageAllocator>(
 mod tests {
     use super::*;
     use crate::threshold::{adaptive_threshold, TileMinMax};
-    use kornia_image::{allocator::CpuAllocator, ImageSize};
+    use kornia_image::ImageSize;
     use kornia_io::png::read_image_png_mono8;
 
     #[test]
@@ -257,7 +257,7 @@ mod tests {
                 height: 4,
             },
             bin_data,
-            CpuAllocator,
+            kornia_image::allocator::host_alloc(),
         )?;
 
         let mut uf = UnionFind::new(20);
@@ -290,7 +290,11 @@ mod tests {
     #[test]
     fn test_segmentation() -> Result<(), Box<dyn std::error::Error>> {
         let src = read_image_png_mono8("../../tests/data/apriltag.png")?;
-        let mut bin = Image::from_size_val(src.size(), Pixel::Skip, CpuAllocator)?;
+        let mut bin = Image::from_size_val(
+            src.size(),
+            Pixel::Skip,
+            kornia_image::allocator::host_alloc(),
+        )?;
 
         let mut tile_min_max = TileMinMax::new(src.size(), 4);
         adaptive_threshold(&src, &mut bin, &mut tile_min_max, 20)?;
@@ -323,7 +327,11 @@ mod tests {
     #[test]
     fn test_gradient_clusters() -> Result<(), Box<dyn std::error::Error>> {
         let src = read_image_png_mono8("../../tests/data/apriltag.png")?;
-        let mut bin = Image::from_size_val(src.size(), Pixel::Skip, CpuAllocator)?;
+        let mut bin = Image::from_size_val(
+            src.size(),
+            Pixel::Skip,
+            kornia_image::allocator::host_alloc(),
+        )?;
 
         let mut tile_min_max = TileMinMax::new(src.size(), 4);
         adaptive_threshold(&src, &mut bin, &mut tile_min_max, 20)?;

--- a/crates/kornia-apriltag/src/threshold.rs
+++ b/crates/kornia-apriltag/src/threshold.rs
@@ -1,7 +1,7 @@
 use crate::iter::ImageTile;
 use crate::utils::{find_full_tiles, Pixel, Point2d};
 use crate::{errors::AprilTagError, iter::TileIterator};
-use kornia_image::{allocator::ImageAllocator, Image, ImageError, ImageSize};
+use kornia_image::{Image, ImageError, ImageSize};
 
 /// Stores the minimum and maximum pixel values for each tile for [adaptive_threshold]
 ///
@@ -163,7 +163,7 @@ impl TileMinMax {
 /// # Examples
 ///
 /// ```
-/// use kornia_image::{allocator::CpuAllocator, Image, ImageSize};
+/// use kornia_image::{Image, ImageSize};
 /// use kornia_apriltag::threshold::{adaptive_threshold, TileMinMax};
 /// use kornia_apriltag::utils::Pixel;
 ///
@@ -173,19 +173,19 @@ impl TileMinMax {
 ///         height: 3,
 ///     },
 ///     vec![0, 50, 100, 150, 200, 250],
-///     CpuAllocator,
+///     kornia_image::allocator::host_alloc(),
 /// )
 /// .unwrap();
-/// let mut dst = Image::from_size_val(src.size(), Pixel::Skip, CpuAllocator).unwrap();
+/// let mut dst = Image::from_size_val(src.size(), Pixel::Skip, kornia_image::allocator::host_alloc()).unwrap();
 ///
 /// let mut tile_buffers = TileMinMax::new(src.size(), 2);
 /// adaptive_threshold(&src, &mut dst, &mut tile_buffers, 20).unwrap();
 /// assert_eq!(dst.as_slice(), &[0, 0, 255, 255, 255, 255]);
 /// ```
 // TODO: Add support for parallelism
-pub fn adaptive_threshold<A1: ImageAllocator, A2: ImageAllocator>(
-    src: &Image<u8, 1, A1>,
-    dst: &mut Image<Pixel, 1, A2>,
+pub fn adaptive_threshold(
+    src: &Image<u8, 1>,
+    dst: &mut Image<Pixel, 1>,
     tile_min_max: &mut TileMinMax,
     min_white_black_diff: u8,
 ) -> Result<(), AprilTagError> {
@@ -316,7 +316,7 @@ pub fn adaptive_threshold<A1: ImageAllocator, A2: ImageAllocator>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kornia_image::{allocator::CpuAllocator, ImageSize};
+    use kornia_image::ImageSize;
     use kornia_io::png::read_image_png_mono8;
 
     #[test]
@@ -355,9 +355,13 @@ mod tests {
                 100, 150, 200, 250, 0,
                 80,  127, 221, 20,  100,
             ],
-            CpuAllocator,
+            kornia_image::allocator::host_alloc(),
         )?;
-        let mut dst = Image::from_size_val(src.size(), Pixel::Skip, CpuAllocator)?;
+        let mut dst = Image::from_size_val(
+            src.size(),
+            Pixel::Skip,
+            kornia_image::allocator::host_alloc(),
+        )?;
 
         let mut tile_buffers = TileMinMax::new(src.size(), 2);
         adaptive_threshold(&src, &mut dst, &mut tile_buffers, 20)?;
@@ -384,9 +388,13 @@ mod tests {
                 height: 4,
             },
             vec![100; 16],
-            CpuAllocator,
+            kornia_image::allocator::host_alloc(),
         )?;
-        let mut dst = Image::from_size_val(src.size(), Pixel::Skip, CpuAllocator)?;
+        let mut dst = Image::from_size_val(
+            src.size(),
+            Pixel::Skip,
+            kornia_image::allocator::host_alloc(),
+        )?;
 
         let mut tile_buffers = TileMinMax::new(src.size(), 2);
         adaptive_threshold(&src, &mut dst, &mut tile_buffers, 20)?;
@@ -397,7 +405,11 @@ mod tests {
     #[test]
     fn test_adaptive_threshold_synthetic_image() -> Result<(), Box<dyn std::error::Error>> {
         let src = read_image_png_mono8("../../tests/data/apriltag.png")?;
-        let mut bin = Image::from_size_val(src.size(), Pixel::Skip, CpuAllocator)?;
+        let mut bin = Image::from_size_val(
+            src.size(),
+            Pixel::Skip,
+            kornia_image::allocator::host_alloc(),
+        )?;
 
         let mut tile_buffers = TileMinMax::new(src.size(), 4);
         adaptive_threshold(&src, &mut bin, &mut tile_buffers, 20)?;
@@ -413,9 +425,17 @@ mod tests {
             height: 4,
         };
 
-        let src = Image::new(img_size, vec![100u8; 16], CpuAllocator)?;
+        let src = Image::new(
+            img_size,
+            vec![100u8; 16],
+            kornia_image::allocator::host_alloc(),
+        )?;
 
-        let mut dst = Image::from_size_val(img_size, Pixel::default(), CpuAllocator)?;
+        let mut dst = Image::from_size_val(
+            img_size,
+            Pixel::default(),
+            kornia_image::allocator::host_alloc(),
+        )?;
 
         let mut tile_buffers = TileMinMax::new(
             ImageSize {

--- a/crates/kornia-apriltag/src/utils.rs
+++ b/crates/kornia-apriltag/src/utils.rs
@@ -2,7 +2,7 @@
 // such as kornia-linalg, or another location we decide on later.
 
 use kornia_algebra::Mat3F32;
-use kornia_image::{allocator::ImageAllocator, Image, ImageSize};
+use kornia_image::{Image, ImageSize};
 
 /// Calculates the total number of tiles needed to cover an image of the given size,
 /// including partial tiles at the edges.
@@ -175,10 +175,7 @@ pub(crate) fn homography_compute(c: [[f32; 4]; 4]) -> Option<Mat3F32> {
 ///
 /// An `Option<f32>` containing the interpolated pixel value, or `None` if the coordinate is out of bounds.
 // TODO: Make interpolate function in kornia-imgproc generic and use that instead
-pub(crate) fn value_for_pixel<A: ImageAllocator>(
-    src: &Image<u8, 1, A>,
-    p: kornia_algebra::Vec2F32,
-) -> Option<f32> {
+pub(crate) fn value_for_pixel(src: &Image<u8, 1>, p: kornia_algebra::Vec2F32) -> Option<f32> {
     let src_slice = src.as_slice();
 
     let x1 = (p.x - 0.5).floor() as isize;

--- a/examples/apriltag/src/main.rs
+++ b/examples/apriltag/src/main.rs
@@ -1,9 +1,5 @@
 use argh::FromArgs;
-use kornia::{
-    image::{allocator::CpuAllocator, Image},
-    imgproc::color::gray_from_rgb_u8,
-    io::functional::read_image_any_rgb8,
-};
+use kornia::{image::Image, imgproc::color::gray_from_rgb_u8, io::functional::read_image_any_rgb8};
 use kornia_apriltag::{family::TagFamilyKind, AprilTagDecoder, DecodeTagsConfig};
 
 /// Detects AprilTags in an image
@@ -61,7 +57,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let img = read_image_any_rgb8(args.path)?;
 
-    let mut grayscale_img = Image::from_size_val(img.size(), 0, CpuAllocator)?;
+    let mut grayscale_img =
+        Image::from_size_val(img.size(), 0, kornia::image::allocator::host_alloc())?;
     gray_from_rgb_u8(&img, &mut grayscale_img)?;
 
     let mut config = DecodeTagsConfig::new(args.kind)?;


### PR DESCRIPTION
## Summary

Isolated view of the **kornia-apriltag** delta from the allocator-removal migration (#955), split out for focused review.

Mechanical changes only:
- Drop `A: ImageAllocator` type params from public fns (`adaptive_threshold`, `fit_quads`, `find_connected_components`, `find_gradient_clusters`, `decode_tags`, …)
- Replace `CpuAllocator` construction values with `host_alloc()`
- Update `examples/apriltag` to the new API

## ⚠️ Does not compile standalone

kornia-apriltag is load-bearing for kornia-py and depends on the `Image<T, C>` signature change that lands in #955. This branch exists for **isolated review of the apriltag delta only** — the actual change ships in #955.

🤖 Generated with [Claude Code](https://claude.com/claude-code)