### PR TITLE
feat(imgproc): residency-dispatched GPU paths for resize_native and the warps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ changes early: `cargo add kornia-imgproc@0.1.15-rc.1` or `pip install --pre korn
 
 ## [Unreleased]
 
+**GPU resize and warps from the high-level API.** `resize_native`,
+`warp_affine`, and `warp_perspective` now run on the GPU when called with
+device-resident images (`Image::to_cuda` / `zeros_cuda`), with **bit-identical
+output to the CPU path**. Same rules as the color conversions: both operands
+must be on the same device (mixed pairs are a typed error, no implicit
+transfers), and unsupported dtype/channel combinations error instead of
+silently falling back (the GPU kernels are 3-channel f32).
+
+
 **OpenCV-compatible resize (opt-in).** New `resize_opencv_u8` / `resize_opencv_f32`
 reproduce OpenCV's reference `INTER_LINEAR` (u8: 11-bit fixed point; f32:
 separable float) and floor-based `INTER_NEAREST` semantics, for migrating from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ changes early: `cargo add kornia-imgproc@0.1.15-rc.1` or `pip install --pre korn
 
 ## [Unreleased]
 
-**GPU resize and warps from the high-level API.** `resize_native`,
+**`resize_native` is renamed to `resize`** (deprecated alias kept for one
+release).
+
+**GPU resize and warps from the high-level API.** `resize` (né `resize_native`),
 `warp_affine`, and `warp_perspective` now run on the GPU when called with
 device-resident images (`Image::to_cuda` / `zeros_cuda`), with **bit-identical
 output to the CPU path**. Same rules as the color conversions: both operands

