### PR TITLE
fix(ci): update CUDA feature name in clippy check (gpu-cuda → cuda)

### DIFF
--- a/.github/workflows/rust_lint.yml
+++ b/.github/workflows/rust_lint.yml
@@ -75,9 +75,9 @@ jobs:
 
       - name: Clippy CUDA-gated crates (deny warnings)
         run: |
-          cargo clippy -p kornia-tensor --features cudarc -- -D warnings
-          cargo clippy -p kornia-image --features cudarc -- -D warnings
-          cargo clippy -p kornia-imgproc --features "cudarc,gpu-cuda" -- -D warnings
+          cargo clippy -p kornia-tensor --features cuda -- -D warnings
+          cargo clippy -p kornia-image --features cuda -- -D warnings
+          cargo clippy -p kornia-imgproc --features cuda -- -D warnings
 
   cross-platform-check-macos:
     name: Check - macOS


### PR DESCRIPTION
The `cuda-feature-check` CI job was still using the old feature names `cudarc` and `gpu-cuda` from before this refactor. This branch renamed them all to `cuda`, so the clippy commands need to match.

**Fix:**
```
cargo clippy -p kornia-tensor --features cuda -- -D warnings
cargo clippy -p kornia-image  --features cuda -- -D warnings
cargo clippy -p kornia-imgproc --features cuda -- -D warnings
```

All three verified passing locally.