### PR TITLE
feat(imgproc)!: resize_native adopts the half-pixel grid; PixelMapping for CUDA resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,9 @@ OpenCV, Pillow, ONNX `Resize` (`half_pixel` default), PyTorch
 (`align_corners=False`), and NVIDIA VPI. Pixel values change for every
 non-identity resize — typically a sub-pixel content shift. The u8 fast paths
 (`resize_fast_*`) are unaffected. This also makes the CPU and CUDA resize
-sample the same grid for the first time; CPU/GPU parity is now tested
-(nearest is bit-exact at dyadic scales).
+sample the same grid (`resize_native` was the sole align-corners holdout —
+the fused CPU preprocess path and the CUDA kernels already sampled
+half-pixel), and CPU/GPU parity is now tested.
 
 - `kornia_imgproc::cuda::resize`: launchers take a new `PixelMapping`
   parameter (`HalfPixel` — the default convention — or `AlignCorners` to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ changes early: `cargo add kornia-imgproc@0.1.15-rc.1` or `pip install --pre korn
      dated section and reset [Unreleased]. Reference the diff range and prior tag
      so the changelog stays navigable (see the "Full changelog" links below). -->
 
+## [Unreleased]
+
+**BREAKING — `resize_native` now samples on the half-pixel grid.** The f32
+resize previously used align-corners (`sx = x * (src-1)/(dst-1)`); it now uses
+the pixel-center convention (`sx = (x + 0.5) * src/dst - 0.5`) shared by
+OpenCV, Pillow, ONNX `Resize` (`half_pixel` default), PyTorch
+(`align_corners=False`), and NVIDIA VPI. Pixel values change for every
+non-identity resize — typically a sub-pixel content shift. The u8 fast paths
+(`resize_fast_*`) are unaffected. This also makes the CPU and CUDA resize
+sample the same grid for the first time; CPU/GPU parity is now tested
+(nearest is bit-exact at dyadic scales).
+
+- `kornia_imgproc::cuda::resize`: launchers take a new `PixelMapping`
+  parameter (`HalfPixel` — the default convention — or `AlignCorners` to
+  reproduce pre-change output); kernels generalized to per-axis affine
+  coefficients with no measured throughput change on Jetson Orin.
+
 ## [0.1.15-rc.4] — 2026-07-06 (pre-release)
 
 **GPU wheels.** Linux wheels now build with `--features cuda`, so

--- a/crates/kornia-imgproc/examples/bench_cuda_resize.rs
+++ b/crates/kornia-imgproc/examples/bench_cuda_resize.rs
@@ -14,6 +14,7 @@
 //! ```
 
 use kornia_image::{Image, ImageSize};
+use kornia_imgproc::cuda::resize::PixelMapping;
 use kornia_imgproc::interpolation::InterpolationMode;
 use kornia_imgproc::resize::resize_native;
 use std::time::Instant;
@@ -129,7 +130,7 @@ fn run_cpu() {
 fn run_gpu_cuda() {
     use cudarc::driver::CudaContext;
     use kornia_imgproc::cuda::resize::{
-        launch_resize_bilinear_downscale_cuda, launch_resize_nearest_downscale_cuda,
+        launch_resize_bilinear_downscale_cuda, launch_resize_nearest_downscale_cuda, PixelMapping,
     };
 
     // Only downscale cases — the CubeCL path already handles upscale well.
@@ -166,11 +167,29 @@ fn run_gpu_cuda() {
                           dst: &mut cudarc::driver::CudaSlice<f32>| {
                 match method {
                     "nearest" => launch_resize_nearest_downscale_cuda(
-                        &ctx, &stream, src, dst, sw, sh, dw, dh, None,
+                        &ctx,
+                        &stream,
+                        src,
+                        dst,
+                        sw,
+                        sh,
+                        dw,
+                        dh,
+                        PixelMapping::HalfPixel,
+                        None,
                     )
                     .expect("nearest launch"),
                     _ => launch_resize_bilinear_downscale_cuda(
-                        &ctx, &stream, src, dst, sw, sh, dw, dh, None,
+                        &ctx,
+                        &stream,
+                        src,
+                        dst,
+                        sw,
+                        sh,
+                        dw,
+                        dh,
+                        PixelMapping::HalfPixel,
+                        None,
                     )
                     .expect("bilinear launch"),
                 }
@@ -231,15 +250,37 @@ fn run_gpu_cuda_bicubic() {
         let mut dst_dev = stream.alloc_zeros::<f32>(npix_dst * nc).expect("alloc dst");
 
         for _ in 0..WARMUP {
-            launch_resize_bicubic_cuda(&ctx, &stream, &src_dev, &mut dst_dev, sw, sh, dw, dh, None)
-                .expect("bicubic launch");
+            launch_resize_bicubic_cuda(
+                &ctx,
+                &stream,
+                &src_dev,
+                &mut dst_dev,
+                sw,
+                sh,
+                dw,
+                dh,
+                PixelMapping::HalfPixel,
+                None,
+            )
+            .expect("bicubic launch");
         }
         stream.synchronize().expect("sync");
 
         let t = std::time::Instant::now();
         for _ in 0..ITERS {
-            launch_resize_bicubic_cuda(&ctx, &stream, &src_dev, &mut dst_dev, sw, sh, dw, dh, None)
-                .expect("bicubic launch");
+            launch_resize_bicubic_cuda(
+                &ctx,
+                &stream,
+                &src_dev,
+                &mut dst_dev,
+                sw,
+                sh,
+                dw,
+                dh,
+                PixelMapping::HalfPixel,
+                None,
+            )
+            .expect("bicubic launch");
         }
         stream.synchronize().expect("sync");
         let ms = t.elapsed().as_secs_f64() * 1e3 / ITERS as f64;
@@ -285,15 +326,37 @@ fn run_gpu_cuda_lanczos() {
         let mut dst_dev = stream.alloc_zeros::<f32>(npix_dst * nc).expect("alloc dst");
 
         for _ in 0..WARMUP {
-            launch_resize_lanczos_cuda(&ctx, &stream, &src_dev, &mut dst_dev, sw, sh, dw, dh, None)
-                .expect("lanczos launch");
+            launch_resize_lanczos_cuda(
+                &ctx,
+                &stream,
+                &src_dev,
+                &mut dst_dev,
+                sw,
+                sh,
+                dw,
+                dh,
+                PixelMapping::HalfPixel,
+                None,
+            )
+            .expect("lanczos launch");
         }
         stream.synchronize().expect("sync");
 
         let t = std::time::Instant::now();
         for _ in 0..ITERS {
-            launch_resize_lanczos_cuda(&ctx, &stream, &src_dev, &mut dst_dev, sw, sh, dw, dh, None)
-                .expect("lanczos launch");
+            launch_resize_lanczos_cuda(
+                &ctx,
+                &stream,
+                &src_dev,
+                &mut dst_dev,
+                sw,
+                sh,
+                dw,
+                dh,
+                PixelMapping::HalfPixel,
+                None,
+            )
+            .expect("lanczos launch");
         }
         stream.synchronize().expect("sync");
         let ms = t.elapsed().as_secs_f64() * 1e3 / ITERS as f64;
@@ -315,7 +378,7 @@ fn run_gpu_cuda_lanczos() {
 fn run_gpu_cuda_fused_normalize() {
     use cudarc::driver::CudaContext;
     use kornia_imgproc::cuda::resize::{
-        launch_resize_bilinear_downscale_cuda, launch_resize_bilinear_normalize_cuda,
+        launch_resize_bilinear_downscale_cuda, launch_resize_bilinear_normalize_cuda, PixelMapping,
     };
 
     const DOWNSCALE_CASES: &[(u32, u32, u32, u32)] = &[
@@ -361,6 +424,7 @@ fn run_gpu_cuda_fused_normalize() {
                 sh,
                 dw,
                 dh,
+                PixelMapping::HalfPixel,
                 None,
             )
             .expect("bilinear launch");
@@ -378,6 +442,7 @@ fn run_gpu_cuda_fused_normalize() {
                 sh,
                 dw,
                 dh,
+                PixelMapping::HalfPixel,
                 None,
             )
             .expect("bilinear launch");
@@ -398,6 +463,7 @@ fn run_gpu_cuda_fused_normalize() {
                 dh,
                 mean,
                 std,
+                PixelMapping::HalfPixel,
                 None,
             )
             .expect("fused launch");
@@ -417,6 +483,7 @@ fn run_gpu_cuda_fused_normalize() {
                 dh,
                 mean,
                 std,
+                PixelMapping::HalfPixel,
                 None,
             )
             .expect("fused launch");

--- a/crates/kornia-imgproc/examples/bench_cuda_resize.rs
+++ b/crates/kornia-imgproc/examples/bench_cuda_resize.rs
@@ -14,6 +14,7 @@
 //! ```
 
 use kornia_image::{Image, ImageSize};
+#[cfg(feature = "cuda")]
 use kornia_imgproc::cuda::resize::PixelMapping;
 use kornia_imgproc::interpolation::InterpolationMode;
 use kornia_imgproc::resize::resize_native;

--- a/crates/kornia-imgproc/examples/bench_cuda_resize.rs
+++ b/crates/kornia-imgproc/examples/bench_cuda_resize.rs
@@ -131,7 +131,7 @@ fn run_cpu() {
 fn run_gpu_cuda() {
     use cudarc::driver::CudaContext;
     use kornia_imgproc::cuda::resize::{
-        launch_resize_bilinear_downscale_cuda, launch_resize_nearest_downscale_cuda, PixelMapping,
+        launch_resize_bilinear_downscale_cuda, launch_resize_nearest_downscale_cuda,
     };
 
     // Only downscale cases — the CubeCL path already handles upscale well.
@@ -379,7 +379,7 @@ fn run_gpu_cuda_lanczos() {
 fn run_gpu_cuda_fused_normalize() {
     use cudarc::driver::CudaContext;
     use kornia_imgproc::cuda::resize::{
-        launch_resize_bilinear_downscale_cuda, launch_resize_bilinear_normalize_cuda, PixelMapping,
+        launch_resize_bilinear_downscale_cuda, launch_resize_bilinear_normalize_cuda,
     };
 
     const DOWNSCALE_CASES: &[(u32, u32, u32, u32)] = &[

--- a/crates/kornia-imgproc/src/cuda/resize.rs
+++ b/crates/kornia-imgproc/src/cuda/resize.rs
@@ -506,7 +506,8 @@ pub enum PixelMapping {
     HalfPixel,
     /// Corner-aligned sampling, `src = dst * (src_len-1)/(dst_len-1)`.
     ///
-    /// Matches kornia's pre-0.2 CPU resize and frameworks running with
+    /// Reproduces the align-corners output kornia's CPU resize produced
+    /// before the half-pixel switch, and matches frameworks running with
     /// `align_corners=True`. A single-pixel destination axis maps to source
     /// coordinate 0.
     AlignCorners,
@@ -571,6 +572,11 @@ pub fn launch_resize_bilinear_downscale_cuda(
     mapping: PixelMapping,
     block_dim: Option<(u32, u32)>,
 ) -> Result<(), CudaResizeError> {
+    if src_width == 0 || src_height == 0 || dst_width == 0 || dst_height == 0 {
+        return Err(CudaResizeError::Cuda(
+            "image dimensions must be non-zero".into(),
+        ));
+    }
     let need = (dst_width as usize) * (dst_height as usize) * 3;
     if dst.len() < need {
         return Err(CudaResizeError::SliceTooSmall {
@@ -643,6 +649,11 @@ pub fn launch_resize_bilinear_normalize_cuda(
     mapping: PixelMapping,
     block_dim: Option<(u32, u32)>,
 ) -> Result<(), CudaResizeError> {
+    if src_width == 0 || src_height == 0 || dst_width == 0 || dst_height == 0 {
+        return Err(CudaResizeError::Cuda(
+            "image dimensions must be non-zero".into(),
+        ));
+    }
     let need = (dst_width as usize) * (dst_height as usize) * 3;
     if dst.len() < need {
         return Err(CudaResizeError::SliceTooSmall {
@@ -718,6 +729,11 @@ pub fn launch_resize_nearest_downscale_cuda(
     mapping: PixelMapping,
     block_dim: Option<(u32, u32)>,
 ) -> Result<(), CudaResizeError> {
+    if src_width == 0 || src_height == 0 || dst_width == 0 || dst_height == 0 {
+        return Err(CudaResizeError::Cuda(
+            "image dimensions must be non-zero".into(),
+        ));
+    }
     let need = (dst_width as usize) * (dst_height as usize) * 3;
     if dst.len() < need {
         return Err(CudaResizeError::SliceTooSmall {

--- a/crates/kornia-imgproc/src/cuda/resize.rs
+++ b/crates/kornia-imgproc/src/cuda/resize.rs
@@ -100,16 +100,16 @@ extern "C" __global__ void resize_bilinear_downscale_3c(
     unsigned int src_h,
     unsigned int dst_w,
     unsigned int dst_h,
-    float scale_x,
-    float scale_y
+    float ax, float bx,
+    float ay, float by
 ) {
     unsigned int dst_x = blockIdx.x * blockDim.x + threadIdx.x;
     unsigned int dst_y = blockIdx.y * blockDim.y + threadIdx.y;
     if (dst_x >= dst_w || dst_y >= dst_h) return;
 
     // Half-pixel center alignment: matches OpenCV / PIL convention.
-    float sx = fmaxf(fminf((dst_x + 0.5f) * scale_x - 0.5f, (float)(src_w - 1u)), 0.0f);
-    float sy = fmaxf(fminf((dst_y + 0.5f) * scale_y - 0.5f, (float)(src_h - 1u)), 0.0f);
+    float sx = fmaxf(fminf(fmaf(ax, (float)dst_x, bx), (float)(src_w - 1u)), 0.0f);
+    float sy = fmaxf(fminf(fmaf(ay, (float)dst_y, by), (float)(src_h - 1u)), 0.0f);
 
     unsigned int x0 = (unsigned int)sx;
     unsigned int y0 = (unsigned int)sy;
@@ -145,16 +145,19 @@ extern "C" __global__ void resize_nearest_downscale_3c(
     unsigned int src_h,
     unsigned int dst_w,
     unsigned int dst_h,
-    float scale_x,
-    float scale_y
+    float ax, float bx,
+    float ay, float by
 ) {
     unsigned int dst_x = blockIdx.x * blockDim.x + threadIdx.x;
     unsigned int dst_y = blockIdx.y * blockDim.y + threadIdx.y;
     if (dst_x >= dst_w || dst_y >= dst_h) return;
 
     // Half-pixel center alignment.
-    unsigned int src_xi = min((unsigned int)((dst_x + 0.5f) * scale_x), src_w - 1u);
-    unsigned int src_yi = min((unsigned int)((dst_y + 0.5f) * scale_y), src_h - 1u);
+    // Round-to-nearest source pixel: the sample coordinate is fmaf(a,x,b);
+    // +0.5-then-truncate is round-half-up, which equals the CPU's
+    // half-away-from-zero `round()` for the non-negative coords produced here.
+    unsigned int src_xi = min((unsigned int)(fmaf(ax, (float)dst_x, bx) + 0.5f), src_w - 1u);
+    unsigned int src_yi = min((unsigned int)(fmaf(ay, (float)dst_y, by) + 0.5f), src_h - 1u);
 
     unsigned int src_base = (src_yi * src_w + src_xi) * 3u;
     unsigned int out = (dst_y * dst_w + dst_x) * 3u;
@@ -178,8 +181,8 @@ extern "C" __global__ void resize_bilinear_normalize_3c(
     unsigned int src_h,
     unsigned int dst_w,
     unsigned int dst_h,
-    float scale_x,
-    float scale_y,
+    float ax, float bx,
+    float ay, float by,
     float mean0,    float mean1,    float mean2,
     float inv_std0, float inv_std1, float inv_std2
 ) {
@@ -188,8 +191,8 @@ extern "C" __global__ void resize_bilinear_normalize_3c(
     if (dst_x >= dst_w || dst_y >= dst_h) return;
 
     // Half-pixel center alignment: matches OpenCV / PIL convention.
-    float sx = fmaxf(fminf((dst_x + 0.5f) * scale_x - 0.5f, (float)(src_w - 1u)), 0.0f);
-    float sy = fmaxf(fminf((dst_y + 0.5f) * scale_y - 0.5f, (float)(src_h - 1u)), 0.0f);
+    float sx = fmaxf(fminf(fmaf(ax, (float)dst_x, bx), (float)(src_w - 1u)), 0.0f);
+    float sy = fmaxf(fminf(fmaf(ay, (float)dst_y, by), (float)(src_h - 1u)), 0.0f);
 
     unsigned int x0 = (unsigned int)sx;
     unsigned int y0 = (unsigned int)sy;
@@ -236,16 +239,16 @@ extern "C" __global__ void resize_bicubic_3c(
     unsigned int src_h,
     unsigned int dst_w,
     unsigned int dst_h,
-    float scale_x,
-    float scale_y
+    float ax, float bx,
+    float ay, float by
 ) {
     unsigned int dst_x = blockIdx.x * blockDim.x + threadIdx.x;
     unsigned int dst_y = blockIdx.y * blockDim.y + threadIdx.y;
     if (dst_x >= dst_w || dst_y >= dst_h) return;
 
     // Half-pixel centre alignment (matches OpenCV / PIL convention).
-    float sx = fmaxf(fminf((dst_x + 0.5f) * scale_x - 0.5f, (float)(src_w - 1u)), 0.0f);
-    float sy = fmaxf(fminf((dst_y + 0.5f) * scale_y - 0.5f, (float)(src_h - 1u)), 0.0f);
+    float sx = fmaxf(fminf(fmaf(ax, (float)dst_x, bx), (float)(src_w - 1u)), 0.0f);
+    float sy = fmaxf(fminf(fmaf(ay, (float)dst_y, by), (float)(src_h - 1u)), 0.0f);
 
     int x0 = (int)floorf(sx);
     int y0 = (int)floorf(sy);
@@ -326,13 +329,13 @@ extern "C" __global__ void resize_lanczos_h_3c(
     unsigned int src_w,
     unsigned int src_h,
     unsigned int dst_w,
-    float scale_x
+    float ax, float bx
 ) {
     unsigned int dst_x = blockIdx.x * blockDim.x + threadIdx.x;
     unsigned int src_y = blockIdx.y * blockDim.y + threadIdx.y;
     if (dst_x >= dst_w || src_y >= src_h) return;
 
-    float sx = fmaxf(fminf((dst_x + 0.5f) * scale_x - 0.5f, (float)(src_w - 1u)), 0.0f);
+    float sx = fmaxf(fminf(fmaf(ax, (float)dst_x, bx), (float)(src_w - 1u)), 0.0f);
     int x0 = (int)floorf(sx);
     float frac = sx - (float)x0;
 
@@ -380,13 +383,13 @@ extern "C" __global__ void resize_lanczos_v_3c(
     unsigned int inter_w,
     unsigned int inter_h,
     unsigned int dst_h,
-    float scale_y
+    float ay, float by
 ) {
     unsigned int dst_x = blockIdx.x * blockDim.x + threadIdx.x;
     unsigned int dst_y = blockIdx.y * blockDim.y + threadIdx.y;
     if (dst_x >= inter_w || dst_y >= dst_h) return;
 
-    float sy = fmaxf(fminf((dst_y + 0.5f) * scale_y - 0.5f, (float)(inter_h - 1u)), 0.0f);
+    float sy = fmaxf(fminf(fmaf(ay, (float)dst_y, by), (float)(inter_h - 1u)), 0.0f);
     int y0 = (int)floorf(sy);
     float frac = sy - (float)y0;
 
@@ -485,6 +488,49 @@ fn try_compile_with_l1(
     Ok(k)
 }
 
+// ── Pixel mapping ─────────────────────────────────────────────────────────────
+
+/// How destination pixel coordinates map to source coordinates.
+///
+/// Every mapping is affine in the destination index, `src = a*dst + b`; the
+/// variants only differ in the coefficients.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PixelMapping {
+    /// Pixel-center sampling, `src = (dst + 0.5) * (src_len/dst_len) - 0.5`.
+    ///
+    /// The convention of OpenCV, Pillow, ONNX `Resize`
+    /// (`coordinate_transformation_mode = half_pixel`), PyTorch
+    /// (`align_corners=False`), and NVIDIA VPI — and of the CPU
+    /// [`resize_native`](crate::resize::resize_native). Use this unless you
+    /// specifically need to reproduce align-corners output.
+    HalfPixel,
+    /// Corner-aligned sampling, `src = dst * (src_len-1)/(dst_len-1)`.
+    ///
+    /// Matches kornia's pre-0.2 CPU resize and frameworks running with
+    /// `align_corners=True`. A single-pixel destination axis maps to source
+    /// coordinate 0.
+    AlignCorners,
+}
+
+impl PixelMapping {
+    /// Per-axis affine coefficients `(a, b)` of `src = a*dst + b`.
+    fn coeffs(self, src_len: u32, dst_len: u32) -> (f32, f32) {
+        match self {
+            PixelMapping::HalfPixel => {
+                let a = src_len as f32 / dst_len as f32;
+                (a, 0.5 * a - 0.5)
+            }
+            PixelMapping::AlignCorners => {
+                if dst_len > 1 {
+                    ((src_len - 1) as f32 / (dst_len - 1) as f32, 0.0)
+                } else {
+                    (0.0, 0.0)
+                }
+            }
+        }
+    }
+}
+
 // ── Public launchers ──────────────────────────────────────────────────────────
 
 /// Launch the bilinear downscale kernel for a 3-channel f32 image.
@@ -522,6 +568,7 @@ pub fn launch_resize_bilinear_downscale_cuda(
     src_height: u32,
     dst_width: u32,
     dst_height: u32,
+    mapping: PixelMapping,
     block_dim: Option<(u32, u32)>,
 ) -> Result<(), CudaResizeError> {
     let need = (dst_width as usize) * (dst_height as usize) * 3;
@@ -535,8 +582,8 @@ pub fn launch_resize_bilinear_downscale_cuda(
     let kernel = BILINEAR_KERNEL
         .get_or_init(|| compile_with_l1(ctx, BILINEAR_SRC, "resize_bilinear_downscale_3c"));
 
-    let scale_x = src_width as f32 / dst_width as f32;
-    let scale_y = src_height as f32 / dst_height as f32;
+    let (ax, bx) = mapping.coeffs(src_width, dst_width);
+    let (ay, by) = mapping.coeffs(src_height, dst_height);
 
     kernel
         .launch_builder(stream)
@@ -546,8 +593,10 @@ pub fn launch_resize_bilinear_downscale_cuda(
         .arg(&src_height)
         .arg(&dst_width)
         .arg(&dst_height)
-        .arg(&scale_x)
-        .arg(&scale_y)
+        .arg(&ax)
+        .arg(&bx)
+        .arg(&ay)
+        .arg(&by)
         .launch_2d(
             dst_width,
             dst_height,
@@ -591,6 +640,7 @@ pub fn launch_resize_bilinear_normalize_cuda(
     dst_height: u32,
     mean: [f32; 3],
     std: [f32; 3],
+    mapping: PixelMapping,
     block_dim: Option<(u32, u32)>,
 ) -> Result<(), CudaResizeError> {
     let need = (dst_width as usize) * (dst_height as usize) * 3;
@@ -610,8 +660,8 @@ pub fn launch_resize_bilinear_normalize_cuda(
         compile_with_l1(ctx, BILINEAR_NORMALIZE_SRC, "resize_bilinear_normalize_3c")
     });
 
-    let scale_x = src_width as f32 / dst_width as f32;
-    let scale_y = src_height as f32 / dst_height as f32;
+    let (ax, bx) = mapping.coeffs(src_width, dst_width);
+    let (ay, by) = mapping.coeffs(src_height, dst_height);
 
     let inv_std0 = 1.0_f32 / std[0];
     let inv_std1 = 1.0_f32 / std[1];
@@ -625,8 +675,10 @@ pub fn launch_resize_bilinear_normalize_cuda(
         .arg(&src_height)
         .arg(&dst_width)
         .arg(&dst_height)
-        .arg(&scale_x)
-        .arg(&scale_y)
+        .arg(&ax)
+        .arg(&bx)
+        .arg(&ay)
+        .arg(&by)
         .arg(&mean[0])
         .arg(&mean[1])
         .arg(&mean[2])
@@ -663,6 +715,7 @@ pub fn launch_resize_nearest_downscale_cuda(
     src_height: u32,
     dst_width: u32,
     dst_height: u32,
+    mapping: PixelMapping,
     block_dim: Option<(u32, u32)>,
 ) -> Result<(), CudaResizeError> {
     let need = (dst_width as usize) * (dst_height as usize) * 3;
@@ -676,8 +729,8 @@ pub fn launch_resize_nearest_downscale_cuda(
     let kernel = NEAREST_KERNEL
         .get_or_init(|| compile_with_l1(ctx, NEAREST_SRC, "resize_nearest_downscale_3c"));
 
-    let scale_x = src_width as f32 / dst_width as f32;
-    let scale_y = src_height as f32 / dst_height as f32;
+    let (ax, bx) = mapping.coeffs(src_width, dst_width);
+    let (ay, by) = mapping.coeffs(src_height, dst_height);
 
     kernel
         .launch_builder(stream)
@@ -687,8 +740,10 @@ pub fn launch_resize_nearest_downscale_cuda(
         .arg(&src_height)
         .arg(&dst_width)
         .arg(&dst_height)
-        .arg(&scale_x)
-        .arg(&scale_y)
+        .arg(&ax)
+        .arg(&bx)
+        .arg(&ay)
+        .arg(&by)
         .launch_2d(
             dst_width,
             dst_height,
@@ -731,6 +786,7 @@ pub fn launch_resize_bicubic_cuda(
     src_height: u32,
     dst_width: u32,
     dst_height: u32,
+    mapping: PixelMapping,
     block_dim: Option<(u32, u32)>,
 ) -> Result<(), CudaResizeError> {
     if src_width == 0 || src_height == 0 || dst_width == 0 || dst_height == 0 {
@@ -752,8 +808,8 @@ pub fn launch_resize_bicubic_cuda(
         .as_ref()
         .map_err(|e| CudaResizeError::Cuda(e.clone()))?;
 
-    let scale_x = src_width as f32 / dst_width as f32;
-    let scale_y = src_height as f32 / dst_height as f32;
+    let (ax, bx) = mapping.coeffs(src_width, dst_width);
+    let (ay, by) = mapping.coeffs(src_height, dst_height);
 
     kernel
         .launch_builder(stream)
@@ -763,8 +819,10 @@ pub fn launch_resize_bicubic_cuda(
         .arg(&src_height)
         .arg(&dst_width)
         .arg(&dst_height)
-        .arg(&scale_x)
-        .arg(&scale_y)
+        .arg(&ax)
+        .arg(&bx)
+        .arg(&ay)
+        .arg(&by)
         .launch_2d(
             dst_width,
             dst_height,
@@ -808,6 +866,7 @@ pub fn launch_resize_lanczos_cuda(
     src_height: u32,
     dst_width: u32,
     dst_height: u32,
+    mapping: PixelMapping,
     block_dim: Option<(u32, u32)>,
 ) -> Result<(), CudaResizeError> {
     if src_width == 0 || src_height == 0 || dst_width == 0 || dst_height == 0 {
@@ -841,7 +900,7 @@ pub fn launch_resize_lanczos_cuda(
         .map_err(|e| CudaResizeError::Cuda(e.to_string()))?;
 
     // Pass 1 — horizontal: (src_w, src_h) → (dst_w, src_h).
-    let scale_x = src_width as f32 / dst_width as f32;
+    let (ax, bx) = mapping.coeffs(src_width, dst_width);
     kernel_h
         .launch_builder(stream)
         .arg(src)
@@ -849,7 +908,8 @@ pub fn launch_resize_lanczos_cuda(
         .arg(&src_width)
         .arg(&src_height)
         .arg(&dst_width)
-        .arg(&scale_x)
+        .arg(&ax)
+        .arg(&bx)
         .launch_2d(
             dst_width,
             src_height,
@@ -858,7 +918,7 @@ pub fn launch_resize_lanczos_cuda(
         .map_err(|e| CudaResizeError::Cuda(e.to_string()))?;
 
     // Pass 2 — vertical: (dst_w, src_h) → (dst_w, dst_h).
-    let scale_y = src_height as f32 / dst_height as f32;
+    let (ay, by) = mapping.coeffs(src_height, dst_height);
     kernel_v
         .launch_builder(stream)
         .arg(&intermediate)
@@ -866,11 +926,218 @@ pub fn launch_resize_lanczos_cuda(
         .arg(&dst_width)
         .arg(&src_height)
         .arg(&dst_height)
-        .arg(&scale_y)
+        .arg(&ay)
+        .arg(&by)
         .launch_2d(
             dst_width,
             dst_height,
             make_config(dst_width, dst_height, block_dim),
         )
         .map_err(|e| CudaResizeError::Cuda(e.to_string()))
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(all(test, feature = "cuda"))]
+mod tests {
+    use super::*;
+    use crate::cuda::color::test_utils::{default_stream, pattern_f32};
+    use crate::interpolation::InterpolationMode;
+    use crate::resize::resize_native;
+    use kornia_image::{Image, ImageSize};
+
+    #[test]
+    fn pixel_mapping_coeffs() {
+        // HalfPixel: a = src/dst, b = a/2 - 1/2.
+        assert_eq!(PixelMapping::HalfPixel.coeffs(640, 320), (2.0, 0.5));
+        assert_eq!(PixelMapping::HalfPixel.coeffs(320, 640), (0.5, -0.25));
+        // A 1-wide destination samples the source centre.
+        assert_eq!(PixelMapping::HalfPixel.coeffs(9, 1), (9.0, 4.0));
+        // AlignCorners: a = (src-1)/(dst-1), b = 0; 1-wide dst pins to 0.
+        assert_eq!(PixelMapping::AlignCorners.coeffs(641, 321), (2.0, 0.0));
+        assert_eq!(PixelMapping::AlignCorners.coeffs(9, 1), (0.0, 0.0));
+    }
+
+    /// Run CPU `resize_native` (half-pixel) and the GPU launcher on the same
+    /// deterministic input; return both outputs.
+    fn cpu_and_gpu(
+        (sw, sh): (usize, usize),
+        (dw, dh): (usize, usize),
+        interpolation: InterpolationMode,
+    ) -> (Vec<f32>, Vec<f32>) {
+        let data = pattern_f32(sw * sh * 3);
+        let src = Image::<f32, 3>::new(
+            ImageSize {
+                width: sw,
+                height: sh,
+            },
+            data.clone(),
+        )
+        .unwrap();
+        let mut cpu = Image::<f32, 3>::from_size_val(
+            ImageSize {
+                width: dw,
+                height: dh,
+            },
+            0.0,
+        )
+        .unwrap();
+        resize_native(&src, &mut cpu, interpolation).unwrap();
+
+        let stream = default_stream();
+        let ctx = &stream.context();
+        let d_src = stream.clone_htod(&data).unwrap();
+        let mut d_dst = stream.alloc_zeros::<f32>(dw * dh * 3).unwrap();
+        let (swu, shu, dwu, dhu) = (sw as u32, sh as u32, dw as u32, dh as u32);
+        match interpolation {
+            InterpolationMode::Bilinear => launch_resize_bilinear_downscale_cuda(
+                ctx,
+                &stream,
+                &d_src,
+                &mut d_dst,
+                swu,
+                shu,
+                dwu,
+                dhu,
+                PixelMapping::HalfPixel,
+                None,
+            ),
+            InterpolationMode::Nearest => launch_resize_nearest_downscale_cuda(
+                ctx,
+                &stream,
+                &d_src,
+                &mut d_dst,
+                swu,
+                shu,
+                dwu,
+                dhu,
+                PixelMapping::HalfPixel,
+                None,
+            ),
+            other => panic!("unsupported mode in test: {other:?}"),
+        }
+        .unwrap_or_else(|e| panic!("launch failed {sw}x{sh}->{dw}x{dh} ({interpolation:?}): {e}"));
+        let gpu: Vec<f32> = stream.clone_dtoh(&d_dst).unwrap();
+        stream.synchronize().unwrap();
+        (cpu.as_slice().to_vec(), gpu)
+    }
+
+    /// Destination pixels whose source coordinate sits within `eps` of a `.5`
+    /// rounding tie — only meaningful for nearest. The CPU computes
+    /// `(x+0.5)*scale - 0.5` while the GPU computes `fmaf(a, x, b)`; the two
+    /// agree only to within a float ulp, so a coordinate an ulp either side of
+    /// the tie can legitimately snap to different source pixels, a full-pixel
+    /// value jump. Bilinear needs no exclusion: it is continuous across tap
+    /// boundaries, so the same ulp drift moves the value by ~gradient·ulp,
+    /// which the tolerance absorbs. Excluded pixels must stay rare — asserted
+    /// by the caller.
+    fn ambiguous(
+        (sw, sh): (usize, usize),
+        (dw, dh): (usize, usize),
+        interpolation: InterpolationMode,
+        eps: f32,
+    ) -> Vec<bool> {
+        let (ax, bx) = PixelMapping::HalfPixel.coeffs(sw as u32, dw as u32);
+        let (ay, by) = PixelMapping::HalfPixel.coeffs(sh as u32, dh as u32);
+        if !matches!(interpolation, InterpolationMode::Nearest) {
+            return vec![false; dw * dh];
+        }
+        let near_boundary = |v: f32| {
+            let frac = v - v.floor();
+            (frac - 0.5).abs() < eps
+        };
+        let mut out = vec![false; dw * dh];
+        for y in 0..dh {
+            for x in 0..dw {
+                let sx = ax * x as f32 + bx;
+                let sy = ay * y as f32 + by;
+                out[y * dw + x] = near_boundary(sx) || near_boundary(sy);
+            }
+        }
+        out
+    }
+
+    fn assert_matches(
+        src: (usize, usize),
+        dst: (usize, usize),
+        interpolation: InterpolationMode,
+        tol: f32,
+        eps: f32,
+    ) {
+        let (cpu, gpu) = cpu_and_gpu(src, dst, interpolation);
+        let amb = ambiguous(src, dst, interpolation, eps);
+        let mut skipped = 0usize;
+        for (p, &is_amb) in amb.iter().enumerate() {
+            if is_amb {
+                skipped += 1;
+                continue;
+            }
+            for c in 0..3 {
+                let i = p * 3 + c;
+                let d = (gpu[i] - cpu[i]).abs();
+                assert!(
+                    d <= tol,
+                    "{src:?}->{dst:?} {interpolation:?}: pixel {p} ch {c} diff {d} > {tol} \
+                     (cpu {} gpu {})",
+                    cpu[i],
+                    gpu[i]
+                );
+            }
+        }
+        assert!(
+            skipped * 10 < amb.len(),
+            "{skipped}/{} pixels excluded as boundary-ambiguous — too many for a \
+             sound comparison",
+            amb.len()
+        );
+    }
+
+    /// Dyadic 2× downscale: every coefficient and coordinate is exact in f32 on
+    /// both paths, so nearest must be bit-exact and bilinear near-exact (the
+    /// only residue is fmaf vs separate multiply-add in the weight arithmetic).
+    #[test]
+    fn resize_2x_downscale_matches_cpu() {
+        let (cpu, gpu) = cpu_and_gpu((640, 480), (320, 240), InterpolationMode::Nearest);
+        assert_eq!(gpu, cpu, "dyadic nearest resize must be bit-exact vs CPU");
+
+        assert_matches(
+            (640, 480),
+            (320, 240),
+            InterpolationMode::Bilinear,
+            1e-6,
+            0.0,
+        );
+    }
+
+    /// Upscale goes through the same kernels (the "downscale" in the launcher
+    /// names is historical) — parity must hold in both directions.
+    #[test]
+    fn resize_2x_upscale_matches_cpu() {
+        assert_matches(
+            (320, 240),
+            (640, 480),
+            InterpolationMode::Bilinear,
+            1e-6,
+            0.0,
+        );
+        let (cpu, gpu) = cpu_and_gpu((320, 240), (640, 480), InterpolationMode::Nearest);
+        assert_eq!(gpu, cpu, "dyadic nearest upscale must be bit-exact vs CPU");
+    }
+
+    /// Odd, prime-ish, and unaligned sizes: catches block-clamping and any
+    /// residual alignment assumption. Non-dyadic scales drift by a coordinate
+    /// ulp between the two paths, so boundary-ambiguous pixels are excluded
+    /// and the tolerance is looser.
+    #[test]
+    fn resize_odd_sizes_match_cpu() {
+        for &(src, dst) in &[
+            ((127, 63), (65, 33)),
+            ((129, 97), (64, 48)),
+            ((255, 130), (133, 67)),
+            ((63, 129), (127, 255)), // upscale
+        ] {
+            assert_matches(src, dst, InterpolationMode::Bilinear, 1e-3, 0.0);
+            assert_matches(src, dst, InterpolationMode::Nearest, 0.0, 1e-3);
+        }
+    }
 }

--- a/crates/kornia-imgproc/src/resize/mod.rs
+++ b/crates/kornia-imgproc/src/resize/mod.rs
@@ -55,7 +55,7 @@ use common::FilterKind;
 /// Sampling uses the **half-pixel** (pixel-center) grid,
 /// `sx = (x + 0.5) * src/dst - 0.5`, the convention shared by OpenCV, Pillow,
 /// ONNX `Resize`, PyTorch (`align_corners=False`), and NVIDIA VPI, and by this
-/// crate's CUDA resize kernels. Versions up to 0.1.x used align-corners, which
+/// crate's CUDA resize kernels. Earlier releases used align-corners, which
 /// produced different pixel values for the same inputs.
 ///
 /// # Arguments

--- a/crates/kornia-imgproc/src/resize/mod.rs
+++ b/crates/kornia-imgproc/src/resize/mod.rs
@@ -52,6 +52,12 @@ use common::FilterKind;
 /// The function resizes an image to a new size using the specified interpolation mode.
 /// It supports any number of channels and data types.
 ///
+/// Sampling uses the **half-pixel** (pixel-center) grid,
+/// `sx = (x + 0.5) * src/dst - 0.5`, the convention shared by OpenCV, Pillow,
+/// ONNX `Resize`, PyTorch (`align_corners=False`), and NVIDIA VPI, and by this
+/// crate's CUDA resize kernels. Versions up to 0.1.x used align-corners, which
+/// produced different pixel values for the same inputs.
+///
 /// # Arguments
 ///
 /// * `src` - The input image container.
@@ -110,19 +116,28 @@ pub fn resize_native<const C: usize>(
     }
 
     let (dst_rows, dst_cols) = (dst.rows(), dst.cols());
-    let step_x = if dst.cols() > 1 {
-        (src.cols() - 1) as f32 / (dst.cols() - 1) as f32
-    } else {
-        0.0
-    };
-    let step_y = if dst.rows() > 1 {
-        (src.rows() - 1) as f32 / (dst.rows() - 1) as f32
-    } else {
-        0.0
-    };
-    let (map_x, map_y) = meshgrid_from_fn(dst_cols, dst_rows, |x, y| {
-        Ok((x as f32 * step_x, y as f32 * step_y))
-    })?;
+
+    // Half-pixel (pixel-center) sampling grid: `sx = (x + 0.5) * scale - 0.5`,
+    // clamped to the source. This is the convention of OpenCV, Pillow, ONNX
+    // `Resize` (default `coordinate_transformation_mode = half_pixel`),
+    // PyTorch's recommended `align_corners=False`, and NVIDIA VPI — and the
+    // grid the CUDA resize kernels in this crate already sample on, so CPU and
+    // GPU agree. Earlier releases used align-corners
+    // (`sx = x * (src-1)/(dst-1)`), which shifts content relative to every
+    // mainstream library; outputs changed accordingly.
+    let scale_x = src.cols() as f32 / dst.cols() as f32;
+    let scale_y = src.rows() as f32 / dst.rows() as f32;
+    let x_max = (src.cols() - 1) as f32;
+    let y_max = (src.rows() - 1) as f32;
+    // The grid is separable: evaluate each axis once (dst_w + dst_h values)
+    // and let the per-pixel closure be two table loads.
+    let xs: Vec<f32> = (0..dst_cols)
+        .map(|x| ((x as f32 + 0.5) * scale_x - 0.5).clamp(0.0, x_max))
+        .collect();
+    let ys: Vec<f32> = (0..dst_rows)
+        .map(|y| ((y as f32 + 0.5) * scale_y - 0.5).clamp(0.0, y_max))
+        .collect();
+    let (map_x, map_y) = meshgrid_from_fn(dst_cols, dst_rows, |x, y| Ok((xs[x], ys[y])))?;
 
     parallel::par_iter_rows_resample(dst, &map_x, &map_y, |&x, &y, dst_pixel| {
         for (k, pixel) in dst_pixel.iter_mut().enumerate() {
@@ -383,13 +398,20 @@ mod tests {
         assert_eq!(image_resized.size().width, 2);
         assert_eq!(image_resized.size().height, 3);
 
-        assert_eq!(
-            image_resized.as_slice(),
-            [
-                0.0, 1.0, 2.0, 6.0, 7.0, 8.0, 13.5, 14.5, 15.5, 19.5, 20.5, 21.5, 27.0, 28.0, 29.0,
-                33.0, 34.0, 35.0
-            ]
-        );
+        // Half-pixel grid: sx = (x+0.5)*3/2 - 0.5 ∈ {0.25, 1.75},
+        // sy = (y+0.5)*4/3 - 0.5 ∈ {1/6, 1.5, 17/6}. The source value is
+        // linear in position (v = 9y + 3x + c), so bilinear reproduces it
+        // exactly up to float error: v = 9*sy + 3*sx + c.
+        let expected = [
+            2.25, 3.25, 4.25, 6.75, 7.75, 8.75, 14.25, 15.25, 16.25, 18.75, 19.75, 20.75, 26.25,
+            27.25, 28.25, 30.75, 31.75, 32.75,
+        ];
+        for (i, (got, want)) in image_resized.as_slice().iter().zip(expected).enumerate() {
+            assert!(
+                (got - want).abs() < 1e-4,
+                "pixel {i}: got {got}, want {want}"
+            );
+        }
 
         Ok(())
     }

--- a/crates/kornia-imgproc/src/warp/perspective.rs
+++ b/crates/kornia-imgproc/src/warp/perspective.rs
@@ -511,10 +511,15 @@ mod tests {
             ],
         )?;
 
-        // resize matrix (from get_perspective_transform)
-        let m = [0.3333, 0.0, 0.0, 0.0, 0.3333, 0.0, 0.0, 0.0, 1.0];
+        // The homography equivalent of a half-pixel 2× downscale: resize
+        // samples at sx = (dst_x + 0.5) * 2 - 0.5 = 2*dst_x + 0.5, so the
+        // forward (src → dst) map is dst_x = 0.5*sx - 0.25. All entries are
+        // dyadic, so the internal inversion and the interpolation are exact
+        // and the equality with `resize_native` below is bit-exact.
+        let m = [0.5, 0.0, -0.25, 0.0, 0.5, -0.25, 0.0, 0.0, 1.0];
 
-        let image_expected = vec![0.0, 3.0, 12.0, 15.0];
+        // v(sx, sy) = 4*sy + sx sampled at (2x+0.5, 2y+0.5).
+        let image_expected = vec![2.5, 4.5, 10.5, 12.5];
 
         let new_size = ImageSize {
             width: 2,


### PR DESCRIPTION
## 📝 Description

**BREAKING CHANGE.** `resize_native` moves from align-corners to the **half-pixel** (pixel-center) sampling grid — the convention of OpenCV, Pillow, ONNX `Resize` (`half_pixel` is the spec default), PyTorch (`align_corners=False`), and NVIDIA VPI. kornia's CPU resize was the outlier, and it disagreed with our own CUDA resize kernels, which already sample half-pixel: the same resize produced **different images depending on where the memory lived**, which blocks any residency-dispatched GPU path for resize.

This is P0.b of the CUDA-integration plan (following #1001).

### What changes for users
- `resize_native` output shifts by a sub-pixel amount for every non-identity resize. It now matches what OpenCV/PIL/ONNX users expect.
- The u8 fast paths (`resize_fast_*`) are **unaffected**.
- CUDA resize launchers take a new `PixelMapping` parameter: `HalfPixel` (the convention), or `AlignCorners` to reproduce pre-change output.

### Implementation notes
- Kernels generalize from `(scale_x, scale_y)` to per-axis affine coefficients (`sx = fmaf(a, x, b)`) computed by `PixelMapping::coeffs` — this is what lets one kernel serve both conventions, and it's the hook the upcoming OpenCV-compat mode plugs into.
- Under `AlignCorners`, the nearest kernel now rounds like the CPU (`round()`); the old floor-of-center only matched under half-pixel.
- The CPU coordinate LUT is precomputed **per axis** rather than per pixel. First cut computed the half-pixel expression in the per-pixel meshgrid closure and cost 15–22% on the CPU resize bench; the LUT brings it back to parity with the old code.

### First-ever CPU↔GPU resize parity tests
Possible only now that both sample the same grid:
- Dyadic 2× down/upscale: **nearest bit-exact** (every coefficient exact in f32 on both paths), bilinear ≤1e-6.
- Odd/unaligned sizes (127×63→65×33, 129×97→64×48, 255×130→133×67, upscale): bilinear ≤1e-3 with **no pixel exclusions** (bilinear is continuous across tap boundaries, so coordinate-ulp drift can't jump); nearest exact away from genuine `.5` rounding ties, which are excluded and asserted rare.
- `PixelMapping::coeffs` unit-tested including the 1-wide-axis edge cases.

## 🧪 How Was This Tested?

- [x] Full suite on Jetson Orin with `--features cuda`: 323 lib + 51 integration + doctests, clippy clean.
- [x] **Benchmarks (Jetson Orin, same-hour A/B vs `main`):**
  - CPU criterion `bench_resize` (`kornia_par`): 128.1/352.6/1130 µs (main) vs 129.6/359.4/1175 µs (branch) — within jitter after the LUT fix.
  - GPU `bench_cuda_resize`: bilinear/nearest flat; bicubic 1024→512 repeated runs 0.203–0.206 ms vs main 0.232 ms (slightly faster); the rest within jitter.
- [x] Updated value-asserting tests re-derived analytically (linear-in-position source ⇒ bilinear reproduces `9·sy + 3·sx + c` exactly); `test_warp_perspective_resize` now uses the half-pixel-equivalent homography and stays bit-exact.

## 💭 Additional Context

CHANGELOG has the user-facing breaking-change entry. Follow-ups per the plan: P0.c (CPU↔GPU byte-exact via `fmad=false` + identical coordinate expressions), P0.d (OpenCV byte-compat mode against `cv2` reference vectors), then the residency dispatch that routes `resize_native` to these kernels.

## 🕵️ AI Usage Disclosure

- [x] 🟡 **AI-assisted:** authored with Claude Code; every change verified on-device (Jetson Orin) against the CPU reference and benchmarked A/B vs main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)