### PR TITLE
fix(kornia-apriltag): dedup drops repeated tag ids — spatial overlap dedup

### DIFF
--- a/crates/kornia-apriltag/PARITY.md
+++ b/crates/kornia-apriltag/PARITY.md
@@ -28,6 +28,7 @@ Key C files: `apriltag.c`, `apriltag_quad_thresh.c`, `common/image_u8.c`, `commo
 | `decode_sharpening` default | `lib.rs:109` | MATCH | Both default to `0.25` |
 | `refine_edges` enabled default | `lib.rs:107` | MATCH | Both default to `true` |
 | `quad_decimate` default | `lib.rs:76` | MATCH (effective) | C default=2.0; Rust `DEFAULT_DOWNSCALE_FACTOR=2` |
+| reconcile / dedup (apriltag.c Step 3) | `decoder.rs` `dedup_detections` | **DIVERGENCE D6** (intentional) | Same semantics (repeated non-overlapping ids survive; best hamming/margin wins per overlap cluster); overlap predicate is a center-distance heuristic, not C's exact `g2d_polygon_overlaps_polygon` |
 
 ---
 
@@ -154,6 +155,18 @@ back at the end. Should be done if the numeric parity test (Task A2) shows bit-d
 disagreements attributable to homography precision.
 
 ---
+
+### D6. Detection reconcile — overlap predicate (LOW, intentional)
+
+C's `apriltag_detect` Step 3 dedups detections that share family+id AND whose
+quads pass `g2d_polygon_overlaps_polygon` (exact convex-polygon intersection);
+non-overlapping repeats of the same id all survive. Rust `dedup_detections`
+mirrors the semantics but approximates the overlap test: centers closer than
+half the mean of the two quads' 0→2 diagonals. Duplicate candidates originate
+from the same physical quad boundary, so their centers nearly coincide — the
+approximation only diverges for strongly perspective-skewed overlapping quads.
+Exact SAT-based quad overlap (~25 lines) is the upgrade path if a parity count
+mismatch ever appears on skewed repeated-tag scenes.
 
 ## Intentional Omissions
 

--- a/crates/kornia-apriltag/examples/nmaxima_sweep.rs
+++ b/crates/kornia-apriltag/examples/nmaxima_sweep.rs
@@ -26,69 +26,47 @@ fn detections_for(nmaxima: usize, gray: &Image<u8, 1>) -> Vec<Detection> {
     out
 }
 
-fn parity(base: &[Detection], cand: &[Detection]) -> (bool, String) {
+fn parity(base: &[Detection], cand: &[Detection]) -> Option<String> {
     if base.len() != cand.len() {
-        return (false, format!("count {} vs {}", base.len(), cand.len()));
+        return Some(format!("count {} vs {}", base.len(), cand.len()));
     }
     for (b, c) in base.iter().zip(cand) {
         if b.id != c.id || b._family_idx != c._family_idx {
-            return (false, format!("id mismatch {} vs {}", b.id, c.id));
+            return Some(format!("id mismatch {} vs {}", b.id, c.id));
         }
         let dx = (b.center.x - c.center.x).abs();
         let dy = (b.center.y - c.center.y).abs();
         if dx > 0.5 || dy > 0.5 {
-            return (
-                false,
-                format!("id {} center off by ({dx:.3},{dy:.3})", b.id),
-            );
+            return Some(format!("id {} center off by ({dx:.3},{dy:.3})", b.id));
         }
     }
-    (true, String::new())
+    None
 }
 
-fn main() {
-    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../tests/data");
-    let images = ["apriltags_tag36h11.jpg"];
+/// `decode_timed` stage order: [decimate, threshold, conn_comp, gradient,
+/// fit_quads, decode_tags].
+const FIT_QUADS_STAGE: usize = 4;
 
-    let grays: Vec<(String, Image<u8, 1>)> = images
-        .iter()
-        .map(|name| {
-            let img = read_image_any_rgb8(root.join(name)).unwrap();
-            let mut gray = Image::from_size_val(img.size(), 0).unwrap();
-            gray_from_rgb_u8(&img, &mut gray).unwrap();
-            (name.to_string(), gray)
-        })
-        .collect();
+fn main() {
+    let img_path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../tests/data/apriltags_tag36h11.jpg");
+    let img = read_image_any_rgb8(img_path).unwrap();
+    let mut gray = Image::<u8, 1>::from_size_val(img.size(), 0).unwrap();
+    gray_from_rgb_u8(&img, &mut gray).unwrap();
 
     // Baseline detections at the C-default nmaxima=10.
-    let baselines: Vec<Vec<Detection>> = grays.iter().map(|(_, g)| detections_for(10, g)).collect();
-    for ((name, _), base) in grays.iter().zip(&baselines) {
-        println!("{name}: {} baseline detections", base.len());
-    }
-
-    // Timing target: bench image, fit_quads stage (index 4 of decode_timed).
-    let bench_gray = &grays[0].1;
+    let base = detections_for(10, &gray);
+    println!("apriltags_tag36h11.jpg: {} baseline detections", base.len());
 
     for nmaxima in [10usize, 8, 6, 5, 4] {
-        // Parity across all images.
-        let mut ok = true;
-        let mut why = String::new();
-        for ((name, gray), base) in grays.iter().zip(&baselines) {
-            let cand = detections_for(nmaxima, gray);
-            let (p, reason) = parity(base, &cand);
-            if !p {
-                ok = false;
-                why = format!("{name}: {reason}");
-                break;
-            }
-        }
+        let why = parity(&base, &detections_for(nmaxima, &gray));
 
         // fit_quads timing: min over batches (least scheduler noise).
         let mut config = DecodeTagsConfig::new(vec![TagFamilyKind::Tag36H11]).unwrap();
         config.fit_quad_config.max_nmaxima = nmaxima;
-        let mut det = AprilTagDecoder::new(config, bench_gray.size()).unwrap();
+        let mut det = AprilTagDecoder::new(config, gray.size()).unwrap();
         for _ in 0..20 {
-            let _ = det.decode_timed(bench_gray).unwrap();
+            let _ = det.decode_timed(&gray).unwrap();
             det.clear();
         }
         let mut best_fit = u64::MAX;
@@ -98,9 +76,9 @@ fn main() {
             let mut total_us = 0u64;
             const N: usize = 50;
             for _ in 0..N {
-                let (_, us) = det.decode_timed(bench_gray).unwrap();
+                let (_, us) = det.decode_timed(&gray).unwrap();
                 det.clear();
-                fit_us += us[4];
+                fit_us += us[FIT_QUADS_STAGE];
                 total_us += us.iter().sum::<u64>();
             }
             best_fit = best_fit.min(fit_us / N as u64);
@@ -108,10 +86,9 @@ fn main() {
         }
         println!(
             "nmaxima={nmaxima:>2}: fit_quads {best_fit:>4} µs  total {best_total:>5} µs  parity {}",
-            if ok {
-                "OK".into()
-            } else {
-                format!("FAIL ({why})")
+            match &why {
+                None => "OK".to_string(),
+                Some(w) => format!("FAIL ({w})"),
             }
         );
     }

--- a/crates/kornia-apriltag/examples/nmaxima_sweep.rs
+++ b/crates/kornia-apriltag/examples/nmaxima_sweep.rs
@@ -1,0 +1,118 @@
+//! Sweep `FitQuadConfig::max_nmaxima` and report speed vs detection parity.
+//!
+//! For each candidate value: run the detector over the test images, compare
+//! the detection set (family, id, center within 0.5 px) against the
+//! nmaxima=10 baseline, and time the fit_quads stage on the bench image.
+
+use kornia_apriltag::{
+    decoder::Detection, family::TagFamilyKind, AprilTagDecoder, DecodeTagsConfig,
+};
+use kornia_image::Image;
+use kornia_imgproc::color::gray_from_rgb_u8;
+use kornia_io::functional::read_image_any_rgb8;
+use std::path::PathBuf;
+
+fn detections_for(nmaxima: usize, gray: &Image<u8, 1>) -> Vec<Detection> {
+    let mut config = DecodeTagsConfig::new(vec![
+        TagFamilyKind::Tag36H11,
+        TagFamilyKind::Tag16H5,
+        TagFamilyKind::TagStandard41H12,
+    ])
+    .unwrap();
+    config.fit_quad_config.max_nmaxima = nmaxima;
+    let mut det = AprilTagDecoder::new(config, gray.size()).unwrap();
+    let mut out = det.decode(gray).unwrap();
+    out.sort_by_key(|d| (d._family_idx, d.id));
+    out
+}
+
+fn parity(base: &[Detection], cand: &[Detection]) -> (bool, String) {
+    if base.len() != cand.len() {
+        return (false, format!("count {} vs {}", base.len(), cand.len()));
+    }
+    for (b, c) in base.iter().zip(cand) {
+        if b.id != c.id || b._family_idx != c._family_idx {
+            return (false, format!("id mismatch {} vs {}", b.id, c.id));
+        }
+        let dx = (b.center.x - c.center.x).abs();
+        let dy = (b.center.y - c.center.y).abs();
+        if dx > 0.5 || dy > 0.5 {
+            return (
+                false,
+                format!("id {} center off by ({dx:.3},{dy:.3})", b.id),
+            );
+        }
+    }
+    (true, String::new())
+}
+
+fn main() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../tests/data");
+    let images = ["apriltags_tag36h11.jpg"];
+
+    let grays: Vec<(String, Image<u8, 1>)> = images
+        .iter()
+        .map(|name| {
+            let img = read_image_any_rgb8(root.join(name)).unwrap();
+            let mut gray = Image::from_size_val(img.size(), 0).unwrap();
+            gray_from_rgb_u8(&img, &mut gray).unwrap();
+            (name.to_string(), gray)
+        })
+        .collect();
+
+    // Baseline detections at the C-default nmaxima=10.
+    let baselines: Vec<Vec<Detection>> = grays.iter().map(|(_, g)| detections_for(10, g)).collect();
+    for ((name, _), base) in grays.iter().zip(&baselines) {
+        println!("{name}: {} baseline detections", base.len());
+    }
+
+    // Timing target: bench image, fit_quads stage (index 4 of decode_timed).
+    let bench_gray = &grays[0].1;
+
+    for nmaxima in [10usize, 8, 6, 5, 4] {
+        // Parity across all images.
+        let mut ok = true;
+        let mut why = String::new();
+        for ((name, gray), base) in grays.iter().zip(&baselines) {
+            let cand = detections_for(nmaxima, gray);
+            let (p, reason) = parity(base, &cand);
+            if !p {
+                ok = false;
+                why = format!("{name}: {reason}");
+                break;
+            }
+        }
+
+        // fit_quads timing: min over batches (least scheduler noise).
+        let mut config = DecodeTagsConfig::new(vec![TagFamilyKind::Tag36H11]).unwrap();
+        config.fit_quad_config.max_nmaxima = nmaxima;
+        let mut det = AprilTagDecoder::new(config, bench_gray.size()).unwrap();
+        for _ in 0..20 {
+            let _ = det.decode_timed(bench_gray).unwrap();
+            det.clear();
+        }
+        let mut best_fit = u64::MAX;
+        let mut best_total = u64::MAX;
+        for _ in 0..5 {
+            let mut fit_us = 0u64;
+            let mut total_us = 0u64;
+            const N: usize = 50;
+            for _ in 0..N {
+                let (_, us) = det.decode_timed(bench_gray).unwrap();
+                det.clear();
+                fit_us += us[4];
+                total_us += us.iter().sum::<u64>();
+            }
+            best_fit = best_fit.min(fit_us / N as u64);
+            best_total = best_total.min(total_us / N as u64);
+        }
+        println!(
+            "nmaxima={nmaxima:>2}: fit_quads {best_fit:>4} µs  total {best_total:>5} µs  parity {}",
+            if ok {
+                "OK".into()
+            } else {
+                format!("FAIL ({why})")
+            }
+        );
+    }
+}

--- a/crates/kornia-apriltag/src/decoder.rs
+++ b/crates/kornia-apriltag/src/decoder.rs
@@ -455,51 +455,42 @@ pub fn decode_tags(
         .collect()
 }
 
-/// Deduplicates a list of detections, keeping the best (lowest hamming, then highest margin)
-/// per `(family_idx, id)` pair — matching C's `apriltag_detect` dedup behaviour.
+/// Deduplicates detections, keeping the best (lowest hamming, then highest
+/// margin) per cluster of **spatially overlapping** detections that share
+/// `(family_idx, id)`. Repeated ids at distinct locations all survive —
+/// mirrors C `apriltag_detect`'s reconcile step ("allow non-overlapping
+/// duplicate detections"), with a center-distance approximation of C's exact
+/// polygon-overlap test (see PARITY.md, D6).
 pub fn dedup_detections(all: Vec<Detection>) -> Vec<Detection> {
-    // The same physical tag is often decoded from several overlapping quads,
-    // but the SAME id can also legitimately appear at several places in the
-    // scene (repeated markers). Two detections are duplicates only when they
-    // share family+id AND overlap spatially — keying by id alone would keep
-    // one tag per id and silently drop every repeat (the C library keeps
-    // them). O(n²) over the per-frame detection count, which is small.
+    // O(n²) over the per-frame detection count, which is small.
     let mut kept: Vec<Detection> = Vec::with_capacity(all.len());
-    'outer: for det in all {
-        for prev in kept.iter_mut() {
-            if prev._family_idx == det._family_idx
-                && prev.id == det.id
-                && quads_overlap(&prev.quad, &det.quad)
-            {
+    for det in all {
+        match kept.iter_mut().find(|prev| is_duplicate(prev, &det)) {
+            Some(prev) => {
                 if det.hamming < prev.hamming
                     || (det.hamming == prev.hamming && det.decision_margin > prev.decision_margin)
                 {
                     *prev = det;
                 }
-                continue 'outer;
             }
+            None => kept.push(det),
         }
-        kept.push(det);
     }
     kept
 }
 
-/// Duplicate test for [`dedup_detections`]: quad centers closer than half the
-/// mean of the two quads' diagonals — i.e. the quads materially overlap.
-/// Distinct physical tags of the same id sit at least a tag width apart.
-fn quads_overlap(a: &Quad, b: &Quad) -> bool {
-    fn center_and_diag(q: &Quad) -> (f32, f32, f32) {
-        let cx = (q.corners[0].x + q.corners[1].x + q.corners[2].x + q.corners[3].x) * 0.25;
-        let cy = (q.corners[0].y + q.corners[1].y + q.corners[2].y + q.corners[3].y) * 0.25;
-        let dx = q.corners[2].x - q.corners[0].x;
-        let dy = q.corners[2].y - q.corners[0].y;
-        (cx, cy, (dx * dx + dy * dy).sqrt())
+/// Duplicate test for [`dedup_detections`]: same family+id and (homography)
+/// centers closer than half the mean of the two quads' diagonals — i.e. the
+/// quads materially overlap. Distinct physical tags of the same id sit at
+/// least a tag width apart.
+fn is_duplicate(a: &Detection, b: &Detection) -> bool {
+    if a._family_idx != b._family_idx || a.id != b.id {
+        return false;
     }
-    let (ax, ay, ad) = center_and_diag(a);
-    let (bx, by, bd) = center_and_diag(b);
-    let dist2 = (ax - bx) * (ax - bx) + (ay - by) * (ay - by);
-    let thresh = 0.25 * (ad + bd); // half the mean diagonal
-    dist2 < thresh * thresh
+    let diag = |q: &Quad| (q.corners[2] - q.corners[0]).length();
+    let d = a.center - b.center;
+    let thresh = 0.25 * (diag(&a.quad) + diag(&b.quad)); // half the mean diagonal
+    d.dot(d) < thresh * thresh
 }
 
 /// Refines the edges of a quadrilateral in the image by adjusting its corners based on local image gradients.

--- a/crates/kornia-apriltag/src/decoder.rs
+++ b/crates/kornia-apriltag/src/decoder.rs
@@ -1005,13 +1005,15 @@ mod tests {
 
     fn det_at(x: f32, y: f32, size: f32, id: u16, margin: f32) -> Detection {
         let h = size * 0.5;
-        let mut quad = Quad::default();
-        quad.corners = [
-            Vec2F32::new(x - h, y + h),
-            Vec2F32::new(x + h, y + h),
-            Vec2F32::new(x + h, y - h),
-            Vec2F32::new(x - h, y - h),
-        ];
+        let quad = Quad {
+            corners: [
+                Vec2F32::new(x - h, y + h),
+                Vec2F32::new(x + h, y + h),
+                Vec2F32::new(x + h, y - h),
+                Vec2F32::new(x - h, y - h),
+            ],
+            ..Default::default()
+        };
         Detection {
             _family_idx: 0,
             tag_family_kind: TagFamilyKind::Tag36H11,

--- a/crates/kornia-apriltag/src/decoder.rs
+++ b/crates/kornia-apriltag/src/decoder.rs
@@ -1,8 +1,6 @@
 use rayon::prelude::*;
 use std::{f32::consts::PI, ops::ControlFlow};
 
-use rustc_hash::FxHashMap;
-
 use crate::{
     errors::AprilTagError,
     family::{TagFamily, TagFamilyKind},
@@ -460,22 +458,48 @@ pub fn decode_tags(
 /// Deduplicates a list of detections, keeping the best (lowest hamming, then highest margin)
 /// per `(family_idx, id)` pair — matching C's `apriltag_detect` dedup behaviour.
 pub fn dedup_detections(all: Vec<Detection>) -> Vec<Detection> {
-    let mut dedup: FxHashMap<(usize, u16), Detection> = FxHashMap::default();
-    for det in all {
-        match dedup.get_mut(&(det._family_idx, det.id)) {
-            None => {
-                dedup.insert((det._family_idx, det.id), det);
-            }
-            Some(prev) => {
+    // The same physical tag is often decoded from several overlapping quads,
+    // but the SAME id can also legitimately appear at several places in the
+    // scene (repeated markers). Two detections are duplicates only when they
+    // share family+id AND overlap spatially — keying by id alone would keep
+    // one tag per id and silently drop every repeat (the C library keeps
+    // them). O(n²) over the per-frame detection count, which is small.
+    let mut kept: Vec<Detection> = Vec::with_capacity(all.len());
+    'outer: for det in all {
+        for prev in kept.iter_mut() {
+            if prev._family_idx == det._family_idx
+                && prev.id == det.id
+                && quads_overlap(&prev.quad, &det.quad)
+            {
                 if det.hamming < prev.hamming
                     || (det.hamming == prev.hamming && det.decision_margin > prev.decision_margin)
                 {
                     *prev = det;
                 }
+                continue 'outer;
             }
         }
+        kept.push(det);
     }
-    dedup.into_values().collect()
+    kept
+}
+
+/// Duplicate test for [`dedup_detections`]: quad centers closer than half the
+/// mean of the two quads' diagonals — i.e. the quads materially overlap.
+/// Distinct physical tags of the same id sit at least a tag width apart.
+fn quads_overlap(a: &Quad, b: &Quad) -> bool {
+    fn center_and_diag(q: &Quad) -> (f32, f32, f32) {
+        let cx = (q.corners[0].x + q.corners[1].x + q.corners[2].x + q.corners[3].x) * 0.25;
+        let cy = (q.corners[0].y + q.corners[1].y + q.corners[2].y + q.corners[3].y) * 0.25;
+        let dx = q.corners[2].x - q.corners[0].x;
+        let dy = q.corners[2].y - q.corners[0].y;
+        (cx, cy, (dx * dx + dy * dy).sqrt())
+    }
+    let (ax, ay, ad) = center_and_diag(a);
+    let (bx, by, bd) = center_and_diag(b);
+    let dist2 = (ax - bx) * (ax - bx) + (ay - by) * (ay - by);
+    let thresh = 0.25 * (ad + bd); // half the mean diagonal
+    dist2 < thresh * thresh
 }
 
 /// Refines the edges of a quadrilateral in the image by adjusting its corners based on local image gradients.
@@ -978,6 +1002,49 @@ mod tests {
     use kornia_io::png::read_image_png_mono8;
 
     const EPSILON: f32 = 0.0001;
+
+    fn det_at(x: f32, y: f32, size: f32, id: u16, margin: f32) -> Detection {
+        let h = size * 0.5;
+        let mut quad = Quad::default();
+        quad.corners = [
+            Vec2F32::new(x - h, y + h),
+            Vec2F32::new(x + h, y + h),
+            Vec2F32::new(x + h, y - h),
+            Vec2F32::new(x - h, y - h),
+        ];
+        Detection {
+            _family_idx: 0,
+            tag_family_kind: TagFamilyKind::Tag36H11,
+            id,
+            hamming: 0,
+            decision_margin: margin,
+            center: Vec2F32::new(x, y),
+            quad,
+        }
+    }
+
+    /// Repeated ids at distinct locations are distinct physical tags and must
+    /// all survive dedup; overlapping same-id quads collapse to the best one.
+    #[test]
+    fn dedup_keeps_repeated_ids_merges_overlaps() {
+        let dets = vec![
+            det_at(100.0, 100.0, 40.0, 0, 50.0), // tag A
+            det_at(102.0, 101.0, 40.0, 0, 80.0), // overlaps A, better margin
+            det_at(300.0, 100.0, 40.0, 0, 60.0), // same id, far away: distinct tag B
+            det_at(100.0, 300.0, 40.0, 7, 60.0), // different id entirely
+        ];
+        let mut out = dedup_detections(dets);
+        out.sort_by(|a, b| (a.id, a.center.x as i32).cmp(&(b.id, b.center.x as i32)));
+        assert_eq!(out.len(), 3, "two id-0 tags + one id-7 tag");
+        assert_eq!(out[0].id, 0);
+        assert_eq!(
+            out[0].decision_margin, 80.0,
+            "overlap kept the better margin"
+        );
+        assert_eq!(out[1].id, 0);
+        assert_eq!(out[1].center.x, 300.0);
+        assert_eq!(out[2].id, 7);
+    }
 
     #[test]
     fn test_decode_tags() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/kornia-apriltag/tests/parity.rs
+++ b/crates/kornia-apriltag/tests/parity.rs
@@ -85,18 +85,21 @@ fn build_kornia_detector(width: usize, height: usize) -> AprilTagDecoder {
     AprilTagDecoder::new(config, ImageSize { width, height }).unwrap()
 }
 
-/// Run the C detector on a grayscale byte slice and return `id → (hamming, corners)`.
+/// Run the C detector on a grayscale byte slice. Returns every detection as
+/// `(id, hamming, corners)` — a scene can legitimately contain the same tag
+/// id several times, so this must NOT be keyed by id (an id-keyed map here
+/// once masked a kornia dedup bug that dropped repeated ids).
 fn run_c(
     gray: &[u8],
     width: usize,
     height: usize,
     det: &mut apriltag::Detector,
-) -> HashMap<usize, (usize, [[f64; 2]; 4])> {
+) -> Vec<(usize, usize, [[f64; 2]; 4])> {
     let mut c_img = apriltag::Image::zeros_with_stride(width, height, width).unwrap();
     c_img.as_slice_mut().copy_from_slice(gray);
     det.detect(&c_img)
         .into_iter()
-        .map(|d| (d.id(), (d.hamming(), d.corners())))
+        .map(|d| (d.id(), d.hamming(), d.corners()))
         .collect()
 }
 
@@ -179,20 +182,21 @@ fn check_image(
 ) -> (usize, usize, f32) {
     println!("=== Testing: {} ({}×{}) ===", label, width, height);
 
-    let c_map = run_c(gray, width, height, c_det);
+    let c_dets = run_c(gray, width, height, c_det);
     // All kornia detections before dedup — lets us match C by spatial proximity.
     let k_all = run_kornia(gray, width, height, k_det);
 
     println!(
         "  C detections: {}, kornia detections: {}",
-        c_map.len(),
+        c_dets.len(),
         k_all.len()
     );
 
     let mut global_max_delta: f32 = 0.0;
 
     // Every C detection must have a spatially close Kornia candidate with matching hamming.
-    for (&c_id, (c_hamming, c_corners)) in &c_map {
+    for (c_id, c_hamming, c_corners) in &c_dets {
+        let (c_id, c_hamming) = (*c_id, c_hamming);
         // Filter candidates to those with same id AND hamming ≤ c_hamming (including equal).
         // We match on id AND hamming to mirror C's quick-decode semantics.
         let candidates: Vec<&KorniaDetection> = k_all
@@ -259,7 +263,7 @@ fn check_image(
         );
     }
 
-    (c_map.len(), k_all.len(), global_max_delta)
+    (c_dets.len(), k_all.len(), global_max_delta)
 }
 
 // ─── test functions ──────────────────────────────────────────────────────────
@@ -296,6 +300,24 @@ fn test_parity_tag36h11_apriltags_jpg() {
     assert!(
         c_count > 0,
         "C detector found no tags in apriltags_tag36h11.jpg — image load or C library issue?"
+    );
+
+    // Regression guard: the scene contains the SAME tag id at several
+    // locations. Post-dedup kornia must keep every physical instance exactly
+    // like C does (an id-keyed dedup once collapsed all seven to one).
+    let img = Image::<u8, 1>::from_size_slice(
+        ImageSize {
+            width: w,
+            height: h,
+        },
+        &gray,
+    )
+    .unwrap();
+    let deduped = k_det.decode(&img).unwrap();
+    assert_eq!(
+        deduped.len(),
+        c_count,
+        "post-dedup kornia detection count must match C on the repeated-id scene"
     );
 }
 

--- a/crates/kornia-apriltag/tests/parity.rs
+++ b/crates/kornia-apriltag/tests/parity.rs
@@ -19,7 +19,7 @@
 //! coordinate offset, D4 refine_edges search-range difference) cause sub-pixel gaps that will
 //! be fixed in A3, after which the tolerance should tighten to ≤ 0.1 px.
 
-use std::{collections::HashMap, path::PathBuf};
+use std::path::PathBuf;
 
 use apriltag::DetectorBuilder;
 use kornia_apriltag::{

--- a/crates/kornia-apriltag/tests/parity.rs
+++ b/crates/kornia-apriltag/tests/parity.rs
@@ -86,9 +86,7 @@ fn build_kornia_detector(width: usize, height: usize) -> AprilTagDecoder {
 }
 
 /// Run the C detector on a grayscale byte slice. Returns every detection as
-/// `(id, hamming, corners)` — a scene can legitimately contain the same tag
-/// id several times, so this must NOT be keyed by id (an id-keyed map here
-/// once masked a kornia dedup bug that dropped repeated ids).
+/// `(id, hamming, corners)` — scenes contain repeated ids; never key by id.
 fn run_c(
     gray: &[u8],
     width: usize,
@@ -195,13 +193,13 @@ fn check_image(
     let mut global_max_delta: f32 = 0.0;
 
     // Every C detection must have a spatially close Kornia candidate with matching hamming.
-    for (c_id, c_hamming, c_corners) in &c_dets {
-        let (c_id, c_hamming) = (*c_id, c_hamming);
+    for &(c_id, c_hamming, c_corners) in &c_dets {
+        let c_corners = &c_corners;
         // Filter candidates to those with same id AND hamming ≤ c_hamming (including equal).
         // We match on id AND hamming to mirror C's quick-decode semantics.
         let candidates: Vec<&KorniaDetection> = k_all
             .iter()
-            .filter(|d| d.id == c_id as u16 && d.hamming as usize == *c_hamming)
+            .filter(|d| d.id == c_id as u16 && d.hamming as usize == c_hamming)
             .collect();
 
         if candidates.is_empty() {
@@ -302,9 +300,10 @@ fn test_parity_tag36h11_apriltags_jpg() {
         "C detector found no tags in apriltags_tag36h11.jpg — image load or C library issue?"
     );
 
-    // Regression guard: the scene contains the SAME tag id at several
-    // locations. Post-dedup kornia must keep every physical instance exactly
-    // like C does (an id-keyed dedup once collapsed all seven to one).
+    // Regression guard: the scene repeats the same tag id — post-dedup kornia
+    // must keep every physical instance like C does. Exact-count equality is
+    // stricter than the tolerance-based matching above; if a borderline
+    // non-dedup divergence ever trips this, compare spatial clusters instead.
     let img = Image::<u8, 1>::from_size_slice(
         ImageSize {
             width: w,


### PR DESCRIPTION
## Bug

`dedup_detections` deduplicated by `(family, id)`: any scene containing the **same tag id at several locations** kept exactly one detection. The parity bench scene `apriltags_tag36h11.jpg` contains seven physical copies of tag36h11 id 0 — the C library returns all seven, kornia returned **one**. Repeated-marker rigs and calibration setups silently undercounted tags.

The detector core was never at fault: pre-dedup kornia output matches C's seven detections to sub-pixel.

## Why tests never caught it

The parity harness's `run_c` collected C detections into an **id-keyed HashMap** — collapsing C's repeats exactly the same way, so both sides always agreed on the masked view.

## Fix

- Two detections are duplicates only when they share family+id **and** their quads overlap spatially (centers closer than half the mean quad diagonal). Overlapping duplicates keep the better (hamming, then decision margin). O(n²) over per-frame detections (small).
- Parity harness keeps every C detection and matches each individually; `test_parity_tag36h11_apriltags_jpg` gains a regression assert: post-dedup kornia count == C count on the repeated-id scene.
- Unit test: repeated ids at distinct locations survive; overlapping same-id quads merge to the best.
- `examples/nmaxima_sweep.rs`: measured with the fixed dedup — no reliable win below the C-default `max_nmaxima = 10`, and the detection set changes at ≤6, so the default stays.

Tests: 50 lib + 3 parity + 2 integration green on Jetson Orin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)