### PR TITLE
ci(python-release): exclude 3.13t from linux matrix; fail-fast off

### DIFF
--- a/.github/workflows/python_release.yml
+++ b/.github/workflows/python_release.yml
@@ -11,9 +11,17 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t"]
         target: [x86_64, aarch64]
+        exclude:
+          # The maturin bundled in the manylinux image cannot build the
+          # free-threaded 3.13 interpreter ("Free-threaded Python interpreter
+          # is only supported on 3.14 and later"). 3.13t wheels still build on
+          # macOS/Windows (newer host maturin). Restore here once the manylinux
+          # maturin gains free-threaded 3.13 support.
+          - python-version: "3.13t"
     # Neutralize the in-repo `.cargo/config.toml` (which targets the local
     # Jetson cross-test setup: `x86_64-linux-gnu-gcc` cross-linker plus
     # `x86-64-v3` / `aarch64+fp16+fhm` baselines). Released wheels need


### PR DESCRIPTION
Second unblock for the 0.1.15-rc.1 wheel rollout.

**Problem:** manylinux-bundled maturin can't build free-threaded 3.13 — `Free-threaded Python interpreter is only supported on 3.14 and later`. Linux `3.13t` fails; fail-fast then cancelled all other linux jobs and skipped the PyPI upload.

**Fix:**
- Exclude `3.13t` from the **linux** matrix (macOS/Windows keep 3.13t — newer host maturin builds it fine).
- `fail-fast: false` on linux so one version's failure no longer masks the rest.

**Follow-up:** restore 3.13t-linux once the manylinux maturin supports free-threaded 3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)