### PR TITLE
feat(imgproc): byte-exact CPU/CUDA warp-affine and warp-perspective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ changes early: `cargo add kornia-imgproc@0.1.15-rc.1` or `pip install --pre korn
 
 ## [Unreleased]
 
+**CPU and CUDA warp-affine / warp-perspective are now byte-exact** (f32,
+bilinear + nearest): the CPU evaluates the source coordinate per pixel with the
+same expression tree as the kernels (no more per-row accumulation drift), the
+perspective kernels divide by `w` directly instead of multiplying by a
+reciprocal, and the interpolation expression shapes match — parity tests assert
+`f32::to_bits` equality on rotations, shears, and projective homographies.
+Fixes a real GPU artifact along the way: `cos(90°)` is an ulp of noise rather
+than zero, and the old strict border test zero-filled edge pixels of exact
+right-angle rotations (splitting rows into half-warped, half-black); validity
+of a near-constant axis is now judged on its row constant on both CPU and GPU.
+No measured throughput change on Jetson Orin (CPU and GPU within run-to-run
+jitter).
+
 **CPU and CUDA resize are now byte-exact.** NVRTC kernels compile with
 `--fmad=false` (no automatic FP contraction), and the resize coordinate and
 bilinear arithmetic use the identical expression shapes on both sides, so

--- a/crates/kornia-imgproc/src/cuda/warp_affine.rs
+++ b/crates/kornia-imgproc/src/cuda/warp_affine.rs
@@ -90,19 +90,35 @@ extern "C" __global__ void warp_affine_bilinear_3c(
     unsigned long long out = ((unsigned long long)gy * dst_w + gx) * 3ull;
 
     // Inverse affine: map output pixel → floating-point source coordinate.
-    float sx = m0 * (float)gx + m1 * (float)gy + m2;
-    float sy = m3 * (float)gx + m4 * (float)gy + m5;
+    // Grouped as mul + (row term): identical expression tree to the CPU's
+    // per-row `sx0 = m1*y + m2` then per-pixel `sx = m0*x + sx0`. With
+    // --fmad=false both sides round identically — the byte-exact contract the
+    // parity tests assert. Do not regroup.
+    float sx0 = m1 * (float)gy + m2;
+    float sy0 = m4 * (float)gy + m5;
+    float sx = m0 * (float)gx + sx0;
+    float sy = m3 * (float)gx + sy0;
 
-    // BORDER_CONSTANT: outside the source, emit 0 (CPU valid-range guard).
-    if (sx < 0.0f || sx >= (float)src_w || sy < 0.0f || sy >= (float)src_h) {
+    // BORDER_CONSTANT validity — the CPU rule, exactly. For a degenerate axis
+    // (per-column step below 1e-6, e.g. cos(90°) ≈ -4.4e-8 in a right-angle
+    // rotation) validity is judged on the row constant, so ulp noise cannot
+    // split a row into half-warped, half-zeroed output; the noise is absorbed
+    // by the interpolation clamp below.
+    bool x_ok = (fabsf(m0) < 1e-6f) ? (sx0 >= 0.0f && sx0 < (float)src_w)
+                                    : (sx  >= 0.0f && sx  < (float)src_w);
+    bool y_ok = (fabsf(m3) < 1e-6f) ? (sy0 >= 0.0f && sy0 < (float)src_h)
+                                    : (sy  >= 0.0f && sy  < (float)src_h);
+    if (!x_ok || !y_ok) {
         dst[out] = 0.0f; dst[out+1] = 0.0f; dst[out+2] = 0.0f;
         return;
     }
 
     // Clamp into [0, src-1] and take the +1 tap with a per-axis edge clamp —
-    // the rule the CPU f32 `warp_affine` inner loop uses.
-    float sxc = fminf(sx, (float)(src_w - 1u));
-    float syc = fminf(sy, (float)(src_h - 1u));
+    // the rule the CPU f32 `warp_affine` inner loop uses. The lower clamp is
+    // required: degenerate-axis pixels can arrive with an ulp-negative
+    // coordinate that the CPU clamps to exactly 0.
+    float sxc = fmaxf(fminf(sx, (float)(src_w - 1u)), 0.0f);
+    float syc = fmaxf(fminf(sy, (float)(src_h - 1u)), 0.0f);
 
     unsigned int x0 = (unsigned int)sxc;
     unsigned int y0 = (unsigned int)syc;
@@ -131,7 +147,9 @@ extern "C" __global__ void warp_affine_bilinear_3c(
         float v10 = __ldg(&src[b10 + c]);
         float v01 = __ldg(&src[b01 + c]);
         float v11 = __ldg(&src[b11 + c]);
-        dst[out + c] = fmaf(w00, v00, fmaf(w10, v10, fmaf(w01, v01, w11 * v11)));
+        // Plain left-to-right sum, NOT an fmaf chain: matches the CPU inner
+        // loop's expression under --fmad=false. Same ops, same roundings.
+        dst[out + c] = w00 * v00 + w10 * v10 + w01 * v01 + w11 * v11;
     }
 }
 "#;
@@ -159,14 +177,29 @@ extern "C" __global__ void warp_affine_nearest_3c(
 
     unsigned long long out = ((unsigned long long)gy * dst_w + gx) * 3ull;
 
-    float sx = m0 * (float)gx + m1 * (float)gy + m2;
-    float sy = m3 * (float)gx + m4 * (float)gy + m5;
+    // Grouped as mul + (row term): identical expression tree to the CPU's
+    // per-row `sx0 = m1*y + m2` then per-pixel `sx = m0*x + sx0`. With
+    // --fmad=false both sides round identically — the byte-exact contract the
+    // parity tests assert. Do not regroup.
+    float sx0 = m1 * (float)gy + m2;
+    float sy0 = m4 * (float)gy + m5;
+    float sx = m0 * (float)gx + sx0;
+    float sy = m3 * (float)gx + sy0;
 
-    if (sx < 0.0f || sx >= (float)src_w || sy < 0.0f || sy >= (float)src_h) {
+    // Same degenerate-axis validity rule as the bilinear kernel above (and
+    // the CPU): judge a near-constant axis on its row constant so trig noise
+    // cannot zero-fill right-angle rotations.
+    bool x_ok = (fabsf(m0) < 1e-6f) ? (sx0 >= 0.0f && sx0 < (float)src_w)
+                                    : (sx  >= 0.0f && sx  < (float)src_w);
+    bool y_ok = (fabsf(m3) < 1e-6f) ? (sy0 >= 0.0f && sy0 < (float)src_h)
+                                    : (sy  >= 0.0f && sy  < (float)src_h);
+    if (!x_ok || !y_ok) {
         dst[out] = 0.0f; dst[out+1] = 0.0f; dst[out+2] = 0.0f;
         return;
     }
 
+    // roundf of an ulp-negative degenerate-axis coordinate gives -0.0, which
+    // casts to index 0 — the same pixel the CPU's round-then-clamp selects.
     unsigned int xi = min((unsigned int)roundf(sx), src_w - 1u);
     unsigned int yi = min((unsigned int)roundf(sy), src_h - 1u);
 
@@ -700,52 +733,8 @@ mod tests {
     use crate::warp::warp_affine;
     use kornia_image::{Image, ImageSize};
 
-    /// A transform whose **inverse** has dyadic coefficients (exact in binary).
-    /// The CPU walks a row by accumulating `sx += dsx` where `dsx` comes from the
-    /// *inverted* matrix; when that is dyadic the accumulation is exact, so CPU
-    /// and GPU derive bit-identical source coordinates and the comparison
-    /// isolates what we actually want to test — the interpolation and edge rules
-    /// — instead of measuring the CPU's coordinate drift.
-    ///
-    /// Integer entries with a power-of-two determinant guarantee it: here
-    /// `det = 2*4 - 2*2 = 4`, so every inverse entry is an integer over 4.
-    /// `dyadic_m_inverse_is_exact` pins that property. Both axes shear (`dsx` and
-    /// `dsy` are both non-zero) and the translation pushes part of the output off
-    /// the source, so the border path is exercised too.
-    const DYADIC_M: [f32; 6] = [2.0, 2.0, -8.0, 2.0, 4.0, 6.0];
-
-    /// Guards the premise of every strict comparison below: if this ever stops
-    /// holding, the tight tolerances are measuring float drift, not the kernel.
-    #[test]
-    fn dyadic_m_inverse_is_exact() {
-        let mi = crate::warp::invert_affine_transform(&DYADIC_M);
-        for (i, v) in mi.iter().enumerate() {
-            let scaled = v * 4.0;
-            assert_eq!(
-                scaled,
-                scaled.round(),
-                "m_inv[{i}] = {v} is not an exact multiple of 1/4; the CPU's \
-                 `sx += dsx` accumulation will drift and the strict tolerances \
-                 in this module are no longer meaningful"
-            );
-        }
-    }
-
-    /// With DYADIC_M the only remaining divergence is `fmaf` fusing the weighted
-    /// accumulate where the CPU rounds each product — a few ulps on values in
-    /// [0, 1]. An edge-rule mismatch is ~0.5 (an earlier revision of this kernel
-    /// used the wrong rule and the test caught it at 0.7), so this is strict.
-    const BILINEAR_TOL: f32 = 1e-5;
-
-    /// A realistic non-dyadic transform. Here the CPU's accumulated `sx` drifts a
-    /// few ulps from the GPU's direct evaluation, and on the deliberately random
-    /// test pattern (adjacent pixels differ by up to 1.0) that surfaces as a
-    /// ~1e-3 value difference. Loose on purpose: this case guards against gross
-    /// errors under a rotation, while DYADIC_M does the strict rule-checking.
-    const ROTATION_TOL: f32 = 5e-3;
-
     /// Run the CPU reference and the CUDA kernel on the same input and return
-    /// both buffers. `dst` dims equal `src` dims.
+    /// both buffers. `dst` dims equal `src` dims; both start zeroed.
     fn cpu_and_gpu(
         w: usize,
         h: usize,
@@ -785,146 +774,75 @@ mod tests {
         (cpu.as_slice().to_vec(), gpu)
     }
 
-    /// Pixels whose CPU/GPU results may legitimately differ, for either of two
-    /// reasons — both rooted in the same ulp-level coordinate drift:
-    ///
-    /// * **Validity boundary.** The CPU decides in/out-of-source from `sx`
-    ///   accumulated along the row (`compute_range`); the GPU evaluates the map
-    ///   directly. A coordinate sitting within an ulp of 0 or `src_w` can be
-    ///   judged inside by one and outside by the other — one writes an
-    ///   interpolated value, the other writes the `BORDER_CONSTANT` 0.
-    /// * **Rounding tie (nearest only).** A coordinate landing on an exact `.5`
-    ///   can round to either neighbour.
-    ///
-    /// Excluding only these keeps the assertion strict everywhere else — nearest
-    /// stays bit-exact — instead of hiding real disagreement behind a tolerance.
-    ///
-    /// Pass `eps = 0.0` to disable exclusion entirely. That is correct whenever
-    /// both sides compute the coordinate *exactly* (see [`DYADIC_M`]): with no
-    /// drift there is nothing to be ambiguous about — a `.5` tie resolves the
-    /// same way on both paths, since `roundf` and Rust's `f32::round` are both
-    /// half-away-from-zero — so those runs demand agreement even on ties.
-    fn ambiguous_pixels(
-        w: usize,
-        h: usize,
-        m: &[f32; 6],
-        mode: InterpolationMode,
-        eps: f32,
-    ) -> Vec<bool> {
-        let mi = crate::warp::invert_affine_transform(m);
-        let (fw, fh) = (w as f32, h as f32);
-        let mut out = vec![false; w * h];
-        for y in 0..h {
-            for x in 0..w {
-                let sx = mi[0] * x as f32 + mi[1] * y as f32 + mi[2];
-                let sy = mi[3] * x as f32 + mi[4] * y as f32 + mi[5];
-
-                let near = |v: f32, edge: f32| (v - edge).abs() < eps;
-                let mut amb = near(sx, 0.0) || near(sx, fw) || near(sy, 0.0) || near(sy, fh);
-
-                if matches!(mode, InterpolationMode::Nearest) {
-                    let near_half = |v: f32| (v - v.floor() - 0.5).abs() < eps;
-                    amb = amb || near_half(sx) || near_half(sy);
-                }
-                out[y * w + x] = amb;
-            }
+    /// Byte-exact comparison: the CPU evaluates `dsx*x + (m1*y + m2)` per pixel
+    /// and the kernel evaluates the identically grouped expression under
+    /// `--fmad=false`, with matching interpolation expression shapes and a
+    /// valid-span refined against the same per-pixel predicate the GPU uses —
+    /// so CPU and GPU must agree bit-for-bit. No tolerance, no exclusions,
+    /// arbitrary (non-dyadic) transforms included.
+    fn assert_bit_exact(w: usize, h: usize, m: &[f32; 6], interpolation: InterpolationMode) {
+        let (cpu, gpu) = cpu_and_gpu(w, h, m, interpolation);
+        for (i, (c, g)) in cpu.iter().zip(&gpu).enumerate() {
+            assert!(
+                c.to_bits() == g.to_bits(),
+                "{w}x{h} {interpolation:?}: element {i}: cpu {c} ({:#010x}) gpu {g} ({:#010x})",
+                c.to_bits(),
+                g.to_bits()
+            );
         }
-        out
     }
 
-    /// Compare CPU vs GPU, skipping the ambiguous pixels above. Returns how many
-    /// were skipped so callers can assert they stay a rounding curiosity.
-    fn assert_matches_cpu(
-        w: usize,
-        h: usize,
-        m: &[f32; 6],
-        mode: InterpolationMode,
-        tol: f32,
-        eps: f32,
-    ) -> usize {
-        let (cpu, gpu) = cpu_and_gpu(w, h, m, mode);
-        let amb = ambiguous_pixels(w, h, m, mode, eps);
-        let mut skipped = 0;
-        for (p, &is_amb) in amb.iter().enumerate() {
-            if is_amb {
-                skipped += 1;
-                continue;
-            }
-            for c in 0..3 {
-                let i = p * 3 + c;
-                let d = (gpu[i] - cpu[i]).abs();
-                assert!(
-                    d <= tol,
-                    "{w}x{h} {mode:?}: pixel {p} ch {c} diff {d} > {tol} (cpu {} gpu {})",
-                    cpu[i],
-                    gpu[i]
-                );
-            }
-        }
-        assert!(
-            skipped * 20 < w * h,
-            "{skipped}/{} pixels excluded as ambiguous — too many to still be a \
-             boundary/tie effect; the coordinate mapping itself is probably wrong",
-            w * h
-        );
-        skipped
-    }
-
-    /// Regression for issue #1000: the pitch-2D texture path required
-    /// `src_w * 3 * 4` bytes to be a multiple of the 32-byte texture pitch
-    /// alignment, so every width not a multiple of 8 failed the launch outright
-    /// with `CUDA_ERROR_INVALID_VALUE`. The `__ldg` kernels have no such
-    /// constraint — every width below must both launch and match the CPU.
+    /// Regression for issue #1000: the old pitch-2D texture path failed the
+    /// launch outright for any source width not a multiple of 8. Every width
+    /// here must launch and match the CPU bit-for-bit.
     #[test]
     fn warp_affine_unaligned_widths_match_cpu() {
-        // 128/136 are 8-aligned (worked before); the rest are the regression.
         const WIDTHS: &[usize] = &[128, 129, 130, 132, 133, 135, 136];
+        let m = crate::warp::get_rotation_matrix2d((32.0, 24.0), 30.0, 1.0);
 
         for &w in WIDTHS {
-            assert_matches_cpu(
-                w,
-                49,
-                &DYADIC_M,
-                InterpolationMode::Bilinear,
-                BILINEAR_TOL,
-                0.0,
-            );
-            assert_matches_cpu(w, 49, &DYADIC_M, InterpolationMode::Nearest, 0.0, 0.0);
+            assert_bit_exact(w, 49, &m, InterpolationMode::Bilinear);
+            assert_bit_exact(w, 49, &m, InterpolationMode::Nearest);
         }
     }
 
-    #[test]
-    fn warp_affine_bilinear_matches_cpu() {
-        assert_matches_cpu(
-            320,
-            240,
-            &DYADIC_M,
-            InterpolationMode::Bilinear,
-            BILINEAR_TOL,
-            0.0,
-        );
-    }
-
-    /// Non-dyadic rotation: guards against gross errors on a realistic transform.
-    /// See ROTATION_TOL for why this cannot be strict.
+    /// Non-dyadic rotation + scale — exactly the case that needed tolerances
+    /// and rounding-tie exclusions before the byte-exact contract.
     #[test]
     fn warp_affine_rotation_matches_cpu() {
         let m = crate::warp::get_rotation_matrix2d((160.0, 120.0), 37.0, 1.3);
-        assert_matches_cpu(
-            320,
-            240,
-            &m,
-            InterpolationMode::Bilinear,
-            ROTATION_TOL,
-            1e-3,
+        assert_bit_exact(320, 240, &m, InterpolationMode::Bilinear);
+        assert_bit_exact(320, 240, &m, InterpolationMode::Nearest);
+    }
+
+    /// Exact right-angle rotation: cos(90°) is an ulp of noise, not zero, so
+    /// this pins the degenerate-axis validity rule on both sides. Before that
+    /// rule, the GPU zero-filled edge pixels of every 90° rotation (and a
+    /// strict CPU refine briefly reproduced the same bug).
+    #[test]
+    fn warp_affine_rot90_matches_cpu_with_no_dropped_edges() {
+        let m = crate::warp::get_rotation_matrix2d((32.0, 32.0), 90.0, 1.0);
+        assert_bit_exact(64, 64, &m, InterpolationMode::Nearest);
+        assert_bit_exact(64, 64, &m, InterpolationMode::Bilinear);
+
+        // And the rotation must actually carry pixels into the edge rows —
+        // bit-equality alone would also pass if both sides dropped them.
+        let (cpu, _) = cpu_and_gpu(64, 64, &m, InterpolationMode::Nearest);
+        let last_row = &cpu[63 * 64 * 3..];
+        assert!(
+            last_row.iter().any(|&v| v != 0.0),
+            "90° rotation must populate the last row, not zero-fill it"
         );
     }
 
-    /// Nearest selects a single source pixel on both paths, so away from exact
-    /// rounding ties any difference is a coordinate-rule bug, not float error.
+    /// Shear + translation with negative steps on both axes: exercises the
+    /// refined valid-span logic (negative-step boundaries land on exact
+    /// integers) and the border zero-fill agreement.
     #[test]
-    fn warp_affine_nearest_is_bit_exact_vs_cpu() {
-        assert_matches_cpu(320, 240, &DYADIC_M, InterpolationMode::Nearest, 0.0, 0.0);
+    fn warp_affine_flip_shear_matches_cpu() {
+        let m = [-0.75, 0.25, 200.0, 0.5, -1.25, 180.0];
+        assert_bit_exact(320, 240, &m, InterpolationMode::Bilinear);
+        assert_bit_exact(320, 240, &m, InterpolationMode::Nearest);
     }
 
     #[test]

--- a/crates/kornia-imgproc/src/cuda/warp_perspective.rs
+++ b/crates/kornia-imgproc/src/cuda/warp_perspective.rs
@@ -23,7 +23,9 @@
 //!   [`super::warp_affine`] for the full rationale.
 //! * **`CU_FUNC_CACHE_PREFER_L1`** — enlarges L1 to 64 KB; no shared memory used.
 //! * **32×8 thread block (default)** — full warp per output row for coalesced writes.
-//! * **`1/w` reciprocal** — one FP division replaces two per output pixel.
+//! * **`1/w` reciprocal** (bicubic/Lanczos only) — one FP division replaces two
+//!   per output pixel. Bilinear/nearest divide directly to stay byte-exact with
+//!   the CPU `transform_point`, which divides.
 //!
 //! # Public API
 //!
@@ -68,9 +70,12 @@ extern "C" __global__ void warp_perspective_bilinear_3c(
         dst[out] = 0.0f; dst[out+1] = 0.0f; dst[out+2] = 0.0f;
         return;
     }
-    float rw = 1.0f / w;
-    float sx = (h0 * (float)gx + h1 * (float)gy + h2) * rw;
-    float sy = (h3 * (float)gx + h4 * (float)gy + h5) * rw;
+    // Direct division, NOT reciprocal-multiply: the CPU `transform_point`
+    // divides, and x/w rounds differently from x*(1/w). Numerator grouping is
+    // the CPU's left-to-right `m0*x + m1*y + m2`. Byte-exact contract with the
+    // parity tests; do not "optimize" back to a reciprocal.
+    float sx = (h0 * (float)gx + h1 * (float)gy + h2) / w;
+    float sy = (h3 * (float)gx + h4 * (float)gy + h5) / w;
 
     // BORDER_CONSTANT: outside the source, emit 0 (CPU valid-range guard).
     if (sx < 0.0f || sx >= (float)src_w || sy < 0.0f || sy >= (float)src_h) {
@@ -108,7 +113,9 @@ extern "C" __global__ void warp_perspective_bilinear_3c(
         float v01 = __ldg(&src[b01 + c]);
         float v10 = __ldg(&src[b10 + c]);
         float v11 = __ldg(&src[b11 + c]);
-        dst[out + c] = fmaf(w00, v00, fmaf(w01, v01, fmaf(w10, v10, w11 * v11)));
+        // Plain sum in the CPU tap order (val00, x+1, y+1, both): matches
+        // `bilinear_interpolation` under --fmad=false. Same ops, same roundings.
+        dst[out + c] = w00 * v00 + w01 * v01 + w10 * v10 + w11 * v11;
     }
 }
 "#;
@@ -137,9 +144,12 @@ extern "C" __global__ void warp_perspective_nearest_3c(
         dst[out] = 0.0f; dst[out+1] = 0.0f; dst[out+2] = 0.0f;
         return;
     }
-    float rw = 1.0f / w;
-    float sx = (h0 * (float)gx + h1 * (float)gy + h2) * rw;
-    float sy = (h3 * (float)gx + h4 * (float)gy + h5) * rw;
+    // Direct division, NOT reciprocal-multiply: the CPU `transform_point`
+    // divides, and x/w rounds differently from x*(1/w). Numerator grouping is
+    // the CPU's left-to-right `m0*x + m1*y + m2`. Byte-exact contract with the
+    // parity tests; do not "optimize" back to a reciprocal.
+    float sx = (h0 * (float)gx + h1 * (float)gy + h2) / w;
+    float sy = (h3 * (float)gx + h4 * (float)gy + h5) / w;
 
     if (sx < 0.0f || sx >= (float)src_w || sy < 0.0f || sy >= (float)src_h) {
         dst[out] = 0.0f; dst[out+1] = 0.0f; dst[out+2] = 0.0f;
@@ -659,4 +669,132 @@ pub fn launch_warp_perspective_lanczos_cuda(
             make_config(dst_width, dst_height, block_dim),
         )
         .map_err(|e| CudaWarpPerspectiveError::Cuda(e.to_string()))
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(all(test, feature = "cuda"))]
+mod tests {
+    use super::*;
+    use crate::cuda::color::test_utils::{default_stream, pattern_f32};
+    use crate::interpolation::InterpolationMode;
+    use crate::warp::warp_perspective;
+    use kornia_image::{Image, ImageSize};
+
+    /// Run the CPU reference and the CUDA kernel on the same input and return
+    /// both buffers. Both destinations start zeroed — the CPU leaves
+    /// out-of-bounds pixels untouched while the kernel writes 0, so a zeroed
+    /// destination is part of the comparison contract.
+    fn cpu_and_gpu(
+        w: usize,
+        h: usize,
+        hm: &[f32; 9],
+        interpolation: InterpolationMode,
+    ) -> (Vec<f32>, Vec<f32>) {
+        let data = pattern_f32(w * h * 3);
+        let size = ImageSize {
+            width: w,
+            height: h,
+        };
+
+        let src = Image::<f32, 3>::new(size, data.clone()).unwrap();
+        let mut cpu = Image::<f32, 3>::from_size_val(size, 0.0).unwrap();
+        warp_perspective(&src, &mut cpu, hm, interpolation).unwrap();
+
+        let stream = default_stream();
+        let ctx = &stream.context();
+        let d_src = stream.clone_htod(&data).unwrap();
+        let mut d_dst = stream.alloc_zeros::<f32>(w * h * 3).unwrap();
+
+        let (wu, hu) = (w as u32, h as u32);
+        match interpolation {
+            InterpolationMode::Bilinear => launch_warp_perspective_bilinear_cuda(
+                ctx, &stream, &d_src, &mut d_dst, wu, hu, wu, hu, hm, None,
+            ),
+            InterpolationMode::Nearest => launch_warp_perspective_nearest_cuda(
+                ctx, &stream, &d_src, &mut d_dst, wu, hu, wu, hu, hm, None,
+            ),
+            other => panic!("unsupported mode in test: {other:?}"),
+        }
+        .unwrap_or_else(|e| panic!("launch failed at {w}x{h} ({interpolation:?}): {e}"));
+
+        let gpu: Vec<f32> = stream.clone_dtoh(&d_dst).unwrap();
+        stream.synchronize().unwrap();
+
+        (cpu.as_slice().to_vec(), gpu)
+    }
+
+    /// Byte-exact: the CPU `transform_point` divides the identically grouped
+    /// numerator by `w`, and the kernels do the same (direct division, not
+    /// reciprocal-multiply) under `--fmad=false`; `bilinear_interpolation`'s
+    /// expression shape matches the kernel's tap sum. Both paths evaluate the
+    /// coordinate per pixel, so there is no span/accumulation caveat at all.
+    fn assert_bit_exact(w: usize, h: usize, hm: &[f32; 9], interpolation: InterpolationMode) {
+        let (cpu, gpu) = cpu_and_gpu(w, h, hm, interpolation);
+        for (i, (c, g)) in cpu.iter().zip(&gpu).enumerate() {
+            assert!(
+                c.to_bits() == g.to_bits(),
+                "{w}x{h} {interpolation:?}: element {i}: cpu {c} ({:#010x}) gpu {g} ({:#010x})",
+                c.to_bits(),
+                g.to_bits()
+            );
+        }
+    }
+
+    /// Genuinely projective homography (non-zero third row) at a non-dyadic,
+    /// unaligned size: the w-divide is exercised on every pixel.
+    #[test]
+    fn warp_perspective_projective_matches_cpu() {
+        let hm = [
+            1.03,
+            0.05,
+            -3.0,
+            -0.02,
+            0.97,
+            4.0,
+            2.0 / (97.0 * 129.0),
+            1.5 / (129.0 * 97.0),
+            1.0,
+        ];
+        assert_bit_exact(129, 97, &hm, InterpolationMode::Bilinear);
+        assert_bit_exact(129, 97, &hm, InterpolationMode::Nearest);
+    }
+
+    /// An affine-equivalent homography (third row [0, 0, 1]) must also agree —
+    /// and cross-checks the internal inversion against the CPU's.
+    #[test]
+    fn warp_perspective_affine_equivalent_matches_cpu() {
+        let hm = [0.9, 0.15, 10.0, -0.1, 1.1, -6.0, 0.0, 0.0, 1.0];
+        assert_bit_exact(320, 240, &hm, InterpolationMode::Bilinear);
+        assert_bit_exact(320, 240, &hm, InterpolationMode::Nearest);
+    }
+
+    /// Identity homography reproduces the source exactly.
+    #[test]
+    fn warp_perspective_identity_is_exact_copy() {
+        let hm = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
+        for mode in [InterpolationMode::Bilinear, InterpolationMode::Nearest] {
+            let (cpu, gpu) = cpu_and_gpu(65, 33, &hm, mode);
+            assert_eq!(
+                gpu, cpu,
+                "identity warp ({mode:?}) must reproduce the source"
+            );
+        }
+    }
+
+    /// A singular homography must be rejected before any launch.
+    #[test]
+    fn warp_perspective_rejects_singular_homography() {
+        let stream = default_stream();
+        let ctx = &stream.context();
+        let d_src = stream.clone_htod(&vec![0.0f32; 8 * 8 * 3]).unwrap();
+        let mut d_dst = stream.alloc_zeros::<f32>(8 * 8 * 3).unwrap();
+        // Rank-1 matrix.
+        let hm = [1.0, 2.0, 3.0, 2.0, 4.0, 6.0, 3.0, 6.0, 9.0];
+        let err = launch_warp_perspective_bilinear_cuda(
+            ctx, &stream, &d_src, &mut d_dst, 8, 8, 8, 8, &hm, None,
+        )
+        .unwrap_err();
+        assert!(matches!(err, CudaWarpPerspectiveError::SingularHomography));
+    }
 }

--- a/crates/kornia-imgproc/src/warp/affine.rs
+++ b/crates/kornia-imgproc/src/warp/affine.rs
@@ -157,6 +157,75 @@ pub fn warp_affine<const C: usize>(
     const ROWS_PER_TASK: usize = 16;
     let src_slice = src.as_slice();
 
+    // BYTE-EXACT CONTRACT with the CUDA warp kernels: the source coordinate is
+    // `dsx * x + sx0` with `sx0 = m_inv[1]*y + m_inv[2]`, evaluated PER PIXEL
+    // (not accumulated `sx += dsx`, which drifts by an ulp per column), and the
+    // kernels compute the identically grouped `m0*gx + (m1*gy + m2)` under
+    // `--fmad=false`. Same expression tree, same roundings, bit-identical
+    // coordinates — asserted by the CPU/GPU parity tests. Do not regroup or
+    // reintroduce accumulation on one side only.
+    let coord_at = move |d: f32, s0: f32, x: usize| d * x as f32 + s0;
+
+    // Per-call product tables: `xstep[x] = fl(d * x)`, so the inner loop's
+    // `xstep[x] + s0` performs the identical mul-then-add (one rounding each)
+    // as `coord_at` and the GPU kernel — bit-identical, but the int→float
+    // convert and multiply leave the per-pixel path. Without this the direct
+    // per-pixel evaluation costs 15–60% on the CPU warp bench.
+    let xstep_x: Vec<f32> = (0..dst_w).map(|x| dsx * x as f32).collect();
+    let xstep_y: Vec<f32> = (0..dst_w).map(|x| dsy * x as f32).collect();
+
+    // The analytic span from `compute_range` can disagree with the per-pixel
+    // float predicate by one column when a boundary quotient rounds across an
+    // integer, so each end is refined against the exact validity predicate —
+    // a couple of probes per row. The GPU kernels evaluate this IDENTICAL
+    // predicate per pixel, so the zero-filled region matches bit-for-bit.
+    //
+    // The degenerate-axis branch is load-bearing: for an axis whose per-column
+    // step is below 1e-6 (e.g. cos(90°) ≈ -4.4e-8 in a right-angle rotation),
+    // the coordinate is the row constant plus trig noise, and an ulp-negative
+    // value must NOT invalidate the pixel — validity is judged on the row
+    // constant and the noise is absorbed by the interpolation clamp. A strict
+    // per-pixel test here zero-fills edge pixels of exact 90° rotations
+    // (which is what the GPU kernels used to do).
+    let in_bounds = move |sx0: f32, sy0: f32, x: usize| -> bool {
+        let x_ok = if dsx.abs() < 1e-6 {
+            sx0 >= 0.0 && sx0 < src_w_f
+        } else {
+            let sx = coord_at(dsx, sx0, x);
+            sx >= 0.0 && sx < src_w_f
+        };
+        let y_ok = if dsy.abs() < 1e-6 {
+            sy0 >= 0.0 && sy0 < src_h_f
+        } else {
+            let sy = coord_at(dsy, sy0, x);
+            sy >= 0.0 && sy < src_h_f
+        };
+        x_ok && y_ok
+    };
+    let refine_range = move |sx0: f32, sy0: f32| -> (usize, usize) {
+        let (mut lo, mut hi) = compute_range(sx0, sy0);
+        if lo >= hi {
+            return (0, 0);
+        }
+        while lo < hi && !in_bounds(sx0, sy0, lo) {
+            lo += 1;
+        }
+        while lo > 0 && in_bounds(sx0, sy0, lo - 1) {
+            lo -= 1;
+        }
+        while hi > lo && !in_bounds(sx0, sy0, hi - 1) {
+            hi -= 1;
+        }
+        while hi < dst_w && in_bounds(sx0, sy0, hi) {
+            hi += 1;
+        }
+        if lo >= hi {
+            (0, 0)
+        } else {
+            (lo, hi)
+        }
+    };
+
     // Lift the interpolation branch outside the parallel loop so each task is
     // branch-free in its inner loop.
     macro_rules! run_rows {
@@ -165,13 +234,11 @@ pub fn warp_affine<const C: usize>(
                 let y_f = ($y_base + dy) as f32;
                 let sx0 = m_inv[1] * y_f + m_inv[2];
                 let sy0 = m_inv[4] * y_f + m_inv[5];
-                let (x_lo, x_hi) = compute_range(sx0, sy0);
+                let (x_lo, x_hi) = refine_range(sx0, sy0);
                 dst_row[..x_lo * C].fill(0.0);
                 dst_row[x_hi * C..].fill(0.0);
                 if x_lo < x_hi {
-                    let mut sx = sx0 + dsx * x_lo as f32;
-                    let mut sy = sy0 + dsy * x_lo as f32;
-                    $inner(dst_row, x_lo, x_hi, &mut sx, &mut sy);
+                    $inner(dst_row, x_lo, x_hi, sx0, sy0);
                 }
             }
         };
@@ -186,17 +253,15 @@ pub fn warp_affine<const C: usize>(
                     run_rows!(
                         chunk,
                         ci * ROWS_PER_TASK,
-                        |dst_row: &mut [f32],
-                         x_lo: usize,
-                         x_hi: usize,
-                         sx: &mut f32,
-                         sy: &mut f32| {
-                            for dst_pixel in dst_row[x_lo * C..x_hi * C].chunks_exact_mut(C) {
+                        |dst_row: &mut [f32], x_lo: usize, x_hi: usize, sx0: f32, sy0: f32| {
+                            let pixels = dst_row[x_lo * C..x_hi * C].chunks_exact_mut(C);
+                            let steps = xstep_x[x_lo..x_hi].iter().zip(&xstep_y[x_lo..x_hi]);
+                            for (dst_pixel, (&tx, &ty)) in pixels.zip(steps) {
+                                let sx = tx + sx0;
+                                let sy = ty + sy0;
                                 let xi = sx.round().clamp(0.0, src_w_f - 1.0) as usize;
                                 let yi = sy.round().clamp(0.0, src_h_f - 1.0) as usize;
                                 dst_pixel.copy_from_slice(&src_slice[(yi * src_w + xi) * C..][..C]);
-                                *sx += dsx;
-                                *sy += dsy;
                             }
                         }
                     );
@@ -210,12 +275,12 @@ pub fn warp_affine<const C: usize>(
                     run_rows!(
                         chunk,
                         ci * ROWS_PER_TASK,
-                        |dst_row: &mut [f32],
-                         x_lo: usize,
-                         x_hi: usize,
-                         sx: &mut f32,
-                         sy: &mut f32| {
-                            for dst_pixel in dst_row[x_lo * C..x_hi * C].chunks_exact_mut(C) {
+                        |dst_row: &mut [f32], x_lo: usize, x_hi: usize, sx0: f32, sy0: f32| {
+                            let pixels = dst_row[x_lo * C..x_hi * C].chunks_exact_mut(C);
+                            let steps = xstep_x[x_lo..x_hi].iter().zip(&xstep_y[x_lo..x_hi]);
+                            for (dst_pixel, (&tx, &ty)) in pixels.zip(steps) {
+                                let sx = tx + sx0;
+                                let sy = ty + sy0;
                                 let sx_c = sx.clamp(0.0, src_w_f - 1.0);
                                 let sy_c = sy.clamp(0.0, src_h_f - 1.0);
                                 let x0 = sx_c as usize;
@@ -238,8 +303,6 @@ pub fn warp_affine<const C: usize>(
                                         + w01 * src_slice[b01 + k]
                                         + w11 * src_slice[b11 + k];
                                 }
-                                *sx += dsx;
-                                *sy += dsy;
                             }
                         }
                     );


### PR DESCRIPTION
## 📝 Description

Completes the byte-exact program (P0.c) for the warp ops, following #1003's resize half. CPU and GPU now produce **bit-identical f32 output** for bilinear and nearest warp-affine and warp-perspective, asserted with `f32::to_bits` equality across non-dyadic rotations, shears, unaligned widths, and genuinely projective homographies — including the **first parity tests the perspective kernels have ever had**.

### Mechanisms
- **CPU drops per-row coordinate accumulation** (`sx += dsx` drifts an ulp per column): it evaluates `fl(dsx·x) + sx0` per pixel from a per-call product table — the identical mul-then-add the kernels perform as `m0*gx + (m1*gy + m2)` under `--fmad=false`.
- **Perspective kernels divide by `w` directly** — `x/w` rounds differently from `x·(1/w)`, and the CPU divides. Free on Orin (bandwidth-bound). Bicubic/Lanczos keep the reciprocal (no byte-exact contract there).
- **Bilinear tap sums are plain left-to-right expressions** matching each op's own CPU reference (affine ↔ the `warp_affine` inner loop; perspective ↔ `bilinear_interpolation`), not `fmaf` chains.

### Real bug found and fixed: half-black rows on exact 90° rotations
`cos(90°)` is `-4.4e-8`, not zero, so an edge row's source coordinate sits an ulp either side of the image boundary — and the GPU's strict border test zero-filled the part of the row where the noise crossed, producing **half-warped, half-black rows** on plain right-angle rotations (latent since #979; the dyadic-only tests never used trig). Both sides now judge a near-constant axis (|step| < 1e-6) on its row constant; the interpolation clamp absorbs the noise. A rot90 parity test pins the rule and asserts the edge rows are actually populated.

### Performance (Jetson Orin, back-to-back A/B vs main)
The naive per-pixel form cost 14–20% on the CPU warp bench; the shipped product-table + zipped-iterator form is **within run-to-run jitter**:
- CPU warp-affine: 254/940/4327 µs vs main 240/934/4160 (main itself swung 234–257 on the small case)
- CPU warp-perspective: flat to −9%
- GPU affine: flat (bicubic/lanczos timings byte-identical); GPU perspective: flat (nearest 4K 2.376→2.225 ms, bilinear 1080p 0.538→0.525 ms)

## 🧪 How Was This Tested?

- [x] Full suite on Jetson Orin with `--features cuda`: 342 lib + 51 integration + doctests, clippy clean.
- [x] New bit-exact parity tests: affine (unaligned-width sweep, 37° rotation, flip+shear, rot90, identity) and perspective (projective at 129×97, affine-equivalent homography cross-check, identity, singular rejection).
- [x] Benchmarks A/B'd against a fresh main worktree in the same session (numbers above); one polluted main run detected and discarded by re-measurement.

## 💭 Additional Context

With this, resize + both warps are byte-exact CPU↔GPU. Next per the plan: P0.d (opt-in OpenCV byte-compat mode with `cv2` reference vectors), then the residency dispatch that makes these kernels reachable from `resize_native`/`warp_*`.

## 🕵️ AI Usage Disclosure

- [x] 🟡 **AI-assisted:** authored with Claude Code; bit-exactness and benchmarks verified on-device (Jetson Orin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)