### PR TITLE
ci(python-release): drop --sdist from linux wheel build

### DIFF
--- a/.github/workflows/python_release.yml
+++ b/.github/workflows/python_release.yml
@@ -41,7 +41,11 @@ jobs:
           before-script-linux: |
             if command -v dnf &> /dev/null; then dnf install cmake3 -y; elif command -v yum &> /dev/null; then yum install cmake3 -y; elif command -v apt-get &> /dev/null; then apt-get update && apt-get install cmake -y; else echo "None of dnf, yum, or apt found."; fi
             if command -v cmake3 &> /dev/null; then export CMAKE=cmake3; fi
-          args: --release --out dist -i python${{ matrix.python-version }} -m kornia-py/Cargo.toml --sdist
+          # No --sdist: the sdist build is not self-contained (kornia-tensor's
+          # optional dlpack-rs git dependency can't resolve inside the extracted
+          # tarball), which breaks the manylinux build. Wheels build directly
+          # like the macOS/Windows jobs. Revisit once dlpack-rs is on crates.io.
+          args: --release --out dist -i python${{ matrix.python-version }} -m kornia-py/Cargo.toml
       - name: Verify SIMD paths are present in the built wheel
         env:
           MATRIX_TARGET: ${{ matrix.target }}


### PR DESCRIPTION
Unblocks the 0.1.15-rc.1 Python wheel rollout.

**Problem:** the linux release job builds with `--sdist`; the extracted sdist tarball can't resolve kornia-tensor's optional `dlpack-rs` git dep (tag v0.3.2, not on crates.io) → `maturin failed` at 'Building wheels from source distribution'. macOS/Windows build wheels directly and pass.

**Fix:** drop `--sdist` so linux builds wheels directly too. No sdist uploaded this rc (source installs unavailable — acceptable for a pre-release; wheels cover all supported py/arch).

**Follow-up:** restore `--sdist` once `dlpack-rs` is on crates.io under a usable name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)