### PR TITLE
feat(imgproc): bicubic GPU kernels for resize and warp-affine (NVRTC/cudarc)

### DIFF
--- a/crates/kornia-3d/src/pnp/epnp.rs
+++ b/crates/kornia-3d/src/pnp/epnp.rs
@@ -314,7 +314,7 @@ fn select_control_points(points_world: &[Vec3AF32]) -> [Vec3AF32; 4] {
         (s_diag[1].sqrt(), Vec3AF32::new(v_y.x, v_y.y, v_y.z)),
         (s_diag[2].sqrt(), Vec3AF32::new(v_z.x, v_z.y, v_z.z)),
     ];
-    axes_sig.sort_by(|a, b| a.0.total_cmp(&b.0).reverse());
+    axes_sig.sort_by(|a, b| b.0.total_cmp(&a.0));
 
     let mut cw = [Vec3AF32::ZERO; 4];
     cw[0] = c;

--- a/crates/kornia-3d/src/pnp/epnp.rs
+++ b/crates/kornia-3d/src/pnp/epnp.rs
@@ -314,7 +314,7 @@ fn select_control_points(points_world: &[Vec3AF32]) -> [Vec3AF32; 4] {
         (s_diag[1].sqrt(), Vec3AF32::new(v_y.x, v_y.y, v_y.z)),
         (s_diag[2].sqrt(), Vec3AF32::new(v_z.x, v_z.y, v_z.z)),
     ];
-    axes_sig.sort_by(|a, b| b.0.total_cmp(&a.0));
+    axes_sig.sort_by(|a, b| a.0.total_cmp(&b.0).reverse());
 
     let mut cw = [Vec3AF32::ZERO; 4];
     cw[0] = c;

--- a/crates/kornia-apriltag/src/decoder.rs
+++ b/crates/kornia-apriltag/src/decoder.rs
@@ -1027,7 +1027,7 @@ mod tests {
             det_at(100.0, 300.0, 40.0, 7, 60.0), // different id entirely
         ];
         let mut out = dedup_detections(dets);
