### PR TITLE
chore(release): v0.1.15-rc.3 — apriltag threshold + GPU texture kernels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ changes early: `cargo add kornia-imgproc@0.1.15-rc.1` or `pip install --pre korn
      dated section and reset [Unreleased]. Reference the diff range and prior tag
      so the changelog stays navigable (see the "Full changelog" links below). -->
 
+## [0.1.15-rc.3] — 2026-07-06 (pre-release)
+
+Two fixes on top of rc.2 (which brought the crates.io publish):
+
+- **AprilTag**: bias the adaptive binarization toward white (`threshold_split`,
+  default `0.33`) so small / glary / low-contrast Tag36H11 markers decode instead
+  of returning zero detections; the tag's black border no longer merges with
+  adjacent dark regions (#985).
+- **imgproc (GPU/CUDA)**: texture-object warp-affine kernels — a `CudaTexObject`
+  RAII wrapper with `CU_TR_ADDRESS_MODE_BORDER` replaces the per-pixel OOB
+  bounds-check branch, cutting warp divergence on rotated images (~30–40% of
+  output pixels map outside the source); optional `block_dim` tuning (#979).
+
+**Full changelog:** `v0.1.15-rc.2...v0.1.15-rc.3`
+
 ## [0.1.15-rc.2] — 2026-07-06 (pre-release)
 
 Same contents as rc.1; unblocks the **crates.io** publish. The `dlpack-rs`
@@ -102,6 +117,7 @@ linear layer / kornia-nn, kornia-apriltag, zero-copy gstreamer images. See the
 [GitHub release](https://github.com/kornia/kornia-rs/releases/tag/v0.1.10) for
 the full per-PR list.
 
+[0.1.15-rc.3]: https://github.com/kornia/kornia-rs/compare/v0.1.15-rc.2...v0.1.15-rc.3
 [0.1.15-rc.2]: https://github.com/kornia/kornia-rs/compare/v0.1.15-rc.1...v0.1.15-rc.2
 [0.1.15-rc.1]: https://github.com/kornia/kornia-rs/compare/v0.1.14...v0.1.15-rc.1
 [0.1.14]: https://github.com/kornia/kornia-rs/releases/tag/v0.1.14

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "apriltag"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "argh",
  "ctrlc",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "apriltag-pose"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "argh",
  "kornia",
@@ -1488,7 +1488,7 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "binarize"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "argh",
  "kornia",
@@ -2421,7 +2421,7 @@ dependencies = [
 
 [[package]]
 name = "colmap_rerun"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "argh",
  "kornia",
@@ -2463,7 +2463,7 @@ dependencies = [
 
 [[package]]
 name = "color_detector"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "argh",
  "kornia",
@@ -2478,7 +2478,7 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "color_spaces"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "kornia-image",
  "kornia-imgproc",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "contours"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "argh",
  "kornia",
@@ -2735,7 +2735,7 @@ dependencies = [
 
 [[package]]
 name = "copper"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "cu29",
  "kornia",
@@ -5373,7 +5373,7 @@ dependencies = [
 
 [[package]]
 name = "exif_auto_orient"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "kornia-io",
 ]
@@ -6897,7 +6897,7 @@ dependencies = [
 
 [[package]]
 name = "hello_world"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "argh",
  "kornia",
@@ -7083,7 +7083,7 @@ dependencies = [
 
 [[package]]
 name = "histogram"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "argh",
  "kornia",
@@ -7350,7 +7350,7 @@ dependencies = [
 
 [[package]]
 name = "icp_registration"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "argh",
  "env_logger",
@@ -7509,7 +7509,7 @@ dependencies = [
 
 [[package]]
 name = "image_api"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "kornia-image",
 ]
@@ -7559,7 +7559,7 @@ checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
 
 [[package]]
 name = "imgproc"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "argh",
  "kornia",
@@ -8079,7 +8079,7 @@ checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "kornia"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "kornia-3d",
  "kornia-algebra",
@@ -8093,7 +8093,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-3d"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "approx",
  "bincode 2.0.1",
@@ -8115,7 +8115,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-algebra"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "approx",
  "criterion 0.8.2",
@@ -8128,7 +8128,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-apriltag"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "aprilgrid",
  "apriltag 0.4.0",
@@ -8146,7 +8146,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-bow"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "bincode 2.0.1",
  "criterion 0.8.2",
@@ -8159,7 +8159,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-cpp"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -8170,7 +8170,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-image"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "arrow 59.0.0",
  "criterion 0.8.2",
@@ -8185,7 +8185,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-imgproc"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "criterion 0.8.2",
  "cubecl-core",
@@ -8210,7 +8210,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-io"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "circular-buffer",
  "criterion 0.8.2",
@@ -8235,7 +8235,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-py"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "cudarc 0.19.8",
  "dlpack-rs",
@@ -8255,7 +8255,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-tensor"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "bincode 2.0.1",
  "criterion 0.8.2",
@@ -8272,7 +8272,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-tensor-ops"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "approx",
  "criterion 0.8.2",
@@ -8284,7 +8284,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-vlm"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "candle-core",
  "candle-flash-attn",
@@ -8947,7 +8947,7 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "argh",
  "kornia",
@@ -9079,7 +9079,7 @@ dependencies = [
 
 [[package]]
 name = "morphology"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "argh",
  "kornia",
@@ -9567,7 +9567,7 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "normalize"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "argh",
  "kornia",
@@ -9575,7 +9575,7 @@ dependencies = [
 
 [[package]]
 name = "normalize_ii"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "argh",
  "kornia",
@@ -10303,7 +10303,7 @@ dependencies = [
 
 [[package]]
 name = "onnx"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "argh",
  "kornia",
@@ -10634,7 +10634,7 @@ dependencies = [
 
 [[package]]
 name = "paligemma"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "argh",
  "kornia-io",
@@ -11077,7 +11077,7 @@ dependencies = [
 
 [[package]]
 name = "ply_rerun"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "argh",
  "kornia",
@@ -11144,7 +11144,7 @@ dependencies = [
 
 [[package]]
 name = "pnp_demo"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "argh",
  "env_logger",
@@ -14377,7 +14377,7 @@ dependencies = [
 
 [[package]]
 name = "rerun_viz"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "argh",
  "kornia",
@@ -14500,7 +14500,7 @@ dependencies = [
 
 [[package]]
 name = "rotate"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "argh",
  "kornia",
@@ -15522,7 +15522,7 @@ dependencies = [
 
 [[package]]
 name = "smol_vlm"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "argh",
  "kornia-image",
@@ -15573,7 +15573,7 @@ dependencies = [
 
 [[package]]
 name = "smol_vlm_convo"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "argh",
  "color-eyre",
@@ -15831,7 +15831,7 @@ dependencies = [
 
 [[package]]
 name = "std_mean"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "argh",
  "indicatif 0.18.5",
@@ -17268,7 +17268,7 @@ dependencies = [
 
 [[package]]
 name = "undistort"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "argh",
  "kornia",
@@ -17277,7 +17277,7 @@ dependencies = [
 
 [[package]]
 name = "undistort_points"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "argh",
  "kornia",
@@ -17702,7 +17702,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "video_player"
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 dependencies = [
  "eframe",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = ["examples/cuda_imgproc", "examples/dora"]
 default-members = ["crates/*"]
 
 [workspace.package]
-version = "0.1.15-rc.2"
+version = "0.1.15-rc.3"
 authors = ["kornia.org <edgar@kornia.org>"]
 edition = "2021"
 rust-version = "1.89"
@@ -55,17 +55,17 @@ imageproc = "0.27"
 indicatif = { version = "0.18.4", features = ["rayon"] }
 kiddo = "5.3"
 # NOTE: remember to update the kornia-py package version in `kornia-py/Cargo.toml` when updating the Rust package version
-kornia = { path = "crates/kornia", version = "0.1.15-rc.2" }
-kornia-3d = { path = "crates/kornia-3d", version = "0.1.15-rc.2" }
-kornia-algebra = { path = "crates/kornia-algebra", version = "0.1.15-rc.2" }
-kornia-apriltag = { path = "crates/kornia-apriltag", version = "0.1.15-rc.2" }
-kornia-bow = { path = "crates/kornia-bow", version = "0.1.15-rc.2" }
-kornia-image = { path = "crates/kornia-image", version = "0.1.15-rc.2" }
-kornia-imgproc = { path = "crates/kornia-imgproc", version = "0.1.15-rc.2" }
-kornia-io = { path = "crates/kornia-io", version = "0.1.15-rc.2" }
-kornia-tensor = { path = "crates/kornia-tensor", version = "0.1.15-rc.2" }
-kornia-tensor-ops = { path = "crates/kornia-tensor-ops", version = "0.1.15-rc.2" }
-kornia-vlm = { path = "crates/kornia-vlm", version = "0.1.15-rc.2" }
+kornia = { path = "crates/kornia", version = "0.1.15-rc.3" }
+kornia-3d = { path = "crates/kornia-3d", version = "0.1.15-rc.3" }
+kornia-algebra = { path = "crates/kornia-algebra", version = "0.1.15-rc.3" }
+kornia-apriltag = { path = "crates/kornia-apriltag", version = "0.1.15-rc.3" }
+kornia-bow = { path = "crates/kornia-bow", version = "0.1.15-rc.3" }
+kornia-image = { path = "crates/kornia-image", version = "0.1.15-rc.3" }
+kornia-imgproc = { path = "crates/kornia-imgproc", version = "0.1.15-rc.3" }
+kornia-io = { path = "crates/kornia-io", version = "0.1.15-rc.3" }
+kornia-tensor = { path = "crates/kornia-tensor", version = "0.1.15-rc.3" }
+kornia-tensor-ops = { path = "crates/kornia-tensor-ops", version = "0.1.15-rc.3" }
+kornia-vlm = { path = "crates/kornia-vlm", version = "0.1.15-rc.3" }
 log = "0.4"
 minijinja = { version = "2.20", features = ["loader"] }
 nalgebra = "0.35"


### PR DESCRIPTION
Pre-release `0.1.15-rc.3`, both channels. Adds two fixes on top of rc.2:

- **#985** AprilTag adaptive-threshold white bias (`threshold_split`, default 0.33) — small/glary Tag36H11 markers now decode.
- **#979** CUDA texture-object warp-affine kernels — border-mode replaces the OOB bounds-check branch, cutting warp divergence on rotated images.

Bump rc.2 → rc.3 (+ internal pins, Cargo.lock), CHANGELOG entry.

After merge: tag `v0.1.15-rc.3` → `rust_release.yml` (crates.io) + `python_release.yml` (wheels).

Try it: `cargo add kornia-imgproc@0.1.15-rc.3` · `pip install --pre kornia-rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)