### PR TITLE
feat(imgproc): GPU image→tensor preprocessor + cudarc kernel ergonomics

### DIFF
--- a/crates/kornia-imgproc/Cargo.toml
+++ b/crates/kornia-imgproc/Cargo.toml
@@ -112,6 +112,11 @@ ndarray = { workspace = true, features = ["rayon"] }
 rand = { workspace = true }
 
 [features]
+# cudarc device backend + custom CUDA kernels (enables the `preprocess` module).
+cudarc = [
+  "dep:cudarc",
+  "kornia-tensor/cudarc",
+]
 gpu-cubecl = [
   "dep:cubecl",
   "dep:cubecl-cpu",

--- a/crates/kornia-imgproc/examples/bench_gpu_resize.rs
+++ b/crates/kornia-imgproc/examples/bench_gpu_resize.rs
@@ -17,7 +17,6 @@
 //! cargo run --example bench_gpu_resize --features gpu-cubecl,gpu-cuda --release
 //! ```
 
-use kornia_image::allocator::CpuAllocator;
 use kornia_image::{Image, ImageSize};
 use kornia_imgproc::interpolation::InterpolationMode;
 use kornia_imgproc::resize::resize_native;
@@ -98,7 +97,6 @@ fn run_cpu() {
                 height: sh as usize,
             },
             src_data,
-            CpuAllocator,
         )
         .expect("src image");
         let mut dst = Image::<f32, 3>::from_size_val(
@@ -107,7 +105,6 @@ fn run_cpu() {
                 height: dh as usize,
             },
             0.0,
-            CpuAllocator,
         )
         .expect("dst image");
 
@@ -202,7 +199,6 @@ fn run_gpu() {
                     height: sh as usize,
                 },
                 src_data,
