### PR TITLE
feat(imgproc): add CUDA warp-perspective kernels (bilinear, nearest, bicubic)

### DIFF
--- a/crates/kornia-imgproc/examples/bench_cuda_warp_perspective.rs
+++ b/crates/kornia-imgproc/examples/bench_cuda_warp_perspective.rs
@@ -15,14 +15,6 @@
 //! cargo run --example bench_cuda_warp_perspective --features cuda --release
 //! ```
 
-use std::time::Instant;
-
-const WARMUP: u32 = 50;
-const ITERS: u32 = 200;
-const NC: u32 = 3;
-
-const CASES: &[(u32, u32)] = &[(512, 512), (1280, 720), (1920, 1080), (3840, 2160)];
-
 fn main() {
     #[cfg(feature = "cuda")]
     run_benchmark();
@@ -34,6 +26,12 @@ fn main() {
 #[cfg(feature = "cuda")]
 fn run_benchmark() {
     use std::sync::Arc;
+    use std::time::Instant;
+
+    const WARMUP: u32 = 50;
+    const ITERS: u32 = 200;
+    const NC: u32 = 3;
+    const CASES: &[(u32, u32)] = &[(512, 512), (1280, 720), (1920, 1080), (3840, 2160)];
 
     use cudarc::driver::CudaContext;
     use kornia_imgproc::cuda::warp_perspective::{

--- a/crates/kornia-imgproc/examples/bench_cuda_warp_perspective.rs
+++ b/crates/kornia-imgproc/examples/bench_cuda_warp_perspective.rs
@@ -8,6 +8,7 @@
 //! 2. `warp_perspective_nearest`   — texture-backed nearest-neighbor, 3-ch f32.
 //! 3. `warp_perspective_bicubic`   — Keys a=−0.5 via `__ldg`, 3-ch f32.
 //! 4. `warp_perspective_lanczos`   — Lanczos-3 (6×6 taps) via `__ldg`, 3-ch f32.
+//!
 //! All use a perspective-tilt homography so the homogeneous w-divide is exercised
 //! on every pixel.
 //!

--- a/crates/kornia-imgproc/examples/bench_cuda_warp_perspective.rs
+++ b/crates/kornia-imgproc/examples/bench_cuda_warp_perspective.rs
@@ -1,0 +1,245 @@
+//! Micro-benchmark: CUDA warp-perspective (bilinear, nearest, bicubic).
+//!
+//! **Purpose:** Measure the throughput of the three warp-perspective kernels
+//! across typical image sizes, and compare bicubic quality vs speed vs
+//! warp-affine bilinear.
+//!
+//! **What is measured:**
+//! 1. `warp_perspective_bilinear`  — texture-backed bilinear, 3-ch f32.
+//! 2. `warp_perspective_nearest`   — texture-backed nearest-neighbor, 3-ch f32.
+//! 3. `warp_perspective_bicubic`   — Keys a=-0.5 via `__ldg`, 3-ch f32.
+//! 4. `warp_affine_bilinear`       — reference: same rotation, no perspective.
+//! All use a perspective-tilt homography (top edge scaled to 80% of bottom)
+//! so the homogeneous w-divide is exercised on every pixel.
+//!
+//! ```text
+//! cargo run --example bench_cuda_warp_perspective --features cuda --release
+//! ```
+
+use std::time::Instant;
+
+const WARMUP: u32 = 50;
+const ITERS: u32 = 200;
+const NC: u32 = 3;
+
+const CASES: &[(u32, u32)] = &[(512, 512), (1280, 720), (1920, 1080), (3840, 2160)];
+
+fn main() {
+    #[cfg(feature = "cuda")]
+    run_benchmark();
+
+    #[cfg(not(feature = "cuda"))]
+    println!("(build with --features cuda to run the benchmark)");
+}
+
+#[cfg(feature = "cuda")]
+fn run_benchmark() {
+    use std::sync::Arc;
+
+    use cudarc::driver::CudaContext;
+    use kornia_imgproc::cuda::warp_affine::launch_warp_affine_bilinear_cuda;
+    use kornia_imgproc::cuda::warp_perspective::{
+        launch_warp_perspective_bicubic_cuda, launch_warp_perspective_bilinear_cuda,
+        launch_warp_perspective_nearest_cuda,
+    };
+    use kornia_imgproc::warp::get_rotation_matrix2d;
+
+    let ctx = Arc::new(CudaContext::new(0).expect("CUDA device 0"));
+    let stream = ctx.default_stream();
+
+    // Perspective-tilt homography: top edge at 80% width, bottom at full width.
+    // h maps destination → source (forward homography; inverted internally).
+    fn tilt_homography(w: u32, h: u32) -> [f32; 9] {
+        let fw = w as f32;
+        let fh = h as f32;
+        // Projective tilt: H = [[1, s/fh, 0], [0, 1, 0], [0, s/(fw*fh), 1]], s=0.2.
+        // Exercises the w-divide on every pixel (w varies from 1.0 to ~1.2 across the image).
+        let s = 0.2_f32;
+        [1.0, s / fh, 0.0, 0.0, 1.0, 0.0, 0.0, s / (fw * fh), 1.0]
+    }
+
+    println!("\n=== CUDA warp-perspective benchmark ({ITERS} iters, perspective-tilt H) ===\n");
+    println!(
+        "  {:<20}  {:>10}  {:>10}  {:>10}  {:>10}",
+        "case (W×H)", "bilinear", "nearest", "bicubic", "affine-BL"
+    );
+    println!(
+        "  {:<20}  {:>10}  {:>10}  {:>10}  {:>10}",
+        "", "ms/frame", "ms/frame", "ms/frame", "ms/frame"
+    );
+    println!("  {}", "-".repeat(68));
+
+    for &(w, h) in CASES {
+        let npix = (w * h) as usize;
+        let src_data: Vec<f32> = (0..npix * NC as usize)
+            .map(|i| (i % 256) as f32 / 255.0)
+            .collect();
+
+        let homo = tilt_homography(w, h);
+        let center = (w as f32 / 2.0, h as f32 / 2.0);
+        let affine_m = get_rotation_matrix2d(center, 0.0_f32, 1.0); // identity-ish for comparison
+
+        let src_dev = stream.clone_htod(&src_data).expect("H→D src");
+        let mut dst_bl = stream
+            .alloc_zeros::<f32>(npix * NC as usize)
+            .expect("alloc");
+        let mut dst_nn = stream
+            .alloc_zeros::<f32>(npix * NC as usize)
+            .expect("alloc");
+        let mut dst_bc = stream
+            .alloc_zeros::<f32>(npix * NC as usize)
+            .expect("alloc");
+        let mut dst_aff = stream
+            .alloc_zeros::<f32>(npix * NC as usize)
+            .expect("alloc");
+
+        // Warmup — compile kernels and warm caches.
+        for _ in 0..WARMUP {
+            launch_warp_perspective_bilinear_cuda(
+                &ctx,
+                &stream,
+                &src_dev,
+                &mut dst_bl,
+                w,
+                h,
+                w,
+                h,
+                &homo,
+                None,
+            )
+            .expect("persp bilinear");
+            launch_warp_perspective_nearest_cuda(
+                &ctx,
+                &stream,
+                &src_dev,
+                &mut dst_nn,
+                w,
+                h,
+                w,
+                h,
+                &homo,
+                None,
+            )
+            .expect("persp nearest");
+            launch_warp_perspective_bicubic_cuda(
+                &ctx,
+                &stream,
+                &src_dev,
+                &mut dst_bc,
+                w,
+                h,
+                w,
+                h,
+                &homo,
+                None,
+            )
+            .expect("persp bicubic");
+            launch_warp_affine_bilinear_cuda(
+                &ctx,
+                &stream,
+                &src_dev,
+                &mut dst_aff,
+                w,
+                h,
+                w,
+                h,
+                &affine_m,
+                None,
+            )
+            .expect("affine bilinear");
+        }
+        stream.synchronize().expect("sync");
+
+        // Time bilinear perspective.
+        let t = Instant::now();
+        for _ in 0..ITERS {
+            launch_warp_perspective_bilinear_cuda(
+                &ctx,
+                &stream,
+                &src_dev,
+                &mut dst_bl,
+                w,
+                h,
+                w,
+                h,
+                &homo,
+                None,
+            )
+            .expect("persp bilinear");
+        }
+        stream.synchronize().expect("sync");
+        let bl_ms = t.elapsed().as_secs_f64() * 1e3 / ITERS as f64;
+
+        // Time nearest perspective.
+        let t = Instant::now();
+        for _ in 0..ITERS {
+            launch_warp_perspective_nearest_cuda(
+                &ctx,
+                &stream,
+                &src_dev,
+                &mut dst_nn,
+                w,
+                h,
+                w,
+                h,
+                &homo,
+                None,
+            )
+            .expect("persp nearest");
+        }
+        stream.synchronize().expect("sync");
+        let nn_ms = t.elapsed().as_secs_f64() * 1e3 / ITERS as f64;
+
+        // Time bicubic perspective.
+        let t = Instant::now();
+        for _ in 0..ITERS {
+            launch_warp_perspective_bicubic_cuda(
+                &ctx,
+                &stream,
+                &src_dev,
+                &mut dst_bc,
+                w,
+                h,
+                w,
+                h,
+                &homo,
+                None,
+            )
+            .expect("persp bicubic");
+        }
+        stream.synchronize().expect("sync");
+        let bc_ms = t.elapsed().as_secs_f64() * 1e3 / ITERS as f64;
+
+        // Time affine bilinear (reference).
+        let t = Instant::now();
+        for _ in 0..ITERS {
+            launch_warp_affine_bilinear_cuda(
+                &ctx,
+                &stream,
+                &src_dev,
+                &mut dst_aff,
+                w,
+                h,
+                w,
+                h,
+                &affine_m,
+                None,
+            )
+            .expect("affine bilinear");
+        }
+        stream.synchronize().expect("sync");
+        let aff_ms = t.elapsed().as_secs_f64() * 1e3 / ITERS as f64;
+
+        println!(
+            "  {:<20}  {:>10.3}  {:>10.3}  {:>10.3}  {:>10.3}",
+            format!("{w}×{h}"),
+            bl_ms,
+            nn_ms,
+            bc_ms,
+            aff_ms,
+        );
+    }
+
+    println!("\n  Note: bicubic uses __ldg on raw src (no texture), so OOB taps are clamped");
+    println!("  (BORDER_REPLICATE on the 4×4 neighbourhood) while the OOB centre → 0.");
+}

--- a/crates/kornia-imgproc/examples/bench_cuda_warp_perspective.rs
+++ b/crates/kornia-imgproc/examples/bench_cuda_warp_perspective.rs
@@ -1,16 +1,15 @@
-//! Micro-benchmark: CUDA warp-perspective (bilinear, nearest, bicubic).
+//! Micro-benchmark: CUDA warp-perspective (bilinear, nearest, bicubic, Lanczos-3).
 //!
-//! **Purpose:** Measure the throughput of the three warp-perspective kernels
-//! across typical image sizes, and compare bicubic quality vs speed vs
-//! warp-affine bilinear.
+//! **Purpose:** Measure throughput of all four warp-perspective kernels across
+//! typical image sizes, and compare each against the equivalent warp-affine mode.
 //!
 //! **What is measured:**
 //! 1. `warp_perspective_bilinear`  — texture-backed bilinear, 3-ch f32.
 //! 2. `warp_perspective_nearest`   — texture-backed nearest-neighbor, 3-ch f32.
-//! 3. `warp_perspective_bicubic`   — Keys a=-0.5 via `__ldg`, 3-ch f32.
-//! 4. `warp_affine_bilinear`       — reference: same rotation, no perspective.
-//! All use a perspective-tilt homography (top edge scaled to 80% of bottom)
-//! so the homogeneous w-divide is exercised on every pixel.
+//! 3. `warp_perspective_bicubic`   — Keys a=−0.5 via `__ldg`, 3-ch f32.
+//! 4. `warp_perspective_lanczos`   — Lanczos-3 (6×6 taps) via `__ldg`, 3-ch f32.
+//! All use a perspective-tilt homography so the homogeneous w-divide is exercised
+//! on every pixel.
 //!
 //! ```text
 //! cargo run --example bench_cuda_warp_perspective --features cuda --release
@@ -37,209 +36,121 @@ fn run_benchmark() {
     use std::sync::Arc;
 
     use cudarc::driver::CudaContext;
-    use kornia_imgproc::cuda::warp_affine::launch_warp_affine_bilinear_cuda;
     use kornia_imgproc::cuda::warp_perspective::{
         launch_warp_perspective_bicubic_cuda, launch_warp_perspective_bilinear_cuda,
-        launch_warp_perspective_nearest_cuda,
+        launch_warp_perspective_lanczos_cuda, launch_warp_perspective_nearest_cuda,
     };
-    use kornia_imgproc::warp::get_rotation_matrix2d;
 
     let ctx = Arc::new(CudaContext::new(0).expect("CUDA device 0"));
     let stream = ctx.default_stream();
 
-    // Perspective-tilt homography: top edge at 80% width, bottom at full width.
-    // h maps destination → source (forward homography; inverted internally).
+    // Projective tilt: w varies from 1.0 to ~1.2 across the image.
     fn tilt_homography(w: u32, h: u32) -> [f32; 9] {
         let fw = w as f32;
         let fh = h as f32;
-        // Projective tilt: H = [[1, s/fh, 0], [0, 1, 0], [0, s/(fw*fh), 1]], s=0.2.
-        // Exercises the w-divide on every pixel (w varies from 1.0 to ~1.2 across the image).
         let s = 0.2_f32;
         [1.0, s / fh, 0.0, 0.0, 1.0, 0.0, 0.0, s / (fw * fh), 1.0]
     }
 
     println!("\n=== CUDA warp-perspective benchmark ({ITERS} iters, perspective-tilt H) ===\n");
-    println!(
-        "  {:<20}  {:>10}  {:>10}  {:>10}  {:>10}",
-        "case (W×H)", "bilinear", "nearest", "bicubic", "affine-BL"
-    );
-    println!(
-        "  {:<20}  {:>10}  {:>10}  {:>10}  {:>10}",
-        "", "ms/frame", "ms/frame", "ms/frame", "ms/frame"
-    );
-    println!("  {}", "-".repeat(68));
 
-    for &(w, h) in CASES {
-        let npix = (w * h) as usize;
-        let src_data: Vec<f32> = (0..npix * NC as usize)
-            .map(|i| (i % 256) as f32 / 255.0)
-            .collect();
+    for method in ["nearest", "bilinear", "bicubic", "lanczos"] {
+        println!("  [{method}]");
+        println!("  {:<20}  {:>12}  {:>12}", "case (W×H)", "ms/frame", "GB/s");
+        println!("  {}", "-".repeat(48));
 
-        let homo = tilt_homography(w, h);
-        let center = (w as f32 / 2.0, h as f32 / 2.0);
-        let affine_m = get_rotation_matrix2d(center, 0.0_f32, 1.0); // identity-ish for comparison
+        for &(w, h) in CASES {
+            let npix = (w * h) as usize;
+            let src_data: Vec<f32> = (0..npix * NC as usize)
+                .map(|i| (i % 256) as f32 / 255.0)
+                .collect();
 
-        let src_dev = stream.clone_htod(&src_data).expect("H→D src");
-        let mut dst_bl = stream
-            .alloc_zeros::<f32>(npix * NC as usize)
-            .expect("alloc");
-        let mut dst_nn = stream
-            .alloc_zeros::<f32>(npix * NC as usize)
-            .expect("alloc");
-        let mut dst_bc = stream
-            .alloc_zeros::<f32>(npix * NC as usize)
-            .expect("alloc");
-        let mut dst_aff = stream
-            .alloc_zeros::<f32>(npix * NC as usize)
-            .expect("alloc");
+            let homo = tilt_homography(w, h);
+            let src_dev = stream.clone_htod(&src_data).expect("H→D src");
+            let mut dst_dev = stream
+                .alloc_zeros::<f32>(npix * NC as usize)
+                .expect("alloc dst");
 
-        // Warmup — compile kernels and warm caches.
-        for _ in 0..WARMUP {
-            launch_warp_perspective_bilinear_cuda(
-                &ctx,
-                &stream,
-                &src_dev,
-                &mut dst_bl,
-                w,
-                h,
-                w,
-                h,
-                &homo,
-                None,
-            )
-            .expect("persp bilinear");
-            launch_warp_perspective_nearest_cuda(
-                &ctx,
-                &stream,
-                &src_dev,
-                &mut dst_nn,
-                w,
-                h,
-                w,
-                h,
-                &homo,
-                None,
-            )
-            .expect("persp nearest");
-            launch_warp_perspective_bicubic_cuda(
-                &ctx,
-                &stream,
-                &src_dev,
-                &mut dst_bc,
-                w,
-                h,
-                w,
-                h,
-                &homo,
-                None,
-            )
-            .expect("persp bicubic");
-            launch_warp_affine_bilinear_cuda(
-                &ctx,
-                &stream,
-                &src_dev,
-                &mut dst_aff,
-                w,
-                h,
-                w,
-                h,
-                &affine_m,
-                None,
-            )
-            .expect("affine bilinear");
+            macro_rules! launch {
+                () => {
+                    match method {
+                        "bilinear" => launch_warp_perspective_bilinear_cuda(
+                            &ctx,
+                            &stream,
+                            &src_dev,
+                            &mut dst_dev,
+                            w,
+                            h,
+                            w,
+                            h,
+                            &homo,
+                            None,
+                        )
+                        .expect("bilinear"),
+                        "nearest" => launch_warp_perspective_nearest_cuda(
+                            &ctx,
+                            &stream,
+                            &src_dev,
+                            &mut dst_dev,
+                            w,
+                            h,
+                            w,
+                            h,
+                            &homo,
+                            None,
+                        )
+                        .expect("nearest"),
+                        "bicubic" => launch_warp_perspective_bicubic_cuda(
+                            &ctx,
+                            &stream,
+                            &src_dev,
+                            &mut dst_dev,
+                            w,
+                            h,
+                            w,
+                            h,
+                            &homo,
+                            None,
+                        )
+                        .expect("bicubic"),
+                        "lanczos" => launch_warp_perspective_lanczos_cuda(
+                            &ctx,
+                            &stream,
+                            &src_dev,
+                            &mut dst_dev,
+                            w,
+                            h,
+                            w,
+                            h,
+                            &homo,
+                            None,
+                        )
+                        .expect("lanczos"),
+                        _ => unreachable!(),
+                    }
+                };
+            }
+
+            for _ in 0..WARMUP {
+                launch!();
+            }
+            stream.synchronize().expect("sync");
+
+            let t = Instant::now();
+            for _ in 0..ITERS {
+                launch!();
+            }
+            stream.synchronize().expect("sync");
+            let ms = t.elapsed().as_secs_f64() * 1e3 / ITERS as f64;
+
+            // 1 src read + 1 dst write per output pixel, 3 channels, 4 bytes each.
+            let gb_s = (npix as f64 * NC as f64 * 8.0) / (ms * 1e-3) / 1e9;
+
+            println!("  {:<20}  {:>12.3}  {:>12.2}", format!("{w}×{h}"), ms, gb_s,);
         }
-        stream.synchronize().expect("sync");
-
-        // Time bilinear perspective.
-        let t = Instant::now();
-        for _ in 0..ITERS {
-            launch_warp_perspective_bilinear_cuda(
-                &ctx,
-                &stream,
-                &src_dev,
-                &mut dst_bl,
-                w,
-                h,
-                w,
-                h,
-                &homo,
-                None,
-            )
-            .expect("persp bilinear");
-        }
-        stream.synchronize().expect("sync");
-        let bl_ms = t.elapsed().as_secs_f64() * 1e3 / ITERS as f64;
-
-        // Time nearest perspective.
-        let t = Instant::now();
-        for _ in 0..ITERS {
-            launch_warp_perspective_nearest_cuda(
-                &ctx,
-                &stream,
-                &src_dev,
-                &mut dst_nn,
-                w,
-                h,
-                w,
-                h,
-                &homo,
-                None,
-            )
-            .expect("persp nearest");
-        }
-        stream.synchronize().expect("sync");
-        let nn_ms = t.elapsed().as_secs_f64() * 1e3 / ITERS as f64;
-
-        // Time bicubic perspective.
-        let t = Instant::now();
-        for _ in 0..ITERS {
-            launch_warp_perspective_bicubic_cuda(
-                &ctx,
-                &stream,
-                &src_dev,
-                &mut dst_bc,
-                w,
-                h,
-                w,
-                h,
-                &homo,
-                None,
-            )
-            .expect("persp bicubic");
-        }
-        stream.synchronize().expect("sync");
-        let bc_ms = t.elapsed().as_secs_f64() * 1e3 / ITERS as f64;
-
-        // Time affine bilinear (reference).
-        let t = Instant::now();
-        for _ in 0..ITERS {
-            launch_warp_affine_bilinear_cuda(
-                &ctx,
-                &stream,
-                &src_dev,
-                &mut dst_aff,
-                w,
-                h,
-                w,
-                h,
-                &affine_m,
-                None,
-            )
-            .expect("affine bilinear");
-        }
-        stream.synchronize().expect("sync");
-        let aff_ms = t.elapsed().as_secs_f64() * 1e3 / ITERS as f64;
-
-        println!(
-            "  {:<20}  {:>10.3}  {:>10.3}  {:>10.3}  {:>10.3}",
-            format!("{w}×{h}"),
-            bl_ms,
-            nn_ms,
-            bc_ms,
-            aff_ms,
-        );
+        println!();
     }
 
-    println!("\n  Note: bicubic uses __ldg on raw src (no texture), so OOB taps are clamped");
-    println!("  (BORDER_REPLICATE on the 4×4 neighbourhood) while the OOB centre → 0.");
+    println!("  Note: nearest/bilinear use texture objects; bicubic/lanczos use __ldg on raw src.");
+    println!("  Bicubic/Lanczos OOB taps clamped (BORDER_REPLICATE); OOB centre → 0.");
 }

--- a/crates/kornia-imgproc/src/cuda/mod.rs
+++ b/crates/kornia-imgproc/src/cuda/mod.rs
@@ -10,7 +10,7 @@ pub mod resize;
 /// Native CUDA warp-affine kernels (bilinear and nearest-neighbor).
 pub mod warp_affine;
 
-/// Native CUDA warp-perspective kernels (homography, bilinear / nearest / bicubic).
+/// Native CUDA warp-perspective kernels (homography, bilinear / nearest / bicubic / Lanczos-3).
 pub mod warp_perspective;
 
 /// Native CUDA color-space conversion kernels.

--- a/crates/kornia-imgproc/src/cuda/mod.rs
+++ b/crates/kornia-imgproc/src/cuda/mod.rs
@@ -10,6 +10,9 @@ pub mod resize;
 /// Native CUDA warp-affine kernels (bilinear and nearest-neighbor).
 pub mod warp_affine;
 
+/// Native CUDA warp-perspective kernels (homography, bilinear / nearest / bicubic).
+pub mod warp_perspective;
+
 /// Native CUDA color-space conversion kernels.
 pub mod color;
 

--- a/crates/kornia-imgproc/src/cuda/warp_perspective.rs
+++ b/crates/kornia-imgproc/src/cuda/warp_perspective.rs
@@ -395,6 +395,9 @@ fn make_tex(
     src_width: u32,
     src_height: u32,
 ) -> Result<(CudaTexObject, u64), CudaWarpPerspectiveError> {
+    // Safety: DevicePtr::device_ptr returns the raw CUdeviceptr; the _guard
+    // records a stream event on drop (after the texture is destroyed) which is
+    // the correct ordering.
     let (dev_ptr, _guard) = src.device_ptr(stream);
     let tex =
         CudaTexObject::new_pitch2d_border(dev_ptr, src_width as usize * 3, src_height as usize)
@@ -403,6 +406,7 @@ fn make_tex(
     Ok((tex, handle))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn validate_and_invert(
     src: &CudaSlice<f32>,
     dst: &CudaSlice<f32>,
@@ -418,7 +422,7 @@ fn validate_and_invert(
             "image dimensions must be non-zero".into(),
         ));
     }
-    if block_dim.map_or(false, |(bw, bh)| bw == 0 || bh == 0) {
+    if block_dim.is_some_and(|(bw, bh)| bw == 0 || bh == 0) {
         return Err(CudaWarpPerspectiveError::Cuda(
             "block_dim components must be non-zero".into(),
         ));

--- a/crates/kornia-imgproc/src/cuda/warp_perspective.rs
+++ b/crates/kornia-imgproc/src/cuda/warp_perspective.rs
@@ -403,6 +403,31 @@ fn make_tex(
     Ok((tex, handle))
 }
 
+fn validate_and_invert(
+    src: &CudaSlice<f32>,
+    dst: &CudaSlice<f32>,
+    src_width: u32,
+    src_height: u32,
+    dst_width: u32,
+    dst_height: u32,
+    h: &[f32; 9],
+    block_dim: Option<(u32, u32)>,
+) -> Result<[f32; 9], CudaWarpPerspectiveError> {
+    if src_width == 0 || src_height == 0 || dst_width == 0 || dst_height == 0 {
+        return Err(CudaWarpPerspectiveError::Cuda(
+            "image dimensions must be non-zero".into(),
+        ));
+    }
+    if block_dim.map_or(false, |(bw, bh)| bw == 0 || bh == 0) {
+        return Err(CudaWarpPerspectiveError::Cuda(
+            "block_dim components must be non-zero".into(),
+        ));
+    }
+    check_image_slice(src, "src", src_width, src_height)?;
+    check_image_slice(dst, "dst", dst_width, dst_height)?;
+    invert_homography(h).ok_or(CudaWarpPerspectiveError::SingularHomography)
+}
+
 // ── Public launchers ──────────────────────────────────────────────────────────
 
 /// Launch the bilinear warp-perspective kernel for a 3-channel f32 image.
@@ -444,20 +469,9 @@ pub fn launch_warp_perspective_bilinear_cuda(
     h: &[f32; 9],
     block_dim: Option<(u32, u32)>,
 ) -> Result<(), CudaWarpPerspectiveError> {
-    if src_width == 0 || src_height == 0 || dst_width == 0 || dst_height == 0 {
-        return Err(CudaWarpPerspectiveError::Cuda(
-            "image dimensions must be non-zero".into(),
-        ));
-    }
-    if block_dim.map_or(false, |(bw, bh)| bw == 0 || bh == 0) {
-        return Err(CudaWarpPerspectiveError::Cuda(
-            "block_dim components must be non-zero".into(),
-        ));
-    }
-    check_image_slice(src, "src", src_width, src_height)?;
-    check_image_slice(dst, "dst", dst_width, dst_height)?;
-
-    let hi = invert_homography(h).ok_or(CudaWarpPerspectiveError::SingularHomography)?;
+    let hi = validate_and_invert(
+        src, dst, src_width, src_height, dst_width, dst_height, h, block_dim,
+    )?;
     let kernel = BILINEAR_KERNEL
         .get_or_init(|| try_compile_with_l1(ctx, BILINEAR_SRC, "warp_perspective_bilinear_tex_3c"))
         .as_ref()
@@ -513,20 +527,9 @@ pub fn launch_warp_perspective_nearest_cuda(
     h: &[f32; 9],
     block_dim: Option<(u32, u32)>,
 ) -> Result<(), CudaWarpPerspectiveError> {
-    if src_width == 0 || src_height == 0 || dst_width == 0 || dst_height == 0 {
-        return Err(CudaWarpPerspectiveError::Cuda(
-            "image dimensions must be non-zero".into(),
-        ));
-    }
-    if block_dim.map_or(false, |(bw, bh)| bw == 0 || bh == 0) {
-        return Err(CudaWarpPerspectiveError::Cuda(
-            "block_dim components must be non-zero".into(),
-        ));
-    }
-    check_image_slice(src, "src", src_width, src_height)?;
-    check_image_slice(dst, "dst", dst_width, dst_height)?;
-
-    let hi = invert_homography(h).ok_or(CudaWarpPerspectiveError::SingularHomography)?;
+    let hi = validate_and_invert(
+        src, dst, src_width, src_height, dst_width, dst_height, h, block_dim,
+    )?;
     let kernel = NEAREST_KERNEL
         .get_or_init(|| try_compile_with_l1(ctx, NEAREST_SRC, "warp_perspective_nearest_tex_3c"))
         .as_ref()
@@ -586,20 +589,9 @@ pub fn launch_warp_perspective_bicubic_cuda(
     h: &[f32; 9],
     block_dim: Option<(u32, u32)>,
 ) -> Result<(), CudaWarpPerspectiveError> {
-    if src_width == 0 || src_height == 0 || dst_width == 0 || dst_height == 0 {
-        return Err(CudaWarpPerspectiveError::Cuda(
-            "image dimensions must be non-zero".into(),
-        ));
-    }
-    if block_dim.map_or(false, |(bw, bh)| bw == 0 || bh == 0) {
-        return Err(CudaWarpPerspectiveError::Cuda(
-            "block_dim components must be non-zero".into(),
-        ));
-    }
-    check_image_slice(src, "src", src_width, src_height)?;
-    check_image_slice(dst, "dst", dst_width, dst_height)?;
-
-    let hi = invert_homography(h).ok_or(CudaWarpPerspectiveError::SingularHomography)?;
+    let hi = validate_and_invert(
+        src, dst, src_width, src_height, dst_width, dst_height, h, block_dim,
+    )?;
     let kernel = BICUBIC_KERNEL
         .get_or_init(|| try_compile_with_l1(ctx, BICUBIC_SRC, "warp_perspective_bicubic_3c"))
         .as_ref()
@@ -661,20 +653,9 @@ pub fn launch_warp_perspective_lanczos_cuda(
     h: &[f32; 9],
     block_dim: Option<(u32, u32)>,
 ) -> Result<(), CudaWarpPerspectiveError> {
-    if src_width == 0 || src_height == 0 || dst_width == 0 || dst_height == 0 {
-        return Err(CudaWarpPerspectiveError::Cuda(
-            "image dimensions must be non-zero".into(),
-        ));
-    }
-    if block_dim.map_or(false, |(bw, bh)| bw == 0 || bh == 0) {
-        return Err(CudaWarpPerspectiveError::Cuda(
-            "block_dim components must be non-zero".into(),
-        ));
-    }
-    check_image_slice(src, "src", src_width, src_height)?;
-    check_image_slice(dst, "dst", dst_width, dst_height)?;
-
-    let hi = invert_homography(h).ok_or(CudaWarpPerspectiveError::SingularHomography)?;
+    let hi = validate_and_invert(
+        src, dst, src_width, src_height, dst_width, dst_height, h, block_dim,
+    )?;
     let kernel = LANCZOS_KERNEL
         .get_or_init(|| try_compile_with_l1(ctx, LANCZOS_SRC, "warp_perspective_lanczos_3c"))
         .as_ref()

--- a/crates/kornia-imgproc/src/cuda/warp_perspective.rs
+++ b/crates/kornia-imgproc/src/cuda/warp_perspective.rs
@@ -2,17 +2,22 @@
 //!
 //! # Algorithm
 //!
-//! Both kernels use **inverse mapping**: each output thread computes the
+//! All kernels use **inverse mapping**: each output thread computes the
 //! floating-point source coordinate by applying the inverted 3×3 homography
 //! to its `(dst_x, dst_y)` position and dividing by the homogeneous weight `w`.
 //! Pixels whose `|w| < 1e-10` (degenerate projection) are written as 0.
-//! Source coordinates outside the image also return 0 (`BORDER_CONSTANT`),
-//! matching [`warp_perspective`](crate::warp::warp_perspective).
+//!
+//! **Border handling differs by interpolation mode:**
+//! * Bilinear / nearest: source reads via a texture object with
+//!   `CU_TR_ADDRESS_MODE_BORDER`; out-of-bounds taps return 0 (`BORDER_CONSTANT`).
+//! * Bicubic / Lanczos-3: OOB taps in the 4×4 / 6×6 support window are clamped
+//!   to the nearest source border pixel (`BORDER_REPLICATE`); pixels whose
+//!   inverse-mapped centre falls outside the source are written as 0.
 //!
 //! # Optimisations
 //!
-//! * **CUDA texture objects** — source reads via the 2D-spatial texture cache
-//!   with `CU_TR_ADDRESS_MODE_BORDER`, eliminating divergent OOB branches.
+//! * **CUDA texture objects** — bilinear/nearest reads via the 2D-spatial texture
+//!   cache with `CU_TR_ADDRESS_MODE_BORDER`, eliminating divergent OOB branches.
 //! * **`CU_FUNC_CACHE_PREFER_L1`** — enlarges L1 to 64 KB; no shared memory used.
 //! * **32×8 thread block (default)** — full warp per output row for coalesced writes.
 //! * **`1/w` reciprocal** — one FP division replaces two per output pixel.
@@ -314,8 +319,8 @@ extern "C" __global__ void warp_perspective_lanczos_3c(
 
 // ── Kernel caches ─────────────────────────────────────────────────────────────
 
-static BILINEAR_KERNEL: OnceLock<CudaKernel> = OnceLock::new();
-static NEAREST_KERNEL: OnceLock<CudaKernel> = OnceLock::new();
+static BILINEAR_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
+static NEAREST_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
 static BICUBIC_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
 static LANCZOS_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
 
@@ -354,13 +359,6 @@ fn make_config(dst_width: u32, dst_height: u32, block_dim: Option<(u32, u32)>) -
         grid_dim: (dst_width.div_ceil(bw), dst_height.div_ceil(bh), 1),
         shared_mem_bytes: 0,
     }
-}
-
-fn compile_with_l1(ctx: &Arc<CudaContext>, src: &str, fn_name: &str) -> CudaKernel {
-    let k = CudaKernel::compile(ctx, src, fn_name)
-        .unwrap_or_else(|e| panic!("failed to compile {fn_name}: {e}"));
-    let _ = k.prefer_l1_cache();
-    k
 }
 
 fn try_compile_with_l1(
@@ -451,12 +449,19 @@ pub fn launch_warp_perspective_bilinear_cuda(
             "image dimensions must be non-zero".into(),
         ));
     }
+    if block_dim.map_or(false, |(bw, bh)| bw == 0 || bh == 0) {
+        return Err(CudaWarpPerspectiveError::Cuda(
+            "block_dim components must be non-zero".into(),
+        ));
+    }
     check_image_slice(src, "src", src_width, src_height)?;
     check_image_slice(dst, "dst", dst_width, dst_height)?;
 
     let hi = invert_homography(h).ok_or(CudaWarpPerspectiveError::SingularHomography)?;
     let kernel = BILINEAR_KERNEL
-        .get_or_init(|| compile_with_l1(ctx, BILINEAR_SRC, "warp_perspective_bilinear_tex_3c"));
+        .get_or_init(|| try_compile_with_l1(ctx, BILINEAR_SRC, "warp_perspective_bilinear_tex_3c"))
+        .as_ref()
+        .map_err(|e| CudaWarpPerspectiveError::Cuda(e.clone()))?;
     let (_tex, tex_handle) = make_tex(src, stream, src_width, src_height)?;
 
     kernel
@@ -513,12 +518,19 @@ pub fn launch_warp_perspective_nearest_cuda(
             "image dimensions must be non-zero".into(),
         ));
     }
+    if block_dim.map_or(false, |(bw, bh)| bw == 0 || bh == 0) {
+        return Err(CudaWarpPerspectiveError::Cuda(
+            "block_dim components must be non-zero".into(),
+        ));
+    }
     check_image_slice(src, "src", src_width, src_height)?;
     check_image_slice(dst, "dst", dst_width, dst_height)?;
 
     let hi = invert_homography(h).ok_or(CudaWarpPerspectiveError::SingularHomography)?;
     let kernel = NEAREST_KERNEL
-        .get_or_init(|| compile_with_l1(ctx, NEAREST_SRC, "warp_perspective_nearest_tex_3c"));
+        .get_or_init(|| try_compile_with_l1(ctx, NEAREST_SRC, "warp_perspective_nearest_tex_3c"))
+        .as_ref()
+        .map_err(|e| CudaWarpPerspectiveError::Cuda(e.clone()))?;
     let (_tex, tex_handle) = make_tex(src, stream, src_width, src_height)?;
 
     kernel
@@ -577,6 +589,11 @@ pub fn launch_warp_perspective_bicubic_cuda(
     if src_width == 0 || src_height == 0 || dst_width == 0 || dst_height == 0 {
         return Err(CudaWarpPerspectiveError::Cuda(
             "image dimensions must be non-zero".into(),
+        ));
+    }
+    if block_dim.map_or(false, |(bw, bh)| bw == 0 || bh == 0) {
+        return Err(CudaWarpPerspectiveError::Cuda(
+            "block_dim components must be non-zero".into(),
         ));
     }
     check_image_slice(src, "src", src_width, src_height)?;
@@ -647,6 +664,11 @@ pub fn launch_warp_perspective_lanczos_cuda(
     if src_width == 0 || src_height == 0 || dst_width == 0 || dst_height == 0 {
         return Err(CudaWarpPerspectiveError::Cuda(
             "image dimensions must be non-zero".into(),
+        ));
+    }
+    if block_dim.map_or(false, |(bw, bh)| bw == 0 || bh == 0) {
+        return Err(CudaWarpPerspectiveError::Cuda(
+            "block_dim components must be non-zero".into(),
         ));
     }
     check_image_slice(src, "src", src_width, src_height)?;

--- a/crates/kornia-imgproc/src/cuda/warp_perspective.rs
+++ b/crates/kornia-imgproc/src/cuda/warp_perspective.rs
@@ -1,0 +1,517 @@
+//! Native CUDA warp-perspective kernels for `kornia-imgproc`.
+//!
+//! # Algorithm
+//!
+//! Both kernels use **inverse mapping**: each output thread computes the
+//! floating-point source coordinate by applying the inverted 3×3 homography
+//! to its `(dst_x, dst_y)` position and dividing by the homogeneous weight `w`.
+//! Pixels whose `|w| < 1e-10` (degenerate projection) are written as 0.
+//! Source coordinates outside the image also return 0 (`BORDER_CONSTANT`),
+//! matching [`warp_perspective`](crate::warp::warp_perspective).
+//!
+//! # Optimisations
+//!
+//! * **CUDA texture objects** — source reads via the 2D-spatial texture cache
+//!   with `CU_TR_ADDRESS_MODE_BORDER`, eliminating divergent OOB branches.
+//! * **`CU_FUNC_CACHE_PREFER_L1`** — enlarges L1 to 64 KB; no shared memory used.
+//! * **32×8 thread block (default)** — full warp per output row for coalesced writes.
+//! * **`1/w` reciprocal** — one FP division replaces two per output pixel.
+//!
+//! # Public API
+//!
+//! * [`launch_warp_perspective_bilinear_cuda`] — bilinear, 3-ch f32.
+//! * [`launch_warp_perspective_nearest_cuda`]  — nearest-neighbor, 3-ch f32.
+//! * [`launch_warp_perspective_bicubic_cuda`]  — bicubic (Keys a=-0.5), 3-ch f32.
+
+use std::sync::{Arc, OnceLock};
+
+use cudarc::driver::{CudaContext, CudaSlice, CudaStream, DevicePtr, LaunchConfig};
+use kornia_tensor::CudaKernel;
+
+use crate::warp::invert_homography;
+
+use super::texture::CudaTexObject;
+
+// ── CUDA C source: bilinear warp perspective via texture object ───────────────
+//
+// The only difference from warp_affine_bilinear_tex_3c is the coordinate
+// transform: affine uses a 2×3 linear map; perspective adds a w-divide from
+// the third row of the 3×3 homography.
+
+static BILINEAR_SRC: &str = r#"
+extern "C" __global__ void warp_perspective_bilinear_tex_3c(
+    unsigned long long tex,
+    float* __restrict__  dst,
+    unsigned int dst_w,
+    unsigned int dst_h,
+    float h0, float h1, float h2,
+    float h3, float h4, float h5,
+    float h6, float h7, float h8
+) {
+    unsigned int gx = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int gy = blockIdx.y * blockDim.y + threadIdx.y;
+    if (gx >= dst_w || gy >= dst_h) return;
+
+    unsigned int out = (gy * dst_w + gx) * 3u;
+    float w = h6 * (float)gx + h7 * (float)gy + h8;
+    if (fabsf(w) < 1e-10f) {
+        dst[out] = 0.0f; dst[out+1] = 0.0f; dst[out+2] = 0.0f;
+        return;
+    }
+    float rw = 1.0f / w;
+    float sx = (h0 * (float)gx + h1 * (float)gy + h2) * rw;
+    float sy = (h3 * (float)gx + h4 * (float)gy + h5) * rw;
+
+    // Bilinear weights.
+    float x0f = floorf(sx);
+    float y0f = floorf(sy);
+    float fx   = sx - x0f;
+    float fy   = sy - y0f;
+    float w00 = (1.0f - fy) * (1.0f - fx);
+    float w10 = (1.0f - fy) * fx;
+    float w01 = fy * (1.0f - fx);
+    float w11 = fy * fx;
+
+    float tx0 = x0f * 3.0f;
+    float ty1 = y0f + 1.0f;
+
+    // Border mode: OOB fetches return 0.0.
+    cudaTextureObject_t t = (cudaTextureObject_t)tex;
+
+    float r00 = tex2D<float>(t, tx0,       y0f);
+    float r10 = tex2D<float>(t, tx0+3.0f,  y0f);
+    float r01 = tex2D<float>(t, tx0,       ty1);
+    float r11 = tex2D<float>(t, tx0+3.0f,  ty1);
+    dst[out]   = fmaf(w00, r00, fmaf(w10, r10, fmaf(w01, r01, w11 * r11)));
+
+    float g00 = tex2D<float>(t, tx0+1.0f,  y0f);
+    float g10 = tex2D<float>(t, tx0+4.0f,  y0f);
+    float g01 = tex2D<float>(t, tx0+1.0f,  ty1);
+    float g11 = tex2D<float>(t, tx0+4.0f,  ty1);
+    dst[out+1] = fmaf(w00, g00, fmaf(w10, g10, fmaf(w01, g01, w11 * g11)));
+
+    float b00 = tex2D<float>(t, tx0+2.0f,  y0f);
+    float b10 = tex2D<float>(t, tx0+5.0f,  y0f);
+    float b01 = tex2D<float>(t, tx0+2.0f,  ty1);
+    float b11 = tex2D<float>(t, tx0+5.0f,  ty1);
+    dst[out+2] = fmaf(w00, b00, fmaf(w10, b10, fmaf(w01, b01, w11 * b11)));
+}
+"#;
+
+// ── CUDA C source: nearest-neighbor warp perspective via texture object ───────
+
+static NEAREST_SRC: &str = r#"
+extern "C" __global__ void warp_perspective_nearest_tex_3c(
+    unsigned long long tex,
+    float* __restrict__  dst,
+    unsigned int dst_w,
+    unsigned int dst_h,
+    float h0, float h1, float h2,
+    float h3, float h4, float h5,
+    float h6, float h7, float h8
+) {
+    unsigned int gx = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int gy = blockIdx.y * blockDim.y + threadIdx.y;
+    if (gx >= dst_w || gy >= dst_h) return;
+
+    unsigned int out = (gy * dst_w + gx) * 3u;
+    float w = h6 * (float)gx + h7 * (float)gy + h8;
+    if (fabsf(w) < 1e-10f) {
+        dst[out] = 0.0f; dst[out+1] = 0.0f; dst[out+2] = 0.0f;
+        return;
+    }
+    float rw = 1.0f / w;
+    float sx = (h0 * (float)gx + h1 * (float)gy + h2) * rw;
+    float sy = (h3 * (float)gx + h4 * (float)gy + h5) * rw;
+
+    // Round to nearest; border mode handles OOB → 0.
+    float tx = roundf(sx) * 3.0f;
+    float ty = roundf(sy);
+
+    cudaTextureObject_t t = (cudaTextureObject_t)tex;
+    dst[out]   = tex2D<float>(t, tx,       ty);
+    dst[out+1] = tex2D<float>(t, tx+1.0f,  ty);
+    dst[out+2] = tex2D<float>(t, tx+2.0f,  ty);
+}
+"#;
+
+// ── CUDA C source: bicubic warp perspective ───────────────────────────────────
+//
+// Keys cubic (a = -0.5, matches OpenCV INTER_CUBIC).  Same weight computation
+// as warp_affine_bicubic_3c; only the coordinate transform differs (w-divide).
+
+static BICUBIC_SRC: &str = r#"
+extern "C" __global__ void warp_perspective_bicubic_3c(
+    const float* __restrict__ src,
+    float* __restrict__       dst,
+    unsigned int src_w,
+    unsigned int src_h,
+    unsigned int dst_w,
+    unsigned int dst_h,
+    float h0, float h1, float h2,
+    float h3, float h4, float h5,
+    float h6, float h7, float h8
+) {
+    unsigned int dst_x = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int dst_y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (dst_x >= dst_w || dst_y >= dst_h) return;
+
+    unsigned int out = (dst_y * dst_w + dst_x) * 3u;
+    float w = h6 * (float)dst_x + h7 * (float)dst_y + h8;
+    if (fabsf(w) < 1e-10f) {
+        dst[out] = 0.0f; dst[out+1] = 0.0f; dst[out+2] = 0.0f;
+        return;
+    }
+    float rw = 1.0f / w;
+    float sx = (h0 * (float)dst_x + h1 * (float)dst_y + h2) * rw;
+    float sy = (h3 * (float)dst_x + h4 * (float)dst_y + h5) * rw;
+
+    if (sx < 0.0f || sx >= (float)src_w || sy < 0.0f || sy >= (float)src_h) {
+        dst[out] = 0.0f; dst[out+1] = 0.0f; dst[out+2] = 0.0f;
+        return;
+    }
+
+    int x0 = (int)floorf(sx);
+    int y0 = (int)floorf(sy);
+    float frac_x = sx - (float)x0;
+    float frac_y = sy - (float)y0;
+
+    // Horner-form Keys cubic weights (a = -0.5), branch-free.
+    float wx[4], wy[4];
+    {
+        float t;
+        t = 1.0f + frac_x; wx[0] = ((-0.5f*t + 2.5f)*t - 4.0f)*t + 2.0f;
+        t =         frac_x; wx[1] = (( 1.5f*t - 2.5f)*t       )*t + 1.0f;
+        t = 1.0f - frac_x; wx[2] = (( 1.5f*t - 2.5f)*t       )*t + 1.0f;
+        t = 2.0f - frac_x; wx[3] = ((-0.5f*t + 2.5f)*t - 4.0f)*t + 2.0f;
+        t = 1.0f + frac_y; wy[0] = ((-0.5f*t + 2.5f)*t - 4.0f)*t + 2.0f;
+        t =         frac_y; wy[1] = (( 1.5f*t - 2.5f)*t       )*t + 1.0f;
+        t = 1.0f - frac_y; wy[2] = (( 1.5f*t - 2.5f)*t       )*t + 1.0f;
+        t = 2.0f - frac_y; wy[3] = ((-0.5f*t + 2.5f)*t - 4.0f)*t + 2.0f;
+    }
+
+    unsigned int row[4];
+    #pragma unroll
+    for (int i = 0; i < 4; ++i) {
+        int yi = max(0, min(y0 + i - 1, (int)src_h - 1));
+        row[i] = (unsigned int)yi * src_w * 3u;
+    }
+
+    float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f;
+    #pragma unroll
+    for (int dy = 0; dy < 4; ++dy) {
+        #pragma unroll
+        for (int dx = 0; dx < 4; ++dx) {
+            int xi = max(0, min(x0 + dx - 1, (int)src_w - 1));
+            unsigned int b = row[dy] + (unsigned int)xi * 3u;
+            float wt = wx[dx] * wy[dy];
+            acc0 = fmaf(wt, __ldg(&src[b]),   acc0);
+            acc1 = fmaf(wt, __ldg(&src[b+1]), acc1);
+            acc2 = fmaf(wt, __ldg(&src[b+2]), acc2);
+        }
+    }
+    dst[out]   = acc0;
+    dst[out+1] = acc1;
+    dst[out+2] = acc2;
+}
+"#;
+
+// ── Kernel caches ─────────────────────────────────────────────────────────────
+
+static BILINEAR_KERNEL: OnceLock<CudaKernel> = OnceLock::new();
+static NEAREST_KERNEL: OnceLock<CudaKernel> = OnceLock::new();
+static BICUBIC_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
+
+const BLOCK_W: u32 = 32;
+const BLOCK_H: u32 = 8;
+
+// ── Error type ────────────────────────────────────────────────────────────────
+
+/// Error returned by the CUDA warp-perspective launchers.
+#[derive(Debug, thiserror::Error)]
+pub enum CudaWarpPerspectiveError {
+    /// CUDA driver / compile / launch error.
+    #[error("CUDA warp-perspective error: {0}")]
+    Cuda(String),
+    /// A device slice is smaller than required.
+    #[error("device slice '{what}' length {got} < required {need}")]
+    SliceTooSmall {
+        /// Which operand was too small (`"src"` or `"dst"`).
+        what: &'static str,
+        /// Actual slice length (in elements).
+        got: usize,
+        /// Minimum required length.
+        need: usize,
+    },
+    /// The homography matrix is singular and cannot be inverted.
+    #[error("homography matrix is singular (|det| < 1e-10)")]
+    SingularHomography,
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+fn make_config(dst_width: u32, dst_height: u32, block_dim: Option<(u32, u32)>) -> LaunchConfig {
+    let (bw, bh) = block_dim.unwrap_or_else(|| (BLOCK_W.min(dst_width), BLOCK_H.min(dst_height)));
+    LaunchConfig {
+        block_dim: (bw, bh, 1),
+        grid_dim: (dst_width.div_ceil(bw), dst_height.div_ceil(bh), 1),
+        shared_mem_bytes: 0,
+    }
+}
+
+fn compile_with_l1(ctx: &Arc<CudaContext>, src: &str, fn_name: &str) -> CudaKernel {
+    let k = CudaKernel::compile(ctx, src, fn_name)
+        .unwrap_or_else(|e| panic!("failed to compile {fn_name}: {e}"));
+    let _ = k.prefer_l1_cache();
+    k
+}
+
+fn try_compile_with_l1(
+    ctx: &Arc<CudaContext>,
+    src: &str,
+    fn_name: &str,
+) -> Result<CudaKernel, String> {
+    let k = CudaKernel::compile(ctx, src, fn_name)
+        .map_err(|e| format!("failed to compile {fn_name}: {e}"))?;
+    let _ = k.prefer_l1_cache();
+    Ok(k)
+}
+
+fn check_image_slice(
+    slice: &CudaSlice<f32>,
+    what: &'static str,
+    width: u32,
+    height: u32,
+) -> Result<(), CudaWarpPerspectiveError> {
+    let need = (width as usize) * (height as usize) * 3;
+    if slice.len() < need {
+        return Err(CudaWarpPerspectiveError::SliceTooSmall {
+            what,
+            got: slice.len(),
+            need,
+        });
+    }
+    Ok(())
+}
+
+fn make_tex(
+    src: &CudaSlice<f32>,
+    stream: &Arc<CudaStream>,
+    src_width: u32,
+    src_height: u32,
+) -> Result<(CudaTexObject, u64), CudaWarpPerspectiveError> {
+    let (dev_ptr, _guard) = src.device_ptr(stream);
+    let tex =
+        CudaTexObject::new_pitch2d_border(dev_ptr, src_width as usize * 3, src_height as usize)
+            .map_err(CudaWarpPerspectiveError::Cuda)?;
+    let handle = tex.handle();
+    Ok((tex, handle))
+}
+
+// ── Public launchers ──────────────────────────────────────────────────────────
+
+/// Launch the bilinear warp-perspective kernel for a 3-channel f32 image.
+///
+/// Applies the 3×3 forward homography `h` to warp `src` into `dst`.
+/// The matrix is inverted internally so the API matches the CPU
+/// [`warp_perspective`](crate::warp::warp_perspective).
+///
+/// Source pixels are fetched via a CUDA texture object (border-mode).
+/// Out-of-bounds coordinates return 0 (`BORDER_CONSTANT`).
+/// Pixels whose homogeneous weight `|w| < 1e-10` after inversion are
+/// written as 0 (degenerate projection).
+///
+/// # Arguments
+///
+/// * `ctx`        — CUDA context for one-time kernel compilation.
+/// * `stream`     — Stream for kernel execution.
+/// * `src`        — Source image, `src_h × src_w × 3` f32 (HWC).
+/// * `dst`        — Destination buffer, at least `dst_h × dst_w × 3` f32.
+/// * `src_width`  / `src_height` — Source image dimensions.
+/// * `dst_width`  / `dst_height` — Output canvas dimensions.
+/// * `h`          — Forward 3×3 homography in row-major order.
+/// * `block_dim`  — Optional thread-block override; `None` → 32×8.
+///
+/// # Errors
+///
+/// Returns [`CudaWarpPerspectiveError`] on compile failure, singular homography,
+/// texture-creation error, launch error, or if any slice is too small.
+#[allow(clippy::too_many_arguments)]
+pub fn launch_warp_perspective_bilinear_cuda(
+    ctx: &Arc<CudaContext>,
+    stream: &Arc<CudaStream>,
+    src: &CudaSlice<f32>,
+    dst: &mut CudaSlice<f32>,
+    src_width: u32,
+    src_height: u32,
+    dst_width: u32,
+    dst_height: u32,
+    h: &[f32; 9],
+    block_dim: Option<(u32, u32)>,
+) -> Result<(), CudaWarpPerspectiveError> {
+    if src_width == 0 || src_height == 0 || dst_width == 0 || dst_height == 0 {
+        return Err(CudaWarpPerspectiveError::Cuda(
+            "image dimensions must be non-zero".into(),
+        ));
+    }
+    check_image_slice(src, "src", src_width, src_height)?;
+    check_image_slice(dst, "dst", dst_width, dst_height)?;
+
+    let hi = invert_homography(h).ok_or(CudaWarpPerspectiveError::SingularHomography)?;
+    let kernel = BILINEAR_KERNEL
+        .get_or_init(|| compile_with_l1(ctx, BILINEAR_SRC, "warp_perspective_bilinear_tex_3c"));
+    let (_tex, tex_handle) = make_tex(src, stream, src_width, src_height)?;
+
+    kernel
+        .launch_builder(stream)
+        .arg(&tex_handle)
+        .arg(dst)
+        .arg(&dst_width)
+        .arg(&dst_height)
+        .arg(&hi[0])
+        .arg(&hi[1])
+        .arg(&hi[2])
+        .arg(&hi[3])
+        .arg(&hi[4])
+        .arg(&hi[5])
+        .arg(&hi[6])
+        .arg(&hi[7])
+        .arg(&hi[8])
+        .launch_2d(
+            dst_width,
+            dst_height,
+            make_config(dst_width, dst_height, block_dim),
+        )
+        .map_err(|e| CudaWarpPerspectiveError::Cuda(e.to_string()))
+}
+
+/// Launch the nearest-neighbor warp-perspective kernel for a 3-channel f32 image.
+///
+/// Same as [`launch_warp_perspective_bilinear_cuda`] but uses round-to-nearest
+/// source sampling.  Faster; suitable for integer-aligned transforms.
+///
+/// # Arguments
+///
+/// See [`launch_warp_perspective_bilinear_cuda`] — arguments are identical.
+///
+/// # Errors
+///
+/// Returns [`CudaWarpPerspectiveError`] on compile failure, singular homography,
+/// texture-creation error, launch error, or if any slice is too small.
+#[allow(clippy::too_many_arguments)]
+pub fn launch_warp_perspective_nearest_cuda(
+    ctx: &Arc<CudaContext>,
+    stream: &Arc<CudaStream>,
+    src: &CudaSlice<f32>,
+    dst: &mut CudaSlice<f32>,
+    src_width: u32,
+    src_height: u32,
+    dst_width: u32,
+    dst_height: u32,
+    h: &[f32; 9],
+    block_dim: Option<(u32, u32)>,
+) -> Result<(), CudaWarpPerspectiveError> {
+    if src_width == 0 || src_height == 0 || dst_width == 0 || dst_height == 0 {
+        return Err(CudaWarpPerspectiveError::Cuda(
+            "image dimensions must be non-zero".into(),
+        ));
+    }
+    check_image_slice(src, "src", src_width, src_height)?;
+    check_image_slice(dst, "dst", dst_width, dst_height)?;
+
+    let hi = invert_homography(h).ok_or(CudaWarpPerspectiveError::SingularHomography)?;
+    let kernel = NEAREST_KERNEL
+        .get_or_init(|| compile_with_l1(ctx, NEAREST_SRC, "warp_perspective_nearest_tex_3c"));
+    let (_tex, tex_handle) = make_tex(src, stream, src_width, src_height)?;
+
+    kernel
+        .launch_builder(stream)
+        .arg(&tex_handle)
+        .arg(dst)
+        .arg(&dst_width)
+        .arg(&dst_height)
+        .arg(&hi[0])
+        .arg(&hi[1])
+        .arg(&hi[2])
+        .arg(&hi[3])
+        .arg(&hi[4])
+        .arg(&hi[5])
+        .arg(&hi[6])
+        .arg(&hi[7])
+        .arg(&hi[8])
+        .launch_2d(
+            dst_width,
+            dst_height,
+            make_config(dst_width, dst_height, block_dim),
+        )
+        .map_err(|e| CudaWarpPerspectiveError::Cuda(e.to_string()))
+}
+
+/// Launch the bicubic warp-perspective kernel for a 3-channel f32 image.
+///
+/// Uses Keys cubic (a = −0.5), matching OpenCV `INTER_CUBIC`.
+/// Unlike bilinear/nearest, this kernel reads from a raw device pointer via
+/// `__ldg` rather than a texture object (required for the 4×4 tap window).
+/// Out-of-bounds taps are clamped to the source border (BORDER_REPLICATE);
+/// pixels whose inverse-mapped centre falls outside the source are written as 0.
+///
+/// # Arguments
+///
+/// See [`launch_warp_perspective_bilinear_cuda`] — arguments are identical.
+///
+/// # Errors
+///
+/// Returns [`CudaWarpPerspectiveError::Cuda`] if the kernel fails to compile
+/// (NVRTC; happens at most once per process) or fails to launch.
+/// Returns [`CudaWarpPerspectiveError::SingularHomography`] for degenerate `h`.
+#[allow(clippy::too_many_arguments)]
+pub fn launch_warp_perspective_bicubic_cuda(
+    ctx: &Arc<CudaContext>,
+    stream: &Arc<CudaStream>,
+    src: &CudaSlice<f32>,
+    dst: &mut CudaSlice<f32>,
+    src_width: u32,
+    src_height: u32,
+    dst_width: u32,
+    dst_height: u32,
+    h: &[f32; 9],
+    block_dim: Option<(u32, u32)>,
+) -> Result<(), CudaWarpPerspectiveError> {
+    if src_width == 0 || src_height == 0 || dst_width == 0 || dst_height == 0 {
+        return Err(CudaWarpPerspectiveError::Cuda(
+            "image dimensions must be non-zero".into(),
+        ));
+    }
+    check_image_slice(src, "src", src_width, src_height)?;
+    check_image_slice(dst, "dst", dst_width, dst_height)?;
+
+    let hi = invert_homography(h).ok_or(CudaWarpPerspectiveError::SingularHomography)?;
+    let kernel = BICUBIC_KERNEL
+        .get_or_init(|| try_compile_with_l1(ctx, BICUBIC_SRC, "warp_perspective_bicubic_3c"))
+        .as_ref()
+        .map_err(|e| CudaWarpPerspectiveError::Cuda(e.clone()))?;
+
+    kernel
+        .launch_builder(stream)
+        .arg(src)
+        .arg(dst)
+        .arg(&src_width)
+        .arg(&src_height)
+        .arg(&dst_width)
+        .arg(&dst_height)
+        .arg(&hi[0])
+        .arg(&hi[1])
+        .arg(&hi[2])
+        .arg(&hi[3])
+        .arg(&hi[4])
+        .arg(&hi[5])
+        .arg(&hi[6])
+        .arg(&hi[7])
+        .arg(&hi[8])
+        .launch_2d(
+            dst_width,
+            dst_height,
+            make_config(dst_width, dst_height, block_dim),
+        )
+        .map_err(|e| CudaWarpPerspectiveError::Cuda(e.to_string()))
+}

--- a/crates/kornia-imgproc/src/cuda/warp_perspective.rs
+++ b/crates/kornia-imgproc/src/cuda/warp_perspective.rs
@@ -22,6 +22,7 @@
 //! * [`launch_warp_perspective_bilinear_cuda`] — bilinear, 3-ch f32.
 //! * [`launch_warp_perspective_nearest_cuda`]  — nearest-neighbor, 3-ch f32.
 //! * [`launch_warp_perspective_bicubic_cuda`]  — bicubic (Keys a=-0.5), 3-ch f32.
+//! * [`launch_warp_perspective_lanczos_cuda`]  — Lanczos-3 (6×6 taps), 3-ch f32.
 
 use std::sync::{Arc, OnceLock};
 
@@ -216,11 +217,107 @@ extern "C" __global__ void warp_perspective_bicubic_3c(
 }
 "#;
 
+// ── CUDA C source: Lanczos-3 warp perspective ────────────────────────────────
+//
+// 3-lobe Lanczos filter (6×6 taps, 36 source reads per output pixel).
+// Same weight computation as warp_affine_lanczos_3c; only the coordinate
+// transform differs (w-divide from the homography third row).
+
+static LANCZOS_SRC: &str = r#"
+__device__ inline float lanczos3(float x) {
+    const float PI = 3.14159265358979f;
+    if (fabsf(x) < 1e-5f) return 1.0f;
+    if (fabsf(x) >= 3.0f) return 0.0f;
+    float pix  = PI * x;
+    float pix3 = pix * 0.33333333f;
+    return __sinf(pix) * __sinf(pix3) * __fdividef(1.0f, pix * pix3);
+}
+
+extern "C" __global__ void warp_perspective_lanczos_3c(
+    const float* __restrict__ src,
+    float* __restrict__       dst,
+    unsigned int src_w,
+    unsigned int src_h,
+    unsigned int dst_w,
+    unsigned int dst_h,
+    float h0, float h1, float h2,
+    float h3, float h4, float h5,
+    float h6, float h7, float h8
+) {
+    unsigned int dst_x = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int dst_y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (dst_x >= dst_w || dst_y >= dst_h) return;
+
+    unsigned int out = (dst_y * dst_w + dst_x) * 3u;
+    float w = h6 * (float)dst_x + h7 * (float)dst_y + h8;
+    if (fabsf(w) < 1e-10f) {
+        dst[out] = 0.0f; dst[out+1] = 0.0f; dst[out+2] = 0.0f;
+        return;
+    }
+    float rw = 1.0f / w;
+    float sx = (h0 * (float)dst_x + h1 * (float)dst_y + h2) * rw;
+    float sy = (h3 * (float)dst_x + h4 * (float)dst_y + h5) * rw;
+
+    if (sx < 0.0f || sx >= (float)src_w || sy < 0.0f || sy >= (float)src_h) {
+        dst[out] = 0.0f; dst[out+1] = 0.0f; dst[out+2] = 0.0f;
+        return;
+    }
+
+    int x0 = (int)floorf(sx);
+    int y0 = (int)floorf(sy);
+    float frac_x = sx - (float)x0;
+    float frac_y = sy - (float)y0;
+
+    float wx[6], wy[6];
+    wx[0] = lanczos3(frac_x + 2.0f); wx[1] = lanczos3(frac_x + 1.0f);
+    wx[2] = lanczos3(frac_x);        wx[3] = lanczos3(frac_x - 1.0f);
+    wx[4] = lanczos3(frac_x - 2.0f); wx[5] = lanczos3(frac_x - 3.0f);
+    wy[0] = lanczos3(frac_y + 2.0f); wy[1] = lanczos3(frac_y + 1.0f);
+    wy[2] = lanczos3(frac_y);        wy[3] = lanczos3(frac_y - 1.0f);
+    wy[4] = lanczos3(frac_y - 2.0f); wy[5] = lanczos3(frac_y - 3.0f);
+
+    float sum_wx = wx[0]+wx[1]+wx[2]+wx[3]+wx[4]+wx[5];
+    float sum_wy = wy[0]+wy[1]+wy[2]+wy[3]+wy[4]+wy[5];
+    float inv_x = __fdividef(1.0f, sum_wx);
+    float inv_y = __fdividef(1.0f, sum_wy);
+    #pragma unroll
+    for (int i = 0; i < 6; i++) { wx[i] *= inv_x; wy[i] *= inv_y; }
+
+    unsigned int row[6];
+    #pragma unroll
+    for (int i = 0; i < 6; i++) {
+        int yi = max(0, min(y0 + i - 2, (int)src_h - 1));
+        row[i] = (unsigned int)yi * src_w * 3u;
+    }
+
+    float acc0 = 0.0f, acc1 = 0.0f, acc2 = 0.0f;
+    #pragma unroll
+    for (int dy = 0; dy < 6; dy++) {
+        float rx = 0.0f, gx = 0.0f, bx = 0.0f;
+        #pragma unroll
+        for (int dx = 0; dx < 6; dx++) {
+            int xi = max(0, min(x0 + dx - 2, (int)src_w - 1));
+            unsigned int b = row[dy] + (unsigned int)xi * 3u;
+            rx = fmaf(wx[dx], __ldg(&src[b]),   rx);
+            gx = fmaf(wx[dx], __ldg(&src[b+1]), gx);
+            bx = fmaf(wx[dx], __ldg(&src[b+2]), bx);
+        }
+        acc0 = fmaf(wy[dy], rx, acc0);
+        acc1 = fmaf(wy[dy], gx, acc1);
+        acc2 = fmaf(wy[dy], bx, acc2);
+    }
+    dst[out]   = acc0;
+    dst[out+1] = acc1;
+    dst[out+2] = acc2;
+}
+"#;
+
 // ── Kernel caches ─────────────────────────────────────────────────────────────
 
 static BILINEAR_KERNEL: OnceLock<CudaKernel> = OnceLock::new();
 static NEAREST_KERNEL: OnceLock<CudaKernel> = OnceLock::new();
 static BICUBIC_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
+static LANCZOS_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
 
 const BLOCK_W: u32 = 32;
 const BLOCK_H: u32 = 8;
@@ -488,6 +585,76 @@ pub fn launch_warp_perspective_bicubic_cuda(
     let hi = invert_homography(h).ok_or(CudaWarpPerspectiveError::SingularHomography)?;
     let kernel = BICUBIC_KERNEL
         .get_or_init(|| try_compile_with_l1(ctx, BICUBIC_SRC, "warp_perspective_bicubic_3c"))
+        .as_ref()
+        .map_err(|e| CudaWarpPerspectiveError::Cuda(e.clone()))?;
+
+    kernel
+        .launch_builder(stream)
+        .arg(src)
+        .arg(dst)
+        .arg(&src_width)
+        .arg(&src_height)
+        .arg(&dst_width)
+        .arg(&dst_height)
+        .arg(&hi[0])
+        .arg(&hi[1])
+        .arg(&hi[2])
+        .arg(&hi[3])
+        .arg(&hi[4])
+        .arg(&hi[5])
+        .arg(&hi[6])
+        .arg(&hi[7])
+        .arg(&hi[8])
+        .launch_2d(
+            dst_width,
+            dst_height,
+            make_config(dst_width, dst_height, block_dim),
+        )
+        .map_err(|e| CudaWarpPerspectiveError::Cuda(e.to_string()))
+}
+
+/// Launch the Lanczos-3 warp-perspective kernel for a 3-channel f32 image.
+///
+/// Uses a 6×6 tap (36 source reads per output pixel) with sinc-based Lanczos
+/// weights normalised per output pixel to prevent brightness drift at clamped
+/// boundaries.  Highest quality; slower than bicubic.
+///
+/// Like bicubic, reads from raw device memory via `__ldg`.  OOB taps within the
+/// 6×6 neighbourhood are clamped (BORDER_REPLICATE); pixels whose inverse-mapped
+/// centre falls outside the source are written as 0 (BORDER_CONSTANT).
+///
+/// # Arguments
+///
+/// See [`launch_warp_perspective_bilinear_cuda`] — arguments are identical.
+///
+/// # Errors
+///
+/// Returns [`CudaWarpPerspectiveError::Cuda`] on compile or launch failure.
+/// Returns [`CudaWarpPerspectiveError::SingularHomography`] for degenerate `h`.
+#[allow(clippy::too_many_arguments)]
+pub fn launch_warp_perspective_lanczos_cuda(
+    ctx: &Arc<CudaContext>,
+    stream: &Arc<CudaStream>,
+    src: &CudaSlice<f32>,
+    dst: &mut CudaSlice<f32>,
+    src_width: u32,
+    src_height: u32,
+    dst_width: u32,
+    dst_height: u32,
+    h: &[f32; 9],
+    block_dim: Option<(u32, u32)>,
+) -> Result<(), CudaWarpPerspectiveError> {
+    if src_width == 0 || src_height == 0 || dst_width == 0 || dst_height == 0 {
+        return Err(CudaWarpPerspectiveError::Cuda(
+            "image dimensions must be non-zero".into(),
+        ));
+    }
+    check_image_slice(src, "src", src_width, src_height)?;
+    check_image_slice(dst, "dst", dst_width, dst_height)?;
+
+    let hi = invert_homography(h).ok_or(CudaWarpPerspectiveError::SingularHomography)?;
+    let kernel = LANCZOS_KERNEL
+        .get_or_init(|| try_compile_with_l1(ctx, LANCZOS_SRC, "warp_perspective_lanczos_3c"))
         .as_ref()
         .map_err(|e| CudaWarpPerspectiveError::Cuda(e.clone()))?;
 

--- a/crates/kornia-imgproc/src/warp/mod.rs
+++ b/crates/kornia-imgproc/src/warp/mod.rs
@@ -4,5 +4,6 @@ mod kernels;
 mod perspective;
 
 pub use affine::{get_rotation_matrix2d, invert_affine_transform, warp_affine, warp_affine_u8};
+#[cfg(feature = "cuda")]
 pub(crate) use perspective::invert_homography;
 pub use perspective::{warp_perspective, warp_perspective_u8};

--- a/crates/kornia-imgproc/src/warp/mod.rs
+++ b/crates/kornia-imgproc/src/warp/mod.rs
@@ -4,4 +4,5 @@ mod kernels;
 mod perspective;
 
 pub use affine::{get_rotation_matrix2d, invert_affine_transform, warp_affine, warp_affine_u8};
+pub(crate) use perspective::invert_homography;
 pub use perspective::{warp_perspective, warp_perspective_u8};

--- a/crates/kornia-imgproc/src/warp/perspective.rs
+++ b/crates/kornia-imgproc/src/warp/perspective.rs
@@ -29,6 +29,25 @@ fn adjugate3x3(m: &[f32; 9]) -> [f32; 9] {
     ]
 }
 
+/// Invert a 3×3 homography matrix.
+///
+/// Returns `None` for degenerate matrices (|det| < 1e-10).  The CUDA
+/// warp-perspective kernel writes zeros for any output pixel whose w-coordinate
+/// falls below the same threshold.
+pub(crate) fn invert_homography(m: &[f32; 9]) -> Option<[f32; 9]> {
+    let det = determinant3x3(m);
+    if det.abs() < 1e-10 {
+        return None;
+    }
+    let adj = adjugate3x3(m);
+    let inv_det = 1.0 / det;
+    let mut inv = [0.0f32; 9];
+    for i in 0..9 {
+        inv[i] = adj[i] * inv_det;
+    }
+    Some(inv)
+}
+
 fn inverse_perspective_matrix(m: &[f32; 9]) -> Result<[f32; 9], ImageError> {
     let det = determinant3x3(m);
 

--- a/crates/kornia-imgproc/src/warp/perspective.rs
+++ b/crates/kornia-imgproc/src/warp/perspective.rs
@@ -51,7 +51,7 @@ pub(crate) fn invert_homography(m: &[f32; 9]) -> Option<[f32; 9]> {
 fn inverse_perspective_matrix(m: &[f32; 9]) -> Result<[f32; 9], ImageError> {
     let det = determinant3x3(m);
 
-    if det == 0.0 {
+    if det.abs() < 1e-10 {
         return Err(ImageError::CannotComputeDeterminant);
     }
 

--- a/crates/kornia-imgproc/src/warp/perspective.rs
+++ b/crates/kornia-imgproc/src/warp/perspective.rs
@@ -49,21 +49,7 @@ pub(crate) fn invert_homography(m: &[f32; 9]) -> Option<[f32; 9]> {
 }
 
 fn inverse_perspective_matrix(m: &[f32; 9]) -> Result<[f32; 9], ImageError> {
-    let det = determinant3x3(m);
-
-    if det.abs() < 1e-10 {
-        return Err(ImageError::CannotComputeDeterminant);
-    }
-
-    let adj = adjugate3x3(m);
-    let inv_det = 1.0 / det;
-
-    let mut inv_m = [0.0; 9];
-    for i in 0..9 {
-        inv_m[i] = adj[i] * inv_det;
-    }
-
-    Ok(inv_m)
+    invert_homography(m).ok_or(ImageError::CannotComputeDeterminant)
 }
 
 // implement later as batched operation

--- a/crates/kornia-imgproc/src/warp/perspective.rs
+++ b/crates/kornia-imgproc/src/warp/perspective.rs
@@ -346,10 +346,7 @@ mod tests {
         let expected: [f32; 9] = [1.0, 0.0, -2.0, 0.0, 1.0, -3.0, 0.0, 0.0, 1.0];
         let inv = super::invert_homography(&h).expect("translation H must be invertible");
         for (a, b) in inv.iter().zip(expected.iter()) {
-            assert!(
-                (a - b).abs() < 1e-6,
-                "inv[i]={a} expected {b}"
-            );
+            assert!((a - b).abs() < 1e-6, "inv[i]={a} expected {b}");
         }
     }
 

--- a/crates/kornia-imgproc/src/warp/perspective.rs
+++ b/crates/kornia-imgproc/src/warp/perspective.rs
@@ -31,12 +31,23 @@ fn adjugate3x3(m: &[f32; 9]) -> [f32; 9] {
 
 /// Invert a 3×3 homography matrix.
 ///
-/// Returns `None` for degenerate matrices (|det| < 1e-10).  The CUDA
-/// warp-perspective kernel writes zeros for any output pixel whose w-coordinate
-/// falls below the same threshold.
+/// Returns `None` for singular or near-singular matrices.  The singularity
+/// test is **scale-invariant**: the determinant is normalised by `|h[8]|³`
+/// before comparison so that a geometrically valid but unnormalised homography
+/// (all entries multiplied by a small scalar) is not incorrectly rejected —
+/// `det(kH) = k³ det(H)` would shrink the raw det below a fixed ε even when
+/// the geometry is perfectly sound.  Falls back to the raw det when `h[8]`
+/// itself is near zero.
 pub(crate) fn invert_homography(m: &[f32; 9]) -> Option<[f32; 9]> {
     let det = determinant3x3(m);
-    if det.abs() < 1e-10 {
+    // Normalise by |h[8]|³ to get a scale-invariant singularity indicator.
+    let h8_sq = m[8] * m[8];
+    let det_norm = if h8_sq > f32::EPSILON {
+        det / (h8_sq * m[8].abs())
+    } else {
+        det
+    };
+    if det_norm.abs() < 1e-10 {
         return None;
     }
     let adj = adjugate3x3(m);
@@ -312,6 +323,71 @@ pub fn warp_perspective_u8<const C: usize>(
 #[cfg(test)]
 mod tests {
     use kornia_image::{Image, ImageError, ImageSize};
+
+    // ── invert_homography unit tests ──────────────────────────────────────────
+
+    /// Helper: multiply two 3×3 row-major matrices.
+    fn mat3_mul(a: &[f32; 9], b: &[f32; 9]) -> [f32; 9] {
+        let mut c = [0.0f32; 9];
+        for row in 0..3 {
+            for col in 0..3 {
+                for k in 0..3 {
+                    c[row * 3 + col] += a[row * 3 + k] * b[k * 3 + col];
+                }
+            }
+        }
+        c
+    }
+
+    #[test]
+    fn invert_homography_known() {
+        // Translation: H maps (x,y) → (x+2, y+3).  Inverse: (x,y) → (x-2, y-3).
+        let h: [f32; 9] = [1.0, 0.0, 2.0, 0.0, 1.0, 3.0, 0.0, 0.0, 1.0];
+        let expected: [f32; 9] = [1.0, 0.0, -2.0, 0.0, 1.0, -3.0, 0.0, 0.0, 1.0];
+        let inv = super::invert_homography(&h).expect("translation H must be invertible");
+        for (a, b) in inv.iter().zip(expected.iter()) {
+            assert!(
+                (a - b).abs() < 1e-6,
+                "inv[i]={a} expected {b}"
+            );
+        }
+    }
+
+    #[test]
+    fn invert_homography_round_trip() {
+        // Non-trivial projective H; H · H⁻¹ must be ≈ identity.
+        let h: [f32; 9] = [1.02, 0.03, -5.0, -0.01, 0.99, 2.0, 0.00005, 0.00003, 1.0];
+        let inv = super::invert_homography(&h).expect("valid H must be invertible");
+        let prod = mat3_mul(&h, &inv);
+        let identity = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
+        for (a, b) in prod.iter().zip(identity.iter()) {
+            assert!((a - b).abs() < 1e-5, "H·H⁻¹[i]={a} expected {b}");
+        }
+    }
+
+    #[test]
+    fn invert_homography_singular_returns_none() {
+        // All-zero matrix is singular.
+        let h = [0.0f32; 9];
+        assert!(super::invert_homography(&h).is_none());
+
+        // Rank-1 matrix (rows are scalar multiples).
+        let h2: [f32; 9] = [1.0, 2.0, 3.0, 2.0, 4.0, 6.0, 3.0, 6.0, 9.0];
+        assert!(super::invert_homography(&h2).is_none());
+    }
+
+    #[test]
+    fn invert_homography_small_scale_accepted() {
+        // Scale-invariant check: H/1000 must still be accepted.
+        // A fixed-magnitude det threshold would reject this even though the
+        // geometry is perfectly valid.
+        let h: [f32; 9] = [1.0, 0.0, 2.0, 0.0, 1.0, 3.0, 0.0, 0.0, 1.0];
+        let small: [f32; 9] = h.map(|v| v * 0.001);
+        assert!(
+            super::invert_homography(&small).is_some(),
+            "scaled-down valid H must not be rejected as singular"
+        );
+    }
 
     #[test]
     fn inverse_perspective_matrix() -> Result<(), ImageError> {


### PR DESCRIPTION
## 📝 Description

**Fixes/Relates to:** 

Adds GPU-accelerated warp-perspective (homography transform) kernels alongside the existing warp-affine kernels. Implements inverse-mapping with a homogeneous w-divide: each output thread computes the source coordinate from the inverted 3×3 homography. Architecture decision: implemented as separate fused kernels (not via remap) after benchmarking showed remap NN is 30–51% slower than fused affine.

---

## 🛠️ Changes Made

- [x] `crates/kornia-imgproc/src/cuda/warp_perspective.rs` — new module with:
  - `launch_warp_perspective_bilinear_cuda` — texture-backed bilinear, 3-ch f32
  - `launch_warp_perspective_nearest_cuda` — texture-backed nearest-neighbor, 3-ch f32
  - `launch_warp_perspective_bicubic_cuda` — Keys cubic a=−0.5 via `__ldg`, 3-ch f32
  - `CudaWarpPerspectiveError` with `Cuda`, `SliceTooSmall`, and `SingularHomography` variants
  - Zero-dimension guard + `check_image_slice` for src and dst in all launchers
- [x] `crates/kornia-imgproc/src/warp/perspective.rs` — expose `pub(crate) invert_homography` reusing existing `adjugate3x3` / `determinant3x3` helpers
- [x] `crates/kornia-imgproc/src/warp/mod.rs` — re-export `invert_homography`
- [x] `crates/kornia-imgproc/src/cuda/mod.rs` — register `pub mod warp_perspective`
- [x] `crates/kornia-imgproc/examples/bench_cuda_warp_perspective.rs` — benchmark all three kernels + affine-BL reference

---

## 🧪 How Was This Tested?

- [x] **Build:** `cargo check -p kornia-imgproc --features cuda` — clean
- [x] **Lint:** `cargo clippy -p kornia-imgproc --features cuda` — no warnings
- [x] **Format:** `cargo fmt -p kornia-imgproc` — applied
- [x] **Manual Verification:** Benchmark ran successfully on GTX 1650 (perspective-tilt homography, 200 iters)

| case | bilinear | nearest | bicubic | affine-BL (ref) |
|------|----------|---------|---------|-----------------|
| 512×512 | 0.073 ms | 0.048 ms | 0.079 ms | 0.076 ms |
| 1280×720 | 0.262 ms | 0.157 ms | 0.299 ms | 0.279 ms |
| 1920×1080 | 0.563 ms | 0.350 ms | 0.723 ms | 0.574 ms |
| 3840×2160 | 2.219 ms | 1.390 ms | 2.943 ms | 2.185 ms |

Bilinear overhead vs warp-affine: 1–4% (the w-divide is the only extra cost per pixel). The texture path is otherwise identical.

- [x] **Performance/Edge Cases:**
  - Zero-dimension guard returns `CudaWarpPerspectiveError::Cuda` before any GPU work
  - Singular homography (|det| < 1e-10) returns `SingularHomography` error before kernel launch
  - Degenerate w per pixel (|w| < 1e-10) writes 0 output in kernel without divergent OOB branch
  - Src slice size validated before texture creation

---

## 🕵️ AI Usage Disclosure

- [x] 🟡 **AI-assisted:** I used AI for boilerplate/refactoring but have manually reviewed and tested every line.

---

## 🚦 Checklist

- [ ] I am assigned to the linked issue (required before PR submission)
- [ ] The linked issue has been approved by a maintainer
- [x] This PR strictly implements what the linked issue describes (no scope creep)
- [x] I have performed a **self-review** of my code (no "ghost" variables or hallucinations).
- [x] My code follows the existing style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.

---

## 💭 Additional Context

**Architecture decision:** Warp-perspective is implemented as separate fused kernels (not via remap base) because the remap benchmark showed nearest-neighbor remap is 30–51% slower than fused affine due to the extra `__ldg` map reads. The fused perspective kernel adds only a single FP reciprocal (`rw = 1/w`) vs the affine kernel — essentially free on modern CUDA hardware.

**Bicubic note:** Bicubic uses raw `__ldg` on the source pointer (4×4 tap window). OOB taps within the neighbourhood are clamped to the source border (BORDER_REPLICATE); pixels whose inverse-mapped centre falls outside the source are written as 0 (BORDER_CONSTANT for the output pixel).