### PR TITLE
feat(imgproc): byte-exact CPU/CUDA resize via fmad=false + mirrored expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,10 @@ bilinear arithmetic use the identical expression shapes on both sides, so
 `resize_native` and the CUDA resize kernels produce bit-identical f32 output —
 asserted by parity tests across dyadic and non-dyadic sizes. Kernels that want
 fused multiply-adds keep them via explicit `fmaf()` (unaffected by the flag);
-no measured throughput change on Jetson Orin. `bilinear_interpolation` values
-shift by ~1 ulp (weights are now formed before the tap products).
+no measured throughput change on Jetson Orin. The `bilinear_interpolation`
+restructure (weights formed before the tap products) shifts f32 bilinear
+output by up to 1 ulp in every consumer — `warp_perspective`, `remap`, and
+the optical-flow border path, not just resize.
 
 **BREAKING — `resize_native` now samples on the half-pixel grid.** The f32
 resize previously used align-corners (`sx = x * (src-1)/(dst-1)`); it now uses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ changes early: `cargo add kornia-imgproc@0.1.15-rc.1` or `pip install --pre korn
 
 ## [Unreleased]
 
+**CPU and CUDA resize are now byte-exact.** NVRTC kernels compile with
+`--fmad=false` (no automatic FP contraction), and the resize coordinate and
+bilinear arithmetic use the identical expression shapes on both sides, so
+`resize_native` and the CUDA resize kernels produce bit-identical f32 output —
+asserted by parity tests across dyadic and non-dyadic sizes. Kernels that want
+fused multiply-adds keep them via explicit `fmaf()` (unaffected by the flag);
+no measured throughput change on Jetson Orin. `bilinear_interpolation` values
+shift by ~1 ulp (weights are now formed before the tap products).
+
 **BREAKING — `resize_native` now samples on the half-pixel grid.** The f32
 resize previously used align-corners (`sx = x * (src-1)/(dst-1)`); it now uses
 the pixel-center convention (`sx = (x + 0.5) * src/dst - 0.5`) shared by

--- a/crates/kornia-imgproc/src/cuda/resize.rs
+++ b/crates/kornia-imgproc/src/cuda/resize.rs
@@ -107,9 +107,12 @@ extern "C" __global__ void resize_bilinear_downscale_3c(
     unsigned int dst_y = blockIdx.y * blockDim.y + threadIdx.y;
     if (dst_x >= dst_w || dst_y >= dst_h) return;
 
-    // Half-pixel center alignment: matches OpenCV / PIL convention.
-    float sx = fmaxf(fminf(fmaf(ax, (float)dst_x, bx), (float)(src_w - 1u)), 0.0f);
-    float sy = fmaxf(fminf(fmaf(ay, (float)dst_y, by), (float)(src_h - 1u)), 0.0f);
+    // Plain multiply-add, NOT fmaf: with --fmad=false this rounds twice,
+    // exactly like the CPU LUT's `a * x + b` — the coordinate is byte-exact
+    // across CPU and GPU, which the parity tests assert. Clamp order (min
+    // then max) is equivalent to Rust's f32::clamp for lo <= hi.
+    float sx = fmaxf(fminf(ax * (float)dst_x + bx, (float)(src_w - 1u)), 0.0f);
+    float sy = fmaxf(fminf(ay * (float)dst_y + by, (float)(src_h - 1u)), 0.0f);
 
     unsigned int x0 = (unsigned int)sx;
     unsigned int y0 = (unsigned int)sy;
@@ -153,11 +156,13 @@ extern "C" __global__ void resize_nearest_downscale_3c(
     if (dst_x >= dst_w || dst_y >= dst_h) return;
 
     // Half-pixel center alignment.
-    // Round-to-nearest source pixel: the sample coordinate is fmaf(a,x,b);
-    // +0.5-then-truncate is round-half-up, which equals the CPU's
-    // half-away-from-zero `round()` for the non-negative coords produced here.
-    unsigned int src_xi = min((unsigned int)(fmaf(ax, (float)dst_x, bx) + 0.5f), src_w - 1u);
-    unsigned int src_yi = min((unsigned int)(fmaf(ay, (float)dst_y, by) + 0.5f), src_h - 1u);
+    // Plain multiply-add (not fmaf) so the coordinate is bit-identical to the
+    // CPU LUT under --fmad=false. +0.5-then-truncate is round-half-up, which
+    // equals the CPU's half-away-from-zero `round()` for the non-negative
+    // coordinates produced here — including exact .5 ties, since both sides
+    // compute the identical f32 coordinate.
+    unsigned int src_xi = min((unsigned int)((ax * (float)dst_x + bx) + 0.5f), src_w - 1u);
+    unsigned int src_yi = min((unsigned int)((ay * (float)dst_y + by) + 0.5f), src_h - 1u);
 
     unsigned int src_base = (src_yi * src_w + src_xi) * 3u;
     unsigned int out = (dst_y * dst_w + dst_x) * 3u;
@@ -190,9 +195,12 @@ extern "C" __global__ void resize_bilinear_normalize_3c(
     unsigned int dst_y = blockIdx.y * blockDim.y + threadIdx.y;
     if (dst_x >= dst_w || dst_y >= dst_h) return;
 
-    // Half-pixel center alignment: matches OpenCV / PIL convention.
-    float sx = fmaxf(fminf(fmaf(ax, (float)dst_x, bx), (float)(src_w - 1u)), 0.0f);
-    float sy = fmaxf(fminf(fmaf(ay, (float)dst_y, by), (float)(src_h - 1u)), 0.0f);
+    // Plain multiply-add, NOT fmaf: with --fmad=false this rounds twice,
+    // exactly like the CPU LUT's `a * x + b` — the coordinate is byte-exact
+    // across CPU and GPU, which the parity tests assert. Clamp order (min
+    // then max) is equivalent to Rust's f32::clamp for lo <= hi.
+    float sx = fmaxf(fminf(ax * (float)dst_x + bx, (float)(src_w - 1u)), 0.0f);
+    float sy = fmaxf(fminf(ay * (float)dst_y + by, (float)(src_h - 1u)), 0.0f);
 
     unsigned int x0 = (unsigned int)sx;
     unsigned int y0 = (unsigned int)sy;
@@ -259,14 +267,14 @@ extern "C" __global__ void resize_bicubic_3c(
     float wx[4], wy[4];
     {
         float t;
-        t = 1.0f + frac_x; wx[0] = ((-0.5f*t + 2.5f)*t - 4.0f)*t + 2.0f;
-        t =         frac_x; wx[1] = (( 1.5f*t - 2.5f)*t       )*t + 1.0f;
-        t = 1.0f - frac_x; wx[2] = (( 1.5f*t - 2.5f)*t       )*t + 1.0f;
-        t = 2.0f - frac_x; wx[3] = ((-0.5f*t + 2.5f)*t - 4.0f)*t + 2.0f;
-        t = 1.0f + frac_y; wy[0] = ((-0.5f*t + 2.5f)*t - 4.0f)*t + 2.0f;
-        t =         frac_y; wy[1] = (( 1.5f*t - 2.5f)*t       )*t + 1.0f;
-        t = 1.0f - frac_y; wy[2] = (( 1.5f*t - 2.5f)*t       )*t + 1.0f;
-        t = 2.0f - frac_y; wy[3] = ((-0.5f*t + 2.5f)*t - 4.0f)*t + 2.0f;
+        t = 1.0f + frac_x; wx[0] = fmaf(fmaf(fmaf(-0.5f, t, 2.5f), t, -4.0f), t, 2.0f);
+        t =         frac_x; wx[1] = fmaf(fmaf( 1.5f, t, -2.5f) * t,       t, 1.0f);
+        t = 1.0f - frac_x; wx[2] = fmaf(fmaf( 1.5f, t, -2.5f) * t,       t, 1.0f);
+        t = 2.0f - frac_x; wx[3] = fmaf(fmaf(fmaf(-0.5f, t, 2.5f), t, -4.0f), t, 2.0f);
+        t = 1.0f + frac_y; wy[0] = fmaf(fmaf(fmaf(-0.5f, t, 2.5f), t, -4.0f), t, 2.0f);
+        t =         frac_y; wy[1] = fmaf(fmaf( 1.5f, t, -2.5f) * t,       t, 1.0f);
+        t = 1.0f - frac_y; wy[2] = fmaf(fmaf( 1.5f, t, -2.5f) * t,       t, 1.0f);
+        t = 2.0f - frac_y; wy[3] = fmaf(fmaf(fmaf(-0.5f, t, 2.5f), t, -4.0f), t, 2.0f);
     }
 
     unsigned int row[4];
@@ -1038,112 +1046,50 @@ mod tests {
         (cpu.as_slice().to_vec(), gpu)
     }
 
-    /// Destination pixels whose source coordinate sits within `eps` of a `.5`
-    /// rounding tie — only meaningful for nearest. The CPU computes
-    /// `(x+0.5)*scale - 0.5` while the GPU computes `fmaf(a, x, b)`; the two
-    /// agree only to within a float ulp, so a coordinate an ulp either side of
-    /// the tie can legitimately snap to different source pixels, a full-pixel
-    /// value jump. Bilinear needs no exclusion: it is continuous across tap
-    /// boundaries, so the same ulp drift moves the value by ~gradient·ulp,
-    /// which the tolerance absorbs. Excluded pixels must stay rare — asserted
-    /// by the caller.
-    fn ambiguous(
-        (sw, sh): (usize, usize),
-        (dw, dh): (usize, usize),
-        interpolation: InterpolationMode,
-        eps: f32,
-    ) -> Vec<bool> {
-        let (ax, bx) = PixelMapping::HalfPixel.coeffs(sw as u32, dw as u32);
-        let (ay, by) = PixelMapping::HalfPixel.coeffs(sh as u32, dh as u32);
-        if !matches!(interpolation, InterpolationMode::Nearest) {
-            return vec![false; dw * dh];
-        }
-        let near_boundary = |v: f32| {
-            let frac = v - v.floor();
-            (frac - 0.5).abs() < eps
-        };
-        let mut out = vec![false; dw * dh];
-        for y in 0..dh {
-            for x in 0..dw {
-                let sx = ax * x as f32 + bx;
-                let sy = ay * y as f32 + by;
-                out[y * dw + x] = near_boundary(sx) || near_boundary(sy);
-            }
-        }
-        out
-    }
-
-    fn assert_matches(
+    /// Byte-exact comparison: the CPU LUT and the kernels compute the identical
+    /// uncontracted `a*x + b` coordinate (see the contract note in
+    /// `resize_native`), and the bilinear weight/sum expression shapes match,
+    /// so CPU and GPU must agree bit-for-bit — no tolerance, no exclusions.
+    fn assert_bit_exact(
         src: (usize, usize),
         dst: (usize, usize),
         interpolation: InterpolationMode,
-        tol: f32,
-        eps: f32,
     ) {
         let (cpu, gpu) = cpu_and_gpu(src, dst, interpolation);
-        let amb = ambiguous(src, dst, interpolation, eps);
-        let mut skipped = 0usize;
-        for (p, &is_amb) in amb.iter().enumerate() {
-            if is_amb {
-                skipped += 1;
-                continue;
-            }
-            for c in 0..3 {
-                let i = p * 3 + c;
-                let d = (gpu[i] - cpu[i]).abs();
-                assert!(
-                    d <= tol,
-                    "{src:?}->{dst:?} {interpolation:?}: pixel {p} ch {c} diff {d} > {tol} \
-                     (cpu {} gpu {})",
-                    cpu[i],
-                    gpu[i]
-                );
-            }
+        let bad = cpu
+            .iter()
+            .zip(&gpu)
+            .enumerate()
+            .find(|(_, (c, g))| c.to_bits() != g.to_bits());
+        if let Some((i, (c, g))) = bad {
+            panic!(
+                "{src:?}->{dst:?} {interpolation:?}: first mismatch at element {i}: cpu {c} ({:#010x}) gpu {g} ({:#010x})",
+                c.to_bits(),
+                g.to_bits()
+            );
         }
-        assert!(
-            skipped * 10 < amb.len(),
-            "{skipped}/{} pixels excluded as boundary-ambiguous — too many for a \
-             sound comparison",
-            amb.len()
-        );
     }
 
-    /// Dyadic 2× downscale: every coefficient and coordinate is exact in f32 on
-    /// both paths, so nearest must be bit-exact and bilinear near-exact (the
-    /// only residue is fmaf vs separate multiply-add in the weight arithmetic).
+    /// Dyadic 2× downscale — historically the easy case; now just one instance
+    /// of the blanket byte-exact contract.
     #[test]
     fn resize_2x_downscale_matches_cpu() {
-        let (cpu, gpu) = cpu_and_gpu((640, 480), (320, 240), InterpolationMode::Nearest);
-        assert_eq!(gpu, cpu, "dyadic nearest resize must be bit-exact vs CPU");
-
-        assert_matches(
-            (640, 480),
-            (320, 240),
-            InterpolationMode::Bilinear,
-            1e-6,
-            0.0,
-        );
+        assert_bit_exact((640, 480), (320, 240), InterpolationMode::Nearest);
+        assert_bit_exact((640, 480), (320, 240), InterpolationMode::Bilinear);
     }
 
     /// Upscale goes through the same kernels (the "downscale" in the launcher
     /// names is historical) — parity must hold in both directions.
     #[test]
     fn resize_2x_upscale_matches_cpu() {
-        assert_matches(
-            (320, 240),
-            (640, 480),
-            InterpolationMode::Bilinear,
-            1e-6,
-            0.0,
-        );
-        let (cpu, gpu) = cpu_and_gpu((320, 240), (640, 480), InterpolationMode::Nearest);
-        assert_eq!(gpu, cpu, "dyadic nearest upscale must be bit-exact vs CPU");
+        assert_bit_exact((320, 240), (640, 480), InterpolationMode::Bilinear);
+        assert_bit_exact((320, 240), (640, 480), InterpolationMode::Nearest);
     }
 
-    /// Odd, prime-ish, and unaligned sizes: catches block-clamping and any
-    /// residual alignment assumption. Non-dyadic scales drift by a coordinate
-    /// ulp between the two paths, so boundary-ambiguous pixels are excluded
-    /// and the tolerance is looser.
+    /// Odd, prime-ish, and unaligned sizes with non-dyadic scales: exactly the
+    /// cases where the pre-byte-exact code needed tolerances and rounding-tie
+    /// exclusions. Bit-equality here is the point of the fmad=false +
+    /// mirrored-expression contract.
     #[test]
     fn resize_odd_sizes_match_cpu() {
         for &(src, dst) in &[
@@ -1152,8 +1098,8 @@ mod tests {
             ((255, 130), (133, 67)),
             ((63, 129), (127, 255)), // upscale
         ] {
-            assert_matches(src, dst, InterpolationMode::Bilinear, 1e-3, 0.0);
-            assert_matches(src, dst, InterpolationMode::Nearest, 0.0, 1e-3);
+            assert_bit_exact(src, dst, InterpolationMode::Bilinear);
+            assert_bit_exact(src, dst, InterpolationMode::Nearest);
         }
     }
 }

--- a/crates/kornia-imgproc/src/interpolation/bilinear.rs
+++ b/crates/kornia-imgproc/src/interpolation/bilinear.rs
@@ -46,8 +46,16 @@ pub(crate) fn bilinear_interpolation<const C: usize>(
     let frac_uu = 1. - frac_u;
     let frac_vv = 1. - frac_v;
 
-    val00 * frac_uu * frac_vv
-        + val01 * frac_u * frac_vv
-        + val10 * frac_uu * frac_v
-        + val11 * frac_u * frac_v
+    // Weights are formed first and the terms summed left to right — the same
+    // expression shape as the CUDA bilinear kernels, which compile with
+    // `--fmad=false` (uncontracted multiply-adds). Same ops in the same order
+    // means bit-identical results, which the CPU/GPU resize parity tests
+    // assert. `(val * w1) * w2` is NOT the same rounding as `val * (w1 * w2)`;
+    // keep this shape in sync with the kernels.
+    let w00 = frac_vv * frac_uu;
+    let w10 = frac_vv * frac_u;
+    let w01 = frac_v * frac_uu;
+    let w11 = frac_v * frac_u;
+
+    w00 * val00 + w10 * val01 + w01 * val10 + w11 * val11
 }

--- a/crates/kornia-imgproc/src/interpolation/bilinear.rs
+++ b/crates/kornia-imgproc/src/interpolation/bilinear.rs
@@ -47,11 +47,16 @@ pub(crate) fn bilinear_interpolation<const C: usize>(
     let frac_vv = 1. - frac_v;
 
     // Weights are formed first and the terms summed left to right — the same
-    // expression shape as the CUDA bilinear kernels, which compile with
+    // expression shape as `resize_bilinear_downscale_3c` and
+    // `resize_bilinear_normalize_3c` in `cuda/resize.rs`, which compile with
     // `--fmad=false` (uncontracted multiply-adds). Same ops in the same order
     // means bit-identical results, which the CPU/GPU resize parity tests
     // assert. `(val * w1) * w2` is NOT the same rounding as `val * (w1 * w2)`;
-    // keep this shape in sync with the kernels.
+    // keep this shape in sync with those kernels.
+    //
+    // Naming: the weight digit order is (y, x) while the val digit order is
+    // (row-offset, col-offset), so w10 (y+0, x+1) pairs with val01 (row+0,
+    // col+1) — transposed names, same tap.
     let w00 = frac_vv * frac_uu;
     let w10 = frac_vv * frac_u;
     let w01 = frac_v * frac_uu;

--- a/crates/kornia-imgproc/src/resize/mod.rs
+++ b/crates/kornia-imgproc/src/resize/mod.rs
@@ -125,18 +125,27 @@ pub fn resize_native<const C: usize>(
     // GPU agree. Earlier releases used align-corners
     // (`sx = x * (src-1)/(dst-1)`), which shifts content relative to every
     // mainstream library; outputs changed accordingly.
-    let scale_x = src.cols() as f32 / dst.cols() as f32;
-    let scale_y = src.rows() as f32 / dst.rows() as f32;
-    let x_max = (src.cols() - 1) as f32;
-    let y_max = (src.rows() - 1) as f32;
     // The grid is separable: evaluate each axis once (dst_w + dst_h values)
     // and let the per-pixel closure be two table loads.
-    let xs: Vec<f32> = (0..dst_cols)
-        .map(|x| ((x as f32 + 0.5) * scale_x - 0.5).clamp(0.0, x_max))
-        .collect();
-    let ys: Vec<f32> = (0..dst_rows)
-        .map(|y| ((y as f32 + 0.5) * scale_y - 0.5).clamp(0.0, y_max))
-        .collect();
+    //
+    // BYTE-EXACT CONTRACT with the CUDA resize kernels: the coordinate is
+    // computed as `a*x + b` with `a = src/dst` and `b = 0.5*a - 0.5` — the
+    // exact f32 expression `cuda::resize::PixelMapping::HalfPixel.coeffs`
+    // feeds the kernels, which evaluate `a*x + b` as an uncontracted
+    // multiply-add (`--fmad=false`). Same ops, same roundings, identical
+    // coordinates — the CPU/GPU parity tests assert bit-equality on top of
+    // this. Algebraically equivalent forms like `(x + 0.5)*a - 0.5` round
+    // differently; don't "simplify" one side without the other.
+    let axis_lut = |src_len: usize, dst_len: usize| -> Vec<f32> {
+        let a = src_len as f32 / dst_len as f32;
+        let b = 0.5 * a - 0.5;
+        let max = (src_len - 1) as f32;
+        (0..dst_len)
+            .map(|i| (a * i as f32 + b).clamp(0.0, max))
+            .collect()
+    };
+    let xs = axis_lut(src.cols(), dst_cols);
+    let ys = axis_lut(src.rows(), dst_rows);
     let (map_x, map_y) = meshgrid_from_fn(dst_cols, dst_rows, |x, y| Ok((xs[x], ys[y])))?;
 
     parallel::par_iter_rows_resample(dst, &map_x, &map_y, |&x, &y, dst_pixel| {

--- a/crates/kornia-tensor/src/cuda.rs
+++ b/crates/kornia-tensor/src/cuda.rs
@@ -434,6 +434,16 @@ impl CudaKernel {
             src,
             CompileOptions {
                 arch: Some(arch_str),
+                // No automatic FP contraction: a plain `a*b + c` in kernel
+                // source compiles to a multiply and an add with two roundings,
+                // exactly like the same expression on the CPU. This is what
+                // makes CPU↔GPU byte-exactness achievable for kernels written
+                // to mirror their CPU reference. Explicit `fmaf()` calls are
+                // NOT affected — kernels that want fusion (tap accumulation in
+                // bicubic/Lanczos, Horner polynomials) say so in the source.
+                // Measured on Jetson Orin: no throughput change on the
+                // bandwidth-bound image kernels in this workspace.
+                fmad: Some(false),
                 ..Default::default()
             },
         )


### PR DESCRIPTION
## 📝 Description

P0.c (resize half) of the CUDA-integration plan. **Stacked on #1002** (`feat/resize-half-pixel`) — merge that first; this PR's base is set accordingly.

Makes `resize_native` and the CUDA resize kernels produce **bit-identical f32 output**, verified with `f32::to_bits()` equality — no tolerances, no rounding-tie exclusions.

Three pieces:

1. **`--fmad=false` for all NVRTC kernels** (`kornia-tensor`): plain `a*b + c` in kernel source now rounds twice, exactly like the CPU. Explicit `fmaf()` is unaffected, so perf-sensitive fusion is opt-in in the source: the bicubic Horner weights (which silently relied on automatic contraction) now spell their `fmaf` out; the tap accumulations already did.
2. **One coordinate expression, both sides:** `a*x + b` with `a = src/dst`, `b = 0.5*a - 0.5`, uncontracted. The CPU LUT documents this as a contract — algebraically equal forms round differently, so neither side may be "simplified" alone.
3. **One bilinear expression shape:** `bilinear_interpolation` forms the four weights first and sums tap products left-to-right, matching the kernel. Its results shift by ~1 ulp everywhere (all tolerance tests unaffected) and it drops a multiply per pixel — the CPU warp-perspective bench improves ~6%.

The parity tests are the deliverable: dyadic, odd, prime-ish, and unaligned sizes, both interpolation modes, both directions, all `to_bits()`-equal on Jetson Orin.

## 🧪 How Was This Tested?

- [x] Full suite with `--features cuda` on Jetson Orin: 323 lib + 51 integration + doctests green (including the CUDA color tests, which now run under `fmad=false`); `kornia-tensor` CUDA tests green; clippy clean.
- [x] **Benchmarks (Jetson Orin):** GPU bilinear/nearest within the day's jitter band; bicubic 0.200 ms and lanczos 0.365 ms at 1024→512 — byte-identical to the pre-`fmad` build (explicit `fmaf` preserved their codegen). CPU resize bench unchanged; CPU warp-perspective ~6% faster.
- [x] Nearest `.5`-tie behavior: both sides compute the identical f32 coordinate, so ties resolve identically by construction — covered by the bit-equality assertions on non-dyadic sizes.

## 💭 Additional Context

The warp kernels get the same treatment once #1001 merges (their launchers live on that branch). Follow-up after that: P0.d, the opt-in OpenCV byte-compat mode (`INTER_BITS` fixed-point + `cv2` reference vectors).

## 🕵️ AI Usage Disclosure

- [x] 🟡 **AI-assisted:** authored with Claude Code; bit-exactness and benchmarks verified on-device (Jetson Orin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)