### PR TITLE
chore(release): v0.1.15-rc.1 (pre-release)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: release
+description: Use when cutting a kornia-rs release or pre-release (rc) — bumps the workspace version, updates CHANGELOG.md (moving [Unreleased] into a dated section and referencing the previous release), opens the release PR, and triggers the crates.io / wheel publish workflows. Trigger on "cut a release", "prepare a release", "pre-release", "publish to crates.io", "bump version".
+---
+
+# Releasing kornia-rs
+
+Publishing is **irreversible** (crates.io only yanks, never deletes). Never run
+the publish step without explicit human confirmation of version + scope.
+
+## Facts about this repo
+
+- Workspace version: single source in root `Cargo.toml` (`version = "..."`, all
+  crates inherit via `version.workspace = true`).
+- Publish script: `scripts/release_rust.sh` — topological, idempotent, skips
+  already-published versions. Excludes `kornia`, `kornia-vlm`, `kornia-apriltag`.
+- CI publish: `.github/workflows/rust_release.yml` (`workflow_dispatch`, guarded
+  by typing `publish`) and `.github/workflows/python_release.yml` (wheels).
+- Tag convention: `vX.Y.Z`, pre-releases `vX.Y.Z-rc.N`.
+- User-facing notes live in **`CHANGELOG.md`** (newest first) AND the GitHub
+  release body. Keep them consistent.
+
+## Checklist
+
+Create one todo per step.
+
+1. **Confirm with the human** (blocking): version string, whether it is an rc,
+   and scope (Rust crates / Python wheels / both). Do not proceed on a guess.
+2. **Gather what changed.** `git log <last-tag>..main --oneline --no-merges`.
+   Group by theme (not per-commit). Read the previous CHANGELOG.md entries first
+   to match tone and altitude — user-impact prose, not a commit dump.
+3. **Update `CHANGELOG.md`:**
+   - Move the curated items from `## [Unreleased]` into a new dated section
+     `## [X.Y.Z] — YYYY-MM-DD` (for an rc, keep it labelled `(pre-release)`).
+   - Reset `## [Unreleased]` to empty.
+   - Add/refresh the compare link at the bottom **referencing the previous
+     release tag**: `[X.Y.Z]: https://github.com/kornia/kornia-rs/compare/<prev-tag>...vX.Y.Z`.
+     This is what keeps the changelog navigable across releases.
+   - Dates: ask the human or read from the environment; never invent one.
+4. **Bump version** in root `Cargo.toml`. Run `cargo update -p <workspace crate>`
+   / `cargo check` so `Cargo.lock` reflects the bump.
+5. **Release branch + PR:** `release/vX.Y.Z`, commit `chore(release): vX.Y.Z`
+   with the version bump + CHANGELOG. Open PR, let CI pass, get it merged. Never
+   force-push a contributor's fork branch — release commits go on a repo branch.
+6. **Tag** the merged commit `vX.Y.Z` and push the tag.
+7. **Publish** (only after human types the go-ahead):
+   - Rust: run `rust_release.yml` (`workflow_dispatch`, confirm field `publish`),
+     or locally `scripts/release_rust.sh` (plan) → `--execute`.
+   - Python: run `python_release.yml`.
+8. **GitHub release:** `gh release create vX.Y.Z` (add `--prerelease` for rc)
+   with the body copied from the new CHANGELOG section.
+9. **Verify:** crate versions on crates.io, `pip install --pre kornia-rs==X.Y.Z`,
+   release marked pre-release if rc.
+
+## Red flags
+
+- "Just publish real quick" → stop, run the checklist; publish is irreversible.
+- CHANGELOG untouched → a release without a changelog entry is incomplete.
+- No compare link / wrong previous tag → changelog history breaks.
+- Pushing to a fork branch → release work belongs on a repo `release/*` branch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,100 @@
+# Changelog
+
+All notable changes to kornia-rs are recorded here, newest first. Each entry is
+written for users of the Rust crates and the `kornia-rs` Python wheels — what
+changed and why it matters, not a raw commit dump.
+
+Pre-releases (`-rc.N`) are cut before a stable tag so the community can try
+changes early: `cargo add kornia-imgproc@0.1.15-rc.1` or `pip install --pre kornia-rs`.
+
+<!-- When cutting a release, move the curated items from [Unreleased] into a new
+     dated section and reset [Unreleased]. Reference the diff range and prior tag
+     so the changelog stays navigable (see the "Full changelog" links below). -->
+
+## [0.1.15-rc.1] — 2026-07-06 (pre-release)
+
+First pre-release since 0.1.14 (2026-05-19), bundling ~247 commits. Headline is
+**GPU acceleration landing across the stack** plus a **CPU warp-affine rewrite**.
+
+### CUDA / GPU
+- **CUDA color conversions** with residency-aware dispatch and fused camera
+  preprocessing — faster than OpenCV + VPI on the tested paths (#966).
+- **`kornia_rs.cuda` Python module** — GPU color conversions + fused camera
+  preprocess from Python (#969), with a pinned-staging preprocessor and
+  zero-copy DLPack import into torch / TensorRT (#970, #972).
+- **cudarc device-memory integration** — `CudaResource` / `CudaAllocator`,
+  `Tensor::to_cuda`, `CudaKernel` (#950).
+- **GPU resize kernels** (nearest + bilinear) via CubeCL (#946).
+- **GPU image→tensor Preprocessor** + cudarc kernel ergonomics (#960).
+- **DLPack interop** for `Tensor` / `Image` and kornia-py — zero-copy,
+  bidirectional with torch (#951).
+
+### imgproc
+- **CPU warp-affine rewrite** — incremental coordinates, analytical valid-range
+  skip, 16-row Rayon chunks; 2–2.5× faster nearest, bilinear now beats cv2 CPU
+  (#971).
+- **Preprocessor builder** — RGBA source, mean/std normalize, configurable pad
+  (#964).
+
+### AprilTag
+- **3D pose estimation** + SIMD-accelerated detector (#959).
+- Dedup no longer drops repeated tag ids — spatial-overlap dedup (#973).
+
+### Core / breaking
+- **Removed the compile-time allocator type param** on `Tensor` / `Image`;
+  runtime `AllocHandle` + host-default constructors (#955). Migration:
+  `Image<f32, 3, CpuAllocator>` → `Image<f32, 3>`.
+- New `AllocationFailed` error variant preserving the backend message.
+
+**Full changelog:** `v0.1.14...v0.1.15-rc.1`
+
+## [0.1.14] — 2026-05-19
+
+turbojpeg is finally reachable from the Python API. 0.1.13 shipped wheels with
+libjpeg-turbo compiled in, but the Python-facing symbols were silently absent
+because the `#[cfg(feature = "turbojpeg")]` gates checked kornia-py's own flag,
+not the kornia-io dep's. Fixed with `default = ["turbojpeg"]`. Also: Windows CI
+switched to `CMAKE_GENERATOR=Ninja` + `ilammy/msvc-dev-cmd` (VS-version-agnostic).
+
+**Full changelog:** `v0.1.13...v0.1.14`
+
+## [0.1.13] — 2026-05-18
+
+- turbojpeg enabled by default in published wheels (2–4× faster JPEG vs pure-Rust).
+- Windows CI fixed (pin `CMAKE_GENERATOR=Visual Studio 17 2022`).
+- All turbojpeg paths gated behind `#[cfg(feature = "turbojpeg")]`; pure-Rust
+  fallback still works for source builds without cmake.
+
+**Full changelog:** `v0.1.12...v0.1.13`
+
+## [0.1.12] — 2026-05-18
+
+- 3D / BA: Schur-complement bundle adjustment, SE(3) pose-graph optimization,
+  cheirality-robust BA, IRLS Huber + Cauchy loss; `solve_pnp_ransac` → `k3d`.
+- Generic RANSAC framework (NEON + AVX2 scorer, LO-RANSAC) + homography estimator.
+- Segmentation + depth: COCO RLE ↔ mask, `depth.sample_depth` (19× vs Python).
+
+**Full changelog:** `v0.1.11...v0.1.12`
+
+## [0.1.11] — 2026-05-04
+
+First release in 6 months, 122 commits. New crates: kornia-vlm, kornia-pnp,
+kornia-lie, kornia-nn, kornia-apriltag, kornia-algebra, v4l2 camera capture.
+Python: PIL-parity Image API with zero-copy numpy, u16/f32 dtypes, WebP/TIFF,
+AprilTag bindings, Python 3.14t free-threaded builds.
+
+**Full changelog:** `v0.1.10...v0.1.11`
+
+## [0.1.10] — 2025-11-08
+
+Video reader, custom `Allocator` for `Image`, kornia-lie on glam-rs, SIMD DNN
+linear layer / kornia-nn, kornia-apriltag, zero-copy gstreamer images. See the
+[GitHub release](https://github.com/kornia/kornia-rs/releases/tag/v0.1.10) for
+the full per-PR list.
+
+[0.1.15-rc.1]: https://github.com/kornia/kornia-rs/compare/v0.1.14...v0.1.15-rc.1
+[0.1.14]: https://github.com/kornia/kornia-rs/releases/tag/v0.1.14
+[0.1.13]: https://github.com/kornia/kornia-rs/releases/tag/v0.1.13
+[0.1.12]: https://github.com/kornia/kornia-rs/releases/tag/v0.1.12
+[0.1.11]: https://github.com/kornia/kornia-rs/releases/tag/v0.1.11
+[0.1.10]: https://github.com/kornia/kornia-rs/releases/tag/v0.1.10

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "apriltag"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "argh",
  "ctrlc",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "apriltag-pose"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "argh",
  "kornia",
@@ -1488,7 +1488,7 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "binarize"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "argh",
  "kornia",
@@ -2421,7 +2421,7 @@ dependencies = [
 
 [[package]]
 name = "colmap_rerun"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "argh",
  "kornia",
@@ -2463,7 +2463,7 @@ dependencies = [
 
 [[package]]
 name = "color_detector"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "argh",
  "kornia",
@@ -2478,7 +2478,7 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "color_spaces"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "kornia-image",
  "kornia-imgproc",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "contours"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "argh",
  "kornia",
@@ -2735,7 +2735,7 @@ dependencies = [
 
 [[package]]
 name = "copper"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "cu29",
  "kornia",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "exif_auto_orient"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "kornia-io",
 ]
@@ -6902,7 +6902,7 @@ dependencies = [
 
 [[package]]
 name = "hello_world"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "argh",
  "kornia",
@@ -7088,7 +7088,7 @@ dependencies = [
 
 [[package]]
 name = "histogram"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "argh",
  "kornia",
@@ -7355,7 +7355,7 @@ dependencies = [
 
 [[package]]
 name = "icp_registration"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "argh",
  "env_logger",
@@ -7514,7 +7514,7 @@ dependencies = [
 
 [[package]]
 name = "image_api"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "kornia-image",
 ]
@@ -7564,7 +7564,7 @@ checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
 
 [[package]]
 name = "imgproc"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "argh",
  "kornia",
@@ -8084,7 +8084,7 @@ checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "kornia"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "kornia-3d",
  "kornia-algebra",
@@ -8098,7 +8098,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-3d"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "approx",
  "bincode 2.0.1",
@@ -8120,7 +8120,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-algebra"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "approx",
  "criterion 0.8.2",
@@ -8133,7 +8133,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-apriltag"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "aprilgrid",
  "apriltag 0.4.0",
@@ -8151,7 +8151,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-bow"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "bincode 2.0.1",
  "criterion 0.8.2",
@@ -8164,7 +8164,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-cpp"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -8175,7 +8175,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-image"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "arrow 59.0.0",
  "criterion 0.8.2",
@@ -8190,7 +8190,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-imgproc"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "criterion 0.8.2",
  "cubecl-core",
@@ -8215,7 +8215,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-io"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "circular-buffer",
  "criterion 0.8.2",
@@ -8240,7 +8240,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-py"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "cudarc 0.19.8",
  "dlpack-rs",
@@ -8260,7 +8260,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-tensor"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "bincode 2.0.1",
  "criterion 0.8.2",
@@ -8277,7 +8277,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-tensor-ops"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "approx",
  "criterion 0.8.2",
@@ -8289,7 +8289,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-vlm"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "candle-core",
  "candle-flash-attn",
@@ -8952,7 +8952,7 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "argh",
  "kornia",
@@ -9084,7 +9084,7 @@ dependencies = [
 
 [[package]]
 name = "morphology"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "argh",
  "kornia",
@@ -9572,7 +9572,7 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "normalize"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "argh",
  "kornia",
@@ -9580,7 +9580,7 @@ dependencies = [
 
 [[package]]
 name = "normalize_ii"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "argh",
  "kornia",
@@ -10308,7 +10308,7 @@ dependencies = [
 
 [[package]]
 name = "onnx"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "argh",
  "kornia",
@@ -10639,7 +10639,7 @@ dependencies = [
 
 [[package]]
 name = "paligemma"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "argh",
  "kornia-io",
@@ -11082,7 +11082,7 @@ dependencies = [
 
 [[package]]
 name = "ply_rerun"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "argh",
  "kornia",
@@ -11149,7 +11149,7 @@ dependencies = [
 
 [[package]]
 name = "pnp_demo"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "argh",
  "env_logger",
@@ -14382,7 +14382,7 @@ dependencies = [
 
 [[package]]
 name = "rerun_viz"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "argh",
  "kornia",
@@ -14505,7 +14505,7 @@ dependencies = [
 
 [[package]]
 name = "rotate"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "argh",
  "kornia",
@@ -15527,7 +15527,7 @@ dependencies = [
 
 [[package]]
 name = "smol_vlm"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "argh",
  "kornia-image",
@@ -15578,7 +15578,7 @@ dependencies = [
 
 [[package]]
 name = "smol_vlm_convo"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "argh",
  "color-eyre",
@@ -15836,7 +15836,7 @@ dependencies = [
 
 [[package]]
 name = "std_mean"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "argh",
  "indicatif 0.18.5",
@@ -17273,7 +17273,7 @@ dependencies = [
 
 [[package]]
 name = "undistort"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "argh",
  "kornia",
@@ -17282,7 +17282,7 @@ dependencies = [
 
 [[package]]
 name = "undistort_points"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "argh",
  "kornia",
@@ -17707,7 +17707,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "video_player"
-version = "0.1.14"
+version = "0.1.15-rc.1"
 dependencies = [
  "eframe",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = ["examples/cuda_imgproc", "examples/dora"]
 default-members = ["crates/*"]
 
 [workspace.package]
-version = "0.1.14"
+version = "0.1.15-rc.1"
 authors = ["kornia.org <edgar@kornia.org>"]
 edition = "2021"
 rust-version = "1.89"
@@ -55,17 +55,17 @@ imageproc = "0.27"
 indicatif = { version = "0.18.4", features = ["rayon"] }
 kiddo = "5.3"
 # NOTE: remember to update the kornia-py package version in `kornia-py/Cargo.toml` when updating the Rust package version
-kornia = { path = "crates/kornia", version = "0.1.14" }
-kornia-3d = { path = "crates/kornia-3d", version = "0.1.14" }
-kornia-algebra = { path = "crates/kornia-algebra", version = "0.1.14" }
-kornia-apriltag = { path = "crates/kornia-apriltag", version = "0.1.14" }
-kornia-bow = { path = "crates/kornia-bow", version = "0.1.14" }
-kornia-image = { path = "crates/kornia-image", version = "0.1.14" }
-kornia-imgproc = { path = "crates/kornia-imgproc", version = "0.1.14" }
-kornia-io = { path = "crates/kornia-io", version = "0.1.14" }
-kornia-tensor = { path = "crates/kornia-tensor", version = "0.1.14" }
-kornia-tensor-ops = { path = "crates/kornia-tensor-ops", version = "0.1.14" }
-kornia-vlm = { path = "crates/kornia-vlm", version = "0.1.14" }
+kornia = { path = "crates/kornia", version = "0.1.15-rc.1" }
+kornia-3d = { path = "crates/kornia-3d", version = "0.1.15-rc.1" }
+kornia-algebra = { path = "crates/kornia-algebra", version = "0.1.15-rc.1" }
+kornia-apriltag = { path = "crates/kornia-apriltag", version = "0.1.15-rc.1" }
+kornia-bow = { path = "crates/kornia-bow", version = "0.1.15-rc.1" }
+kornia-image = { path = "crates/kornia-image", version = "0.1.15-rc.1" }
+kornia-imgproc = { path = "crates/kornia-imgproc", version = "0.1.15-rc.1" }
+kornia-io = { path = "crates/kornia-io", version = "0.1.15-rc.1" }
+kornia-tensor = { path = "crates/kornia-tensor", version = "0.1.15-rc.1" }
+kornia-tensor-ops = { path = "crates/kornia-tensor-ops", version = "0.1.15-rc.1" }
+kornia-vlm = { path = "crates/kornia-vlm", version = "0.1.15-rc.1" }
 log = "0.4"
 minijinja = { version = "2.20", features = ["loader"] }
 nalgebra = "0.35"

--- a/crates/kornia-apriltag/src/decoder.rs
+++ b/crates/kornia-apriltag/src/decoder.rs
@@ -1027,7 +1027,7 @@ mod tests {
             det_at(100.0, 300.0, 40.0, 7, 60.0), // different id entirely
         ];
         let mut out = dedup_detections(dets);
-        out.sort_by(|a, b| (a.id, a.center.x as i32).cmp(&(b.id, b.center.x as i32)));
+        out.sort_by_key(|a| (a.id, a.center.x as i32));
         assert_eq!(out.len(), 3, "two id-0 tags + one id-7 tag");
         assert_eq!(out[0].id, 0);
         assert_eq!(


### PR DESCRIPTION
Pre-release **0.1.15-rc.1** so the community can try the new CUDA/GPU stack and the CPU warp-affine rewrite before the stable 0.1.15.

## What's in it
~248 commits since v0.1.14. Full user-facing notes in the new `CHANGELOG.md`. Highlights:

- **CUDA / GPU** — color conversions (residency-aware, faster than OpenCV+VPI), `kornia_rs.cuda` Python module, cudarc device memory, GPU resize kernels, DLPack zero-copy torch/TensorRT interop.
- **imgproc** — CPU warp-affine rewrite (#971): 2–2.5× faster nearest, bilinear now beats cv2 CPU. Preprocessor builder (#964).
- **AprilTag** — 3D pose + SIMD detector (#959).
- **Breaking** — removed compile-time allocator type param (#955): `Image<f32, 3, CpuAllocator>` → `Image<f32, 3>`.

## This PR
- Bump workspace version `0.1.14` → `0.1.15-rc.1` (+ internal dep pins, `Cargo.lock`).
- Add `CHANGELOG.md` — back-filled 0.1.10–0.1.14 from GitHub releases, curated `0.1.15-rc.1` section with prev-tag compare links.
- Add `.claude/skills/release` — release skill codifying the publish flow + CHANGELOG maintenance.

## After merge (rollout)
1. Tag `v0.1.15-rc.1` on the merge commit.
2. Run `rust_release.yml` (confirm `publish`) → crates.io.
3. Run `python_release.yml` → `--pre` wheels.
4. GitHub release marked pre-release.

Try it: `cargo add kornia-imgproc@0.1.15-rc.1` · `pip install --pre kornia-rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)