### PR TITLE
ci(python-release): pin linux maturin to 1.13.3 (restores 3.13t)

### DIFF
--- a/.github/workflows/python_release.yml
+++ b/.github/workflows/python_release.yml
@@ -36,11 +36,13 @@ jobs:
       - uses: actions/checkout@v7
       - uses: messense/maturin-action@v1
         with:
-          # Pin latest maturin (as macOS/Windows jobs do). Without this, linux
-          # uses the action's default bundled maturin, whose free-threaded 3.13
-          # (3.13t) support regressed to "only supported on 3.14 and later" —
-          # 3.13t-linux built fine until the action's default maturin drifted.
-          maturin-version: latest
+          # Pin maturin 1.13.3 — the version that shipped v0.1.14 and built the
+          # whole matrix incl. free-threaded 3.13 (3.13t). Newer maturin sets
+          # FREE_THREADED_MINIMUM_PYTHON_MINOR=14 and drops 3.13t (upstream
+          # deprecated it for 3.14t), so `latest`/default fails 3.13t-linux with
+          # "Free-threaded Python interpreter is only supported on 3.14 and
+          # later". Revisit (unpin) if/when we move to 3.14t-only wheels.
+          maturin-version: v1.13.3
           target: ${{ matrix.target }}
           manylinux: auto
           command: build


### PR DESCRIPTION
**Regression fix — keeps 3.13t.**

v0.1.14 (last green release, May 19) built the linux 3.13t wheels with **maturin 1.13.3** in the manylinux container. maturin-action's default container maturin has since drifted to a version that sets `FREE_THREADED_MINIMUM_PYTHON_MINOR=14` and **drops free-threaded 3.13** (upstream deprecated 3.13t in favor of 3.14t), so 3.13t-linux now fails: *Free-threaded Python interpreter is only supported on 3.14 and later*. macOS/Windows use the host maturin → still build 3.13t (the asymmetry).

**Fix:** pin `maturin-version: v1.13.3` on the linux job — the exact toolchain that shipped v0.1.14 (whole matrix incl. 3.13t / 3.14 / 3.14t). Keep `fail-fast: false`.

Refs: [PyO3/maturin#3206](https://github.com/pyo3/maturin/pull/3206).

**Follow-up:** unpin and move to 3.14t-only free-threaded wheels when we're ready to match upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)