-                CpuAllocator,
             )
             .expect("cpu src image");
             let mut dst_cpu = Image::<f32, 3>::from_size_val(
@@ -211,7 +207,6 @@ fn run_gpu() {
                     height: dh as usize,
                 },
                 0.0,
-                CpuAllocator,
             )
             .expect("cpu dst image");
             for _ in 0..WARMUP {

--- a/crates/kornia-imgproc/examples/bench_gpu_warp_affine.rs
+++ b/crates/kornia-imgproc/examples/bench_gpu_warp_affine.rs
@@ -7,7 +7,6 @@
 //! cargo run --example bench_gpu_warp_affine --features gpu-cuda --release
 //! ```
 
-use kornia_image::allocator::CpuAllocator;
 use kornia_image::{Image, ImageSize};
 use kornia_imgproc::{
     interpolation::InterpolationMode,
@@ -126,7 +125,6 @@ fn run_cpu() {
                     height: h as usize,
                 },
                 src_data,
-                CpuAllocator,
             )
             .expect("src");
             let mut dst = Image::<f32, 3>::from_size_val(
@@ -135,7 +133,6 @@ fn run_cpu() {
                     height: h as usize,
                 },
                 0.0,
-                CpuAllocator,
             )
             .expect("dst");
 

--- a/crates/kornia-imgproc/src/lib.rs
+++ b/crates/kornia-imgproc/src/lib.rs
@@ -57,6 +57,13 @@ pub mod normalize;
 /// utility functions for resizing images.
 pub mod resize;
 
+/// GPU image → model-input preprocessing (resize + pad + normalize to CHW f32).
+///
+/// Enabled by the `cudarc` feature. Runs entirely on the device via kornia's
+/// custom-CUDA-kernel API — see [`preprocess::Preprocessor`].
+#[cfg(feature = "cudarc")]
+pub mod preprocess;
+
 /// operations to threshold images.
 pub mod threshold;
 

--- a/crates/kornia-imgproc/src/preprocess.rs
+++ b/crates/kornia-imgproc/src/preprocess.rs
@@ -1,0 +1,226 @@
+//! GPU image → model-input preprocessing: resize (+ optional pad) and normalize a
+//! device-resident [`Image`] straight into a CHW `f32` [`Tensor`] in one CUDA kernel.
+//!
+//! This is the step every CNN / transformer vision model needs before inference:
+//! take a camera frame of arbitrary size and produce the fixed `[1, 3, H, W]`
+//! CHW `f32` tensor the network expects, in `[0, 1]` RGB. It runs entirely on the
+//! GPU (kornia's [`CudaKernel`]) with no host round-trip — the source image
+//! already lives on the device (`image.to_cuda(&stream)`), and the output tensor
+//! is written in place so it can be reused frame to frame.
+//!
+//! Enabled by the `cudarc` feature.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use std::sync::Arc;
+//! use cudarc::driver::CudaContext;
+//! use kornia_image::Image;
+//! use kornia_tensor::zeros_cuda;
+//! use kornia_imgproc::preprocess::Preprocessor;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let stream = CudaContext::new(0)?.default_stream();
+//!
+//! // Build once (compiles the kernel); reuse across frames.
+//! let pre = Preprocessor::letterbox(stream.clone())?;
+//!
+//! // Model input buffer, allocated once and reused.
+//! let mut input = zeros_cuda::<f32, 4>([1, 3, 640, 640], &stream)?;
+//!
+//! // Per frame: upload the camera image and preprocess into `input`.
+//! # let host: Image<u8, 3> = Image::from_size_val([1280, 720].into(), 0)?;
+//! let frame = Image(host.0.to_cuda(&stream)?);   // device-resident Image<u8, 3>
+//! pre.run(&frame, &mut input)?;                  // input is now [1,3,640,640] RGB [0,1]
+//! # Ok(())
+//! # }
+//! ```
+
+use std::sync::Arc;
+
+use cudarc::driver::CudaStream;
+use kornia_image::Image;
+use kornia_tensor::{CudaError, CudaKernel, Tensor};
+
+/// How the source image is fit into the model's output rectangle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResizeMode {
+    /// Aspect-preserving scale + grey (114) pad — the YOLO / XFeat convention.
+    /// The whole image is kept; the unused border is filled with grey.
+    Letterbox,
+    /// Anisotropic stretch to the full target, no padding — the RT-DETR / RF-DETR
+    /// convention. The aspect ratio is not preserved.
+    Stretch,
+}
+
+/// Errors from GPU preprocessing.
+#[derive(Debug, thiserror::Error)]
+pub enum PreprocessError {
+    /// A CUDA error from kernel compilation or launch.
+    #[error("CUDA error: {0}")]
+    Cuda(#[from] CudaError),
+    /// The source image is host-resident; call `image.to_cuda(&stream)` first.
+    #[error("source image is not device-resident (call `.to_cuda(&stream)` first)")]
+    NotDeviceImage,
+    /// The destination tensor is host-resident; allocate it with `zeros_cuda`.
+    #[error("destination tensor is not device-resident")]
+    NotDeviceTensor,
+}
+
+// 1-D grid over the `dst_w * dst_h` output pixels. The (ox, oy) pair is recovered
+// from the flat index — consecutive threads map to consecutive `ox`, so global
+// writes stay coalesced. Reads interleaved 3-byte RGB from linear device memory
+// with a hand-rolled bilinear sample (CUDA textures only support 1/2/4-channel
+// elements, not 3) and writes channel-planar (CHW) `f32` in `[0, 1]`.
+const KERNEL_SRC: &str = r#"
+extern "C" __global__ void resize_pad_to_chw_rgb8(
+    const unsigned char* __restrict__ src,
+    float* __restrict__ dst,
+    float scale_x, float scale_y, float pad_x, float pad_y,
+    int src_w, int src_h, int src_pitch,
+    int dst_w, int dst_h
+) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    int pixels = dst_w * dst_h;
+    if (i >= pixels) return;
+    int ox = i % dst_w;
+    int oy = i / dst_w;
+
+    float sx = ((float)ox - pad_x) / scale_x;
+    float sy = ((float)oy - pad_y) / scale_y;
+
+    if (sx < 0.0f || sy < 0.0f || sx >= (float)src_w || sy >= (float)src_h) {
+        float g = 114.0f / 255.0f;
+        dst[i] = g; dst[pixels + i] = g; dst[2*pixels + i] = g;
+        return;
+    }
+
+    // Bilinear with clamp-to-edge (texel-center convention).
+    int x0 = (int)floorf(sx), y0 = (int)floorf(sy);
+    float ax = sx - (float)x0, ay = sy - (float)y0;
+    int x1 = min(x0 + 1, src_w - 1), y1 = min(y0 + 1, src_h - 1);
+    x0 = max(x0, 0); y0 = max(y0, 0);
+
+    const unsigned char* r0 = src + (long)y0 * src_pitch;
+    const unsigned char* r1 = src + (long)y1 * src_pitch;
+    #pragma unroll
+    for (int c = 0; c < 3; ++c) {
+        float v00 = (float)r0[x0 * 3 + c], v10 = (float)r0[x1 * 3 + c];
+        float v01 = (float)r1[x0 * 3 + c], v11 = (float)r1[x1 * 3 + c];
+        float top = v00 + (v10 - v00) * ax;
+        float bot = v01 + (v11 - v01) * ax;
+        dst[c * pixels + i] = (top + (bot - top) * ay) / 255.0f;
+    }
+}
+"#;
+
+/// GPU image-to-tensor preprocessor: resize (+ optional pad) + normalize.
+///
+/// Built once for a [`ResizeMode`] (compiles the CUDA kernel for the device
+/// behind its stream), then applied to any number of frames of any resolution via
+/// [`run`](Self::run). It owns only the JIT-compiled kernel and its stream — no
+/// per-frame buffers — so a single instance handles every input size and any
+/// model size (the target H/W is read from the destination tensor each call).
+///
+/// The output is RGB in `[0, 1]`, CHW (`[1, 3, H, W]`). For models that expect a
+/// further mean/std normalization (e.g. ImageNet), apply it as a second step on
+/// the resulting tensor.
+pub struct Preprocessor {
+    kernel: CudaKernel,
+    stream: Arc<CudaStream>,
+    mode: ResizeMode,
+}
+
+impl Preprocessor {
+    /// Build a preprocessor that **letterboxes** (aspect-preserving resize + grey
+    /// pad) on `stream`. Compiles the kernel once (nvrtc JIT; CUDA caches the PTX).
+    pub fn letterbox(stream: Arc<CudaStream>) -> Result<Self, PreprocessError> {
+        Self::with_mode(stream, ResizeMode::Letterbox)
+    }
+
+    /// Build a preprocessor that **stretches** (anisotropic resize, no pad) on
+    /// `stream` — for models trained on a square stretch (e.g. RF-DETR).
+    pub fn stretch(stream: Arc<CudaStream>) -> Result<Self, PreprocessError> {
+        Self::with_mode(stream, ResizeMode::Stretch)
+    }
+
+    /// Build a preprocessor for an explicit [`ResizeMode`] on `stream`.
+    pub fn with_mode(stream: Arc<CudaStream>, mode: ResizeMode) -> Result<Self, PreprocessError> {
+        let ctx = stream.context();
+        let kernel = CudaKernel::compile(ctx, KERNEL_SRC, "resize_pad_to_chw_rgb8")?;
+        Ok(Self {
+            kernel,
+            stream,
+            mode,
+        })
+    }
+
+    /// The CUDA stream this preprocessor launches on.
+    pub fn stream(&self) -> &Arc<CudaStream> {
+        &self.stream
+    }
+
+    /// The resize mode this preprocessor applies.
+    pub fn mode(&self) -> ResizeMode {
+        self.mode
+    }
+
+    /// Resize `src` into `dst` (`[1, 3, H, W]` CHW `f32`, RGB in `[0, 1]`).
+    ///
+    /// The target H/W is read from `dst`'s shape, so one preprocessor handles any
+    /// model size. Both `src` and `dst` must be device-resident (the image via
+    /// `to_cuda`, the tensor via `zeros_cuda`).
+    ///
+    /// # Errors
+    ///
+    /// [`PreprocessError::NotDeviceImage`] / [`PreprocessError::NotDeviceTensor`]
+    /// if either operand is host-resident, or [`PreprocessError::Cuda`] on a CUDA
+    /// launch failure.
+    pub fn run(&self, src: &Image<u8, 3>, dst: &mut Tensor<f32, 4>) -> Result<(), PreprocessError> {
+        let (dst_h, dst_w) = (dst.shape[2], dst.shape[3]);
+        let (src_w, src_h) = (src.width(), src.height());
+
+        let (scale_x, scale_y, pad_x, pad_y) = match self.mode {
+            ResizeMode::Letterbox => {
+                let s = f32::min(dst_w as f32 / src_w as f32, dst_h as f32 / src_h as f32);
+                (
+                    s,
+                    s,
+                    (dst_w as f32 - src_w as f32 * s) * 0.5,
+                    (dst_h as f32 - src_h as f32 * s) * 0.5,
+                )
+            }
+            ResizeMode::Stretch => (
+                dst_w as f32 / src_w as f32,
+                dst_h as f32 / src_h as f32,
+                0.0,
+                0.0,
+            ),
+        };
+
+        let src_slice = src.as_cudaslice().ok_or(PreprocessError::NotDeviceImage)?;
+        let dst_slice = dst
+            .as_cudaslice_mut()
+            .ok_or(PreprocessError::NotDeviceTensor)?;
+
+        let (sw, sh, sp) = (src_w as i32, src_h as i32, (src_w * 3) as i32);
+        let (dw, dh) = (dst_w as i32, dst_h as i32);
+        let total = (dst_w * dst_h) as u32;
+
+        self.kernel
+            .launch_builder(&self.stream)
+            .arg(src_slice)
+            .arg(dst_slice)
+            .arg(&scale_x)
+            .arg(&scale_y)
+            .arg(&pad_x)
+            .arg(&pad_y)
+            .arg(&sw)
+            .arg(&sh)
+            .arg(&sp)
+            .arg(&dw)
+            .arg(&dh)
+            .launch_1d(total)?;
+        Ok(())
+    }
+}