-        out.sort_by(|a, b| (a.id, a.center.x as i32).cmp(&(b.id, b.center.x as i32)));
+        out.sort_by_key(|a| (a.id, a.center.x as i32));
         assert_eq!(out.len(), 3, "two id-0 tags + one id-7 tag");
         assert_eq!(out[0].id, 0);
         assert_eq!(

--- a/crates/kornia-imgproc/benchmarks.md
+++ b/crates/kornia-imgproc/benchmarks.md
@@ -316,6 +316,94 @@ and AVX2 paths separately and in isolation from any GPU activity.
 
 ---
 
+---
+
+## GPU bicubic benchmarks — native CUDA (NVRTC) — 2026-07-06
+
+Keys cubic interpolation (`a = -0.5`, matching OpenCV `INTER_CUBIC`).  4×4 tap
+neighborhood; out-of-range taps clamped (BORDER_REPLICATE); OOB centre pixels
+zero-filled (BORDER_CONSTANT).  All 16 source reads via `__ldg`.
+
+**Kernel optimisations** (relative to the first implementation):
+
+- **Horner-form weight precomputation** — `frac ∈ [0,1)` places each tap in a
+  known polynomial region, making all 8 weight computations branch-free.
+  Eliminates `fabsf` + two conditionals from the naive `cubic_w` helper, and
+  removes the 12 redundant x-weight evaluations the original loop incurred.
+- **Row base hoisting** — 4 row-address multiplies moved outside the inner loop.
+- **`#pragma unroll` + `fmaf`** — ptxas fully unrolls the 4×4 tap loop and
+  emits one fused multiply-add per channel per tap.
+
+Result: **+7–10% downscale**, **+33–34% upscale** vs the unoptimised version.
+Warp-affine bicubic unchanged (scattered DRAM reads from rotation are the bottleneck).
+
+```sh
+cargo run --example bench_gpu_resize    --features gpu-cuda --release
+cargo run --example bench_gpu_warp_affine --features gpu-cuda --release
+# Python comparison (requires opencv-python and/or torch with CUDA)
+python3 crates/kornia-imgproc/examples/bench_opencv_resize.py
+python3 crates/kornia-imgproc/examples/bench_opencv_warp_affine.py
+```
+
+### Hardware / software
+
+| Field | Value |
+|-------|-------|
+| GPU | NVIDIA GeForce GTX 1650 4 GiB — GDDR5, ~128 GB/s peak |
+| CUDA | nvcc 12.4, cudarc 0.19.8, NVRTC |
+| Rust | 1.87.0, `--release` |
+| OpenCV | 5.0.0 (CPU only — no CUDA build; GPU column N/A) |
+| PyTorch | 2.9.1+cu128 |
+| Warmup | 50 iters; Timed | 200 iters |
+
+### Bicubic resize
+
+| Source → Dest | kornia-rs ms | GB/s | cv2 CPU ms | PyTorch GPU ms | vs cv2 CPU | vs PyTorch GPU |
+|---------------|-------------:|-----:|-----------:|---------------:|-----------:|---------------:|
+| 1024²→512² | 0.120 | 52.6 | 1.826 | 0.814 | **15×** | **6.8×** |
+| 512²→1024² | 0.207 | 121.4 | 4.987 | 2.875 | **24×** | **13.9×** |
+| 1920×1080→960×540 | 0.245 | 50.8 | 5.691 | 1.610 | **23×** | **6.6×** |
+| 1920×1080→3840×2160 | 1.709 | 116.5 | 32.204 | 23.170 | **19×** | **13.6×** |
+| 3840×2160→1920×1080 | 0.959 | 51.9 | 15.091 | 6.550 | **16×** | **6.8×** |
+
+### Bicubic warp-affine (45° centre rotation)
+
+| Size | kornia-rs ms | GB/s | cv2 CPU ms | PyTorch GPU ms | vs cv2 CPU | vs PyTorch GPU |
+|------|-------------:|-----:|-----------:|---------------:|-----------:|---------------:|
+| 256×224 | 0.065 | 21.1 | 0.156 | 0.207 | **2.4×** | **3.2×** |
+| 512×448 | 0.244 | 22.6 | 1.072 | 0.750 | **4.4×** | **3.1×** |
+| 1024×896 | 0.936 | 23.5 | 6.916 | 2.769 | **7.4×** | **3.0×** |
+| 1920×1080 | 1.951 | 25.5 | 12.333 | 5.924 | **6.3×** | **3.0×** |
+
+OpenCV CUDA and OpenCV 4.13 CUDA columns are N/A — no CUDA-enabled OpenCV build
+available on this machine; add `-DWITH_CUDA=ON -DCUDA_ARCH_BIN=7.5` when building
+OpenCV from source and rerun the Python scripts to populate these columns.
+
+**Key findings:**
+
+- kornia-rs bicubic resize is **6.6–24× faster than OpenCV 5.0 CPU** and
+  **6.6–14× faster than PyTorch bicubic GPU** across all cases.
+- The upscale cases (512→1024, 1080p→4K) are significantly faster than
+  downscale because output-pixel count drives latency and cache reuse is
+  excellent (many output pixels map to the same small source region).
+- Warp-affine bicubic at 45° rotation is bandwidth-limited by scattered
+  DRAM reads; `__ldg` and `CU_FUNC_CACHE_PREFER_L1` are the main levers.
+  PyTorch `grid_sample(bicubic)` allocates an intermediate grid tensor per
+  call, explaining the 3× gap even for small sizes.
+- Bicubic downscale is ~2× slower than bilinear downscale (both are DRAM-bound;
+  16 reads vs 4 reads, partially amortised by L1 reuse within the 4×4 tap
+  neighbourhood).
+
+### Interpolation comparison — resize 1920×1080→960×540
+
+| Method | kornia-rs ms | GB/s | vs bilinear |
+|--------|-------------:|-----:|------------:|
+| Nearest | 0.107 | 116.5 | 1.6× faster |
+| Bilinear | 0.178 | 70.0 | baseline |
+| Bicubic | 0.245 | 50.8 | 1.4× slower |
+
+---
+
 ## CUDA driver status
 
 Confirmed working as of 2026-06-15.  If the kernel-module / userspace mismatch

--- a/crates/kornia-imgproc/benchmarks.md
+++ b/crates/kornia-imgproc/benchmarks.md
@@ -14,6 +14,13 @@ cargo run --example bench_gpu_resize --features gpu-cubecl --release
 # OpenCV CPU comparison (requires Python + opencv-python)
 python3 crates/kornia-imgproc/examples/bench_opencv_color.py
 python3 crates/kornia-imgproc/examples/bench_opencv_resize.py
+
+# OpenCV CUDA comparison (requires OpenCV built with -DWITH_CUDA=ON)
+# If cv2 CUDA build is in dist-packages rather than site-packages:
+PYTHONPATH=/path/to/cuda-opencv/dist-packages \
+  python3 crates/kornia-imgproc/examples/bench_opencv_resize.py
+PYTHONPATH=/path/to/cuda-opencv/dist-packages \
+  python3 crates/kornia-imgproc/examples/bench_opencv_warp_affine.py
 ```
 
 ## Methodology
@@ -340,9 +347,12 @@ Warp-affine bicubic unchanged (scattered DRAM reads from rotation are the bottle
 ```sh
 cargo run --example bench_gpu_resize    --features gpu-cuda --release
 cargo run --example bench_gpu_warp_affine --features gpu-cuda --release
-# Python comparison (requires opencv-python and/or torch with CUDA)
-python3 crates/kornia-imgproc/examples/bench_opencv_resize.py
-python3 crates/kornia-imgproc/examples/bench_opencv_warp_affine.py
+# Python comparison (requires CUDA-built OpenCV + torch with CUDA)
+# PYTHONPATH points to the CUDA-enabled cv2 build in dist-packages:
+PYTHONPATH=/home/incharanew/.local/lib/python3.10/dist-packages \
+  python3 crates/kornia-imgproc/examples/bench_opencv_resize.py
+PYTHONPATH=/home/incharanew/.local/lib/python3.10/dist-packages \
+  python3 crates/kornia-imgproc/examples/bench_opencv_warp_affine.py
 ```
 
 ### Hardware / software
@@ -352,53 +362,47 @@ python3 crates/kornia-imgproc/examples/bench_opencv_warp_affine.py
 | GPU | NVIDIA GeForce GTX 1650 4 GiB — GDDR5, ~128 GB/s peak |
 | CUDA | nvcc 12.4, cudarc 0.19.8, NVRTC |
 | Rust | 1.87.0, `--release` |
-| OpenCV | 5.0.0 (CPU only — no CUDA build; GPU column N/A) |
+| OpenCV | 4.12.0 built with `-DWITH_CUDA=ON -DCUDA_ARCH_BIN=7.5` |
 | PyTorch | 2.9.1+cu128 |
 | Warmup | 50 iters; Timed | 200 iters |
 
 ### Bicubic resize
 
-| Source → Dest | kornia-rs ms | GB/s | cv2 CPU ms | PyTorch GPU ms | vs cv2 CPU | vs PyTorch GPU |
-|---------------|-------------:|-----:|-----------:|---------------:|-----------:|---------------:|
-| 1024²→512² | 0.120 | 52.6 | 1.826 | 0.814 | **15×** | **6.8×** |
-| 512²→1024² | 0.207 | 121.4 | 4.987 | 2.875 | **24×** | **13.9×** |
-| 1920×1080→960×540 | 0.245 | 50.8 | 5.691 | 1.610 | **23×** | **6.6×** |
-| 1920×1080→3840×2160 | 1.709 | 116.5 | 32.204 | 23.170 | **19×** | **13.6×** |
-| 3840×2160→1920×1080 | 0.959 | 51.9 | 15.091 | 6.550 | **16×** | **6.8×** |
+| Source → Dest | kornia-rs ms | GB/s | cv2 CPU ms | cv2 CUDA ms | PyTorch GPU ms | vs cv2 CPU | vs cv2 CUDA | vs PyTorch GPU |
+|---------------|-------------:|-----:|-----------:|------------:|---------------:|-----------:|------------:|---------------:|
+| 1024²→512² | 0.120 | 52.6 | 1.071 | 0.320 | 0.803 | **8.9×** | **2.7×** | **6.7×** |
+| 512²→1024² | 0.207 | 121.4 | 2.026 | 0.539 | 2.875 | **9.8×** | **2.6×** | **13.9×** |
+| 1920×1080→960×540 | 0.245 | 50.8 | 2.559 | 0.464 | 1.611 | **10.4×** | **1.9×** | **6.6×** |
+| 1920×1080→3840×2160 | 1.709 | 116.5 | 23.620 | 3.289 | 23.168 | **13.8×** | **1.9×** | **13.6×** |
+| 3840×2160→1920×1080 | 0.959 | 51.9 | 10.896 | 1.696 | 6.549 | **11.4×** | **1.8×** | **6.8×** |
 
 ### Bicubic warp-affine (45° centre rotation)
 
-| Size | kornia-rs ms | GB/s | cv2 CPU ms | PyTorch GPU ms | vs cv2 CPU | vs PyTorch GPU |
-|------|-------------:|-----:|-----------:|---------------:|-----------:|---------------:|
-| 256×224 | 0.065 | 21.1 | 0.156 | 0.207 | **2.4×** | **3.2×** |
-| 512×448 | 0.244 | 22.6 | 1.072 | 0.750 | **4.4×** | **3.1×** |
-| 1024×896 | 0.936 | 23.5 | 6.916 | 2.769 | **7.4×** | **3.0×** |
-| 1920×1080 | 1.951 | 25.5 | 12.333 | 5.924 | **6.3×** | **3.0×** |
-
-OpenCV CUDA and OpenCV 4.13 CUDA columns are N/A — no CUDA-enabled OpenCV build
-available on this machine; add `-DWITH_CUDA=ON -DCUDA_ARCH_BIN=7.5` when building
-OpenCV from source and rerun the Python scripts to populate these columns.
+| Size | kornia-rs ms | GB/s | cv2 CPU ms | cv2 CUDA ms | PyTorch GPU ms | vs cv2 CPU | vs cv2 CUDA | vs PyTorch GPU |
+|------|-------------:|-----:|-----------:|------------:|---------------:|-----------:|------------:|---------------:|
+| 256×224 | 0.065 | 21.1 | 1.172 | 0.109 | 0.163 | **18×** | **1.7×** | **2.5×** |
+| 512×448 | 0.244 | 22.6 | 3.278 | 0.419 | 0.657 | **13×** | **1.7×** | **2.7×** |
+| 1024×896 | 0.936 | 23.5 | 10.061 | 1.288 | 2.738 | **11×** | **1.4×** | **2.9×** |
+| 1920×1080 | 1.951 | 25.5 | 32.304 | 2.576 | 5.849 | **17×** | **1.3×** | **3.0×** |
 
 **Key findings:**
 
-- kornia-rs bicubic resize is **6.6–24× faster than OpenCV 5.0 CPU** and
-  **6.6–14× faster than PyTorch bicubic GPU** across all cases.
-- The upscale cases (512→1024, 1080p→4K) are significantly faster than
-  downscale because output-pixel count drives latency and cache reuse is
-  excellent (many output pixels map to the same small source region).
-- Warp-affine bicubic at 45° rotation is bandwidth-limited by scattered
-  DRAM reads; `__ldg` and `CU_FUNC_CACHE_PREFER_L1` are the main levers.
-  PyTorch `grid_sample(bicubic)` allocates an intermediate grid tensor per
-  call, explaining the 3× gap even for small sizes.
-- Bicubic downscale is ~2× slower than bilinear downscale (both are DRAM-bound;
-  16 reads vs 4 reads, partially amortised by L1 reuse within the 4×4 tap
-  neighbourhood).
+- kornia-rs bicubic resize is **8.9–13.8× faster than OpenCV 4.12 CPU** and
+  **1.8–2.7× faster than OpenCV 4.12 CUDA** and **6.6–14× faster than PyTorch GPU**.
+- The upscale cases (512→1024, 1080p→4K) show the largest gap vs PyTorch (~14×)
+  because output-pixel count drives latency, cache reuse is excellent, and
+  PyTorch adds Python/dispatcher overhead per call.
+- Warp-affine bicubic is **1.3–1.7× faster than OpenCV CUDA** and **2.5–3× faster
+  than PyTorch `grid_sample(bicubic)`** (which allocates an intermediate grid
+  tensor per call at every size).
+- Bicubic downscale is ~1.4× slower than bilinear downscale (DRAM-bound; 16
+  reads vs 4, partially amortised by L1 reuse within the 4×4 tap neighbourhood).
 
 ### Interpolation comparison — resize 1920×1080→960×540
 
 | Method | kornia-rs ms | GB/s | vs bilinear |
 |--------|-------------:|-----:|------------:|
-| Nearest | 0.107 | 116.5 | 1.6× faster |
+| Nearest | 0.107 | 116.5 | 1.7× faster |
 | Bilinear | 0.178 | 70.0 | baseline |
 | Bicubic | 0.245 | 50.8 | 1.4× slower |
 

--- a/crates/kornia-imgproc/benchmarks.md
+++ b/crates/kornia-imgproc/benchmarks.md
@@ -348,10 +348,12 @@ Warp-affine bicubic unchanged (scattered DRAM reads from rotation are the bottle
 cargo run --example bench_gpu_resize    --features gpu-cuda --release
 cargo run --example bench_gpu_warp_affine --features gpu-cuda --release
 # Python comparison (requires CUDA-built OpenCV + torch with CUDA)
-# PYTHONPATH points to the CUDA-enabled cv2 build in dist-packages:
-PYTHONPATH=/home/incharanew/.local/lib/python3.10/dist-packages \
+# PYTHONPATH points to the CUDA-enabled cv2 build in dist-packages.
+# Replace <dist-packages> with the path reported by your custom OpenCV build.
+# Example: $(python3 -c "import site; print(site.getusersitepackages())")
+PYTHONPATH=/path/to/cuda-opencv/dist-packages \
   python3 crates/kornia-imgproc/examples/bench_opencv_resize.py
-PYTHONPATH=/home/incharanew/.local/lib/python3.10/dist-packages \
+PYTHONPATH=/path/to/cuda-opencv/dist-packages \
   python3 crates/kornia-imgproc/examples/bench_opencv_warp_affine.py
 ```
 

--- a/crates/kornia-imgproc/examples/bench_gpu_resize.rs
+++ b/crates/kornia-imgproc/examples/bench_gpu_resize.rs
@@ -65,6 +65,9 @@ fn main() {
     run_gpu_cuda();
 
     #[cfg(feature = "gpu-cuda")]
+    run_gpu_cuda_bicubic();
+
+    #[cfg(feature = "gpu-cuda")]
     run_gpu_cuda_fused_normalize();
 
     #[cfg(not(feature = "gpu-cuda"))]
@@ -308,6 +311,60 @@ fn run_gpu_cuda() {
                 gb_per_sec(npix_dst, ms),
             );
         }
+    }
+}
+
+// --------------------------------------------------------------------------
+// Bicubic resize section (feature gpu-cuda)
+// --------------------------------------------------------------------------
+
+#[cfg(feature = "gpu-cuda")]
+fn run_gpu_cuda_bicubic() {
+    use cudarc::driver::CudaContext;
+    use kornia_imgproc::gpu::resize_cuda::launch_resize_bicubic_cuda;
+
+    let ctx = std::sync::Arc::new(CudaContext::new(0).expect("CUDA context"));
+    let stream = ctx.default_stream();
+
+    println!("\n=== native CUDA bicubic resize (__ldg, 4×4 taps, 32×8 grid, {ITERS} iters) ===");
+    println!(
+        "  {:<24}  {:>10}  {:>10}",
+        "case (src→dst)", "ms/iter", "GB/s"
+    );
+    println!("  {}", "-".repeat(50));
+
+    for &(sw, sh, dw, dh) in CASES {
+        let npix_src = (sw * sh) as usize;
+        let npix_dst = (dw * dh) as usize;
+        let nc = NC as usize;
+
+        let src_data: Vec<f32> = (0..npix_src * nc)
+            .map(|i| (i % 256) as f32 / 255.0)
+            .collect();
+
+        let src_dev = stream.clone_htod(&src_data).expect("H→D src copy");
+        let mut dst_dev = stream.alloc_zeros::<f32>(npix_dst * nc).expect("alloc dst");
+
+        for _ in 0..WARMUP {
+            launch_resize_bicubic_cuda(&ctx, &stream, &src_dev, &mut dst_dev, sw, sh, dw, dh)
+                .expect("bicubic launch");
+        }
+        stream.synchronize().expect("sync");
+
+        let t = std::time::Instant::now();
+        for _ in 0..ITERS {
+            launch_resize_bicubic_cuda(&ctx, &stream, &src_dev, &mut dst_dev, sw, sh, dw, dh)
+                .expect("bicubic launch");
+        }
+        stream.synchronize().expect("sync");
+        let ms = t.elapsed().as_secs_f64() * 1e3 / ITERS as f64;
+
+        println!(
+            "  {:<24}  {:>10.3}  {:>10.2}",
+            format!("{sw}×{sh}→{dw}×{dh}"),
+            ms,
+            gb_per_sec(npix_dst, ms),
+        );
     }
 }
 