--- a/crates/kornia-imgproc/benches/bench_resize.rs
+++ b/crates/kornia-imgproc/benches/bench_resize.rs
@@ -129,7 +129,7 @@ fn bench_resize(c: &mut Criterion) {
             |b, i| {
                 let (src, mut dst) = (i.0, i.1.clone());
                 b.iter(|| {
-                    resize::resize_native(
+                    resize::resize(
                         std::hint::black_box(src),
                         std::hint::black_box(&mut dst),
                         std::hint::black_box(InterpolationMode::Nearest),

--- a/crates/kornia-imgproc/examples/bench_cuda_resize.rs
+++ b/crates/kornia-imgproc/examples/bench_cuda_resize.rs
@@ -17,7 +17,7 @@ use kornia_image::{Image, ImageSize};
 #[cfg(feature = "cuda")]
 use kornia_imgproc::cuda::resize::PixelMapping;
 use kornia_imgproc::interpolation::InterpolationMode;
-use kornia_imgproc::resize::resize_native;
+use kornia_imgproc::resize::resize;
 use std::time::Instant;
 
 const WARMUP: u32 = 50;
@@ -105,12 +105,12 @@ fn run_cpu() {
         .expect("dst image");
 
         for _ in 0..WARMUP {
-            resize_native(&src, &mut dst, InterpolationMode::Bilinear).expect("resize");
+            resize(&src, &mut dst, InterpolationMode::Bilinear).expect("resize");
             std::hint::black_box(dst.as_slice());
         }
         let t = Instant::now();
         for _ in 0..ITERS {
-            resize_native(&src, &mut dst, InterpolationMode::Bilinear).expect("resize");
+            resize(&src, &mut dst, InterpolationMode::Bilinear).expect("resize");
             std::hint::black_box(dst.as_slice());
         }
         let ms = t.elapsed().as_secs_f64() * 1e3 / ITERS as f64;

--- a/crates/kornia-imgproc/src/cuda/dispatch.rs
+++ b/crates/kornia-imgproc/src/cuda/dispatch.rs
@@ -171,3 +171,22 @@ macro_rules! __device_slices {
 
 /// Extract the typed device slices from a checked device pair.
 pub(crate) use crate::__device_slices as device_slices;
+
+/// Checked `usize → u32` image dimensions for the CUDA launchers.
+pub(crate) fn dims_u32<T, const C: usize>(img: &Image<T, C>) -> Result<(u32, u32), ImageError> {
+    let w = u32::try_from(img.cols())
+        .map_err(|_| ImageError::Cuda("image width exceeds u32".into()))?;
+    let h = u32::try_from(img.rows())
+        .map_err(|_| ImageError::Cuda("image height exceeds u32".into()))?;
+    Ok((w, h))
+}
+
+/// The uniform error for a device pair whose dtype/channel combination has no
+/// GPU kernel: never a silent CPU fallback (that would be an implicit
+/// device→host→device round trip), never an implicit conversion.
+pub(crate) fn no_gpu_kernel_err(op: &str, constraint: &str) -> ImageError {
+    ImageError::Cuda(format!(
+        "CUDA {op} supports {constraint} only; move the images to the host \
+         (Image::to_host) to use the CPU path"
+    ))
+}

--- a/crates/kornia-imgproc/src/cuda/resize.rs
+++ b/crates/kornia-imgproc/src/cuda/resize.rs
@@ -509,7 +509,7 @@ pub enum PixelMapping {
     /// The convention of OpenCV, Pillow, ONNX `Resize`
     /// (`coordinate_transformation_mode = half_pixel`), PyTorch
     /// (`align_corners=False`), and NVIDIA VPI — and of the CPU
-    /// [`resize_native`](crate::resize::resize_native). Use this unless you
+    /// [`resize`](crate::resize::resize). Use this unless you
     /// specifically need to reproduce align-corners output.
     HalfPixel,
     /// Corner-aligned sampling, `src = dst * (src_len-1)/(dst_len-1)`.
@@ -967,7 +967,7 @@ mod tests {
     use super::*;
     use crate::cuda::color::test_utils::{default_stream, pattern_f32};
     use crate::interpolation::InterpolationMode;
-    use crate::resize::resize_native;
+    use crate::resize::resize;
     use kornia_image::{Image, ImageSize};
 
     #[test]
@@ -982,7 +982,7 @@ mod tests {
         assert_eq!(PixelMapping::AlignCorners.coeffs(9, 1), (0.0, 0.0));
     }
 
-    /// Run CPU `resize_native` (half-pixel) and the GPU launcher on the same
+    /// Run CPU `resize` (half-pixel) and the GPU launcher on the same
     /// deterministic input; return both outputs.
     fn cpu_and_gpu(
         (sw, sh): (usize, usize),
@@ -1006,7 +1006,7 @@ mod tests {
             0.0,
         )
         .unwrap();
-        resize_native(&src, &mut cpu, interpolation).unwrap();
+        resize(&src, &mut cpu, interpolation).unwrap();
 
         let stream = default_stream();
         let ctx = &stream.context();
@@ -1048,7 +1048,7 @@ mod tests {
 
     /// Byte-exact comparison: the CPU LUT and the kernels compute the identical
     /// uncontracted `a*x + b` coordinate (see the contract note in
-    /// `resize_native`), and the bilinear weight/sum expression shapes match,
+    /// `resize`), and the bilinear weight/sum expression shapes match,
     /// so CPU and GPU must agree bit-for-bit — no tolerance, no exclusions.
     fn assert_bit_exact(
         src: (usize, usize),

--- a/crates/kornia-imgproc/src/features/orb/extractor.rs
+++ b/crates/kornia-imgproc/src/features/orb/extractor.rs
@@ -5,7 +5,7 @@ use crate::{
     features::{FastDetector, HarrisResponse},
     filter::{gaussian_blur, gaussian_blur_u8},
     interpolation::InterpolationMode,
-    resize::{resize_fast_u8, resize_native},
+    resize::{resize, resize_fast_u8},
 };
 
 use super::pattern::{POS0, POS1};
@@ -881,7 +881,7 @@ fn pyramid_reduce(
     gaussian_blur(img, &mut smoothed, (0, 0), (sigma, 0.0))?;
 
     let mut resized = Image::from_size_val(target, 0.0)?;
-    resize_native(
+    resize(
         &smoothed,
         &mut resized,
         crate::interpolation::InterpolationMode::Bilinear,

--- a/crates/kornia-imgproc/src/resize/cuda.rs
+++ b/crates/kornia-imgproc/src/resize/cuda.rs
@@ -1,4 +1,4 @@
-//! Device adapter for [`resize_native`](super::resize_native): routes a
+//! Device adapter for [`resize`](super::resize): routes a
 //! checked device pair to the native CUDA resize kernels.
 
 use std::sync::Arc;
@@ -16,7 +16,7 @@ use crate::interpolation::InterpolationMode;
 ///
 /// The kernels are 3-channel only, so `C != 3` errors (never a silent CPU
 /// fallback — see `cuda::dispatch`). Output is bit-identical to the CPU
-/// [`resize_native`](super::resize_native) — the byte-exact contract
+/// [`resize`](super::resize) — the byte-exact contract
 /// established with the half-pixel grid and `--fmad=false`, asserted by the
 /// parity tests in `cuda::resize`.
 pub(super) fn resize_f32_cuda<const C: usize>(
@@ -58,7 +58,7 @@ pub(super) fn resize_f32_cuda<const C: usize>(
             PixelMapping::HalfPixel,
             None,
         ),
-        // validate_interpolation in resize_native rejects everything else
+        // validate_interpolation in resize rejects everything else
         // before this adapter is reached.
         mode => return Err(ImageError::UnsupportedInterpolation(mode)),
     }
@@ -71,7 +71,7 @@ pub(super) fn resize_f32_cuda<const C: usize>(
 mod tests {
     use crate::cuda::color::test_utils::{default_stream, pattern_f32};
     use crate::interpolation::InterpolationMode;
-    use crate::resize::resize_native;
+    use crate::resize::resize;
     use kornia_image::{Image, ImageError, ImageSize};
 
     fn sized(w: usize, h: usize) -> ImageSize {
@@ -81,7 +81,7 @@ mod tests {
         }
     }
 
-    /// The public `resize_native`, called with device images, must produce
+    /// The public `resize`, called with device images, must produce
     /// bit-identical output to the same call with host images — for both
     /// modes, downscale and upscale, at non-dyadic sizes.
     #[test]
@@ -91,11 +91,11 @@ mod tests {
             let src = Image::<f32, 3>::new(sized(sw, sh), pattern_f32(sw * sh * 3)).unwrap();
             for mode in [InterpolationMode::Bilinear, InterpolationMode::Nearest] {
                 let mut cpu_dst = Image::<f32, 3>::from_size_val(sized(dw, dh), 0.0).unwrap();
-                resize_native(&src, &mut cpu_dst, mode).unwrap();
+                resize(&src, &mut cpu_dst, mode).unwrap();
 
                 let d_src = src.to_cuda(&stream).unwrap();
                 let mut d_dst = Image::<f32, 3>::zeros_cuda(sized(dw, dh), &stream).unwrap();
-                resize_native(&d_src, &mut d_dst, mode).unwrap();
+                resize(&d_src, &mut d_dst, mode).unwrap();
 
                 let back = d_dst.to_host_owned().unwrap();
                 assert_eq!(
@@ -116,7 +116,7 @@ mod tests {
         let src = Image::<f32, 3>::new(sized(33, 21), pattern_f32(33 * 21 * 3)).unwrap();
         let d_src = src.to_cuda(&stream).unwrap();
         let mut d_dst = Image::<f32, 3>::zeros_cuda(sized(33, 21), &stream).unwrap();
-        resize_native(&d_src, &mut d_dst, InterpolationMode::Bilinear).unwrap();
+        resize(&d_src, &mut d_dst, InterpolationMode::Bilinear).unwrap();
         let back = d_dst.to_host_owned().unwrap();
         assert_eq!(back.as_slice(), src.as_slice(), "identity resize");
     }
@@ -129,13 +129,13 @@ mod tests {
         let src = Image::<f32, 3>::new(sized(16, 16), pattern_f32(16 * 16 * 3)).unwrap();
         let d_src = src.to_cuda(&stream).unwrap();
         let mut host_dst = Image::<f32, 3>::from_size_val(sized(8, 8), 0.0).unwrap();
-        let err = resize_native(&d_src, &mut host_dst, InterpolationMode::Bilinear).unwrap_err();
+        let err = resize(&d_src, &mut host_dst, InterpolationMode::Bilinear).unwrap_err();
         assert!(matches!(err, ImageError::MixedResidency), "got {err:?}");
 
         let src1 = Image::<f32, 1>::new(sized(16, 16), pattern_f32(16 * 16)).unwrap();
         let d_src1 = src1.to_cuda(&stream).unwrap();
         let mut d_dst1 = Image::<f32, 1>::zeros_cuda(sized(8, 8), &stream).unwrap();
-        let err = resize_native(&d_src1, &mut d_dst1, InterpolationMode::Bilinear).unwrap_err();
+        let err = resize(&d_src1, &mut d_dst1, InterpolationMode::Bilinear).unwrap_err();
         assert!(
             matches!(&err, ImageError::Cuda(msg) if msg.contains("3-channel")),
             "got {err:?}"

--- a/crates/kornia-imgproc/src/resize/cuda.rs
+++ b/crates/kornia-imgproc/src/resize/cuda.rs
@@ -1,0 +1,144 @@
+//! Device adapter for [`resize_native`](super::resize_native): routes a
+//! checked device pair to the native CUDA resize kernels.
+
+use std::sync::Arc;
+
+use cudarc::driver::CudaStream;
+use kornia_image::{Image, ImageError};
+
+use crate::cuda::dispatch::{device_slices, dims_u32, no_gpu_kernel_err, untyped_device_err};
+use crate::cuda::resize::{
+    launch_resize_bilinear_downscale_cuda, launch_resize_nearest_downscale_cuda, PixelMapping,
+};
+use crate::interpolation::InterpolationMode;
+
+/// Run the CUDA resize for a device-resident f32 pair.
+///
+/// The kernels are 3-channel only, so `C != 3` errors (never a silent CPU
+/// fallback — see `cuda::dispatch`). Output is bit-identical to the CPU
+/// [`resize_native`](super::resize_native) — the byte-exact contract
+/// established with the half-pixel grid and `--fmad=false`, asserted by the
+/// parity tests in `cuda::resize`.
+pub(super) fn resize_f32_cuda<const C: usize>(
+    src: &Image<f32, C>,
+    dst: &mut Image<f32, C>,
+    interpolation: InterpolationMode,
+    stream: &Arc<CudaStream>,
+) -> Result<(), ImageError> {
+    if C != 3 {
+        return Err(no_gpu_kernel_err("resize", "3-channel f32 images"));
+    }
+    let (src_w, src_h) = dims_u32(src)?;
+    let (dst_w, dst_h) = dims_u32(dst)?;
+    let ctx = stream.context();
+    let (s, d) = device_slices!(src, dst);
+
+    match interpolation {
+        InterpolationMode::Bilinear => launch_resize_bilinear_downscale_cuda(
+            ctx,
+            stream,
+            s,
+            d,
+            src_w,
+            src_h,
+            dst_w,
+            dst_h,
+            PixelMapping::HalfPixel,
+            None,
+        ),
+        InterpolationMode::Nearest => launch_resize_nearest_downscale_cuda(
+            ctx,
+            stream,
+            s,
+            d,
+            src_w,
+            src_h,
+            dst_w,
+            dst_h,
+            PixelMapping::HalfPixel,
+            None,
+        ),
+        // validate_interpolation in resize_native rejects everything else
+        // before this adapter is reached.
+        mode => return Err(ImageError::UnsupportedInterpolation(mode)),
+    }
+    .map_err(|e| ImageError::Cuda(e.to_string()))
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use crate::cuda::color::test_utils::{default_stream, pattern_f32};
+    use crate::interpolation::InterpolationMode;
+    use crate::resize::resize_native;
+    use kornia_image::{Image, ImageError, ImageSize};
+
+    fn sized(w: usize, h: usize) -> ImageSize {
+        ImageSize {
+            width: w,
+            height: h,
+        }
+    }
+
+    /// The public `resize_native`, called with device images, must produce
+    /// bit-identical output to the same call with host images — for both
+    /// modes, downscale and upscale, at non-dyadic sizes.
+    #[test]
+    fn public_resize_device_equals_host() {
+        let stream = default_stream();
+        for &((sw, sh), (dw, dh)) in &[((129, 97), (64, 48)), ((63, 41), (127, 90))] {
+            let src = Image::<f32, 3>::new(sized(sw, sh), pattern_f32(sw * sh * 3)).unwrap();
+            for mode in [InterpolationMode::Bilinear, InterpolationMode::Nearest] {
+                let mut cpu_dst = Image::<f32, 3>::from_size_val(sized(dw, dh), 0.0).unwrap();
+                resize_native(&src, &mut cpu_dst, mode).unwrap();
+
+                let d_src = src.to_cuda(&stream).unwrap();
+                let mut d_dst = Image::<f32, 3>::zeros_cuda(sized(dw, dh), &stream).unwrap();
+                resize_native(&d_src, &mut d_dst, mode).unwrap();
+
+                let back = d_dst.to_host_owned().unwrap();
+                assert_eq!(
+                    back.as_slice(),
+                    cpu_dst.as_slice(),
+                    "{sw}x{sh}->{dw}x{dh} {mode:?}: device must be bit-identical to host"
+                );
+            }
+        }
+    }
+
+    /// Same-size device resize must run on the device (an identity-coefficient
+    /// kernel pass), NOT fall into the host memcpy short-circuit — which would
+    /// dereference device pointers on the host.
+    #[test]
+    fn same_size_device_resize_is_safe_and_identity() {
+        let stream = default_stream();
+        let src = Image::<f32, 3>::new(sized(33, 21), pattern_f32(33 * 21 * 3)).unwrap();
+        let d_src = src.to_cuda(&stream).unwrap();
+        let mut d_dst = Image::<f32, 3>::zeros_cuda(sized(33, 21), &stream).unwrap();
+        resize_native(&d_src, &mut d_dst, InterpolationMode::Bilinear).unwrap();
+        let back = d_dst.to_host_owned().unwrap();
+        assert_eq!(back.as_slice(), src.as_slice(), "identity resize");
+    }
+
+    /// Mixed residency errors; C != 3 device pairs error instead of silently
+    /// falling back to the CPU.
+    #[test]
+    fn resize_error_semantics() {
+        let stream = default_stream();
+        let src = Image::<f32, 3>::new(sized(16, 16), pattern_f32(16 * 16 * 3)).unwrap();
+        let d_src = src.to_cuda(&stream).unwrap();
+        let mut host_dst = Image::<f32, 3>::from_size_val(sized(8, 8), 0.0).unwrap();
+        let err = resize_native(&d_src, &mut host_dst, InterpolationMode::Bilinear).unwrap_err();
+        assert!(matches!(err, ImageError::MixedResidency), "got {err:?}");
+
+        let src1 = Image::<f32, 1>::new(sized(16, 16), pattern_f32(16 * 16)).unwrap();
+        let d_src1 = src1.to_cuda(&stream).unwrap();
+        let mut d_dst1 = Image::<f32, 1>::zeros_cuda(sized(8, 8), &stream).unwrap();
+        let err = resize_native(&d_src1, &mut d_dst1, InterpolationMode::Bilinear).unwrap_err();
+        assert!(
+            matches!(&err, ImageError::Cuda(msg) if msg.contains("3-channel")),
+            "got {err:?}"
+        );
+    }
+}

--- a/crates/kornia-imgproc/src/resize/mod.rs
+++ b/crates/kornia-imgproc/src/resize/mod.rs
@@ -77,7 +77,7 @@ use common::FilterKind;
 ///
 /// ```
 /// use kornia_image::{Image, ImageSize};
-/// use kornia_imgproc::resize::resize_native;
+/// use kornia_imgproc::resize::resize;
 /// use kornia_imgproc::interpolation::InterpolationMode;
 ///
 /// let image = Image::<_, 3>::new(
@@ -96,7 +96,7 @@ use common::FilterKind;
 ///
 /// let mut image_resized = Image::<_, 3>::from_size_val(new_size, 0.0).unwrap();
 ///
-/// resize_native(
+/// resize(
 ///     &image,
 ///     &mut image_resized,
 ///     InterpolationMode::Nearest,
@@ -107,7 +107,7 @@ use common::FilterKind;
 /// assert_eq!(image_resized.size().width, 2);
 /// assert_eq!(image_resized.size().height, 3);
 /// ```
-pub fn resize_native<const C: usize>(
+pub fn resize<const C: usize>(
     src: &Image<f32, C>,
     dst: &mut Image<f32, C>,
     interpolation: InterpolationMode,
@@ -172,6 +172,16 @@ pub fn resize_native<const C: usize>(
     });
 
     Ok(())
+}
+
+/// Deprecated name of [`resize`].
+#[deprecated(since = "0.1.15", note = "renamed to `resize`")]
+pub fn resize_native<const C: usize>(
+    src: &Image<f32, C>,
+    dst: &mut Image<f32, C>,
+    interpolation: InterpolationMode,
+) -> Result<(), ImageError> {
+    resize(src, dst, interpolation)
 }
 
 /// Resize a 3-channel u8 image. Convenience wrapper around [`resize_fast_u8`].
@@ -414,7 +424,7 @@ mod tests {
 
         let mut image_resized = Image::<_, 3>::from_size_val(new_size, 0.0)?;
 
-        super::resize_native(
+        super::resize(
             &image,
             &mut image_resized,
             super::InterpolationMode::Bilinear,
@@ -460,7 +470,7 @@ mod tests {
 
         let mut image_resized = Image::<_, 1>::from_size_val(new_size, 0.0f32)?;
 
-        super::resize_native(
+        super::resize(
             &image,
             &mut image_resized,
             super::InterpolationMode::Nearest,
@@ -491,7 +501,7 @@ mod tests {
     }
 
     #[test]
-    fn resize_native_unsupported_interpolation() -> Result<(), ImageError> {
+    fn resize_unsupported_interpolation() -> Result<(), ImageError> {
         let image = Image::<_, 1>::new(
             ImageSize {
                 width: 2,
@@ -508,10 +518,10 @@ mod tests {
             0.0f32,
         )?;
 
-        let err = super::resize_native(&image, &mut dst, super::InterpolationMode::Bicubic);
+        let err = super::resize(&image, &mut dst, super::InterpolationMode::Bicubic);
         assert!(err.is_err());
 
-        let err = super::resize_native(&image, &mut dst, super::InterpolationMode::Lanczos);
+        let err = super::resize(&image, &mut dst, super::InterpolationMode::Lanczos);
         assert!(err.is_err());
         Ok(())
     }

--- a/crates/kornia-imgproc/src/resize/mod.rs
+++ b/crates/kornia-imgproc/src/resize/mod.rs
@@ -25,6 +25,8 @@
 
 mod bilinear;
 mod common;
+#[cfg(feature = "cuda")]
+mod cuda;
 mod fused;
 mod kernels;
 mod nearest;
@@ -111,6 +113,18 @@ pub fn resize_native<const C: usize>(
     interpolation: InterpolationMode,
 ) -> Result<(), ImageError> {
     validate_interpolation(interpolation)?;
+
+    // Device pairs route to the CUDA kernels (bit-identical output — see the
+    // byte-exact contract below). This must run BEFORE the same-size
+    // short-circuit: `as_slice_mut` on a device image would be a host access
+    // of device memory. Mixed host/device pairs are a typed error; there is
+    // no implicit transfer in either direction.
+    #[cfg(feature = "cuda")]
+    if let crate::cuda::dispatch::Residency::Device(exec) =
+        crate::cuda::dispatch::pair_residency(src, dst)?
+    {
+        return exec.run(|stream| cuda::resize_f32_cuda(src, dst, interpolation, stream));
+    }
 
     // Short-circuit when the resize is a no-op.
     if src.size() == dst.size() {

--- a/crates/kornia-imgproc/src/resize/opencv_compat.rs
+++ b/crates/kornia-imgproc/src/resize/opencv_compat.rs
@@ -2,7 +2,7 @@
 //!
 //! Opt-in compatibility mode reproducing OpenCV 4.x `INTER_LINEAR` and
 //! `INTER_NEAREST` output exactly, for migration and cross-validation against
-//! OpenCV pipelines. The default kornia resize ([`resize_native`] and the
+//! OpenCV pipelines. The default kornia resize ([`resize`] and the
 //! `resize_fast_*` family) is *not* byte-compatible with OpenCV by design:
 //! OpenCV quantizes u8 interpolation weights to 11-bit fixed point and
 //! evaluates separably, both of which discard precision that kornia's own
@@ -32,7 +32,7 @@
 //!   half-pixel variant is OpenCV's separate `INTER_NEAREST_EXACT`, not
 //!   reproduced here.
 //!
-//! [`resize_native`]: crate::resize::resize_native
+//! [`resize`]: crate::resize::resize
 
 use crate::interpolation::InterpolationMode;
 use kornia_image::{Image, ImageError};

--- a/crates/kornia-imgproc/src/warp/affine.rs
+++ b/crates/kornia-imgproc/src/warp/affine.rs
@@ -128,6 +128,17 @@ pub fn warp_affine<const C: usize>(
 ) -> Result<(), ImageError> {
     validate_interpolation(interpolation)?;
 
+    // Device pairs route to the CUDA kernels (bit-identical output — the
+    // byte-exact contract asserted in `cuda::warp_affine`). Mixed pairs are a
+    // typed error; no implicit transfers.
+    #[cfg(feature = "cuda")]
+    if let crate::cuda::dispatch::Residency::Device(exec) =
+        crate::cuda::dispatch::pair_residency(src, dst)?
+    {
+        return exec
+            .run(|stream| super::cuda::warp_affine_f32_cuda(src, dst, m, interpolation, stream));
+    }
+
     let m_inv = invert_affine_transform(m);
 
     let src_w = src.cols();

--- a/crates/kornia-imgproc/src/warp/cuda.rs
+++ b/crates/kornia-imgproc/src/warp/cuda.rs
@@ -1,0 +1,189 @@
+//! Device adapters for [`warp_affine`](super::warp_affine) and
+//! [`warp_perspective`](super::warp_perspective): route checked device pairs
+//! to the native CUDA warp kernels.
+
+use std::sync::Arc;
+
+use cudarc::driver::CudaStream;
+use kornia_image::{Image, ImageError};
+
+use crate::cuda::dispatch::{device_slices, dims_u32, no_gpu_kernel_err, untyped_device_err};
+use crate::cuda::warp_affine::{launch_warp_affine_bilinear_cuda, launch_warp_affine_nearest_cuda};
+use crate::cuda::warp_perspective::{
+    launch_warp_perspective_bilinear_cuda, launch_warp_perspective_nearest_cuda,
+};
+use crate::interpolation::InterpolationMode;
+
+/// Run the CUDA warp-affine for a device-resident f32 pair.
+///
+/// `m` is the forward matrix — the launchers invert internally, exactly like
+/// the CPU [`warp_affine`](super::warp_affine), so it passes straight
+/// through. Output is bit-identical to the CPU path (the byte-exact contract
+/// asserted by the parity tests in `cuda::warp_affine`).
+pub(super) fn warp_affine_f32_cuda<const C: usize>(
+    src: &Image<f32, C>,
+    dst: &mut Image<f32, C>,
+    m: &[f32; 6],
+    interpolation: InterpolationMode,
+    stream: &Arc<CudaStream>,
+) -> Result<(), ImageError> {
+    if C != 3 {
+        return Err(no_gpu_kernel_err("warp_affine", "3-channel f32 images"));
+    }
+    let (src_w, src_h) = dims_u32(src)?;
+    let (dst_w, dst_h) = dims_u32(dst)?;
+    let ctx = stream.context();
+    let (s, d) = device_slices!(src, dst);
+
+    match interpolation {
+        InterpolationMode::Bilinear => launch_warp_affine_bilinear_cuda(
+            ctx, stream, s, d, src_w, src_h, dst_w, dst_h, m, None,
+        ),
+        InterpolationMode::Nearest => {
+            launch_warp_affine_nearest_cuda(ctx, stream, s, d, src_w, src_h, dst_w, dst_h, m, None)
+        }
+        mode => return Err(ImageError::UnsupportedInterpolation(mode)),
+    }
+    .map_err(|e| ImageError::Cuda(e.to_string()))
+}
+
+/// Run the CUDA warp-perspective for a device-resident f32 pair.
+///
+/// `m` is the forward homography — inverted internally like the CPU path.
+/// Bit-identical to CPU [`warp_perspective`](super::warp_perspective).
+pub(super) fn warp_perspective_f32_cuda<const C: usize>(
+    src: &Image<f32, C>,
+    dst: &mut Image<f32, C>,
+    m: &[f32; 9],
+    interpolation: InterpolationMode,
+    stream: &Arc<CudaStream>,
+) -> Result<(), ImageError> {
+    if C != 3 {
+        return Err(no_gpu_kernel_err(
+            "warp_perspective",
+            "3-channel f32 images",
+        ));
+    }
+    let (src_w, src_h) = dims_u32(src)?;
+    let (dst_w, dst_h) = dims_u32(dst)?;
+    let ctx = stream.context();
+    let (s, d) = device_slices!(src, dst);
+
+    match interpolation {
+        InterpolationMode::Bilinear => launch_warp_perspective_bilinear_cuda(
+            ctx, stream, s, d, src_w, src_h, dst_w, dst_h, m, None,
+        ),
+        InterpolationMode::Nearest => launch_warp_perspective_nearest_cuda(
+            ctx, stream, s, d, src_w, src_h, dst_w, dst_h, m, None,
+        ),
+        mode => return Err(ImageError::UnsupportedInterpolation(mode)),
+    }
+    .map_err(|e| ImageError::Cuda(e.to_string()))
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use crate::cuda::color::test_utils::{default_stream, pattern_f32};
+    use crate::interpolation::InterpolationMode;
+    use crate::warp::{warp_affine, warp_perspective};
+    use kornia_image::{Image, ImageError, ImageSize};
+
+    fn host_pair(w: usize, h: usize) -> (Image<f32, 3>, Image<f32, 3>) {
+        let size = ImageSize {
+            width: w,
+            height: h,
+        };
+        (
+            Image::<f32, 3>::new(size, pattern_f32(w * h * 3)).unwrap(),
+            Image::<f32, 3>::from_size_val(size, 0.0).unwrap(),
+        )
+    }
+
+    /// The public `warp_affine`, called with device images, must produce
+    /// bit-identical output to the same call with host images — the whole
+    /// point of the byte-exact program.
+    #[test]
+    fn public_warp_affine_device_equals_host() {
+        let stream = default_stream();
+        let (src, mut cpu_dst) = host_pair(129, 97);
+        let m = crate::warp::get_rotation_matrix2d((64.0, 48.0), 37.0, 1.3);
+
+        warp_affine(&src, &mut cpu_dst, &m, InterpolationMode::Bilinear).unwrap();
+
+        let d_src = src.to_cuda(&stream).unwrap();
+        let mut d_dst = Image::<f32, 3>::zeros_cuda(src.size(), &stream).unwrap();
+        warp_affine(&d_src, &mut d_dst, &m, InterpolationMode::Bilinear).unwrap();
+
+        let back = d_dst.to_host_owned().unwrap();
+        assert_eq!(
+            back.as_slice(),
+            cpu_dst.as_slice(),
+            "device warp_affine must be bit-identical to host"
+        );
+    }
+
+    /// Same for the public `warp_perspective`, with a genuinely projective
+    /// homography.
+    #[test]
+    fn public_warp_perspective_device_equals_host() {
+        let stream = default_stream();
+        let (src, mut cpu_dst) = host_pair(129, 97);
+        let hm = [
+            1.03,
+            0.05,
+            -3.0,
+            -0.02,
+            0.97,
+            4.0,
+            2.0 / (97.0 * 129.0),
+            1.5 / (129.0 * 97.0),
+            1.0,
+        ];
+
+        warp_perspective(&src, &mut cpu_dst, &hm, InterpolationMode::Bilinear).unwrap();
+
+        let d_src = src.to_cuda(&stream).unwrap();
+        let mut d_dst = Image::<f32, 3>::zeros_cuda(src.size(), &stream).unwrap();
+        warp_perspective(&d_src, &mut d_dst, &hm, InterpolationMode::Bilinear).unwrap();
+
+        let back = d_dst.to_host_owned().unwrap();
+        assert_eq!(
+            back.as_slice(),
+            cpu_dst.as_slice(),
+            "device warp_perspective must be bit-identical to host"
+        );
+    }
+
+    /// Mixed residency is a typed error, not an implicit transfer.
+    #[test]
+    fn mixed_residency_is_a_typed_error() {
+        let stream = default_stream();
+        let (src, mut host_dst) = host_pair(16, 16);
+        let d_src = src.to_cuda(&stream).unwrap();
+        let m = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
+        let err = warp_affine(&d_src, &mut host_dst, &m, InterpolationMode::Nearest).unwrap_err();
+        assert!(matches!(err, ImageError::MixedResidency), "got {err:?}");
+    }
+
+    /// A device pair with a channel count the kernels don't support errors —
+    /// never a silent CPU fallback.
+    #[test]
+    fn unsupported_channels_error_not_fallback() {
+        let stream = default_stream();
+        let size = ImageSize {
+            width: 16,
+            height: 16,
+        };
+        let src = Image::<f32, 1>::new(size, pattern_f32(16 * 16)).unwrap();
+        let d_src = src.to_cuda(&stream).unwrap();
+        let mut d_dst = Image::<f32, 1>::zeros_cuda(size, &stream).unwrap();
+        let m = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
+        let err = warp_affine(&d_src, &mut d_dst, &m, InterpolationMode::Nearest).unwrap_err();
+        assert!(
+            matches!(&err, ImageError::Cuda(msg) if msg.contains("3-channel")),
+            "got {err:?}"
+        );
+    }
+}

--- a/crates/kornia-imgproc/src/warp/cuda.rs
+++ b/crates/kornia-imgproc/src/warp/cuda.rs
@@ -36,9 +36,9 @@ pub(super) fn warp_affine_f32_cuda<const C: usize>(
     let (s, d) = device_slices!(src, dst);
 
     match interpolation {
-        InterpolationMode::Bilinear => launch_warp_affine_bilinear_cuda(
-            ctx, stream, s, d, src_w, src_h, dst_w, dst_h, m, None,
-        ),
+        InterpolationMode::Bilinear => {
+            launch_warp_affine_bilinear_cuda(ctx, stream, s, d, src_w, src_h, dst_w, dst_h, m, None)
+        }
         InterpolationMode::Nearest => {
             launch_warp_affine_nearest_cuda(ctx, stream, s, d, src_w, src_h, dst_w, dst_h, m, None)
         }

--- a/crates/kornia-imgproc/src/warp/mod.rs
+++ b/crates/kornia-imgproc/src/warp/mod.rs
@@ -1,5 +1,7 @@
 mod affine;
 mod common;
+#[cfg(feature = "cuda")]
+mod cuda;
 mod kernels;
 mod perspective;
 mod span;

--- a/crates/kornia-imgproc/src/warp/perspective.rs
+++ b/crates/kornia-imgproc/src/warp/perspective.rs
@@ -120,6 +120,18 @@ pub fn warp_perspective<const C: usize>(
 ) -> Result<(), ImageError> {
     validate_interpolation(interpolation)?;
 
+    // Device pairs route to the CUDA kernels (bit-identical output — the
+    // byte-exact contract asserted in `cuda::warp_perspective`). Mixed pairs
+    // are a typed error; no implicit transfers.
+    #[cfg(feature = "cuda")]
+    if let crate::cuda::dispatch::Residency::Device(exec) =
+        crate::cuda::dispatch::pair_residency(src, dst)?
+    {
+        return exec.run(|stream| {
+            super::cuda::warp_perspective_f32_cuda(src, dst, m, interpolation, stream)
+        });
+    }
+
     // inverse perspective matrix
     // TODO: allow later to skip the inverse calculation if user provides it
     let inv_m = inverse_perspective_matrix(m)?;

--- a/crates/kornia-imgproc/src/warp/perspective.rs
+++ b/crates/kornia-imgproc/src/warp/perspective.rs
@@ -540,7 +540,7 @@ mod tests {
         // samples at sx = (dst_x + 0.5) * 2 - 0.5 = 2*dst_x + 0.5, so the
         // forward (src → dst) map is dst_x = 0.5*sx - 0.25. All entries are
         // dyadic, so the internal inversion and the interpolation are exact
-        // and the equality with `resize_native` below is bit-exact.
+        // and the equality with `resize` below is bit-exact.
         let m = [0.5, 0.0, -0.25, 0.0, 0.5, -0.25, 0.0, 0.0, 1.0];
 
         // v(sx, sy) = 4*sy + sx sampled at (2x+0.5, 2y+0.5).
@@ -562,7 +562,7 @@ mod tests {
 
         let mut image_resized = Image::<_, 1>::from_size_val(new_size, 0.0)?;
 
-        crate::resize::resize_native(
+        crate::resize::resize(
             &image,
             &mut image_resized,
             super::InterpolationMode::Bilinear,

--- a/examples/imgproc/src/main.rs
+++ b/examples/imgproc/src/main.rs
@@ -35,7 +35,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let mut gray_resize = Image::<f32, 1>::from_size_val(new_size, 0.0)?;
-    imgproc::resize::resize_native(
+    imgproc::resize::resize(
         &gray_f32,
         &mut gray_resize,
         imgproc::interpolation::InterpolationMode::Bilinear,


### PR DESCRIPTION
## 📝 Description

Phases 2+3 of the CUDA-integration plan (after #1006). `resize_native`, `warp_affine`, and `warp_perspective` now route device-resident f32 pairs to the native CUDA kernels through the shared `cuda::dispatch` machinery — **the 13 CUDA geometry kernels stop being benchmark-only dead code and become reachable from the public API**, with output **bit-identical** to the CPU path (the byte-exact contract from #1003/#1004, now asserted end-to-end through the public functions).

```rust
let d_src = img.to_cuda(&stream)?;
let mut d_dst = Image::<f32, 3>::zeros_cuda(size, &stream)?;
resize_native(&d_src, &mut d_dst, InterpolationMode::Bilinear)?; // runs on GPU, bits == CPU
```

Semantics match the `ConvertColor` precedent exactly:
| Operands | Behavior |
|---|---|
| host + host | existing CPU path, unchanged |
| device + device, f32 C=3 | CUDA kernel, bit-identical to CPU |
| device + device, other C | typed error naming the constraint — never a silent CPU fallback |
| mixed | `ImageError::MixedResidency` |
| same device, different streams | works — `DeviceExec` event-fences |

Notable details:
- In `resize_native` the residency check precedes the same-size short-circuit, whose `as_slice_mut` memcpy would otherwise dereference device pointers on the host (tested).
- The adapters stay **generic over C with a runtime check** instead of pointer-casting `&Image<f32, C>` to `&Image<f32, 3>`: `Image` is a tuple newtype without `repr(transparent)`, so that cast isn't layout-guaranteed — and the launchers only need slices and dims anyway. Zero `unsafe`.
- Bilinear/nearest only (the CPU ops accept nothing else); bicubic/Lanczos kernels stay launcher-only until the CPU grows f32 equivalents.

## 🧪 How Was This Tested?

- [x] End-to-end tests through the **public** functions: device == host bit-identical (`assert_eq!` on slices) for resize (both modes, up+down, non-dyadic sizes), warp-affine (non-dyadic rotation), warp-perspective (projective homography); same-size device resize safety; mixed-residency and wrong-channel error semantics.
- [x] Full suite on Jetson Orin with `--features cuda`: 353 lib + integration green; CPU-only build clean; clippy clean.
- [x] Host-path perf: same-session A/B vs `origin/main` — main itself swings 1.15–1.39 ms on the 1024×896 resize case run-to-run; branch numbers sit inside that band. The added cost is one enum match per call.

## 💭 Additional Context

Remaining from the plan: Python bindings (Phase 4) — `kornia-py`'s resize/warp are u8+numpy-only today; the device path needs the `color.rs`-style `&Bound<PyAny>` restructure. Separate PR.

## 🕵️ AI Usage Disclosure

- [x] 🟡 **AI-assisted:** authored with Claude Code; parity and benchmarks verified on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)