### PR TITLE
chore(release): v0.1.15-rc.4 — GPU/CUDA wheels

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -8,6 +8,26 @@ description: Use when cutting a kornia-rs release or pre-release (rc) — bumps 
 Publishing is **irreversible** (crates.io only yanks, never deletes). Never run
 the publish step without explicit human confirmation of version + scope.
 
+## CUDA — always in scope (unless the human opts out)
+
+**Every release must include the CUDA/GPU path.** The default `python_release.yml`
+builds wheels **without** `--features cuda`, so `pip install kornia-rs` ships a
+**CPU-only** wheel (no `kornia_rs.cuda`). Do NOT ship a release calling out GPU
+features from a wheel that lacks them.
+
+Before publishing wheels, confirm the GPU story:
+- kornia-py's `cuda` feature uses cudarc **dynamic loading** — a `--features cuda`
+  wheel still imports on machines without CUDA and should fall back to CPU; the
+  GPU path activates at runtime when `libcuda` + `libnvrtc` are present. So a
+  single cuda-built wheel is the goal (universal), not a separate variant.
+- Add `--features cuda` to the linux wheel `args:` in `python_release.yml` (and
+  verify import still works with no CUDA present) so pip users get GPU.
+- Runtime requirements to put in the release notes: NVIDIA driver (`libcuda.so`)
+  **and** `nvrtc` (kernels are JIT-compiled), matching arch (x86_64 / aarch64 /
+  Jetson Tegra). Without nvrtc the GPU path can't compile kernels.
+- Verify on a GPU box before announcing: `bench_gpu_warp_affine --features
+  gpu-cuda` (Rust) and `import kornia_rs; kornia_rs.cuda...` (Python).
+
 ## Facts about this repo
 
 - Workspace version: single source in root `Cargo.toml` (`version = "..."`, all

--- a/.github/workflows/python_release.yml
+++ b/.github/workflows/python_release.yml
@@ -49,11 +49,14 @@ jobs:
           before-script-linux: |
             if command -v dnf &> /dev/null; then dnf install cmake3 -y; elif command -v yum &> /dev/null; then yum install cmake3 -y; elif command -v apt-get &> /dev/null; then apt-get update && apt-get install cmake -y; else echo "None of dnf, yum, or apt found."; fi
             if command -v cmake3 &> /dev/null; then export CMAKE=cmake3; fi
-          # No --sdist: the sdist build is not self-contained (kornia-tensor's
-          # optional dlpack-rs git dependency can't resolve inside the extracted
-          # tarball), which breaks the manylinux build. Wheels build directly
-          # like the macOS/Windows jobs. Revisit once dlpack-rs is on crates.io.
-          args: --release --out dist -i python${{ matrix.python-version }} -m kornia-py/Cargo.toml
+          # --features cuda: ship GPU-capable linux wheels. cudarc uses
+          # `fallback-dynamic-loading`, so the wheel builds in the CUDA-less
+          # manylinux container and dlopens libcuda/libnvrtc at runtime — one
+          # universal wheel that runs on CPU when no GPU/driver is present and
+          # activates CUDA when it is. (macOS/Windows stay CPU-only: no NVIDIA.)
+          # No --sdist: not self-contained (bindgen/vendored deps); wheels build
+          # directly like the macOS/Windows jobs.
+          args: --release --out dist -i python${{ matrix.python-version }} -m kornia-py/Cargo.toml --features cuda
       - name: Verify SIMD paths are present in the built wheel
         env:
           MATRIX_TARGET: ${{ matrix.target }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ changes early: `cargo add kornia-imgproc@0.1.15-rc.1` or `pip install --pre korn
      dated section and reset [Unreleased]. Reference the diff range and prior tag
      so the changelog stays navigable (see the "Full changelog" links below). -->
 
+## [0.1.15-rc.4] — 2026-07-06 (pre-release)
+
+**GPU wheels.** Linux wheels now build with `--features cuda`, so
+`pip install --pre kornia-rs` ships the `kornia_rs.cuda` module (GPU color
+conversions, `CudaImage`/`CudaPreprocessor`, zero-copy DLPack). The wheel loads
+CUDA lazily (cudarc `fallback-dynamic-loading`): it runs on CPU when no GPU is
+present and activates CUDA at runtime when an NVIDIA driver + `nvrtc` are
+available. Same crate/library contents as rc.3 otherwise.
+
+- `python_release.yml`: linux job builds `--features cuda` (macOS/Windows stay
+  CPU-only — no NVIDIA hardware).
+- README: added a **GPU / CUDA** usage section with an `upload → op → download`
+  snippet and the runtime requirements.
+
+**Full changelog:** `v0.1.15-rc.3...v0.1.15-rc.4`
+
 ## [0.1.15-rc.3] — 2026-07-06 (pre-release)
 
 Two fixes on top of rc.2 (which brought the crates.io publish):
@@ -117,6 +133,7 @@ linear layer / kornia-nn, kornia-apriltag, zero-copy gstreamer images. See the
 [GitHub release](https://github.com/kornia/kornia-rs/releases/tag/v0.1.10) for
 the full per-PR list.
 
+[0.1.15-rc.4]: https://github.com/kornia/kornia-rs/compare/v0.1.15-rc.3...v0.1.15-rc.4
 [0.1.15-rc.3]: https://github.com/kornia/kornia-rs/compare/v0.1.15-rc.2...v0.1.15-rc.3
 [0.1.15-rc.2]: https://github.com/kornia/kornia-rs/compare/v0.1.15-rc.1...v0.1.15-rc.2
 [0.1.15-rc.1]: https://github.com/kornia/kornia-rs/compare/v0.1.14...v0.1.15-rc.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "apriltag"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "argh",
  "ctrlc",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "apriltag-pose"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "argh",
  "kornia",
@@ -1488,7 +1488,7 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "binarize"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "argh",
  "kornia",
@@ -2421,7 +2421,7 @@ dependencies = [
 
 [[package]]
 name = "colmap_rerun"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "argh",
  "kornia",
@@ -2463,7 +2463,7 @@ dependencies = [
 
 [[package]]
 name = "color_detector"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "argh",
  "kornia",
@@ -2478,7 +2478,7 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "color_spaces"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "kornia-image",
  "kornia-imgproc",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "contours"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "argh",
  "kornia",
@@ -2735,7 +2735,7 @@ dependencies = [
 
 [[package]]
 name = "copper"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "cu29",
  "kornia",
@@ -5373,7 +5373,7 @@ dependencies = [
 
 [[package]]
 name = "exif_auto_orient"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "kornia-io",
 ]
@@ -6897,7 +6897,7 @@ dependencies = [
 
 [[package]]
 name = "hello_world"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "argh",
  "kornia",
@@ -7083,7 +7083,7 @@ dependencies = [
 
 [[package]]
 name = "histogram"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "argh",
  "kornia",
@@ -7350,7 +7350,7 @@ dependencies = [
 
 [[package]]
 name = "icp_registration"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "argh",
  "env_logger",
@@ -7509,7 +7509,7 @@ dependencies = [
 
 [[package]]
 name = "image_api"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "kornia-image",
 ]
@@ -7559,7 +7559,7 @@ checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
 
 [[package]]
 name = "imgproc"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "argh",
  "kornia",
@@ -8079,7 +8079,7 @@ checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "kornia"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "kornia-3d",
  "kornia-algebra",
@@ -8093,7 +8093,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-3d"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "approx",
  "bincode 2.0.1",
@@ -8115,7 +8115,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-algebra"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "approx",
  "criterion 0.8.2",
@@ -8128,7 +8128,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-apriltag"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "aprilgrid",
  "apriltag 0.4.0",
@@ -8146,7 +8146,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-bow"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "bincode 2.0.1",
  "criterion 0.8.2",
@@ -8159,7 +8159,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-cpp"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -8170,7 +8170,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-image"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "arrow 59.0.0",
  "criterion 0.8.2",
@@ -8185,7 +8185,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-imgproc"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "criterion 0.8.2",
  "cubecl-core",
@@ -8210,7 +8210,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-io"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "circular-buffer",
  "criterion 0.8.2",
@@ -8235,7 +8235,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-py"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "cudarc 0.19.8",
  "dlpack-rs",
@@ -8255,7 +8255,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-tensor"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "bincode 2.0.1",
  "criterion 0.8.2",
@@ -8272,7 +8272,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-tensor-ops"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "approx",
  "criterion 0.8.2",
@@ -8284,7 +8284,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-vlm"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "candle-core",
  "candle-flash-attn",
@@ -8947,7 +8947,7 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "argh",
  "kornia",
@@ -9079,7 +9079,7 @@ dependencies = [
 
 [[package]]
 name = "morphology"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "argh",
  "kornia",
@@ -9567,7 +9567,7 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "normalize"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "argh",
  "kornia",
@@ -9575,7 +9575,7 @@ dependencies = [
 
 [[package]]
 name = "normalize_ii"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "argh",
  "kornia",
@@ -10303,7 +10303,7 @@ dependencies = [
 
 [[package]]
 name = "onnx"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "argh",
  "kornia",
@@ -10634,7 +10634,7 @@ dependencies = [
 
 [[package]]
 name = "paligemma"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "argh",
  "kornia-io",
@@ -11077,7 +11077,7 @@ dependencies = [
 
 [[package]]
 name = "ply_rerun"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "argh",
  "kornia",
@@ -11144,7 +11144,7 @@ dependencies = [
 
 [[package]]
 name = "pnp_demo"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "argh",
  "env_logger",
@@ -14377,7 +14377,7 @@ dependencies = [
 
 [[package]]
 name = "rerun_viz"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "argh",
  "kornia",
@@ -14500,7 +14500,7 @@ dependencies = [
 
 [[package]]
 name = "rotate"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "argh",
  "kornia",
@@ -15522,7 +15522,7 @@ dependencies = [
 
 [[package]]
 name = "smol_vlm"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "argh",
  "kornia-image",
@@ -15573,7 +15573,7 @@ dependencies = [
 
 [[package]]
 name = "smol_vlm_convo"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "argh",
  "color-eyre",
@@ -15831,7 +15831,7 @@ dependencies = [
 
 [[package]]
 name = "std_mean"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "argh",
  "indicatif 0.18.5",
@@ -17268,7 +17268,7 @@ dependencies = [
 
 [[package]]
 name = "undistort"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "argh",
  "kornia",
@@ -17277,7 +17277,7 @@ dependencies = [
 
 [[package]]
 name = "undistort_points"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "argh",
  "kornia",
@@ -17702,7 +17702,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "video_player"
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 dependencies = [
  "eframe",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = ["examples/cuda_imgproc", "examples/dora"]
 default-members = ["crates/*"]
 
 [workspace.package]
-version = "0.1.15-rc.3"
+version = "0.1.15-rc.4"
 authors = ["kornia.org <edgar@kornia.org>"]
 edition = "2021"
 rust-version = "1.89"
@@ -55,17 +55,17 @@ imageproc = "0.27"
 indicatif = { version = "0.18.4", features = ["rayon"] }
 kiddo = "5.3"
 # NOTE: remember to update the kornia-py package version in `kornia-py/Cargo.toml` when updating the Rust package version
-kornia = { path = "crates/kornia", version = "0.1.15-rc.3" }
-kornia-3d = { path = "crates/kornia-3d", version = "0.1.15-rc.3" }
-kornia-algebra = { path = "crates/kornia-algebra", version = "0.1.15-rc.3" }
-kornia-apriltag = { path = "crates/kornia-apriltag", version = "0.1.15-rc.3" }
-kornia-bow = { path = "crates/kornia-bow", version = "0.1.15-rc.3" }
-kornia-image = { path = "crates/kornia-image", version = "0.1.15-rc.3" }
-kornia-imgproc = { path = "crates/kornia-imgproc", version = "0.1.15-rc.3" }
-kornia-io = { path = "crates/kornia-io", version = "0.1.15-rc.3" }
-kornia-tensor = { path = "crates/kornia-tensor", version = "0.1.15-rc.3" }
-kornia-tensor-ops = { path = "crates/kornia-tensor-ops", version = "0.1.15-rc.3" }
-kornia-vlm = { path = "crates/kornia-vlm", version = "0.1.15-rc.3" }
+kornia = { path = "crates/kornia", version = "0.1.15-rc.4" }
+kornia-3d = { path = "crates/kornia-3d", version = "0.1.15-rc.4" }
+kornia-algebra = { path = "crates/kornia-algebra", version = "0.1.15-rc.4" }
+kornia-apriltag = { path = "crates/kornia-apriltag", version = "0.1.15-rc.4" }
+kornia-bow = { path = "crates/kornia-bow", version = "0.1.15-rc.4" }
+kornia-image = { path = "crates/kornia-image", version = "0.1.15-rc.4" }
+kornia-imgproc = { path = "crates/kornia-imgproc", version = "0.1.15-rc.4" }
+kornia-io = { path = "crates/kornia-io", version = "0.1.15-rc.4" }
+kornia-tensor = { path = "crates/kornia-tensor", version = "0.1.15-rc.4" }
+kornia-tensor-ops = { path = "crates/kornia-tensor-ops", version = "0.1.15-rc.4" }
+kornia-vlm = { path = "crates/kornia-vlm", version = "0.1.15-rc.4" }
 log = "0.4"
 minijinja = { version = "2.20", features = ["loader"] }
 nalgebra = "0.35"

--- a/README.md
+++ b/README.md
@@ -312,6 +312,39 @@ resized_img = K.resize(img, (128, 128), interpolation="bilinear")
 assert resized_img.shape == (128, 128, 3)
 ```
 
+### GPU / CUDA
+
+The `kornia_rs.cuda` module runs image ops on an NVIDIA GPU. The published
+wheels are GPU-capable but load CUDA lazily, so the **same wheel runs on CPU
+when no GPU is present** and activates CUDA when it is.
+
+**Runtime requirements for the GPU path:** an NVIDIA driver (`libcuda`) **and**
+`nvrtc` (from the CUDA toolkit — kernels are JIT-compiled), matching your
+architecture (x86_64 / aarch64 / Jetson). Without them the GPU calls are
+unavailable; CPU ops keep working.
+
+```python
+import numpy as np
+import kornia_rs as K
+
+# Guard: falls back to CPU when no CUDA runtime is available.
+if K.cuda.is_available():
+    rgb = np.ascontiguousarray(
+        np.random.randint(0, 255, (480, 640, 3), dtype=np.uint8)
+    )
+
+    cu_img = K.cuda.upload(rgb)              # host -> GPU  (CudaImage)
+    cu_gray = K.cuda.gray_from_rgb(cu_img)   # runs on the GPU
+    gray = np.asarray(cu_gray.download())    # GPU -> host  (H, W, 1) uint8
+
+    assert gray.shape == (480, 640, 1)
+```
+
+Available on the GPU: color conversions (`gray_from_rgb`, `bgr_from_rgb`,
+`hsv_from_rgb`, `lab_from_rgb`, `ycbcr_from_rgb`, `rgb_from_bayer`, `rgba_from_rgb`, …),
+`apply_colormap`, a fused `CudaPreprocessor`, and zero-copy DLPack import
+(`K.cuda.from_dlpack`) for handing tensors to/from PyTorch without a host copy.
+
 ## 🧑‍💻 Development
 
 ### Prerequisites


### PR DESCRIPTION
Ships **GPU-capable Python wheels**. Linux wheels now build with `--features cuda`, so `pip install --pre kornia-rs` exposes `kornia_rs.cuda`.

**Universal wheel:** cudarc `fallback-dynamic-loading` → runs on CPU when no GPU, activates CUDA at runtime when an NVIDIA driver + `nvrtc` are present. macOS/Windows stay CPU-only (no NVIDIA HW).

**Verified on-device (Jetson Orin, driver 540.4.0, nvrtc 12.6):**
- `kr.cuda.is_available()` → True; GPU `gray_from_rgb` round-trip (upload→op→download) matches CPU exactly (max diff 0)
- Rust `--features gpu-cuda` warp-affine ~22× over CPU (1920×1080)

**Changes:**
- `python_release.yml` linux `args += --features cuda`
- README: **GPU / CUDA** usage section (snippet + runtime reqs)
- `release` skill: 'CUDA — always in scope'
- bump rc.3 → rc.4

⚠️ Key CI signal: the manylinux linux wheel build must succeed **without CUDA present** (cudarc fallback). If it fails, cudarc needs an explicit dynamic-loading tweak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)