--- a/crates/kornia-tensor/src/cuda.rs
+++ b/crates/kornia-tensor/src/cuda.rs
@@ -50,8 +50,8 @@ use std::{
 };
 
 use cudarc::driver::{
-    CudaContext, CudaFunction, CudaSlice, CudaStream, DevicePtr, DeviceRepr, LaunchArgs,
-    LaunchConfig, PushKernelArg, ValidAsZeroBits,
+    CudaContext, CudaFunction, CudaModule, CudaSlice, CudaStream, DevicePtr, DeviceRepr,
+    LaunchArgs, LaunchConfig, PushKernelArg, ValidAsZeroBits,
 };
 use cudarc::nvrtc::{compile_ptx_with_opts, CompileOptions};
 
@@ -202,6 +202,40 @@ impl CudaKernel {
     /// Returns [`CudaError::Driver`] on nvrtc compile failure or module/function
     /// load failure.
     pub fn compile(ctx: &Arc<CudaContext>, src: &str, fn_name: &str) -> Result<Self, CudaError> {
+        let module = Self::load_module(ctx, src)?;
+        // `load_function` returns a `CudaFunction` that holds its own
+        // `Arc<CudaModule>`, so `module` may drop at the end of this scope.
+        let func = module
+            .load_function(fn_name)
+            .map_err(|e| CudaError::Driver(e.to_string()))?;
+
+        Ok(CudaKernel { func })
+    }
+
+    /// Compile `src` **once** and load several `extern "C" __global__` functions
+    /// from it — for a source file that defines a whole kernel suite (NMS, top-K,
+    /// matching, …). Returns one [`CudaKernel`] per name, in order. Avoids paying
+    /// the nvrtc compile cost once per function.
+    pub fn compile_many(
+        ctx: &Arc<CudaContext>,
+        src: &str,
+        fn_names: &[&str],
+    ) -> Result<Vec<Self>, CudaError> {
+        let module = Self::load_module(ctx, src)?;
+        fn_names
+            .iter()
+            .map(|name| {
+                module
+                    .load_function(name)
+                    .map(|func| CudaKernel { func })
+                    .map_err(|e| CudaError::Driver(e.to_string()))
+            })
+            .collect()
+    }
+
+    /// nvrtc-compile `src` and load the module on `ctx`'s device, with the target
+    /// arch (`compute_XY`) auto-detected from the device's compute capability.
+    fn load_module(ctx: &Arc<CudaContext>, src: &str) -> Result<Arc<CudaModule>, CudaError> {
         // Detect arch from the context's device.
         let (major, minor) = ctx
             .compute_capability()
@@ -236,16 +270,8 @@ impl CudaKernel {
         )
         .map_err(|e| CudaError::Driver(format!("{e:?}")))?;
 
-        let module = ctx
-            .load_module(ptx)
-            .map_err(|e| CudaError::Driver(e.to_string()))?;
-        // `load_function` returns a `CudaFunction` that holds its own
-        // `Arc<CudaModule>`, so `module` may drop at the end of this scope.
-        let func = module
-            .load_function(fn_name)
-            .map_err(|e| CudaError::Driver(e.to_string()))?;
-
-        Ok(CudaKernel { func })
+        ctx.load_module(ptx)
+            .map_err(|e| CudaError::Driver(e.to_string()))
     }
 
     /// Create a [`CudaLaunchBuilder`] pre-bound to this kernel and the given stream.
@@ -318,13 +344,25 @@ impl<'a> CudaLaunchBuilder<'a> {
     /// # Errors
     ///
     /// Returns [`CudaError::Driver`] on CUDA launch failure.
-    pub fn launch_1d(mut self, n: u32) -> Result<(), CudaError> {
+    pub fn launch_1d(self, n: u32) -> Result<(), CudaError> {
         const BLOCK: u32 = 256;
         let cfg = LaunchConfig {
             block_dim: (BLOCK, 1, 1),
             grid_dim: (n.div_ceil(BLOCK), 1, 1),
             shared_mem_bytes: 0,
         };
+        self.launch_cfg(cfg)
+    }
+
+    /// Launch with an explicit [`LaunchConfig`] — for kernels that need a specific
+    /// grid/block shape or shared memory (2-D image kernels, one-block-per-item
+    /// cooperative reductions, fixed-block-size tiled kernels) that `launch_1d`'s
+    /// flat 256-thread blocks cannot express.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CudaError::Driver`] on CUDA launch failure.
+    pub fn launch_cfg(mut self, cfg: LaunchConfig) -> Result<(), CudaError> {
         // SAFETY: The caller is responsible for ensuring the kernel arguments match
         // the kernel's parameter list in type, count, and alignment.
         unsafe { self.inner.launch(cfg) }
@@ -358,8 +396,10 @@ impl<'a> CudaLaunchBuilder<'a> {
 
 /// Allocate a zero-initialised device tensor with shape `shape` on `stream`.
 ///
-/// Uses [`CudaAllocator`] (which calls `stream.alloc_zeros::<u8>`) so all bytes
-/// are guaranteed to be zero on the device.
+/// The storage is backed by a typed [`CudaResource<T>`], so the resulting tensor's
+/// [`as_cudaslice`](Tensor::as_cudaslice) / [`as_cudaslice_mut`](Tensor::as_cudaslice_mut)
+/// return `Some(&CudaSlice<T>)` — the tensor can be passed straight as a kernel
+/// argument or written in place, with no `from_cudaslice` round-trip.
 ///
 /// # Type parameters
 ///
@@ -382,9 +422,10 @@ where
     let numel: usize = shape.iter().product();
     let n_bytes = numel * std::mem::size_of::<T>();
 
-    // Allocate zero-initialised device memory via the stream.
-    let slice: CudaSlice<u8> = stream
-        .alloc_zeros::<u8>(n_bytes)
+    // Allocate zero-initialised, **typed** device memory so the storage is backed
+    // by `CudaResource<T>` (not `CudaResource<u8>`) — `as_cudaslice::<T>()` then works.
+    let slice: CudaSlice<T> = stream
+        .alloc_zeros::<T>(numel)
         .map_err(|e| CudaError::Driver(e.to_string()))?;
 
     // Cache device pointer before moving `slice` into CudaResource.
@@ -395,7 +436,7 @@ where
         // _sync drops here
     };
 
-    let resource = CudaResource::<u8> { slice, ptr, id };
+    let resource = CudaResource::<T> { slice, ptr, id };
     let alloc: AllocHandle = Arc::new(CudaAllocator {
         ctx: ctx.clone(),
         stream: stream.clone(),
@@ -731,12 +772,12 @@ mod tests {
             "mutation through as_cudaslice_mut must be observable after to_host"
         );
 
-        // None branch: `zeros_cuda` always stores a `CudaResource<u8>`, so an i16 device
-        // tensor's owner does NOT downcast to `CudaResource<i16>` — the mutable query is None.
+        // `zeros_cuda` stores a TYPED `CudaResource<i16>`, so an i16 device tensor's
+        // owner downcasts to `CudaResource<i16>` — the mutable query is Some.
         let mut dev_i16: Tensor<i16, 1> = zeros_cuda([4], &stream).unwrap();
         assert!(
-            dev_i16.as_cudaslice_mut().is_none(),
-            "zeros_cuda stores CudaResource<u8>; querying as CudaSlice<i16> must be None"
+            dev_i16.as_cudaslice_mut().is_some(),
+            "zeros_cuda stores CudaResource<i16>; querying as CudaSlice<i16> must be Some"
         );
     }
 


### PR DESCRIPTION
## What

Adds a user-friendly GPU preprocessing op to `kornia-imgproc` plus the
`kornia-tensor` ergonomics it needs to be usable end-to-end.

### `kornia_imgproc::preprocess::Preprocessor` (feature `cudarc`)
The resize(+pad)+normalize step every vision model needs before inference: turn a
device-resident `Image<u8, 3>` into the `[1, 3, H, W]` CHW `f32` (`[0,1]` RGB)
tensor the network expects, in **one custom CUDA kernel**, no host round-trip.

```rust
let pre = Preprocessor::letterbox(stream.clone())?;        // or ::stretch
let mut input = zeros_cuda::<f32, 4>([1, 3, 640, 640], &stream)?;
let frame = Image(host.0.to_cuda(&stream)?);
pre.run(&frame, &mut input)?;                              // input: [1,3,640,640] RGB [0,1]
```

One instance handles any source resolution and any model size (target H/W read
from the destination tensor) and is reusable across frames.

### `kornia-tensor`
- **`CudaKernel::compile_many`** — compile a source once, load many `__global__`
  functions from the module (a kernel suite pays nvrtc once, not per function).
- **`CudaLaunchBuilder::launch_cfg(LaunchConfig)`** — explicit grid/block/shared
  for 2-D image kernels and one-block-per-item cooperative reductions that
  `launch_1d`'s fixed 256-thread block can't express.
- **`zeros_cuda` typed backing** — its storage is now a typed `CudaResource<T>`
  (was `CudaResource<u8>`), so `as_cudaslice::<T>()` / `as_cudaslice_mut::<T>()` /
  `to_host::<T>()` work on its result. Previously a device-resident
  `zeros_cuda::<f32,4>` tensor reported `None` from `as_cudaslice::<f32>()`.

### Workspace
Centralize the `cudarc` dependency (0.19, shared feature set) at
`[workspace.dependencies]`; `kornia-tensor` and `kornia-imgproc` reference
`{ workspace = true }` so versions/features can't drift.

## Test plan
- `cargo test -p kornia-tensor --features cudarc` — 8/8 cuda tests pass on Jetson
  Orin (incl. the updated typed-backing assertion).
- `cargo test --doc -p kornia-imgproc --features cudarc` — 51/51 doctests pass
  (incl. the new `Preprocessor` example).
- Exercised end-to-end by a downstream TensorRT pipeline (RF-DETR, XFeat, OSNet
  ReID, RF-DETR keypoints) running all preprocessing + custom kernels through
  this API on real engines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)