--- a/crates/kornia-imgproc/examples/bench_gpu_warp_affine.rs
+++ b/crates/kornia-imgproc/examples/bench_gpu_warp_affine.rs
@@ -45,13 +45,14 @@ fn main() {
 fn run_gpu_cuda() {
     use cudarc::driver::CudaContext;
     use kornia_imgproc::gpu::warp_affine_cuda::{
-        launch_warp_affine_bilinear_cuda, launch_warp_affine_nearest_cuda,
+        launch_warp_affine_bicubic_cuda, launch_warp_affine_bilinear_cuda,
+        launch_warp_affine_nearest_cuda,
     };
 
     let ctx = std::sync::Arc::new(CudaContext::new(0).expect("CUDA context"));
     let stream = ctx.default_stream();
 
-    for method in ["nearest", "bilinear"] {
+    for method in ["nearest", "bilinear", "bicubic"] {
         println!(
             "\n=== GPU warp-affine {method} (45° rotation, __ldg, 32×8 grid, {ITERS} iters) ==="
         );
@@ -73,6 +74,10 @@ fn run_gpu_cuda() {
                 "nearest" => {
                     launch_warp_affine_nearest_cuda(&ctx, &stream, &src_dev, dst, w, h, w, h, &m)
                         .expect("nearest launch")
+                }
+                "bicubic" => {
+                    launch_warp_affine_bicubic_cuda(&ctx, &stream, &src_dev, dst, w, h, w, h, &m)
+                        .expect("bicubic launch")
                 }
                 _ => launch_warp_affine_bilinear_cuda(&ctx, &stream, &src_dev, dst, w, h, w, h, &m)
                     .expect("bilinear launch"),

--- a/crates/kornia-imgproc/examples/bench_opencv_resize.py
+++ b/crates/kornia-imgproc/examples/bench_opencv_resize.py
@@ -26,6 +26,15 @@ CASES = [
     ((3840, 2160), (1920, 1080)),
 ]
 
+# All cases including upscale (matches bicubic section of bench_gpu_resize.rs).
+CASES_BICUBIC = [
+    ((1024, 1024), (512, 512)),
+    ((512, 512), (1024, 1024)),
+    ((1920, 1080), (960, 540)),
+    ((1920, 1080), (3840, 2160)),
+    ((3840, 2160), (1920, 1080)),
+]
+
 try:
     import torch
     import torch.nn.functional as F
@@ -193,3 +202,83 @@ print("    bilinear: 1024²→512²=0.082ms  1920×1080→960×540=0.101ms  4K�
 bench_cv2_cpu()
 bench_cv2_cuda()
 bench_torch_gpu()
+
+# ── bicubic ───────────────────────────────────────────────────────────────────
+
+def bench_cv2_cpu_bicubic():
+    print(f"\n=== cv2 {cv2.__version__} CPU  resize bicubic (INTER_CUBIC)  ({ITERS} iters) ===")
+    print(f"  {'case':<28}  {'ms/iter':>9}  {'GB/s':>8}")
+    print("  " + "-" * 50)
+    for (sw, sh), (dw, dh) in CASES_BICUBIC:
+        src = np.random.rand(sh, sw, 3).astype(np.float32)
+        for _ in range(WARMUP):
+            cv2.resize(src, (dw, dh), interpolation=cv2.INTER_CUBIC)
+        t0 = time.perf_counter()
+        for _ in range(ITERS):
+            cv2.resize(src, (dw, dh), interpolation=cv2.INTER_CUBIC)
+        ms = (time.perf_counter() - t0) * 1e3 / ITERS
+        print(f"  {case_label(sw,sh,dw,dh):<28}  {ms:>9.3f}  {gb_per_sec_resize(sw,sh,dw,dh,ms):>8.2f}")
+
+def bench_cv2_cuda_bicubic():
+    if not HAS_CV2_CUDA:
+        print(f"\n=== cv2 CUDA resize bicubic — SKIPPED (no CUDA OpenCV) ===")
+        return
+    print(f"\n=== cv2 CUDA  resize bicubic  ({ITERS} iters) ===")
+    print(f"  {'case':<28}  {'ms/iter':>9}  {'GB/s':>8}  {'vs RS GPU':>12}")
+    print("  " + "-" * 65)
+    rs_ms_bicubic = {
+        (1024,1024,512,512): 0.120, (512,512,1024,1024): 0.207,
+        (1920,1080,960,540): 0.245, (1920,1080,3840,2160): 1.709,
+        (3840,2160,1920,1080): 0.959,
+    }
+    for (sw, sh), (dw, dh) in CASES_BICUBIC:
+        src = np.random.rand(sh, sw, 3).astype(np.float32)
+        gpu_src = cv2.cuda_GpuMat()
+        gpu_src.upload(src)
+        for _ in range(WARMUP):
+            cv2.cuda.resize(gpu_src, (dw, dh), interpolation=cv2.INTER_CUBIC)
+        cv2.cuda.Stream_Null().waitForCompletion()
+        t0 = time.perf_counter()
+        for _ in range(ITERS):
+            cv2.cuda.resize(gpu_src, (dw, dh), interpolation=cv2.INTER_CUBIC)
+        cv2.cuda.Stream_Null().waitForCompletion()
+        ms = (time.perf_counter() - t0) * 1e3 / ITERS
+        rs_ms = rs_ms_bicubic.get((sw, sh, dw, dh), ms)
+        ratio = ms / rs_ms
+        cmp = f"{ratio:.2f}× {'slower' if ratio > 1 else 'faster'}"
+        print(f"  {case_label(sw,sh,dw,dh):<28}  {ms:>9.3f}  {gb_per_sec_resize(sw,sh,dw,dh,ms):>8.2f}  {cmp:>12}")
+
+def bench_torch_gpu_bicubic():
+    if not TORCH_CUDA:
+        print(f"\n=== PyTorch GPU resize bicubic — SKIPPED (no CUDA torch) ===")
+        return
+    print(f"\n=== PyTorch {torch.__version__} GPU  interpolate bicubic  ({ITERS} iters) ===")
+    print(f"  {'case':<28}  {'ms/iter':>9}  {'GB/s':>8}  {'vs RS GPU':>12}")
+    print("  " + "-" * 65)
+    rs_ms_bicubic = {
+        (1024,1024,512,512): 0.120, (512,512,1024,1024): 0.207,
+        (1920,1080,960,540): 0.245, (1920,1080,3840,2160): 1.709,
+        (3840,2160,1920,1080): 0.959,
+    }
+    for (sw, sh), (dw, dh) in CASES_BICUBIC:
+        src_np = np.random.rand(sh, sw, 3).astype(np.float32)
+        src_t  = torch.from_numpy(src_np).permute(2, 0, 1).unsqueeze(0).cuda()
+        for _ in range(WARMUP):
+            F.interpolate(src_t, size=(dh, dw), mode="bicubic", align_corners=False)
+        torch.cuda.synchronize()
+        start = torch.cuda.Event(enable_timing=True)
+        end   = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(ITERS):
+            F.interpolate(src_t, size=(dh, dw), mode="bicubic", align_corners=False)
+        end.record()
+        torch.cuda.synchronize()
+        ms = start.elapsed_time(end) / ITERS
+        rs_ms = rs_ms_bicubic.get((sw, sh, dw, dh), ms)
+        ratio = ms / rs_ms
+        cmp = f"{ratio:.2f}× {'slower' if ratio > 1 else 'faster'}"
+        print(f"  {case_label(sw,sh,dw,dh):<28}  {ms:>9.3f}  {gb_per_sec_resize(sw,sh,dw,dh,ms):>8.2f}  {cmp:>12}")
+
+bench_cv2_cpu_bicubic()
+bench_cv2_cuda_bicubic()
+bench_torch_gpu_bicubic()

--- a/crates/kornia-imgproc/examples/bench_opencv_warp_affine.py
+++ b/crates/kornia-imgproc/examples/bench_opencv_warp_affine.py
@@ -184,3 +184,92 @@ print("    bilinear: 256×224=0.025ms  512×448=0.092ms  1024×896=0.274ms  1920
 bench_cv2_cpu()
 bench_cv2_cuda()
 bench_torch_gpu()
+
+# ── bicubic ───────────────────────────────────────────────────────────────────
+
+def bench_cv2_cpu_bicubic():
+    print(f"\n=== cv2 {cv2.__version__} CPU  warpAffine bicubic (INTER_CUBIC)  ({ITERS} iters) ===")
+    print(f"  {'case':<16}  {'ms/iter':>9}  {'GB/s':>8}  {'speedup vs kornia-rs GPU':>26}")
+    print("  " + "-" * 66)
+    rs_gpu_ms = {(256,224): 0.065, (512,448): 0.244, (1024,896): 0.936, (1920,1080): 1.951}
+    for w, h in CASES:
+        src = np.random.rand(h, w, 3).astype(np.float32)
+        M   = rotation_M(w, h)
+        for _ in range(WARMUP):
+            cv2.warpAffine(src, M, (w, h), flags=cv2.INTER_CUBIC,
+                           borderMode=cv2.BORDER_CONSTANT, borderValue=0)
+        t0 = time.perf_counter()
+        for _ in range(ITERS):
+            cv2.warpAffine(src, M, (w, h), flags=cv2.INTER_CUBIC,
+                           borderMode=cv2.BORDER_CONSTANT, borderValue=0)
+        ms = (time.perf_counter() - t0) * 1e3 / ITERS
+        speedup = ms / rs_gpu_ms.get((w, h), ms)
+        print(f"  {w}×{h:<10}  {ms:>9.3f}  {gb_per_sec(w,h,ms):>8.2f}  {speedup:>6.1f}× slower than RS GPU")
+
+def bench_cv2_cuda_bicubic():
+    if not HAS_CV2_CUDA:
+        print(f"\n=== cv2 CUDA warpAffine bicubic — SKIPPED (no CUDA OpenCV) ===")
+        return
+    print(f"\n=== cv2 CUDA  warpAffine bicubic  ({ITERS} iters) ===")
+    print(f"  {'case':<16}  {'ms/iter':>9}  {'GB/s':>8}  {'vs RS GPU':>12}")
+    print("  " + "-" * 52)
+    rs_gpu_ms = {(256,224): 0.065, (512,448): 0.244, (1024,896): 0.936, (1920,1080): 1.951}
+    for w, h in CASES:
+        src = np.random.rand(h, w, 3).astype(np.float32)
+        M   = rotation_M(w, h)
+        gpu_src = cv2.cuda_GpuMat()
+        gpu_src.upload(src)
+        for _ in range(WARMUP):
+            cv2.cuda.warpAffine(gpu_src, M, (w, h),
+                                flags=cv2.INTER_CUBIC,
+                                borderMode=cv2.BORDER_CONSTANT)
+        cv2.cuda.Stream_Null().waitForCompletion()
+        t0 = time.perf_counter()
+        for _ in range(ITERS):
+            cv2.cuda.warpAffine(gpu_src, M, (w, h),
+                                flags=cv2.INTER_CUBIC,
+                                borderMode=cv2.BORDER_CONSTANT)
+        cv2.cuda.Stream_Null().waitForCompletion()
+        ms = (time.perf_counter() - t0) * 1e3 / ITERS
+        rs_ms = rs_gpu_ms.get((w, h), ms)
+        ratio = ms / rs_ms
+        cmp = f"{ratio:.2f}× {'slower' if ratio > 1 else 'faster'}"
+        print(f"  {w}×{h:<10}  {ms:>9.3f}  {gb_per_sec(w,h,ms):>8.2f}  {cmp:>12}")
+
+def bench_torch_gpu_bicubic():
+    if not TORCH_CUDA:
+        print(f"\n=== PyTorch GPU warpAffine bicubic — SKIPPED (no CUDA torch) ===")
+        return
+    print(f"\n=== PyTorch {torch.__version__} GPU  grid_sample bicubic  ({ITERS} iters) ===")
+    print(f"  {'case':<16}  {'ms/iter':>9}  {'GB/s':>8}  {'vs RS GPU':>12}")
+    print("  " + "-" * 52)
+    rs_gpu_ms = {(256,224): 0.065, (512,448): 0.244, (1024,896): 0.936, (1920,1080): 1.951}
+    for w, h in CASES:
+        src_np = np.random.rand(h, w, 3).astype(np.float32)
+        M      = rotation_M(w, h)
+        theta  = opencv_M_to_torch_theta(M, w, h)
+        theta_t = torch.from_numpy(theta).unsqueeze(0).cuda()
+        src_t   = torch.from_numpy(src_np).permute(2, 0, 1).unsqueeze(0).cuda()
+        for _ in range(WARMUP):
+            grid = F.affine_grid(theta_t, src_t.shape, align_corners=True)
+            F.grid_sample(src_t, grid, mode="bicubic", padding_mode="zeros",
+                          align_corners=True)
+        torch.cuda.synchronize()
+        start = torch.cuda.Event(enable_timing=True)
+        end   = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(ITERS):
+            grid = F.affine_grid(theta_t, src_t.shape, align_corners=True)
+            F.grid_sample(src_t, grid, mode="bicubic", padding_mode="zeros",
+                          align_corners=True)
+        end.record()
+        torch.cuda.synchronize()
+        ms = start.elapsed_time(end) / ITERS
+        rs_ms = rs_gpu_ms.get((w, h), ms)
+        ratio = ms / rs_ms
+        cmp = f"{ratio:.2f}× {'slower' if ratio > 1 else 'faster'}"
+        print(f"  {w}×{h:<10}  {ms:>9.3f}  {gb_per_sec(w,h,ms):>8.2f}  {cmp:>12}")
+
+bench_cv2_cpu_bicubic()
+bench_cv2_cuda_bicubic()
+bench_torch_gpu_bicubic()

--- a/crates/kornia-imgproc/src/gpu/resize_cuda.rs
+++ b/crates/kornia-imgproc/src/gpu/resize_cuda.rs
@@ -271,7 +271,7 @@ extern "C" __global__ void resize_bicubic_3c(
 static BILINEAR_KERNEL: OnceLock<CudaKernel> = OnceLock::new();
 static NEAREST_KERNEL: OnceLock<CudaKernel> = OnceLock::new();
 static BILINEAR_NORMALIZE_KERNEL: OnceLock<CudaKernel> = OnceLock::new();
-static BICUBIC_KERNEL: OnceLock<CudaKernel> = OnceLock::new();
+static BICUBIC_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
 
 // 32 threads wide → full warp maps to one output row (better write coalescing).
 // 8 threads tall → 256 threads total, same occupancy as 16×16.
@@ -313,6 +313,17 @@ fn compile_with_l1(ctx: &Arc<CudaContext>, src: &str, fn_name: &str) -> CudaKern
     // Ignoring errors: unsupported on some platforms but never fatal.
     let _ = k.prefer_l1_cache();
     k
+}
+
+fn try_compile_with_l1(
+    ctx: &Arc<CudaContext>,
+    src: &str,
+    fn_name: &str,
+) -> Result<CudaKernel, String> {
+    let k = CudaKernel::compile(ctx, src, fn_name)
+        .map_err(|e| format!("failed to compile {fn_name}: {e}"))?;
+    let _ = k.prefer_l1_cache();
+    Ok(k)
 }
 
 // ── Public launchers ──────────────────────────────────────────────────────────
@@ -533,6 +544,12 @@ pub fn launch_resize_bicubic_cuda(
     dst_width: u32,
     dst_height: u32,
 ) -> Result<(), CudaResizeError> {
+    if src_width == 0 || src_height == 0 || dst_width == 0 || dst_height == 0 {
+        return Err(CudaResizeError::Cuda(
+            "src and dst dimensions must be non-zero".into(),
+        ));
+    }
+
     let need = (dst_width as usize) * (dst_height as usize) * 3;
     if dst.len() < need {
         return Err(CudaResizeError::SliceTooSmall {
@@ -541,8 +558,10 @@ pub fn launch_resize_bicubic_cuda(
         });
     }
 
-    let kernel =
-        BICUBIC_KERNEL.get_or_init(|| compile_with_l1(ctx, BICUBIC_SRC, "resize_bicubic_3c"));
+    let kernel = BICUBIC_KERNEL
+        .get_or_init(|| try_compile_with_l1(ctx, BICUBIC_SRC, "resize_bicubic_3c"))
+        .as_ref()
+        .map_err(|e| CudaResizeError::Cuda(e.clone()))?;
 
     let scale_x = src_width as f32 / dst_width as f32;
     let scale_y = src_height as f32 / dst_height as f32;

--- a/crates/kornia-imgproc/src/gpu/resize_cuda.rs
+++ b/crates/kornia-imgproc/src/gpu/resize_cuda.rs
@@ -196,18 +196,12 @@ extern "C" __global__ void resize_bilinear_normalize_3c(
 
 // ── CUDA C source: bicubic resize ─────────────────────────────────────────────
 //
-// Reuses the same Keys cubic weight and 4×4 tap loop as the warp-affine
-// bicubic kernel. Half-pixel centre alignment matches the bilinear kernel.
-// Works for both upscale and downscale.
+// Same Keys cubic (a = -0.5) as the warp-affine bicubic kernel. Applies the
+// same Horner-form weight precomputation, row-base hoisting, #pragma unroll,
+// and fmaf accumulation. Half-pixel centre alignment (matches OpenCV/PIL).
+// Handles both upscale and downscale.
 
 static BICUBIC_SRC: &str = r#"
-__device__ __forceinline__ float cubic_w(float t) {
-    t = fabsf(t);
-    if (t < 1.0f) return 1.5f*t*t*t - 2.5f*t*t + 1.0f;
-    if (t < 2.0f) return -0.5f*t*t*t + 2.5f*t*t - 4.0f*t + 2.0f;
-    return 0.0f;
-}
-
 extern "C" __global__ void resize_bicubic_3c(
     const float* __restrict__ src,
     float* __restrict__       dst,
@@ -231,18 +225,38 @@ extern "C" __global__ void resize_bicubic_3c(
     float frac_x = sx - (float)x0;
     float frac_y = sy - (float)y0;
 
+    // Horner-form cubic weights — see warp_affine_bicubic_3c for derivation.
+    float wx[4], wy[4];
+    {
+        float t;
+        t = 1.0f + frac_x; wx[0] = ((-0.5f*t + 2.5f)*t - 4.0f)*t + 2.0f;
+        t =         frac_x; wx[1] = (( 1.5f*t - 2.5f)*t       )*t + 1.0f;
+        t = 1.0f - frac_x; wx[2] = (( 1.5f*t - 2.5f)*t       )*t + 1.0f;
+        t = 2.0f - frac_x; wx[3] = ((-0.5f*t + 2.5f)*t - 4.0f)*t + 2.0f;
+        t = 1.0f + frac_y; wy[0] = ((-0.5f*t + 2.5f)*t - 4.0f)*t + 2.0f;
+        t =         frac_y; wy[1] = (( 1.5f*t - 2.5f)*t       )*t + 1.0f;
+        t = 1.0f - frac_y; wy[2] = (( 1.5f*t - 2.5f)*t       )*t + 1.0f;
+        t = 2.0f - frac_y; wy[3] = ((-0.5f*t + 2.5f)*t - 4.0f)*t + 2.0f;
+    }
+
+    unsigned int row[4];
+    #pragma unroll
+    for (int i = 0; i < 4; ++i) {
+        int yi = max(0, min(y0 + i - 1, (int)src_h - 1));
+        row[i] = (unsigned int)yi * src_w * 3u;
+    }
+
     float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f;
-    for (int dy = -1; dy <= 2; ++dy) {
-        float wy = cubic_w((float)dy - frac_y);
-        for (int dx = -1; dx <= 2; ++dx) {
-            float wx = cubic_w((float)dx - frac_x);
-            int xi = max(0, min(x0 + dx, (int)src_w - 1));
-            int yi = max(0, min(y0 + dy, (int)src_h - 1));
-            unsigned int b = ((unsigned int)yi * src_w + (unsigned int)xi) * 3u;
-            float w = wx * wy;
-            acc0 += w * __ldg(&src[b]);
-            acc1 += w * __ldg(&src[b+1]);
-            acc2 += w * __ldg(&src[b+2]);
+    #pragma unroll
+    for (int dy = 0; dy < 4; ++dy) {
+        #pragma unroll
+        for (int dx = 0; dx < 4; ++dx) {
+            int xi = max(0, min(x0 + dx - 1, (int)src_w - 1));
+            unsigned int b = row[dy] + (unsigned int)xi * 3u;
+            float w = wx[dx] * wy[dy];
+            acc0 = fmaf(w, __ldg(&src[b]),   acc0);
+            acc1 = fmaf(w, __ldg(&src[b+1]), acc1);
+            acc2 = fmaf(w, __ldg(&src[b+2]), acc2);
         }
     }
     unsigned int out = (dst_y * dst_w + dst_x) * 3u;

--- a/crates/kornia-imgproc/src/gpu/resize_cuda.rs
+++ b/crates/kornia-imgproc/src/gpu/resize_cuda.rs
@@ -60,6 +60,7 @@
 //! * [`launch_resize_bilinear_downscale_cuda`]  — bilinear downscale, 3-ch f32.
 //! * [`launch_resize_nearest_downscale_cuda`]   — nearest-neighbor, 3-ch f32.
 //! * [`launch_resize_bilinear_normalize_cuda`]  — bilinear downscale + normalise, 3-ch f32.
+//! * [`launch_resize_bicubic_cuda`]             — bicubic resize (up or down), 3-ch f32.
 
 use std::sync::{Arc, OnceLock};
 
@@ -193,11 +194,70 @@ extern "C" __global__ void resize_bilinear_normalize_3c(
 }
 "#;
 
+// ── CUDA C source: bicubic resize ─────────────────────────────────────────────
+//
+// Reuses the same Keys cubic weight and 4×4 tap loop as the warp-affine
+// bicubic kernel. Half-pixel centre alignment matches the bilinear kernel.
+// Works for both upscale and downscale.
+
+static BICUBIC_SRC: &str = r#"
+__device__ __forceinline__ float cubic_w(float t) {
+    t = fabsf(t);
+    if (t < 1.0f) return 1.5f*t*t*t - 2.5f*t*t + 1.0f;
+    if (t < 2.0f) return -0.5f*t*t*t + 2.5f*t*t - 4.0f*t + 2.0f;
+    return 0.0f;
+}
+
+extern "C" __global__ void resize_bicubic_3c(
+    const float* __restrict__ src,
+    float* __restrict__       dst,
+    unsigned int src_w,
+    unsigned int src_h,
+    unsigned int dst_w,
+    unsigned int dst_h,
+    float scale_x,
+    float scale_y
+) {
+    unsigned int dst_x = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int dst_y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (dst_x >= dst_w || dst_y >= dst_h) return;
+
+    // Half-pixel centre alignment (matches OpenCV / PIL convention).
+    float sx = fmaxf(fminf((dst_x + 0.5f) * scale_x - 0.5f, (float)(src_w - 1u)), 0.0f);
+    float sy = fmaxf(fminf((dst_y + 0.5f) * scale_y - 0.5f, (float)(src_h - 1u)), 0.0f);
+
+    int x0 = (int)floorf(sx);
+    int y0 = (int)floorf(sy);
+    float frac_x = sx - (float)x0;
+    float frac_y = sy - (float)y0;
+
+    float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f;
+    for (int dy = -1; dy <= 2; ++dy) {
+        float wy = cubic_w((float)dy - frac_y);
+        for (int dx = -1; dx <= 2; ++dx) {
+            float wx = cubic_w((float)dx - frac_x);
+            int xi = max(0, min(x0 + dx, (int)src_w - 1));
+            int yi = max(0, min(y0 + dy, (int)src_h - 1));
+            unsigned int b = ((unsigned int)yi * src_w + (unsigned int)xi) * 3u;
+            float w = wx * wy;
+            acc0 += w * __ldg(&src[b]);
+            acc1 += w * __ldg(&src[b+1]);
+            acc2 += w * __ldg(&src[b+2]);
+        }
+    }
+    unsigned int out = (dst_y * dst_w + dst_x) * 3u;
+    dst[out]     = acc0;
+    dst[out + 1] = acc1;
+    dst[out + 2] = acc2;
+}
+"#;
+
 // ── Kernel caches ─────────────────────────────────────────────────────────────
 
 static BILINEAR_KERNEL: OnceLock<CudaKernel> = OnceLock::new();
 static NEAREST_KERNEL: OnceLock<CudaKernel> = OnceLock::new();
 static BILINEAR_NORMALIZE_KERNEL: OnceLock<CudaKernel> = OnceLock::new();
+static BICUBIC_KERNEL: OnceLock<CudaKernel> = OnceLock::new();
 
 // 32 threads wide → full warp maps to one output row (better write coalescing).
 // 8 threads tall → 256 threads total, same occupancy as 16×16.
@@ -412,6 +472,63 @@ pub fn launch_resize_nearest_downscale_cuda(
 
     let kernel = NEAREST_KERNEL
         .get_or_init(|| compile_with_l1(ctx, NEAREST_SRC, "resize_nearest_downscale_3c"));
+
+    let scale_x = src_width as f32 / dst_width as f32;
+    let scale_y = src_height as f32 / dst_height as f32;
+
+    kernel
+        .launch_builder(stream)
+        .arg(src)
+        .arg(dst)
+        .arg(&src_width)
+        .arg(&src_height)
+        .arg(&dst_width)
+        .arg(&dst_height)
+        .arg(&scale_x)
+        .arg(&scale_y)
+        .launch_2d(dst_width, dst_height, make_config(dst_width, dst_height))
+        .map_err(|e| CudaResizeError::Cuda(e.to_string()))
+}
+
+/// Launch the bicubic resize kernel for a 3-channel f32 image.
+///
+/// Uses Keys cubic interpolation (`a = -0.5`, matches OpenCV `INTER_CUBIC`)
+/// with a 4×4 tap neighborhood and half-pixel centre alignment.  Supports
+/// both upscale and downscale.  Out-of-range taps are clamped to the image
+/// border (BORDER_REPLICATE).
+///
+/// Bicubic reads 16 source values per output pixel — more bandwidth-intensive
+/// than bilinear (4 reads) but produces sharper results without ringing at the
+/// default `a = -0.5` coefficient.
+///
+/// # Arguments
+///
+/// See [`launch_resize_bilinear_downscale_cuda`] — arguments are identical.
+///
+/// # Errors
+///
+/// Returns [`CudaResizeError`] on compile failure, launch error, or size mismatch.
+#[allow(clippy::too_many_arguments)]
+pub fn launch_resize_bicubic_cuda(
+    ctx: &Arc<CudaContext>,
+    stream: &Arc<CudaStream>,
+    src: &CudaSlice<f32>,
+    dst: &mut CudaSlice<f32>,
+    src_width: u32,
+    src_height: u32,
+    dst_width: u32,
+    dst_height: u32,
+) -> Result<(), CudaResizeError> {
+    let need = (dst_width as usize) * (dst_height as usize) * 3;
+    if dst.len() < need {
+        return Err(CudaResizeError::SliceTooSmall {
+            got: dst.len(),
+            need,
+        });
+    }
+
+    let kernel =
+        BICUBIC_KERNEL.get_or_init(|| compile_with_l1(ctx, BICUBIC_SRC, "resize_bicubic_3c"));
 
     let scale_x = src_width as f32 / dst_width as f32;
     let scale_y = src_height as f32 / dst_height as f32;

--- a/crates/kornia-imgproc/src/gpu/warp_affine_cuda.rs
+++ b/crates/kornia-imgproc/src/gpu/warp_affine_cuda.rs
@@ -23,6 +23,7 @@
 //!
 //! * [`launch_warp_affine_bilinear_cuda`] — bilinear warp affine, 3-ch f32.
 //! * [`launch_warp_affine_nearest_cuda`]  — nearest-neighbor warp affine, 3-ch f32.
+//! * [`launch_warp_affine_bicubic_cuda`]  — bicubic warp affine, 3-ch f32.
 
 use std::sync::{Arc, OnceLock};
 
@@ -124,10 +125,79 @@ extern "C" __global__ void warp_affine_nearest_3c(
 }
 "#;
 
+// ── CUDA C source: bicubic warp affine ───────────────────────────────────────
+//
+// Keys cubic weight (a = -0.5, matches OpenCV INTER_CUBIC):
+//   w(t) = 1.5t³ - 2.5t² + 1       for |t| ≤ 1
+//   w(t) = -0.5t³ + 2.5t² - 4t + 2 for 1 < |t| ≤ 2
+//
+// The 4×4 tap neighborhood spans dx, dy ∈ {-1, 0, 1, 2} relative to
+// floor(sx)/floor(sy). Out-of-range taps are clamped to the image border
+// (BORDER_REPLICATE). Pixels whose centre falls outside the source image
+// are filled with zero (BORDER_CONSTANT), matching the bilinear kernel.
+
+static BICUBIC_SRC: &str = r#"
+__device__ __forceinline__ float cubic_w(float t) {
+    t = fabsf(t);
+    if (t < 1.0f) return 1.5f*t*t*t - 2.5f*t*t + 1.0f;
+    if (t < 2.0f) return -0.5f*t*t*t + 2.5f*t*t - 4.0f*t + 2.0f;
+    return 0.0f;
+}
+
+extern "C" __global__ void warp_affine_bicubic_3c(
+    const float* __restrict__ src,
+    float* __restrict__       dst,
+    unsigned int src_w,
+    unsigned int src_h,
+    unsigned int dst_w,
+    unsigned int dst_h,
+    float m0, float m1, float m2,
+    float m3, float m4, float m5
+) {
+    unsigned int dst_x = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int dst_y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (dst_x >= dst_w || dst_y >= dst_h) return;
+
+    float sx = m0 * (float)dst_x + m1 * (float)dst_y + m2;
+    float sy = m3 * (float)dst_x + m4 * (float)dst_y + m5;
+
+    unsigned int out = (dst_y * dst_w + dst_x) * 3u;
+
+    if (sx < 0.0f || sx >= (float)src_w || sy < 0.0f || sy >= (float)src_h) {
+        dst[out] = 0.0f; dst[out+1] = 0.0f; dst[out+2] = 0.0f;
+        return;
+    }
+
+    int x0 = (int)floorf(sx);
+    int y0 = (int)floorf(sy);
+    float frac_x = sx - (float)x0;
+    float frac_y = sy - (float)y0;
+
+    float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f;
+    for (int dy = -1; dy <= 2; ++dy) {
+        float wy = cubic_w((float)dy - frac_y);
+        for (int dx = -1; dx <= 2; ++dx) {
+            float wx = cubic_w((float)dx - frac_x);
+            int xi = max(0, min(x0 + dx, (int)src_w - 1));
+            int yi = max(0, min(y0 + dy, (int)src_h - 1));
+            unsigned int b = ((unsigned int)yi * src_w + (unsigned int)xi) * 3u;
+            float w = wx * wy;
+            acc0 += w * __ldg(&src[b]);
+            acc1 += w * __ldg(&src[b+1]);
+            acc2 += w * __ldg(&src[b+2]);
+        }
+    }
+    dst[out]     = acc0;
+    dst[out + 1] = acc1;
+    dst[out + 2] = acc2;
+}
+"#;
+
 // ── Kernel caches ─────────────────────────────────────────────────────────────
 
 static BILINEAR_KERNEL: OnceLock<CudaKernel> = OnceLock::new();
 static NEAREST_KERNEL: OnceLock<CudaKernel> = OnceLock::new();
+static BICUBIC_KERNEL: OnceLock<CudaKernel> = OnceLock::new();
 
 const BLOCK_W: u32 = 32;
 const BLOCK_H: u32 = 8;
@@ -272,6 +342,61 @@ pub fn launch_warp_affine_nearest_cuda(
 
     let kernel =
         NEAREST_KERNEL.get_or_init(|| compile_with_l1(ctx, NEAREST_SRC, "warp_affine_nearest_3c"));
+
+    let mi = invert_affine_transform(m);
+
+    kernel
+        .launch_builder(stream)
+        .arg(src)
+        .arg(dst)
+        .arg(&src_width)
+        .arg(&src_height)
+        .arg(&dst_width)
+        .arg(&dst_height)
+        .arg(&mi[0])
+        .arg(&mi[1])
+        .arg(&mi[2])
+        .arg(&mi[3])
+        .arg(&mi[4])
+        .arg(&mi[5])
+        .launch_2d(dst_width, dst_height, make_config(dst_width, dst_height))
+        .map_err(|e| CudaWarpAffineError::Cuda(e.to_string()))
+}
+
+/// Launch the bicubic warp-affine kernel for a 3-channel f32 image.
+///
+/// Uses Keys cubic interpolation (`a = -0.5`, matches OpenCV `INTER_CUBIC`)
+/// with a 4×4 tap neighborhood.  Out-of-range taps are clamped to the image
+/// border; pixels whose centre maps outside the source are zero-filled.
+///
+/// Bicubic reads 16 source values per output pixel via `__ldg`, making it
+/// more compute- and bandwidth-intensive than bilinear (4 reads).  Best used
+/// when visual quality matters more than raw throughput.
+///
+/// # Arguments
+///
+/// See [`launch_warp_affine_bilinear_cuda`] — arguments are identical.
+///
+/// # Errors
+///
+/// Returns [`CudaWarpAffineError`] on compile failure, launch error, or if
+/// `dst` is too small.
+#[allow(clippy::too_many_arguments)]
+pub fn launch_warp_affine_bicubic_cuda(
+    ctx: &Arc<CudaContext>,
+    stream: &Arc<CudaStream>,
+    src: &CudaSlice<f32>,
+    dst: &mut CudaSlice<f32>,
+    src_width: u32,
+    src_height: u32,
+    dst_width: u32,
+    dst_height: u32,
+    m: &[f32; 6],
+) -> Result<(), CudaWarpAffineError> {
+    check_dst(dst, dst_width, dst_height)?;
+
+    let kernel =
+        BICUBIC_KERNEL.get_or_init(|| compile_with_l1(ctx, BICUBIC_SRC, "warp_affine_bicubic_3c"));
 
     let mi = invert_affine_transform(m);
 

--- a/crates/kornia-imgproc/src/gpu/warp_affine_cuda.rs
+++ b/crates/kornia-imgproc/src/gpu/warp_affine_cuda.rs
@@ -215,7 +215,7 @@ extern "C" __global__ void warp_affine_bicubic_3c(
 
 static BILINEAR_KERNEL: OnceLock<CudaKernel> = OnceLock::new();
 static NEAREST_KERNEL: OnceLock<CudaKernel> = OnceLock::new();
-static BICUBIC_KERNEL: OnceLock<CudaKernel> = OnceLock::new();
+static BICUBIC_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
 
 const BLOCK_W: u32 = 32;
 const BLOCK_H: u32 = 8;
@@ -253,6 +253,17 @@ fn compile_with_l1(ctx: &Arc<CudaContext>, src: &str, fn_name: &str) -> CudaKern
         .unwrap_or_else(|e| panic!("failed to compile {fn_name}: {e}"));
     let _ = k.prefer_l1_cache();
     k
+}
+
+fn try_compile_with_l1(
+    ctx: &Arc<CudaContext>,
+    src: &str,
+    fn_name: &str,
+) -> Result<CudaKernel, String> {
+    let k = CudaKernel::compile(ctx, src, fn_name)
+        .map_err(|e| format!("failed to compile {fn_name}: {e}"))?;
+    let _ = k.prefer_l1_cache();
+    Ok(k)
 }
 
 fn check_dst(
@@ -411,10 +422,17 @@ pub fn launch_warp_affine_bicubic_cuda(
     dst_height: u32,
     m: &[f32; 6],
 ) -> Result<(), CudaWarpAffineError> {
+    if src_width == 0 || src_height == 0 || dst_width == 0 || dst_height == 0 {
+        return Err(CudaWarpAffineError::Cuda(
+            "src and dst dimensions must be non-zero".into(),
+        ));
+    }
     check_dst(dst, dst_width, dst_height)?;
 
-    let kernel =
-        BICUBIC_KERNEL.get_or_init(|| compile_with_l1(ctx, BICUBIC_SRC, "warp_affine_bicubic_3c"));
+    let kernel = BICUBIC_KERNEL
+        .get_or_init(|| try_compile_with_l1(ctx, BICUBIC_SRC, "warp_affine_bicubic_3c"))
+        .as_ref()
+        .map_err(|e| CudaWarpAffineError::Cuda(e.clone()))?;
 
     let mi = invert_affine_transform(m);
 

--- a/crates/kornia-imgproc/src/gpu/warp_affine_cuda.rs
+++ b/crates/kornia-imgproc/src/gpu/warp_affine_cuda.rs
@@ -127,23 +127,16 @@ extern "C" __global__ void warp_affine_nearest_3c(
 
 // ── CUDA C source: bicubic warp affine ───────────────────────────────────────
 //
-// Keys cubic weight (a = -0.5, matches OpenCV INTER_CUBIC):
-//   w(t) = 1.5t³ - 2.5t² + 1       for |t| ≤ 1
-//   w(t) = -0.5t³ + 2.5t² - 4t + 2 for 1 < |t| ≤ 2
-//
-// The 4×4 tap neighborhood spans dx, dy ∈ {-1, 0, 1, 2} relative to
-// floor(sx)/floor(sy). Out-of-range taps are clamped to the image border
-// (BORDER_REPLICATE). Pixels whose centre falls outside the source image
-// are filled with zero (BORDER_CONSTANT), matching the bilinear kernel.
+// Keys cubic (a = -0.5, matches OpenCV INTER_CUBIC). Weights are computed via
+// Horner form without branches: frac ∈ [0,1) places each tap in a known
+// polynomial region, eliminating fabsf and the two conditionals of a generic
+// cubic_w helper. Precomputing wx[4]/wy[4] before the loop removes the 12
+// redundant x-weight evaluations the naive loop would incur. Row base addresses
+// are precomputed outside the inner loop to move the row-multiply out of the
+// critical path. #pragma unroll lets ptxas allocate wx/wy in registers and
+// issue all 16 __ldg loads without loop overhead.
 
 static BICUBIC_SRC: &str = r#"
-__device__ __forceinline__ float cubic_w(float t) {
-    t = fabsf(t);
-    if (t < 1.0f) return 1.5f*t*t*t - 2.5f*t*t + 1.0f;
-    if (t < 2.0f) return -0.5f*t*t*t + 2.5f*t*t - 4.0f*t + 2.0f;
-    return 0.0f;
-}
-
 extern "C" __global__ void warp_affine_bicubic_3c(
     const float* __restrict__ src,
     float* __restrict__       dst,
@@ -173,18 +166,43 @@ extern "C" __global__ void warp_affine_bicubic_3c(
     float frac_x = sx - (float)x0;
     float frac_y = sy - (float)y0;
 
+    // Horner-form cubic weights, branch-free. frac in [0,1) gives:
+    //   i=0 (tap -1): |t|=1+frac → second poly  -0.5t³+2.5t²-4t+2
+    //   i=1 (tap  0): |t|=frac   → first poly    1.5t³-2.5t²+1
+    //   i=2 (tap +1): |t|=1-frac → first poly
+    //   i=3 (tap +2): |t|=2-frac → second poly
+    float wx[4], wy[4];
+    {
+        float t;
+        t = 1.0f + frac_x; wx[0] = ((-0.5f*t + 2.5f)*t - 4.0f)*t + 2.0f;
+        t =         frac_x; wx[1] = (( 1.5f*t - 2.5f)*t       )*t + 1.0f;
+        t = 1.0f - frac_x; wx[2] = (( 1.5f*t - 2.5f)*t       )*t + 1.0f;
+        t = 2.0f - frac_x; wx[3] = ((-0.5f*t + 2.5f)*t - 4.0f)*t + 2.0f;
+        t = 1.0f + frac_y; wy[0] = ((-0.5f*t + 2.5f)*t - 4.0f)*t + 2.0f;
+        t =         frac_y; wy[1] = (( 1.5f*t - 2.5f)*t       )*t + 1.0f;
+        t = 1.0f - frac_y; wy[2] = (( 1.5f*t - 2.5f)*t       )*t + 1.0f;
+        t = 2.0f - frac_y; wy[3] = ((-0.5f*t + 2.5f)*t - 4.0f)*t + 2.0f;
+    }
+
+    // Row base addresses precomputed: moves the row multiply outside the inner loop.
+    unsigned int row[4];
+    #pragma unroll
+    for (int i = 0; i < 4; ++i) {
+        int yi = max(0, min(y0 + i - 1, (int)src_h - 1));
+        row[i] = (unsigned int)yi * src_w * 3u;
+    }
+
     float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f;
-    for (int dy = -1; dy <= 2; ++dy) {
-        float wy = cubic_w((float)dy - frac_y);
-        for (int dx = -1; dx <= 2; ++dx) {
-            float wx = cubic_w((float)dx - frac_x);
-            int xi = max(0, min(x0 + dx, (int)src_w - 1));
-            int yi = max(0, min(y0 + dy, (int)src_h - 1));
-            unsigned int b = ((unsigned int)yi * src_w + (unsigned int)xi) * 3u;
-            float w = wx * wy;
-            acc0 += w * __ldg(&src[b]);
-            acc1 += w * __ldg(&src[b+1]);
-            acc2 += w * __ldg(&src[b+2]);
+    #pragma unroll
+    for (int dy = 0; dy < 4; ++dy) {
+        #pragma unroll
+        for (int dx = 0; dx < 4; ++dx) {
+            int xi = max(0, min(x0 + dx - 1, (int)src_w - 1));
+            unsigned int b = row[dy] + (unsigned int)xi * 3u;
+            float w = wx[dx] * wy[dy];
+            acc0 = fmaf(w, __ldg(&src[b]),   acc0);
+            acc1 = fmaf(w, __ldg(&src[b+1]), acc1);
+            acc2 = fmaf(w, __ldg(&src[b+2]), acc2);
         }
     }
     dst[out]     = acc0;


### PR DESCRIPTION
## Summary

- Adds `launch_warp_affine_bicubic_cuda` and `launch_resize_bicubic_cuda` using Keys cubic interpolation (`a = -0.5`, matching OpenCV `INTER_CUBIC`).
- Each kernel samples a 4×4 tap neighborhood (16 reads) around the inverse-mapped source coordinate.
- Out-of-range taps are clamped to the nearest border pixel (BORDER_REPLICATE); pixels whose center maps outside the source are zero-filled (BORDER_CONSTANT).
- All 16 reads go through `__ldg` (read-only L1 cache). Same 32×8 thread block and `CU_FUNC_CACHE_PREFER_L1` as the existing bilinear/nearest kernels.
- Resize uses half-pixel center alignment (matches OpenCV/PIL) and handles both upscale and downscale.

## Kernel optimizations

Weights are computed via Horner-form polynomials (branch-free, no `fabsf`) rather than a generic `cubic_w` helper. Since `frac ∈ [0,1)` each of the 4 tap distances falls into a known polynomial region:

| tap | distance | polynomial |
|-----|----------|------------|
| -1  | 1+frac   | second (−0.5t³+2.5t²−4t+2) |
|  0  | frac     | first (1.5t³−2.5t²+1) |
| +1  | 1−frac   | first |
| +2  | 2−frac   | second |

Additional micro-opts: `wx[4]/wy[4]` precomputed in registers before the loop, row base addresses hoisted outside the inner loop, `#pragma unroll` on both loop levels, `fmaf()` for all accumulations.

**Speedup vs initial implementation (GTX 1650):**
- Resize bicubic downscale: **+7–10%**
- Resize bicubic upscale: **+33–34%** (was compute-bound, not DRAM-bound)
- Warp-affine bicubic: ~flat (scattered reads from rotation dominate)

## Benchmark results (GTX 1650, f32 3-channel, 200 iters)

### Bicubic resize

| Source → Dest | kornia-rs ms | GB/s | cv2 CPU ms | cv2 CUDA ms | PyTorch GPU ms | vs cv2 CPU | vs cv2 CUDA | vs PyTorch |
|---------------|-------------|------|-----------:|------------:|---------------:|------------|-------------|------------|
| 1024²→512²    | 0.120       | 52.6 | 1.071      | 0.320       | 0.803          | **8.9×**   | **2.7×**    | **6.7×**   |
| 512²→1024²    | 0.207       | 121.4| 2.026      | 0.539       | 2.875          | **9.8×**   | **2.6×**    | **13.9×**  |
| 1080p→540p    | 0.245       | 50.8 | 2.559      | 0.464       | 1.611          | **10.4×**  | **1.9×**    | **6.6×**   |
| 1080p→4K      | 1.709       | 116.5| 23.620     | 3.289       | 23.168         | **13.8×**  | **1.9×**    | **13.6×**  |
| 4K→1080p      | 0.959       | 51.9 | 10.896     | 1.696       | 6.549          | **11.4×**  | **1.8×**    | **6.8×**   |

### Bicubic warp-affine (45° centre rotation)

| Size       | kornia-rs ms | GB/s | cv2 CPU ms | cv2 CUDA ms | PyTorch GPU ms | vs cv2 CPU | vs cv2 CUDA | vs PyTorch |
|------------|-------------|------|------------|-------------|----------------|------------|-------------|------------|
| 256×224    | 0.065       | 21.1 | 1.172      | 0.109       | 0.163          | **18×**    | **1.7×**    | **2.5×**   |
| 512×448    | 0.244       | 22.6 | 3.278      | 0.419       | 0.657          | **13×**    | **1.7×**    | **2.7×**   |
| 1024×896   | 0.936       | 23.5 | 10.061     | 1.288       | 2.738          | **11×**    | **1.4×**    | **2.9×**   |
| 1920×1080  | 1.951       | 25.5 | 32.304     | 2.576       | 5.849          | **17×**    | **1.3×**    | **3.0×**   |

OpenCV 4.12.0 built from source with `-DWITH_CUDA=ON -DCUDA_ARCH_BIN=7.5`. PyTorch 2.9.1+cu128 via `F.interpolate(mode='bicubic')` / `F.grid_sample(mode='bicubic')`.

## Test plan

- [ ] `cargo run --example bench_gpu_warp_affine --features gpu-cuda --release` — bicubic column appears
- [ ] `cargo run --example bench_gpu_resize --features gpu-cuda --release` — bicubic section appears
- [ ] `PYTHONPATH=<cuda-opencv-dist-packages> python3 crates/kornia-imgproc/examples/bench_opencv_resize.py` — bicubic comparison sections run
- [ ] `PYTHONPATH=<cuda-opencv-dist-packages> python3 crates/kornia-imgproc/examples/bench_opencv_warp_affine.py` — bicubic comparison sections run