### PR TITLE
fix(imgproc): add block_dim override to bicubic resize and warp-affine launchers

### DIFF
--- a/crates/kornia-imgproc/examples/bench_gpu_resize.rs
+++ b/crates/kornia-imgproc/examples/bench_gpu_resize.rs
@@ -346,14 +346,14 @@ fn run_gpu_cuda_bicubic() {
         let mut dst_dev = stream.alloc_zeros::<f32>(npix_dst * nc).expect("alloc dst");
 
         for _ in 0..WARMUP {
-            launch_resize_bicubic_cuda(&ctx, &stream, &src_dev, &mut dst_dev, sw, sh, dw, dh)
+            launch_resize_bicubic_cuda(&ctx, &stream, &src_dev, &mut dst_dev, sw, sh, dw, dh, None)
                 .expect("bicubic launch");
         }
         stream.synchronize().expect("sync");
 
         let t = std::time::Instant::now();
         for _ in 0..ITERS {
-            launch_resize_bicubic_cuda(&ctx, &stream, &src_dev, &mut dst_dev, sw, sh, dw, dh)
+            launch_resize_bicubic_cuda(&ctx, &stream, &src_dev, &mut dst_dev, sw, sh, dw, dh, None)
                 .expect("bicubic launch");
         }
         stream.synchronize().expect("sync");

--- a/crates/kornia-imgproc/examples/bench_gpu_warp_affine.rs
+++ b/crates/kornia-imgproc/examples/bench_gpu_warp_affine.rs
@@ -75,10 +75,10 @@ fn run_gpu_cuda() {
                     &ctx, &stream, &src_dev, dst, w, h, w, h, &m, None,
                 )
                 .expect("nearest launch"),
-                "bicubic" => {
-                    launch_warp_affine_bicubic_cuda(&ctx, &stream, &src_dev, dst, w, h, w, h, &m)
-                        .expect("bicubic launch")
-                }
+                "bicubic" => launch_warp_affine_bicubic_cuda(
+                    &ctx, &stream, &src_dev, dst, w, h, w, h, &m, None,
+                )
+                .expect("bicubic launch"),
                 _ => launch_warp_affine_bilinear_cuda(
                     &ctx, &stream, &src_dev, dst, w, h, w, h, &m, None,
                 )

--- a/crates/kornia-imgproc/src/gpu/resize_cuda.rs
+++ b/crates/kornia-imgproc/src/gpu/resize_cuda.rs
@@ -591,6 +591,7 @@ pub fn launch_resize_bicubic_cuda(
     src_height: u32,
     dst_width: u32,
     dst_height: u32,
+    block_dim: Option<(u32, u32)>,
 ) -> Result<(), CudaResizeError> {
     if src_width == 0 || src_height == 0 || dst_width == 0 || dst_height == 0 {
         return Err(CudaResizeError::Cuda(
@@ -627,7 +628,7 @@ pub fn launch_resize_bicubic_cuda(
         .launch_2d(
             dst_width,
             dst_height,
-            make_config(dst_width, dst_height, None),
+            make_config(dst_width, dst_height, block_dim),
         )
         .map_err(|e| CudaResizeError::Cuda(e.to_string()))
 }

--- a/crates/kornia-imgproc/src/gpu/warp_affine_cuda.rs
+++ b/crates/kornia-imgproc/src/gpu/warp_affine_cuda.rs
@@ -452,8 +452,8 @@ pub fn launch_warp_affine_nearest_cuda(
 ///
 /// # Arguments
 ///
-/// See [`launch_warp_affine_bilinear_cuda`] — arguments are identical except
-/// no `block_dim` parameter (always uses 32×8).
+/// See [`launch_warp_affine_bilinear_cuda`] — arguments are identical including
+/// the optional `block_dim` override.
 ///
 /// # Errors
 ///
@@ -470,6 +470,7 @@ pub fn launch_warp_affine_bicubic_cuda(
     dst_width: u32,
     dst_height: u32,
     m: &[f32; 6],
+    block_dim: Option<(u32, u32)>,
 ) -> Result<(), CudaWarpAffineError> {
     if src_width == 0 || src_height == 0 || dst_width == 0 || dst_height == 0 {
         return Err(CudaWarpAffineError::Cuda(
@@ -502,7 +503,7 @@ pub fn launch_warp_affine_bicubic_cuda(
         .launch_2d(
             dst_width,
             dst_height,
-            make_config(dst_width, dst_height, None),
+            make_config(dst_width, dst_height, block_dim),
         )
         .map_err(|e| CudaWarpAffineError::Cuda(e.to_string()))
 }


### PR DESCRIPTION
## Summary

- `block_dim: Option<(u32, u32)>` was already present on all bilinear and nearest launchers (both resize and warp-affine) but bicubic hardcoded `None`.
- This PR adds the parameter to `launch_resize_bicubic_cuda` and `launch_warp_affine_bicubic_cuda` for consistency — callers can now pass `Some((16, 16))` for small images or `None` to keep the default 32×8 block.
- Updates the two bench examples to pass `None` at the existing call sites (no behaviour change).

## Test plan

- [ ] `cargo clippy -p kornia-imgproc --features gpu-cuda -- -D warnings` passes
- [ ] `cargo run --example bench_gpu_resize --features gpu-cuda --release` runs without error
- [ ] `cargo run --example bench_gpu_warp_affine --features gpu-cuda --release` runs without error