### PR TITLE
feat(imgproc): u8 CUDA resize — all modes, byte-exact with the CPU fast paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,15 @@ count the conversion). `resize_fast_u8_aa` (Rust) and `kornia_rs.imgproc.resize`
 integer-only CUDA kernels covering the full CPU cascade: exact-2× pyramid fast
 paths, nearest, Q14 bilinear, and antialiased/plain separable bicubic and
 Lanczos-3. The coordinate and weight tables are built by the same host
-functions the CPU uses and uploaded, so device output is byte-for-byte equal
-to host output (asserted with `assert_eq!` across modes, channel counts, odd
-sizes, and extreme downscales). Kernel compile failures now surface as errors
-instead of panics across all resize launchers.
+functions the CPU uses and uploaded once per geometry (a device-side LUT
+cache — Jetson pageable H2D uploads have a ~250 µs average latency tail that
+otherwise dominates, and the warm path is CUDA-Graph-capturable), so device
+output is byte-for-byte equal to host output (asserted with `assert_eq!`
+across modes, channel counts, odd sizes, and extreme downscales). Measured on
+Jetson Orin at 1080p→720p u8 RGB (median, out= reuse): nearest 0.22 ms,
+bilinear 0.38 ms, bicubic 1.20 ms — faster than VPI-CUDA on every comparable
+op (5.4× / 3.4× / 1.1×) and 3–6× ahead of OpenCV CPU. Kernel compile failures
+now surface as errors instead of panics across all resize launchers.
 
 **Python: `out=` and CUDA Graphs for allocation-free frame loops.** The device
 geometry ops accept a preallocated device `out=` image (torch-style, returned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ changes early: `cargo add kornia-imgproc@0.1.15-rc.1` or `pip install --pre korn
 
 ## [Unreleased]
 
+**u8 CUDA resize — every mode, bit-identical to the CPU fast paths.** Camera
+data is u8; until now the GPU only resized f32 (4× the memory traffic once you
+count the conversion). `resize_fast_u8_aa` (Rust) and `kornia_rs.imgproc.resize`
+(Python, including `out=`) now route u8 device images — 1/3/4-channel — to new
+integer-only CUDA kernels covering the full CPU cascade: exact-2× pyramid fast
+paths, nearest, Q14 bilinear, and antialiased/plain separable bicubic and
+Lanczos-3. The coordinate and weight tables are built by the same host
+functions the CPU uses and uploaded, so device output is byte-for-byte equal
+to host output (asserted with `assert_eq!` across modes, channel counts, odd
+sizes, and extreme downscales). Kernel compile failures now surface as errors
+instead of panics across all resize launchers.
+
 **Python: `out=` and CUDA Graphs for allocation-free frame loops.** The device
 geometry ops accept a preallocated device `out=` image (torch-style, returned
 back); `kornia_rs.cuda.Stream.new()` creates a capturable non-default stream;

--- a/crates/kornia-image/src/image.rs
+++ b/crates/kornia-image/src/image.rs
@@ -54,7 +54,7 @@ impl PixelFormat {
 }
 
 /// Interpolation mode for the image operations
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum InterpolationMode {
     /// Bilinear interpolation
     Bilinear,

--- a/crates/kornia-imgproc/src/cuda/mod.rs
+++ b/crates/kornia-imgproc/src/cuda/mod.rs
@@ -7,6 +7,10 @@
 /// Native CUDA downscale kernels using `__ldg` read-only cache.
 pub mod resize;
 
+/// Native CUDA u8 resize kernels (integer LUT-driven, byte-exact with the
+/// CPU u8 fast paths).
+pub mod resize_u8;
+
 /// Native CUDA warp-affine kernels (bilinear and nearest-neighbor).
 pub mod warp_affine;
 

--- a/crates/kornia-imgproc/src/cuda/resize.rs
+++ b/crates/kornia-imgproc/src/cuda/resize.rs
@@ -80,8 +80,10 @@
 
 use std::sync::{Arc, OnceLock};
 
-use cudarc::driver::{CudaContext, CudaSlice, CudaStream, LaunchConfig};
+use cudarc::driver::{CudaContext, CudaSlice, CudaStream};
 use kornia_tensor::CudaKernel;
+
+use super::{make_config, try_compile_with_l1};
 
 // ── CUDA C source: bilinear, 32×8 block, __ldg reads ─────────────────────────
 //
@@ -401,17 +403,12 @@ extern "C" __global__ void resize_lanczos_v_3c(
 
 // ── Kernel caches ─────────────────────────────────────────────────────────────
 
-static BILINEAR_KERNEL: OnceLock<CudaKernel> = OnceLock::new();
-static NEAREST_KERNEL: OnceLock<CudaKernel> = OnceLock::new();
-static BILINEAR_NORMALIZE_KERNEL: OnceLock<CudaKernel> = OnceLock::new();
+static BILINEAR_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
+static NEAREST_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
+static BILINEAR_NORMALIZE_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
 static BICUBIC_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
 static LANCZOS_H_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
 static LANCZOS_V_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
-
-// 32 threads wide → full warp maps to one output row (better write coalescing).
-// 8 threads tall → 256 threads total, same occupancy as 16×16.
-const BLOCK_W: u32 = 32;
-const BLOCK_H: u32 = 8;
 
 // ── Error type ────────────────────────────────────────────────────────────────
 
@@ -429,42 +426,6 @@ pub enum CudaResizeError {
         /// Minimum required length (dst_w × dst_h × 3).
         need: usize,
     },
-}
-
-// ── Internal helpers ──────────────────────────────────────────────────────────
-
-fn make_config(dst_width: u32, dst_height: u32, block_dim: Option<(u32, u32)>) -> LaunchConfig {
-    let (bw, bh) = block_dim.unwrap_or_else(|| {
-        // Auto mode: clamp to image size so small images don't launch
-        // blocks that are mostly idle (e.g. a 4×4 image with 32×8 = 256
-        // threads has 93% idle threads).
-        (BLOCK_W.min(dst_width), BLOCK_H.min(dst_height))
-    });
-    LaunchConfig {
-        block_dim: (bw, bh, 1),
-        grid_dim: (dst_width.div_ceil(bw), dst_height.div_ceil(bh), 1),
-        shared_mem_bytes: 0,
-    }
-}
-
-fn compile_with_l1(ctx: &Arc<CudaContext>, src: &str, fn_name: &str) -> CudaKernel {
-    let k = CudaKernel::compile(ctx, src, fn_name)
-        .unwrap_or_else(|e| panic!("failed to compile {fn_name}: {e}"));
-    // Prefer L1 over shared memory (kernel uses no smem).
-    // Ignoring errors: unsupported on some platforms but never fatal.
-    let _ = k.prefer_l1_cache();
-    k
-}
-
-fn try_compile_with_l1(
-    ctx: &Arc<CudaContext>,
-    src: &str,
-    fn_name: &str,
-) -> Result<CudaKernel, String> {
-    let k = CudaKernel::compile(ctx, src, fn_name)
-        .map_err(|e| format!("failed to compile {fn_name}: {e}"))?;
-    let _ = k.prefer_l1_cache();
-    Ok(k)
 }
 
 // ── Pixel mapping ─────────────────────────────────────────────────────────────
@@ -565,7 +526,9 @@ pub fn launch_resize_bilinear_downscale_cuda(
     }
 
     let kernel = BILINEAR_KERNEL
-        .get_or_init(|| compile_with_l1(ctx, BILINEAR_SRC, "resize_bilinear_downscale_3c"));
+        .get_or_init(|| try_compile_with_l1(ctx, BILINEAR_SRC, "resize_bilinear_downscale_3c"))
+        .as_ref()
+        .map_err(|e| CudaResizeError::Cuda(e.clone()))?;
 
     let (ax, bx) = mapping.coeffs(src_width, dst_width);
     let (ay, by) = mapping.coeffs(src_height, dst_height);
@@ -646,9 +609,12 @@ pub fn launch_resize_bilinear_normalize_cuda(
         ));
     }
 
-    let kernel = BILINEAR_NORMALIZE_KERNEL.get_or_init(|| {
-        compile_with_l1(ctx, BILINEAR_NORMALIZE_SRC, "resize_bilinear_normalize_3c")
-    });
+    let kernel = BILINEAR_NORMALIZE_KERNEL
+        .get_or_init(|| {
+            try_compile_with_l1(ctx, BILINEAR_NORMALIZE_SRC, "resize_bilinear_normalize_3c")
+        })
+        .as_ref()
+        .map_err(|e| CudaResizeError::Cuda(e.clone()))?;
 
     let (ax, bx) = mapping.coeffs(src_width, dst_width);
     let (ay, by) = mapping.coeffs(src_height, dst_height);
@@ -722,7 +688,9 @@ pub fn launch_resize_nearest_downscale_cuda(
     }
 
     let kernel = NEAREST_KERNEL
-        .get_or_init(|| compile_with_l1(ctx, NEAREST_SRC, "resize_nearest_downscale_3c"));
+        .get_or_init(|| try_compile_with_l1(ctx, NEAREST_SRC, "resize_nearest_downscale_3c"))
+        .as_ref()
+        .map_err(|e| CudaResizeError::Cuda(e.clone()))?;
 
     let (ax, bx) = mapping.coeffs(src_width, dst_width);
     let (ay, by) = mapping.coeffs(src_height, dst_height);

--- a/crates/kornia-imgproc/src/cuda/resize_u8.rs
+++ b/crates/kornia-imgproc/src/cuda/resize_u8.rs
@@ -136,6 +136,79 @@ extern "C" __global__ void resize_u8_pyrup2x_rgb(
 /// output pixels per thread with the channel loop fully unrolled so every
 /// load issues independently.
 fn nearest_src(channels: usize) -> String {
+    // Per-C gather bodies: 4 output pixels per thread, output assembled in
+    // registers and written as whole u32 words when the destination offset
+    // is 4-byte aligned (checked at runtime; byte-store fallback otherwise).
+    // C1: 4 px = one word. C3: 4 px = 12 B = three words packed from the
+    // gathered bytes. C4: each px is naturally one word.
+    let body = match channels {
+        1 => r#"
+        unsigned int b0 = (unsigned int)__ldg(&src[row + (size_t)__ldg(&xmap[x0 + 0u])]);
+        unsigned int b1 = (unsigned int)__ldg(&src[row + (size_t)__ldg(&xmap[x0 + 1u])]);
+        unsigned int b2 = (unsigned int)__ldg(&src[row + (size_t)__ldg(&xmap[x0 + 2u])]);
+        unsigned int b3 = (unsigned int)__ldg(&src[row + (size_t)__ldg(&xmap[x0 + 3u])]);
+        unsigned int w0 = b0 | (b1 << 8) | (b2 << 16) | (b3 << 24);
+        if (((size_t)(dst + d) & 3u) == 0u) {
+            *(unsigned int*)(dst + d) = w0;
+        } else {
+            dst[d + 0] = (unsigned char)b0;
+            dst[d + 1] = (unsigned char)b1;
+            dst[d + 2] = (unsigned char)b2;
+            dst[d + 3] = (unsigned char)b3;
+        }
+"#
+        .to_string(),
+        3 => r#"
+        size_t s0 = row3 + (size_t)__ldg(&xmap[x0 + 0u]) * 3u;
+        size_t s1 = row3 + (size_t)__ldg(&xmap[x0 + 1u]) * 3u;
+        size_t s2 = row3 + (size_t)__ldg(&xmap[x0 + 2u]) * 3u;
+        size_t s3 = row3 + (size_t)__ldg(&xmap[x0 + 3u]) * 3u;
+        unsigned int a0 = (unsigned int)__ldg(&src[s0 + 0u]);
+        unsigned int a1 = (unsigned int)__ldg(&src[s0 + 1u]);
+        unsigned int a2 = (unsigned int)__ldg(&src[s0 + 2u]);
+        unsigned int b0 = (unsigned int)__ldg(&src[s1 + 0u]);
+        unsigned int b1 = (unsigned int)__ldg(&src[s1 + 1u]);
+        unsigned int b2 = (unsigned int)__ldg(&src[s1 + 2u]);
+        unsigned int c0 = (unsigned int)__ldg(&src[s2 + 0u]);
+        unsigned int c1 = (unsigned int)__ldg(&src[s2 + 1u]);
+        unsigned int c2 = (unsigned int)__ldg(&src[s2 + 2u]);
+        unsigned int e0 = (unsigned int)__ldg(&src[s3 + 0u]);
+        unsigned int e1 = (unsigned int)__ldg(&src[s3 + 1u]);
+        unsigned int e2 = (unsigned int)__ldg(&src[s3 + 2u]);
+        if (((size_t)(dst + d) & 3u) == 0u) {
+            *(unsigned int*)(dst + d)      = a0 | (a1 << 8) | (a2 << 16) | (b0 << 24);
+            *(unsigned int*)(dst + d + 4)  = b1 | (b2 << 8) | (c0 << 16) | (c1 << 24);
+            *(unsigned int*)(dst + d + 8)  = c2 | (e0 << 8) | (e1 << 16) | (e2 << 24);
+        } else {
+            dst[d + 0]  = (unsigned char)a0;  dst[d + 1]  = (unsigned char)a1;
+            dst[d + 2]  = (unsigned char)a2;  dst[d + 3]  = (unsigned char)b0;
+            dst[d + 4]  = (unsigned char)b1;  dst[d + 5]  = (unsigned char)b2;
+            dst[d + 6]  = (unsigned char)c0;  dst[d + 7]  = (unsigned char)c1;
+            dst[d + 8]  = (unsigned char)c2;  dst[d + 9]  = (unsigned char)e0;
+            dst[d + 10] = (unsigned char)e1;  dst[d + 11] = (unsigned char)e2;
+        }
+"#
+        .to_string(),
+        _ => r#"
+        #pragma unroll
+        for (unsigned int px = 0; px < 4u; ++px) {
+            size_t so = rowC + (size_t)__ldg(&xmap[x0 + px]) * C;
+            unsigned int w = (unsigned int)__ldg(&src[so + 0u])
+                           | ((unsigned int)__ldg(&src[so + 1u]) << 8)
+                           | ((unsigned int)__ldg(&src[so + 2u]) << 16)
+                           | ((unsigned int)__ldg(&src[so + 3u]) << 24);
+            if (((size_t)(dst + d + (size_t)px * 4u) & 3u) == 0u) {
+                *(unsigned int*)(dst + d + (size_t)px * 4u) = w;
+            } else {
+                dst[d + px * 4u + 0u] = (unsigned char)(w & 0xffu);
+                dst[d + px * 4u + 1u] = (unsigned char)((w >> 8) & 0xffu);
+                dst[d + px * 4u + 2u] = (unsigned char)((w >> 16) & 0xffu);
+                dst[d + px * 4u + 3u] = (unsigned char)((w >> 24) & 0xffu);
+            }
+        }
+"#
+        .to_string(),
+    };
     format!(
         r#"
 #define C {channels}
@@ -148,19 +221,25 @@ extern "C" __global__ void resize_u8_nearest_c{channels}(
     unsigned int dst_w,
     unsigned int dst_h
 ) {{
-    // One pixel per thread: nearest is a pure scatter-gather and hides
-    // latency through occupancy — a 4-px/thread ILP variant measured ~35%
-    // SLOWER (fewer threads, no reuse to exploit). The baked channel count
-    // still unrolls the copy.
-    unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
-    unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
-    if (x >= dst_w || y >= dst_h) return;
+    unsigned int x0 = 4u * (blockIdx.x * blockDim.x + threadIdx.x);
+    unsigned int y  = blockIdx.y * blockDim.y + threadIdx.y;
+    if (y >= dst_h) return;
+    size_t row  = (size_t)__ldg(&ymap[y]) * src_w;
+    size_t row3 = row * 3u;
+    size_t rowC = row * C;
+    (void)row3; (void)rowC;
+    size_t d = ((size_t)y * dst_w + x0) * C;
 
-    size_t so = ((size_t)__ldg(&ymap[y]) * src_w + (size_t)__ldg(&xmap[x])) * C;
-    size_t d  = ((size_t)y * dst_w + x) * C;
-    #pragma unroll
-    for (unsigned int ch = 0; ch < C; ++ch) {{
-        dst[d + ch] = __ldg(&src[so + ch]);
+    if (x0 + 3u < dst_w) {{
+{body}        return;
+    }}
+    if (x0 >= dst_w) return;
+    for (unsigned int x = x0; x < dst_w; ++x) {{
+        size_t so = (row + (size_t)__ldg(&xmap[x])) * C;
+        #pragma unroll
+        for (unsigned int ch = 0; ch < C; ++ch) {{
+            dst[((size_t)y * dst_w + x) * C + ch] = __ldg(&src[so + ch]);
+        }}
     }}
 }}
 "#
@@ -488,7 +567,8 @@ pub fn launch_resize_u8_nearest_cuda(
             .clone()
     };
 
-    let grid_w = dst_width;
+    // Four output pixels per thread in x.
+    let grid_w = dst_width.div_ceil(4);
     kernel
         .launch_builder(stream)
         .arg(src)

--- a/crates/kornia-imgproc/src/cuda/resize_u8.rs
+++ b/crates/kornia-imgproc/src/cuda/resize_u8.rs
@@ -201,6 +201,12 @@ static SEP_H_SRC: &str = r#"
 // i32 accumulate over kx taps, round-half-up at Q14, CLAMP TO i16 — the
 // signed 16-bit intermediate (overshooting lobes included) is part of the
 // CPU contract, not an optimization.
+//
+// Loop order is tap-outer / channel-inner with register accumulators: each
+// LUT entry is loaded once (not once per channel) and the C pixel bytes of a
+// tap are consecutive, which roughly halved the kernel time vs the
+// channel-outer form. Accumulation order over taps is unchanged, so the
+// result is bit-identical.
 extern "C" __global__ void resize_u8_sep_h(
     const unsigned char* __restrict__  src,
     short* __restrict__                hbuf,
@@ -220,14 +226,18 @@ extern "C" __global__ void resize_u8_sep_h(
     size_t ibase = (size_t)x * kx;
     size_t d = ((size_t)y * dst_w + x) * channels;
 
-    for (unsigned int ch = 0; ch < channels; ++ch) {
-        int acc = 0;
-        for (unsigned int t = 0; t < kx; ++t) {
-            unsigned int sx = (unsigned int)__ldg(&xsrc[ibase + t]);
-            acc += (int)__ldg(&src[row + (size_t)sx * channels + ch])
-                 * (int)__ldg(&xw[ibase + t]);
+    int acc[4] = {0, 0, 0, 0};
+    for (unsigned int t = 0; t < kx; ++t) {
+        int w = (int)__ldg(&xw[ibase + t]);
+        const unsigned char* p =
+            src + row + (size_t)__ldg(&xsrc[ibase + t]) * channels;
+        #pragma unroll 4
+        for (unsigned int ch = 0; ch < channels; ++ch) {
+            acc[ch] += (int)__ldg(&p[ch]) * w;
         }
-        int v = (acc + (1 << 13)) >> 14;
+    }
+    for (unsigned int ch = 0; ch < channels; ++ch) {
+        int v = (acc[ch] + (1 << 13)) >> 14;
         v = min(max(v, -32768), 32767);
         hbuf[d + ch] = (short)v;
     }
@@ -258,14 +268,20 @@ extern "C" __global__ void resize_u8_sep_v(
     size_t wbase = (size_t)y * ky;
     size_t d = ((size_t)y * dst_w + x) * channels;
 
-    for (unsigned int ch = 0; ch < channels; ++ch) {
-        int acc = 0;
-        for (unsigned int k = 0; k < ky; ++k) {
-            int sy = min(max(y0 + (int)k, 0), (int)src_h - 1);
-            acc += (int)__ldg(&hbuf[((size_t)sy * dst_w + x) * channels + ch])
-                 * (int)__ldg(&yw[wbase + k]);
+    // Tap-outer / channel-inner (see the horizontal kernel): one LUT load
+    // and one row-base computation per tap, C consecutive i16 reads.
+    int acc[4] = {0, 0, 0, 0};
+    for (unsigned int k = 0; k < ky; ++k) {
+        int w = (int)__ldg(&yw[wbase + k]);
+        int sy = min(max(y0 + (int)k, 0), (int)src_h - 1);
+        const short* p = hbuf + ((size_t)sy * dst_w + x) * channels;
+        #pragma unroll 4
+        for (unsigned int ch = 0; ch < channels; ++ch) {
+            acc[ch] += (int)__ldg(&p[ch]) * w;
         }
-        int v = (acc + (1 << 13)) >> 14;
+    }
+    for (unsigned int ch = 0; ch < channels; ++ch) {
+        int v = (acc[ch] + (1 << 13)) >> 14;
         dst[d + ch] = (unsigned char)min(max(v, 0), 255);
     }
 }
@@ -295,10 +311,6 @@ fn check_dst_len(dst_len: usize, w: u32, h: u32, channels: u32) -> Result<(), Cu
         return Err(CudaResizeError::SliceTooSmall { got: dst_len, need });
     }
     Ok(())
-}
-
-fn to_cuda_err(e: cudarc::driver::result::DriverError) -> CudaResizeError {
-    CudaResizeError::Cuda(e.to_string())
 }
 
 // ── Public launchers ──────────────────────────────────────────────────────────
@@ -376,10 +388,12 @@ pub fn launch_resize_u8_pyrup2x_rgb_cuda(
         .map_err(|e| CudaResizeError::Cuda(e.to_string()))
 }
 
-/// Nearest-neighbor u8 resize via host-built index LUTs (pure gather).
+/// Nearest-neighbor u8 resize via device index LUTs (pure gather).
 ///
-/// `xmap`/`ymap` MUST come from `nearest_axis_lut` for CPU parity; entries
-/// must lie in `[0, src_len-1]` (the builders clamp).
+/// `xmap`/`ymap` are device uploads of `nearest_axis_lut` output (the
+/// `resize::cuda` adapter caches them per geometry — per-call pageable H2D
+/// uploads on Jetson have a catastrophic latency tail, ~250 µs average).
+/// Entries must lie in `[0, src_len-1]` (the builders clamp).
 #[allow(clippy::too_many_arguments)]
 pub fn launch_resize_u8_nearest_cuda(
     ctx: &Arc<CudaContext>,
@@ -391,8 +405,8 @@ pub fn launch_resize_u8_nearest_cuda(
     dst_width: u32,
     dst_height: u32,
     channels: u32,
-    xmap: &[i32],
-    ymap: &[i32],
+    xmap: &CudaSlice<i32>,
+    ymap: &CudaSlice<i32>,
     block_dim: Option<(u32, u32)>,
 ) -> Result<(), CudaResizeError> {
     super::check_geometry(src_width, src_height, dst_width, dst_height, block_dim)
@@ -405,15 +419,13 @@ pub fn launch_resize_u8_nearest_cuda(
     }
 
     let kernel = get_kernel(&NEAREST_KERNEL, ctx, NEAREST_SRC, "resize_u8_nearest")?;
-    let d_xmap = stream.clone_htod(xmap).map_err(to_cuda_err)?;
-    let d_ymap = stream.clone_htod(ymap).map_err(to_cuda_err)?;
 
     kernel
         .launch_builder(stream)
         .arg(src)
         .arg(dst)
-        .arg(&d_xmap)
-        .arg(&d_ymap)
+        .arg(xmap)
+        .arg(ymap)
         .arg(&src_width)
         .arg(&dst_width)
         .arg(&dst_height)
@@ -426,11 +438,12 @@ pub fn launch_resize_u8_nearest_cuda(
         .map_err(|e| CudaResizeError::Cuda(e.to_string()))
 }
 
-/// Q14 bilinear u8 resize via host-built tap LUTs.
+/// Q14 bilinear u8 resize via device tap LUTs.
 ///
-/// `xofs`/`xfx` and `yofs`/`yfy` MUST come from `bilinear_axis_lut` for CPU
-/// parity: offsets clamped to `[0, src_len-2]`, weights in `[0, 16384]`.
-/// Requires a source of at least 2×2 (the `ofs+1` neighbor read).
+/// `xofs`/`xfx` and `yofs`/`yfy` are device uploads of `bilinear_axis_lut`
+/// output (cached per geometry by the `resize::cuda` adapter): offsets
+/// clamped to `[0, src_len-2]`, weights in `[0, 16384]`. Requires a source
+/// of at least 2×2 (the `ofs+1` neighbor read).
 #[allow(clippy::too_many_arguments)]
 pub fn launch_resize_u8_bilinear_cuda(
     ctx: &Arc<CudaContext>,
@@ -442,10 +455,10 @@ pub fn launch_resize_u8_bilinear_cuda(
     dst_width: u32,
     dst_height: u32,
     channels: u32,
-    xofs: &[u32],
-    xfx: &[u32],
-    yofs: &[u32],
-    yfy: &[u32],
+    xofs: &CudaSlice<u32>,
+    xfx: &CudaSlice<u32>,
+    yofs: &CudaSlice<u32>,
+    yfy: &CudaSlice<u32>,
     block_dim: Option<(u32, u32)>,
 ) -> Result<(), CudaResizeError> {
     super::check_geometry(src_width, src_height, dst_width, dst_height, block_dim)
@@ -467,19 +480,15 @@ pub fn launch_resize_u8_bilinear_cuda(
     }
 
     let kernel = get_kernel(&BILINEAR_KERNEL, ctx, BILINEAR_SRC, "resize_u8_bilinear")?;
-    let d_xofs = stream.clone_htod(xofs).map_err(to_cuda_err)?;
-    let d_xfx = stream.clone_htod(xfx).map_err(to_cuda_err)?;
-    let d_yofs = stream.clone_htod(yofs).map_err(to_cuda_err)?;
-    let d_yfy = stream.clone_htod(yfy).map_err(to_cuda_err)?;
 
     kernel
         .launch_builder(stream)
         .arg(src)
         .arg(dst)
-        .arg(&d_xofs)
-        .arg(&d_xfx)
-        .arg(&d_yofs)
-        .arg(&d_yfy)
+        .arg(xofs)
+        .arg(xfx)
+        .arg(yofs)
+        .arg(yfy)
         .arg(&src_width)
         .arg(&dst_width)
         .arg(&dst_height)
@@ -494,11 +503,11 @@ pub fn launch_resize_u8_bilinear_cuda(
 
 /// Q14 separable bicubic / lanczos u8 resize (two passes, i16 intermediate).
 ///
-/// Tables MUST come from `precompute_contribs` + `build_xsrc_lut` +
-/// `pack_xw_i16` — including the antialias kernel widening — for CPU parity.
-/// The i16 scratch (`src_h × dst_w × channels`) is stream-ordered allocated
-/// per call; with the mempool release threshold raised, steady-state cost
-/// is a pool lookup.
+/// Device tables are uploads of `precompute_contribs` + `build_xsrc_lut` +
+/// `pack_xw_i16` output — including the antialias kernel widening — cached
+/// per geometry by the `resize::cuda` adapter. The i16 scratch
+/// (`src_h × dst_w × channels`) is stream-ordered allocated per call; with
+/// the mempool release threshold raised, steady-state cost is a pool lookup.
 #[allow(clippy::too_many_arguments)]
 pub fn launch_resize_u8_separable_cuda(
     ctx: &Arc<CudaContext>,
@@ -510,11 +519,11 @@ pub fn launch_resize_u8_separable_cuda(
     dst_width: u32,
     dst_height: u32,
     channels: u32,
-    xsrc: &[u16],
-    xw: &[i16],
+    xsrc: &CudaSlice<u16>,
+    xw: &CudaSlice<i16>,
     kx: u32,
-    yofs: &[i32],
-    yw: &[i16],
+    yofs: &CudaSlice<i32>,
+    yw: &CudaSlice<i16>,
     ky: u32,
     block_dim: Option<(u32, u32)>,
 ) -> Result<(), CudaResizeError> {
@@ -536,11 +545,6 @@ pub fn launch_resize_u8_separable_cuda(
     let kernel_h = get_kernel(&SEP_H_KERNEL, ctx, SEP_H_SRC, "resize_u8_sep_h")?;
     let kernel_v = get_kernel(&SEP_V_KERNEL, ctx, SEP_V_SRC, "resize_u8_sep_v")?;
 
-    let d_xsrc = stream.clone_htod(xsrc).map_err(to_cuda_err)?;
-    let d_xw = stream.clone_htod(xw).map_err(to_cuda_err)?;
-    let d_yofs = stream.clone_htod(yofs).map_err(to_cuda_err)?;
-    let d_yw = stream.clone_htod(yw).map_err(to_cuda_err)?;
-
     // Intermediate: src_h rows of dst_w pixels, i16. Pass 1 writes every
     // element before pass 2 reads; no zero-fill needed.
     let inter_len = (src_height as usize) * (dst_width as usize) * (channels as usize);
@@ -551,8 +555,8 @@ pub fn launch_resize_u8_separable_cuda(
         .launch_builder(stream)
         .arg(src)
         .arg(&mut hbuf)
-        .arg(&d_xsrc)
-        .arg(&d_xw)
+        .arg(xsrc)
+        .arg(xw)
         .arg(&kx)
         .arg(&src_width)
         .arg(&dst_width)
@@ -569,8 +573,8 @@ pub fn launch_resize_u8_separable_cuda(
         .launch_builder(stream)
         .arg(&hbuf)
         .arg(dst)
-        .arg(&d_yofs)
-        .arg(&d_yw)
+        .arg(yofs)
+        .arg(yw)
         .arg(&ky)
         .arg(&src_height)
         .arg(&dst_width)

--- a/crates/kornia-imgproc/src/cuda/resize_u8.rs
+++ b/crates/kornia-imgproc/src/cuda/resize_u8.rs
@@ -33,7 +33,8 @@
 //! separable kernels rely on for negative bicubic/lanczos accumulators —
 //! same guarantee `cuda/color` documents.
 
-use std::sync::{Arc, OnceLock};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
 
 use cudarc::driver::{CudaContext, CudaSlice, CudaStream};
 use kornia_tensor::CudaKernel;
@@ -131,34 +132,57 @@ extern "C" __global__ void resize_u8_pyrup2x_rgb(
 }
 "#;
 
-static NEAREST_SRC: &str = r#"
-extern "C" __global__ void resize_u8_nearest(
+/// Nearest kernel source, specialized per channel count: pure gather, four
+/// output pixels per thread with the channel loop fully unrolled so every
+/// load issues independently.
+fn nearest_src(channels: usize) -> String {
+    format!(
+        r#"
+#define C {channels}
+extern "C" __global__ void resize_u8_nearest_c{channels}(
     const unsigned char* __restrict__ src,
     unsigned char* __restrict__       dst,
     const int* __restrict__           xmap,
     const int* __restrict__           ymap,
     unsigned int src_w,
     unsigned int dst_w,
-    unsigned int dst_h,
-    unsigned int channels
-) {
+    unsigned int dst_h
+) {{
+    // One pixel per thread: nearest is a pure scatter-gather and hides
+    // latency through occupancy — a 4-px/thread ILP variant measured ~35%
+    // SLOWER (fewer threads, no reuse to exploit). The baked channel count
+    // still unrolls the copy.
     unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
     unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
     if (x >= dst_w || y >= dst_h) return;
 
-    size_t so = ((size_t)__ldg(&ymap[y]) * src_w + (size_t)__ldg(&xmap[x])) * channels;
-    size_t d  = ((size_t)y * dst_w + x) * channels;
-    for (unsigned int ch = 0; ch < channels; ++ch) {
+    size_t so = ((size_t)__ldg(&ymap[y]) * src_w + (size_t)__ldg(&xmap[x])) * C;
+    size_t d  = ((size_t)y * dst_w + x) * C;
+    #pragma unroll
+    for (unsigned int ch = 0; ch < C; ++ch) {{
         dst[d + ch] = __ldg(&src[so + ch]);
-    }
+    }}
+}}
+"#
+    )
 }
-"#;
 
-static BILINEAR_SRC: &str = r#"
-// Q14 bilinear, byte-exact with bilinear_row_u8: the blend runs in 64-bit,
-// with ONE round-half-up at the final Q28 shift. fx/fy come from the host
-// f64 LUTs; fx1 = 16384 - fx is exact in integer arithmetic.
-extern "C" __global__ void resize_u8_bilinear(
+/// Q14 bilinear kernel source, specialized per channel count.
+///
+/// Byte-exact with `bilinear_row_u8`: the blend runs in 64-bit with ONE
+/// round-half-up at the final Q28 shift; fx/fy come from the host f64 LUTs
+/// and `fx1 = 16384 - fx` is exact integer arithmetic.
+///
+/// The channel count is baked into the source (`#pragma unroll` on a
+/// compile-time bound), and each thread produces TWO output pixels, so all
+/// corner loads are named registers issuing independently — the runtime
+/// channel loop of the first version serialized them (the same
+/// latency-bound profile the morphology kernels had before specialization).
+fn bilinear_src(channels: usize) -> String {
+    format!(
+        r#"
+#define C {channels}
+extern "C" __global__ void resize_u8_bilinear_c{channels}(
     const unsigned char* __restrict__ src,
     unsigned char* __restrict__       dst,
     const unsigned int* __restrict__  xofs,
@@ -167,34 +191,40 @@ extern "C" __global__ void resize_u8_bilinear(
     const unsigned int* __restrict__  yfy,
     unsigned int src_w,
     unsigned int dst_w,
-    unsigned int dst_h,
-    unsigned int channels
-) {
+    unsigned int dst_h
+) {{
+    // One pixel per thread (occupancy beats ILP for gather kernels — the
+    // 2-px pair variant measured no better than 1-px, same as nearest's
+    // 4-px quad); the baked channel count unrolls the corner loads into
+    // independent issues.
     unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
     unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
     if (x >= dst_w || y >= dst_h) return;
 
     const unsigned long long SCALE = 16384ull;
-    unsigned long long fx  = (unsigned long long)__ldg(&xfx[x]);
     unsigned long long fy  = (unsigned long long)__ldg(&yfy[y]);
-    unsigned long long fx1 = SCALE - fx;
     unsigned long long fy1 = SCALE - fy;
+    unsigned long long fx  = (unsigned long long)__ldg(&xfx[x]);
+    unsigned long long fx1 = SCALE - fx;
+    size_t row0 = (size_t)__ldg(&yofs[y]) * src_w * C;
+    size_t row1 = row0 + (size_t)src_w * C;
+    size_t c0   = (size_t)__ldg(&xofs[x]) * C;
+    size_t d    = ((size_t)y * dst_w + x) * C;
 
-    size_t r0 = ((size_t)__ldg(&yofs[y]) * src_w + (size_t)__ldg(&xofs[x])) * channels;
-    size_t r1 = r0 + (size_t)src_w * channels;
-    size_t d  = ((size_t)y * dst_w + x) * channels;
-
-    for (unsigned int ch = 0; ch < channels; ++ch) {
-        unsigned long long p00 = (unsigned long long)__ldg(&src[r0 + ch]);
-        unsigned long long p01 = (unsigned long long)__ldg(&src[r0 + channels + ch]);
-        unsigned long long p10 = (unsigned long long)__ldg(&src[r1 + ch]);
-        unsigned long long p11 = (unsigned long long)__ldg(&src[r1 + channels + ch]);
+    #pragma unroll
+    for (unsigned int ch = 0; ch < C; ++ch) {{
+        unsigned long long p00 = (unsigned long long)__ldg(&src[row0 + c0 + ch]);
+        unsigned long long p01 = (unsigned long long)__ldg(&src[row0 + c0 + C + ch]);
+        unsigned long long p10 = (unsigned long long)__ldg(&src[row1 + c0 + ch]);
+        unsigned long long p11 = (unsigned long long)__ldg(&src[row1 + c0 + C + ch]);
         unsigned long long top = p00 * fx1 + p01 * fx;
         unsigned long long bot = p10 * fx1 + p11 * fx;
         dst[d + ch] = (unsigned char)((top * fy1 + bot * fy + (1ull << 27)) >> 28);
-    }
+    }}
+}}
+"#
+    )
 }
-"#;
 
 static SEP_H_SRC: &str = r#"
 // Q14 separable horizontal pass, byte-exact with horizontal_row_scalar:
@@ -289,8 +319,11 @@ extern "C" __global__ void resize_u8_sep_v(
 
 static PYRDOWN2X_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
 static PYRUP2X_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
-static NEAREST_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
-static BILINEAR_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
+type PerCKernelCache = Mutex<HashMap<u32, Arc<CudaKernel>>>;
+static NEAREST_KERNELS: OnceLock<PerCKernelCache> = OnceLock::new();
+/// Per-channel-count specialized bilinear kernels (C is baked into the
+/// source so the pixel loop fully unrolls).
+static BILINEAR_KERNELS: OnceLock<PerCKernelCache> = OnceLock::new();
 static SEP_H_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
 static SEP_V_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
 
@@ -418,8 +451,29 @@ pub fn launch_resize_u8_nearest_cuda(
         ));
     }
 
-    let kernel = get_kernel(&NEAREST_KERNEL, ctx, NEAREST_SRC, "resize_u8_nearest")?;
+    // Per-C specialized kernel (see bilinear for the cache pattern).
+    let cache = NEAREST_KERNELS.get_or_init(Default::default);
+    let cached = cache
+        .lock()
+        .expect("nearest kernel cache poisoned")
+        .get(&channels)
+        .cloned();
+    let kernel = if let Some(hit) = cached {
+        hit
+    } else {
+        let src_code = nearest_src(channels as usize);
+        let name = format!("resize_u8_nearest_c{channels}");
+        let built =
+            Arc::new(try_compile_with_l1(ctx, &src_code, &name).map_err(CudaResizeError::Cuda)?);
+        cache
+            .lock()
+            .expect("nearest kernel cache poisoned")
+            .entry(channels)
+            .or_insert(built)
+            .clone()
+    };
 
+    let grid_w = dst_width;
     kernel
         .launch_builder(stream)
         .arg(src)
@@ -429,11 +483,10 @@ pub fn launch_resize_u8_nearest_cuda(
         .arg(&src_width)
         .arg(&dst_width)
         .arg(&dst_height)
-        .arg(&channels)
         .launch_2d(
-            dst_width,
+            grid_w,
             dst_height,
-            make_config(dst_width, dst_height, block_dim),
+            make_config(grid_w, dst_height, block_dim),
         )
         .map_err(|e| CudaResizeError::Cuda(e.to_string()))
 }
@@ -479,8 +532,30 @@ pub fn launch_resize_u8_bilinear_cuda(
         ));
     }
 
-    let kernel = get_kernel(&BILINEAR_KERNEL, ctx, BILINEAR_SRC, "resize_u8_bilinear")?;
+    // Per-C specialized kernel (scoped-guard lookup: binding `.get()` in an
+    // `if let` scrutinee would hold the lock through the else branch).
+    let cache = BILINEAR_KERNELS.get_or_init(Default::default);
+    let cached = cache
+        .lock()
+        .expect("bilinear kernel cache poisoned")
+        .get(&channels)
+        .cloned();
+    let kernel = if let Some(hit) = cached {
+        hit
+    } else {
+        let src_code = bilinear_src(channels as usize);
+        let name = format!("resize_u8_bilinear_c{channels}");
+        let built =
+            Arc::new(try_compile_with_l1(ctx, &src_code, &name).map_err(CudaResizeError::Cuda)?);
+        cache
+            .lock()
+            .expect("bilinear kernel cache poisoned")
+            .entry(channels)
+            .or_insert(built)
+            .clone()
+    };
 
+    let grid_w = dst_width;
     kernel
         .launch_builder(stream)
         .arg(src)
@@ -492,11 +567,10 @@ pub fn launch_resize_u8_bilinear_cuda(
         .arg(&src_width)
         .arg(&dst_width)
         .arg(&dst_height)
-        .arg(&channels)
         .launch_2d(
-            dst_width,
+            grid_w,
             dst_height,
-            make_config(dst_width, dst_height, block_dim),
+            make_config(grid_w, dst_height, block_dim),
         )
         .map_err(|e| CudaResizeError::Cuda(e.to_string()))
 }

--- a/crates/kornia-imgproc/src/cuda/resize_u8.rs
+++ b/crates/kornia-imgproc/src/cuda/resize_u8.rs
@@ -189,7 +189,7 @@ fn nearest_src(channels: usize) -> String {
         }
 "#
         .to_string(),
-        _ => r#"
+        4 => r#"
         #pragma unroll
         for (unsigned int px = 0; px < 4u; ++px) {
             size_t so = rowC + (size_t)__ldg(&xmap[x0 + px]) * C;
@@ -204,6 +204,22 @@ fn nearest_src(channels: usize) -> String {
                 dst[d + px * 4u + 1u] = (unsigned char)((w >> 8) & 0xffu);
                 dst[d + px * 4u + 2u] = (unsigned char)((w >> 16) & 0xffu);
                 dst[d + px * 4u + 3u] = (unsigned char)((w >> 24) & 0xffu);
+            }
+        }
+"#
+        .to_string(),
+        // Any other channel count: plain per-byte gather. The 4-byte packed
+        // form above is only correct when a pixel is exactly one word — the
+        // old catch-all applied it to every C, which over-read the source
+        // and stored at the wrong stride for C != 4.
+        _ => r#"
+        #pragma unroll
+        for (unsigned int px = 0; px < 4u; ++px) {
+            size_t so = rowC + (size_t)__ldg(&xmap[x0 + px]) * C;
+            size_t dd = d + (size_t)px * C;
+            #pragma unroll
+            for (unsigned int ch = 0; ch < C; ++ch) {
+                dst[dd + ch] = __ldg(&src[so + ch]);
             }
         }
 "#
@@ -538,6 +554,9 @@ pub fn launch_resize_u8_nearest_cuda(
 ) -> Result<(), CudaResizeError> {
     super::check_geometry(src_width, src_height, dst_width, dst_height, block_dim)
         .map_err(CudaResizeError::Cuda)?;
+    if channels == 0 {
+        return Err(CudaResizeError::Cuda("channels must be at least 1".into()));
+    }
     check_dst_len(dst.len(), dst_width, dst_height, channels)?;
     if xmap.len() != dst_width as usize || ymap.len() != dst_height as usize {
         return Err(CudaResizeError::Cuda(
@@ -611,6 +630,11 @@ pub fn launch_resize_u8_bilinear_cuda(
 ) -> Result<(), CudaResizeError> {
     super::check_geometry(src_width, src_height, dst_width, dst_height, block_dim)
         .map_err(CudaResizeError::Cuda)?;
+    if !(channels == 1 || channels == 3 || channels == 4) {
+        return Err(CudaResizeError::Cuda(
+            "bilinear supports 1/3/4-channel u8 images".into(),
+        ));
+    }
     if src_width < 2 || src_height < 2 {
         return Err(CudaResizeError::Cuda(
             "bilinear requires source at least 2x2".into(),
@@ -698,6 +722,11 @@ pub fn launch_resize_u8_separable_cuda(
 ) -> Result<(), CudaResizeError> {
     super::check_geometry(src_width, src_height, dst_width, dst_height, block_dim)
         .map_err(CudaResizeError::Cuda)?;
+    if !(channels == 1 || channels == 3 || channels == 4) {
+        return Err(CudaResizeError::Cuda(
+            "separable resize supports 1/3/4-channel u8 images".into(),
+        ));
+    }
     check_dst_len(dst.len(), dst_width, dst_height, channels)?;
     if kx == 0
         || ky == 0

--- a/crates/kornia-imgproc/src/cuda/resize_u8.rs
+++ b/crates/kornia-imgproc/src/cuda/resize_u8.rs
@@ -132,6 +132,19 @@ extern "C" __global__ void resize_u8_pyrup2x_rgb(
 }
 "#;
 
+// Closed experiment (2026-07-18): a fused separable kernel (H-pass into a
+// dynamic-shared i16 band, V-pass out of it, 32x8 output tiles) was built
+// to eliminate the intermediate's DRAM round-trip (~55% of two-pass
+// traffic at 1080p->720p) and REGRESSED decisively: bicubic 0.60->0.90 ms,
+// lanczos 0.96->1.20 ms sustained (interleaved 3-cycle A/B, locked
+// clocks). ncu autopsy: with the PREFER_L1 carveout these kernels rely on,
+// the per-SM shared-memory budget admits only TWO resident blocks
+// (Block Limit Shared Mem = 2), capping occupancy at 33% vs ~85% for the
+// two-pass pair — the lost latency hiding outweighs the traffic saved
+// (L2 absorbs part of the round-trip regardless). Fifth confirmation of
+// the occupancy-over-cleverness rule on Orin; do not re-try smem banding
+// here without first solving the carveout conflict.
+
 /// Nearest kernel source, specialized per channel count: pure gather, four
 /// output pixels per thread with the channel loop fully unrolled so every
 /// load issues independently.

--- a/crates/kornia-imgproc/src/cuda/resize_u8.rs
+++ b/crates/kornia-imgproc/src/cuda/resize_u8.rs
@@ -226,18 +226,22 @@ extern "C" __global__ void resize_u8_bilinear_c{channels}(
     )
 }
 
-static SEP_H_SRC: &str = r#"
-// Q14 separable horizontal pass, byte-exact with horizontal_row_scalar:
-// i32 accumulate over kx taps, round-half-up at Q14, CLAMP TO i16 — the
-// signed 16-bit intermediate (overshooting lobes included) is part of the
-// CPU contract, not an optimization.
-//
-// Loop order is tap-outer / channel-inner with register accumulators: each
-// LUT entry is loaded once (not once per channel) and the C pixel bytes of a
-// tap are consecutive, which roughly halved the kernel time vs the
-// channel-outer form. Accumulation order over taps is unchanged, so the
-// result is bit-identical.
-extern "C" __global__ void resize_u8_sep_h(
+/// Separable-pass kernel sources, specialized per channel count and —
+/// when the element is narrow enough (`k <= 32`) — per tap count, so both
+/// loops fully unroll into independent load issues. Wide antialiased
+/// kernels (k > 32) keep a runtime tap loop (KTAPS == 0 variant).
+/// Byte-exact either way: same i32 accumulation order, same
+/// round-half-up, same i16 clamp.
+fn sep_h_src(channels: usize, ktaps: usize) -> String {
+    let (loop_head, bound) = if ktaps > 0 {
+        ("#pragma unroll".to_string(), format!("{ktaps}u"))
+    } else {
+        (String::new(), "kx".to_string())
+    };
+    format!(
+        r#"
+#define C {channels}
+extern "C" __global__ void resize_u8_sep_h_c{channels}_k{ktaps}(
     const unsigned char* __restrict__  src,
     short* __restrict__                hbuf,
     const unsigned short* __restrict__ xsrc,
@@ -245,41 +249,48 @@ extern "C" __global__ void resize_u8_sep_h(
     unsigned int kx,
     unsigned int src_w,
     unsigned int dst_w,
-    unsigned int src_h,
-    unsigned int channels
-) {
+    unsigned int src_h
+) {{
     unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
     unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
     if (x >= dst_w || y >= src_h) return;
 
-    size_t row = (size_t)y * src_w * channels;
+    size_t row = (size_t)y * src_w * C;
     size_t ibase = (size_t)x * kx;
-    size_t d = ((size_t)y * dst_w + x) * channels;
+    size_t d = ((size_t)y * dst_w + x) * C;
 
-    int acc[4] = {0, 0, 0, 0};
-    for (unsigned int t = 0; t < kx; ++t) {
+    int acc[C] = {{0}};
+    {loop_head}
+    for (unsigned int t = 0; t < {bound}; ++t) {{
         int w = (int)__ldg(&xw[ibase + t]);
         const unsigned char* p =
-            src + row + (size_t)__ldg(&xsrc[ibase + t]) * channels;
-        #pragma unroll 4
-        for (unsigned int ch = 0; ch < channels; ++ch) {
+            src + row + (size_t)__ldg(&xsrc[ibase + t]) * C;
+        #pragma unroll
+        for (unsigned int ch = 0; ch < C; ++ch) {{
             acc[ch] += (int)__ldg(&p[ch]) * w;
-        }
-    }
-    for (unsigned int ch = 0; ch < channels; ++ch) {
+        }}
+    }}
+    #pragma unroll
+    for (unsigned int ch = 0; ch < C; ++ch) {{
         int v = (acc[ch] + (1 << 13)) >> 14;
         v = min(max(v, -32768), 32767);
         hbuf[d + ch] = (short)v;
-    }
+    }}
+}}
+"#
+    )
 }
-"#;
 
-static SEP_V_SRC: &str = r#"
-// Q14 separable vertical pass, byte-exact with vertical_row_scalar: i16
-// intermediate in, i32 accumulate, round-half-up at Q14, clamp to u8.
-// Row indices clamp to [0, src_h-1] per tap (border replicate), exactly as
-// the CPU's per-tap clamp.
-extern "C" __global__ void resize_u8_sep_v(
+fn sep_v_src(channels: usize, ktaps: usize) -> String {
+    let (loop_head, bound) = if ktaps > 0 {
+        ("#pragma unroll".to_string(), format!("{ktaps}u"))
+    } else {
+        (String::new(), "ky".to_string())
+    };
+    format!(
+        r#"
+#define C {channels}
+extern "C" __global__ void resize_u8_sep_v_c{channels}_k{ktaps}(
     const short* __restrict__ hbuf,
     unsigned char* __restrict__ dst,
     const int* __restrict__     yofs,
@@ -287,35 +298,36 @@ extern "C" __global__ void resize_u8_sep_v(
     unsigned int ky,
     unsigned int src_h,
     unsigned int dst_w,
-    unsigned int dst_h,
-    unsigned int channels
-) {
+    unsigned int dst_h
+) {{
     unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
     unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
     if (x >= dst_w || y >= dst_h) return;
 
     int y0 = __ldg(&yofs[y]);
     size_t wbase = (size_t)y * ky;
-    size_t d = ((size_t)y * dst_w + x) * channels;
+    size_t d = ((size_t)y * dst_w + x) * C;
 
-    // Tap-outer / channel-inner (see the horizontal kernel): one LUT load
-    // and one row-base computation per tap, C consecutive i16 reads.
-    int acc[4] = {0, 0, 0, 0};
-    for (unsigned int k = 0; k < ky; ++k) {
+    int acc[C] = {{0}};
+    {loop_head}
+    for (unsigned int k = 0; k < {bound}; ++k) {{
         int w = (int)__ldg(&yw[wbase + k]);
         int sy = min(max(y0 + (int)k, 0), (int)src_h - 1);
-        const short* p = hbuf + ((size_t)sy * dst_w + x) * channels;
-        #pragma unroll 4
-        for (unsigned int ch = 0; ch < channels; ++ch) {
+        const short* p = hbuf + ((size_t)sy * dst_w + x) * C;
+        #pragma unroll
+        for (unsigned int ch = 0; ch < C; ++ch) {{
             acc[ch] += (int)__ldg(&p[ch]) * w;
-        }
-    }
-    for (unsigned int ch = 0; ch < channels; ++ch) {
+        }}
+    }}
+    #pragma unroll
+    for (unsigned int ch = 0; ch < C; ++ch) {{
         int v = (acc[ch] + (1 << 13)) >> 14;
         dst[d + ch] = (unsigned char)min(max(v, 0), 255);
-    }
+    }}
+}}
+"#
+    )
 }
-"#;
 
 static PYRDOWN2X_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
 static PYRUP2X_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
@@ -324,8 +336,11 @@ static NEAREST_KERNELS: OnceLock<PerCKernelCache> = OnceLock::new();
 /// Per-channel-count specialized bilinear kernels (C is baked into the
 /// source so the pixel loop fully unrolls).
 static BILINEAR_KERNELS: OnceLock<PerCKernelCache> = OnceLock::new();
-static SEP_H_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
-static SEP_V_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
+type SepKernelCache = Mutex<HashMap<(u32, u32, bool), Arc<CudaKernel>>>;
+static SEP_KERNELS: OnceLock<SepKernelCache> = OnceLock::new();
+/// Tap counts up to this are baked into specialized kernels; wider
+/// (strongly antialiased) elements use the runtime-loop variant.
+const SEP_MAX_BAKED_TAPS: u32 = 32;
 
 fn get_kernel<'a>(
     cell: &'a OnceLock<Result<CudaKernel, String>>,
@@ -616,8 +631,42 @@ pub fn launch_resize_u8_separable_cuda(
         ));
     }
 
-    let kernel_h = get_kernel(&SEP_H_KERNEL, ctx, SEP_H_SRC, "resize_u8_sep_h")?;
-    let kernel_v = get_kernel(&SEP_V_KERNEL, ctx, SEP_V_SRC, "resize_u8_sep_v")?;
+    // Per-(C, taps) specialized kernels; wide antialiased elements fall back
+    // to the runtime-loop variant (ktaps = 0). Scoped-guard cache lookups.
+    let sep_kernel = |horizontal: bool, k: u32| -> Result<Arc<CudaKernel>, CudaResizeError> {
+        let baked = if k <= SEP_MAX_BAKED_TAPS { k } else { 0 };
+        let cache = SEP_KERNELS.get_or_init(Default::default);
+        let key = (channels, baked, horizontal);
+        let cached = cache
+            .lock()
+            .expect("separable kernel cache poisoned")
+            .get(&key)
+            .cloned();
+        if let Some(hit) = cached {
+            return Ok(hit);
+        }
+        let (src_code, name) = if horizontal {
+            (
+                sep_h_src(channels as usize, baked as usize),
+                format!("resize_u8_sep_h_c{channels}_k{baked}"),
+            )
+        } else {
+            (
+                sep_v_src(channels as usize, baked as usize),
+                format!("resize_u8_sep_v_c{channels}_k{baked}"),
+            )
+        };
+        let built =
+            Arc::new(try_compile_with_l1(ctx, &src_code, &name).map_err(CudaResizeError::Cuda)?);
+        Ok(cache
+            .lock()
+            .expect("separable kernel cache poisoned")
+            .entry(key)
+            .or_insert(built)
+            .clone())
+    };
+    let kernel_h = sep_kernel(true, kx)?;
+    let kernel_v = sep_kernel(false, ky)?;
 
     // Intermediate: src_h rows of dst_w pixels, i16. Pass 1 writes every
     // element before pass 2 reads; no zero-fill needed.
@@ -635,7 +684,6 @@ pub fn launch_resize_u8_separable_cuda(
         .arg(&src_width)
         .arg(&dst_width)
         .arg(&src_height)
-        .arg(&channels)
         .launch_2d(
             dst_width,
             src_height,
@@ -653,7 +701,6 @@ pub fn launch_resize_u8_separable_cuda(
         .arg(&src_height)
         .arg(&dst_width)
         .arg(&dst_height)
-        .arg(&channels)
         .launch_2d(
             dst_width,
             dst_height,

--- a/crates/kornia-imgproc/src/cuda/resize_u8.rs
+++ b/crates/kornia-imgproc/src/cuda/resize_u8.rs
@@ -1,0 +1,585 @@
+//! Native CUDA u8 resize kernels, byte-exact with the CPU u8 fast paths.
+//!
+//! # Integer-LUT strategy (why this is NOT the f32 `PixelMapping` design)
+//!
+//! The f32 resize kernels achieve CPU/GPU bit-parity by mirroring float
+//! expression trees under `--fmad=false`. The u8 CPU paths are different
+//! animals: they precompute coordinates in **f64** on the host and run pure
+//! integer fixed-point pixel loops (Q14 weights, round-half-up `+half >> Q`).
+//! No device float expression can reproduce host f64 rounding — so instead we
+//! upload the host-built integer tables and keep every kernel integer-only.
+//! Byte-exactness then holds by construction, and the tests `assert_eq!`.
+//!
+//! The tables MUST come from the same builders the CPU uses
+//! (`resize::bilinear::bilinear_axis_lut`, `resize::nearest::nearest_axis_lut`,
+//! `resize::common::precompute_contribs`); the `resize::cuda` adapter is the
+//! one caller and enforces this. The launchers here only check shapes.
+//!
+//! # Kernel ↔ CPU reference map (each pinned by a parity test)
+//!
+//! | Kernel                      | CPU reference                             | Rounding |
+//! |-----------------------------|-------------------------------------------|----------|
+//! | `resize_u8_pyrdown2x_rgb`   | `resize::kernels::pyrdown_row_rgb_u8`     | `(a+b+c+d+2)>>2` |
+//! | `resize_u8_pyrup2x_rgb`     | `resize::kernels::{hinterp_row_rgb_u8, blend_75_25_row}` | nested `(a+b+1)>>1` twice |
+//! | `resize_u8_nearest`         | `resize::nearest::resize_nearest_u8`      | pure gather |
+//! | `resize_u8_bilinear`        | `resize::kernels::bilinear_row_u8`        | u64 `(...+ 1<<27) >> 28` |
+//! | `resize_u8_sep_h` / `_v`    | `resize::kernels::{horizontal_row_scalar, vertical_row_scalar}` | i32 `(acc + 1<<13) >> 14`, i16 intermediate |
+//!
+//! The pyrup kernel reproduces the CPU's **nested rounding averages**
+//! (`avg=(a+b+1)>>1; out=(x+avg+1)>>1`), NOT the algebraic `(3a+b+2)>>2` —
+//! the two round differently (e.g. a=1, b=2).
+//!
+//! Signed `>>` is an arithmetic shift in both CUDA and Rust, which the
+//! separable kernels rely on for negative bicubic/lanczos accumulators —
+//! same guarantee `cuda/color` documents.
+
+use std::sync::{Arc, OnceLock};
+
+use cudarc::driver::{CudaContext, CudaSlice, CudaStream};
+use kornia_tensor::CudaKernel;
+
+use super::resize::CudaResizeError;
+use super::{make_config, try_compile_with_l1};
+
+// ── CUDA C sources ────────────────────────────────────────────────────────────
+
+static PYRDOWN2X_SRC: &str = r#"
+extern "C" __global__ void resize_u8_pyrdown2x_rgb(
+    const unsigned char* __restrict__ src,
+    unsigned char* __restrict__       dst,
+    unsigned int dst_w,
+    unsigned int dst_h
+) {
+    unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x >= dst_w || y >= dst_h) return;
+
+    unsigned int src_w = dst_w * 2u;
+    size_t r0 = (size_t)(2u * y) * src_w * 3u;
+    size_t r1 = r0 + (size_t)src_w * 3u;
+    size_t c0 = (size_t)(2u * x) * 3u;
+    size_t d  = ((size_t)y * dst_w + x) * 3u;
+
+    #pragma unroll
+    for (int ch = 0; ch < 3; ++ch) {
+        unsigned int sum = (unsigned int)__ldg(&src[r0 + c0 + ch])
+                         + (unsigned int)__ldg(&src[r0 + c0 + 3u + ch])
+                         + (unsigned int)__ldg(&src[r1 + c0 + ch])
+                         + (unsigned int)__ldg(&src[r1 + c0 + 3u + ch]);
+        dst[d + ch] = (unsigned char)((sum + 2u) >> 2);
+    }
+}
+"#;
+
+static PYRUP2X_SRC: &str = r#"
+// Horizontal 2x sample of one source row at dst column x (see
+// hinterp_row_rgb_u8): edges are clamped copies, interior pixels are the
+// nested {0.75, 0.25} rounding blend of neighbours j and j+1.
+__device__ __forceinline__ unsigned int pyrup_hval(
+    const unsigned char* __restrict__ row,
+    unsigned int x, unsigned int src_w, unsigned int ch
+) {
+    if (x == 0u) return (unsigned int)__ldg(&row[ch]);
+    if (x == 2u * src_w - 1u) return (unsigned int)__ldg(&row[(size_t)(src_w - 1u) * 3u + ch]);
+    unsigned int j = (x - 1u) >> 1;
+    unsigned int a = (unsigned int)__ldg(&row[(size_t)j * 3u + ch]);
+    unsigned int b = (unsigned int)__ldg(&row[(size_t)(j + 1u) * 3u + ch]);
+    unsigned int avg = (a + b + 1u) >> 1;
+    // dst[2j+1] leans on a (0.75a + 0.25b), dst[2j+2] leans on b.
+    return (x & 1u) ? ((a + avg + 1u) >> 1) : ((b + avg + 1u) >> 1);
+}
+
+extern "C" __global__ void resize_u8_pyrup2x_rgb(
+    const unsigned char* __restrict__ src,
+    unsigned char* __restrict__       dst,
+    unsigned int src_w,
+    unsigned int src_h
+) {
+    unsigned int dst_w = src_w * 2u;
+    unsigned int dst_h = src_h * 2u;
+    unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x >= dst_w || y >= dst_h) return;
+
+    size_t src_stride = (size_t)src_w * 3u;
+    size_t d = ((size_t)y * dst_w + x) * 3u;
+
+    if (y == 0u || y == dst_h - 1u) {
+        // Edge rows: horizontal pass of the clamped source row only.
+        const unsigned char* row = src + (y == 0u ? 0 : (size_t)(src_h - 1u) * src_stride);
+        #pragma unroll
+        for (int ch = 0; ch < 3; ++ch) {
+            dst[d + ch] = (unsigned char)pyrup_hval(row, x, src_w, ch);
+        }
+        return;
+    }
+
+    // Inner rows: block I consumes source rows (I, I+1); dst row 2I+1 leans
+    // on row I, dst row 2I+2 leans on row I+1 (same nested blend as the
+    // horizontal direction).
+    unsigned int i = (y - 1u) >> 1;
+    const unsigned char* ra = src + (size_t)i * src_stride;
+    const unsigned char* rb = src + (size_t)(i + 1u) * src_stride;
+    #pragma unroll
+    for (int ch = 0; ch < 3; ++ch) {
+        unsigned int a = pyrup_hval(ra, x, src_w, ch);
+        unsigned int b = pyrup_hval(rb, x, src_w, ch);
+        unsigned int avg = (a + b + 1u) >> 1;
+        dst[d + ch] = (unsigned char)((y & 1u) ? ((a + avg + 1u) >> 1)
+                                               : ((b + avg + 1u) >> 1));
+    }
+}
+"#;
+
+static NEAREST_SRC: &str = r#"
+extern "C" __global__ void resize_u8_nearest(
+    const unsigned char* __restrict__ src,
+    unsigned char* __restrict__       dst,
+    const int* __restrict__           xmap,
+    const int* __restrict__           ymap,
+    unsigned int src_w,
+    unsigned int dst_w,
+    unsigned int dst_h,
+    unsigned int channels
+) {
+    unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x >= dst_w || y >= dst_h) return;
+
+    size_t so = ((size_t)__ldg(&ymap[y]) * src_w + (size_t)__ldg(&xmap[x])) * channels;
+    size_t d  = ((size_t)y * dst_w + x) * channels;
+    for (unsigned int ch = 0; ch < channels; ++ch) {
+        dst[d + ch] = __ldg(&src[so + ch]);
+    }
+}
+"#;
+
+static BILINEAR_SRC: &str = r#"
+// Q14 bilinear, byte-exact with bilinear_row_u8: the blend runs in 64-bit,
+// with ONE round-half-up at the final Q28 shift. fx/fy come from the host
+// f64 LUTs; fx1 = 16384 - fx is exact in integer arithmetic.
+extern "C" __global__ void resize_u8_bilinear(
+    const unsigned char* __restrict__ src,
+    unsigned char* __restrict__       dst,
+    const unsigned int* __restrict__  xofs,
+    const unsigned int* __restrict__  xfx,
+    const unsigned int* __restrict__  yofs,
+    const unsigned int* __restrict__  yfy,
+    unsigned int src_w,
+    unsigned int dst_w,
+    unsigned int dst_h,
+    unsigned int channels
+) {
+    unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x >= dst_w || y >= dst_h) return;
+
+    const unsigned long long SCALE = 16384ull;
+    unsigned long long fx  = (unsigned long long)__ldg(&xfx[x]);
+    unsigned long long fy  = (unsigned long long)__ldg(&yfy[y]);
+    unsigned long long fx1 = SCALE - fx;
+    unsigned long long fy1 = SCALE - fy;
+
+    size_t r0 = ((size_t)__ldg(&yofs[y]) * src_w + (size_t)__ldg(&xofs[x])) * channels;
+    size_t r1 = r0 + (size_t)src_w * channels;
+    size_t d  = ((size_t)y * dst_w + x) * channels;
+
+    for (unsigned int ch = 0; ch < channels; ++ch) {
+        unsigned long long p00 = (unsigned long long)__ldg(&src[r0 + ch]);
+        unsigned long long p01 = (unsigned long long)__ldg(&src[r0 + channels + ch]);
+        unsigned long long p10 = (unsigned long long)__ldg(&src[r1 + ch]);
+        unsigned long long p11 = (unsigned long long)__ldg(&src[r1 + channels + ch]);
+        unsigned long long top = p00 * fx1 + p01 * fx;
+        unsigned long long bot = p10 * fx1 + p11 * fx;
+        dst[d + ch] = (unsigned char)((top * fy1 + bot * fy + (1ull << 27)) >> 28);
+    }
+}
+"#;
+
+static SEP_H_SRC: &str = r#"
+// Q14 separable horizontal pass, byte-exact with horizontal_row_scalar:
+// i32 accumulate over kx taps, round-half-up at Q14, CLAMP TO i16 — the
+// signed 16-bit intermediate (overshooting lobes included) is part of the
+// CPU contract, not an optimization.
+extern "C" __global__ void resize_u8_sep_h(
+    const unsigned char* __restrict__  src,
+    short* __restrict__                hbuf,
+    const unsigned short* __restrict__ xsrc,
+    const short* __restrict__          xw,
+    unsigned int kx,
+    unsigned int src_w,
+    unsigned int dst_w,
+    unsigned int src_h,
+    unsigned int channels
+) {
+    unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x >= dst_w || y >= src_h) return;
+
+    size_t row = (size_t)y * src_w * channels;
+    size_t ibase = (size_t)x * kx;
+    size_t d = ((size_t)y * dst_w + x) * channels;
+
+    for (unsigned int ch = 0; ch < channels; ++ch) {
+        int acc = 0;
+        for (unsigned int t = 0; t < kx; ++t) {
+            unsigned int sx = (unsigned int)__ldg(&xsrc[ibase + t]);
+            acc += (int)__ldg(&src[row + (size_t)sx * channels + ch])
+                 * (int)__ldg(&xw[ibase + t]);
+        }
+        int v = (acc + (1 << 13)) >> 14;
+        v = min(max(v, -32768), 32767);
+        hbuf[d + ch] = (short)v;
+    }
+}
+"#;
+
+static SEP_V_SRC: &str = r#"
+// Q14 separable vertical pass, byte-exact with vertical_row_scalar: i16
+// intermediate in, i32 accumulate, round-half-up at Q14, clamp to u8.
+// Row indices clamp to [0, src_h-1] per tap (border replicate), exactly as
+// the CPU's per-tap clamp.
+extern "C" __global__ void resize_u8_sep_v(
+    const short* __restrict__ hbuf,
+    unsigned char* __restrict__ dst,
+    const int* __restrict__     yofs,
+    const short* __restrict__   yw,
+    unsigned int ky,
+    unsigned int src_h,
+    unsigned int dst_w,
+    unsigned int dst_h,
+    unsigned int channels
+) {
+    unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x >= dst_w || y >= dst_h) return;
+
+    int y0 = __ldg(&yofs[y]);
+    size_t wbase = (size_t)y * ky;
+    size_t d = ((size_t)y * dst_w + x) * channels;
+
+    for (unsigned int ch = 0; ch < channels; ++ch) {
+        int acc = 0;
+        for (unsigned int k = 0; k < ky; ++k) {
+            int sy = min(max(y0 + (int)k, 0), (int)src_h - 1);
+            acc += (int)__ldg(&hbuf[((size_t)sy * dst_w + x) * channels + ch])
+                 * (int)__ldg(&yw[wbase + k]);
+        }
+        int v = (acc + (1 << 13)) >> 14;
+        dst[d + ch] = (unsigned char)min(max(v, 0), 255);
+    }
+}
+"#;
+
+static PYRDOWN2X_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
+static PYRUP2X_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
+static NEAREST_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
+static BILINEAR_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
+static SEP_H_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
+static SEP_V_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
+
+fn get_kernel<'a>(
+    cell: &'a OnceLock<Result<CudaKernel, String>>,
+    ctx: &Arc<CudaContext>,
+    src: &str,
+    name: &str,
+) -> Result<&'a CudaKernel, CudaResizeError> {
+    cell.get_or_init(|| try_compile_with_l1(ctx, src, name))
+        .as_ref()
+        .map_err(|e| CudaResizeError::Cuda(e.clone()))
+}
+
+fn check_dst_len(dst_len: usize, w: u32, h: u32, channels: u32) -> Result<(), CudaResizeError> {
+    let need = (w as usize) * (h as usize) * (channels as usize);
+    if dst_len < need {
+        return Err(CudaResizeError::SliceTooSmall { got: dst_len, need });
+    }
+    Ok(())
+}
+
+fn to_cuda_err(e: cudarc::driver::result::DriverError) -> CudaResizeError {
+    CudaResizeError::Cuda(e.to_string())
+}
+
+// ── Public launchers ──────────────────────────────────────────────────────────
+
+/// Exact-2× box-average downscale for RGB u8 (`dst = src/2` on both axes).
+/// Byte-exact with `pyrdown_2x_rgb_u8`.
+pub fn launch_resize_u8_pyrdown2x_rgb_cuda(
+    ctx: &Arc<CudaContext>,
+    stream: &Arc<CudaStream>,
+    src: &CudaSlice<u8>,
+    dst: &mut CudaSlice<u8>,
+    dst_width: u32,
+    dst_height: u32,
+    block_dim: Option<(u32, u32)>,
+) -> Result<(), CudaResizeError> {
+    super::check_geometry(
+        dst_width * 2,
+        dst_height * 2,
+        dst_width,
+        dst_height,
+        block_dim,
+    )
+    .map_err(CudaResizeError::Cuda)?;
+    check_dst_len(dst.len(), dst_width, dst_height, 3)?;
+
+    let kernel = get_kernel(
+        &PYRDOWN2X_KERNEL,
+        ctx,
+        PYRDOWN2X_SRC,
+        "resize_u8_pyrdown2x_rgb",
+    )?;
+    kernel
+        .launch_builder(stream)
+        .arg(src)
+        .arg(dst)
+        .arg(&dst_width)
+        .arg(&dst_height)
+        .launch_2d(
+            dst_width,
+            dst_height,
+            make_config(dst_width, dst_height, block_dim),
+        )
+        .map_err(|e| CudaResizeError::Cuda(e.to_string()))
+}
+
+/// Exact-2× bilinear upscale for RGB u8 (`dst = src*2` on both axes).
+/// Byte-exact with `pyrup_2x_rgb_u8` (nested rounding-average blend).
+pub fn launch_resize_u8_pyrup2x_rgb_cuda(
+    ctx: &Arc<CudaContext>,
+    stream: &Arc<CudaStream>,
+    src: &CudaSlice<u8>,
+    dst: &mut CudaSlice<u8>,
+    src_width: u32,
+    src_height: u32,
+    block_dim: Option<(u32, u32)>,
+) -> Result<(), CudaResizeError> {
+    let (dst_w, dst_h) = (src_width * 2, src_height * 2);
+    super::check_geometry(src_width, src_height, dst_w, dst_h, block_dim)
+        .map_err(CudaResizeError::Cuda)?;
+    if src_width < 2 || src_height < 2 {
+        return Err(CudaResizeError::Cuda(
+            "pyrup2x requires source at least 2x2".into(),
+        ));
+    }
+    check_dst_len(dst.len(), dst_w, dst_h, 3)?;
+
+    let kernel = get_kernel(&PYRUP2X_KERNEL, ctx, PYRUP2X_SRC, "resize_u8_pyrup2x_rgb")?;
+    kernel
+        .launch_builder(stream)
+        .arg(src)
+        .arg(dst)
+        .arg(&src_width)
+        .arg(&src_height)
+        .launch_2d(dst_w, dst_h, make_config(dst_w, dst_h, block_dim))
+        .map_err(|e| CudaResizeError::Cuda(e.to_string()))
+}
+
+/// Nearest-neighbor u8 resize via host-built index LUTs (pure gather).
+///
+/// `xmap`/`ymap` MUST come from `nearest_axis_lut` for CPU parity; entries
+/// must lie in `[0, src_len-1]` (the builders clamp).
+#[allow(clippy::too_many_arguments)]
+pub fn launch_resize_u8_nearest_cuda(
+    ctx: &Arc<CudaContext>,
+    stream: &Arc<CudaStream>,
+    src: &CudaSlice<u8>,
+    dst: &mut CudaSlice<u8>,
+    src_width: u32,
+    src_height: u32,
+    dst_width: u32,
+    dst_height: u32,
+    channels: u32,
+    xmap: &[i32],
+    ymap: &[i32],
+    block_dim: Option<(u32, u32)>,
+) -> Result<(), CudaResizeError> {
+    super::check_geometry(src_width, src_height, dst_width, dst_height, block_dim)
+        .map_err(CudaResizeError::Cuda)?;
+    check_dst_len(dst.len(), dst_width, dst_height, channels)?;
+    if xmap.len() != dst_width as usize || ymap.len() != dst_height as usize {
+        return Err(CudaResizeError::Cuda(
+            "xmap/ymap length must equal dst width/height".into(),
+        ));
+    }
+
+    let kernel = get_kernel(&NEAREST_KERNEL, ctx, NEAREST_SRC, "resize_u8_nearest")?;
+    let d_xmap = stream.clone_htod(xmap).map_err(to_cuda_err)?;
+    let d_ymap = stream.clone_htod(ymap).map_err(to_cuda_err)?;
+
+    kernel
+        .launch_builder(stream)
+        .arg(src)
+        .arg(dst)
+        .arg(&d_xmap)
+        .arg(&d_ymap)
+        .arg(&src_width)
+        .arg(&dst_width)
+        .arg(&dst_height)
+        .arg(&channels)
+        .launch_2d(
+            dst_width,
+            dst_height,
+            make_config(dst_width, dst_height, block_dim),
+        )
+        .map_err(|e| CudaResizeError::Cuda(e.to_string()))
+}
+
+/// Q14 bilinear u8 resize via host-built tap LUTs.
+///
+/// `xofs`/`xfx` and `yofs`/`yfy` MUST come from `bilinear_axis_lut` for CPU
+/// parity: offsets clamped to `[0, src_len-2]`, weights in `[0, 16384]`.
+/// Requires a source of at least 2×2 (the `ofs+1` neighbor read).
+#[allow(clippy::too_many_arguments)]
+pub fn launch_resize_u8_bilinear_cuda(
+    ctx: &Arc<CudaContext>,
+    stream: &Arc<CudaStream>,
+    src: &CudaSlice<u8>,
+    dst: &mut CudaSlice<u8>,
+    src_width: u32,
+    src_height: u32,
+    dst_width: u32,
+    dst_height: u32,
+    channels: u32,
+    xofs: &[u32],
+    xfx: &[u32],
+    yofs: &[u32],
+    yfy: &[u32],
+    block_dim: Option<(u32, u32)>,
+) -> Result<(), CudaResizeError> {
+    super::check_geometry(src_width, src_height, dst_width, dst_height, block_dim)
+        .map_err(CudaResizeError::Cuda)?;
+    if src_width < 2 || src_height < 2 {
+        return Err(CudaResizeError::Cuda(
+            "bilinear requires source at least 2x2".into(),
+        ));
+    }
+    check_dst_len(dst.len(), dst_width, dst_height, channels)?;
+    if xofs.len() != dst_width as usize
+        || xfx.len() != dst_width as usize
+        || yofs.len() != dst_height as usize
+        || yfy.len() != dst_height as usize
+    {
+        return Err(CudaResizeError::Cuda(
+            "bilinear LUT lengths must equal dst width/height".into(),
+        ));
+    }
+
+    let kernel = get_kernel(&BILINEAR_KERNEL, ctx, BILINEAR_SRC, "resize_u8_bilinear")?;
+    let d_xofs = stream.clone_htod(xofs).map_err(to_cuda_err)?;
+    let d_xfx = stream.clone_htod(xfx).map_err(to_cuda_err)?;
+    let d_yofs = stream.clone_htod(yofs).map_err(to_cuda_err)?;
+    let d_yfy = stream.clone_htod(yfy).map_err(to_cuda_err)?;
+
+    kernel
+        .launch_builder(stream)
+        .arg(src)
+        .arg(dst)
+        .arg(&d_xofs)
+        .arg(&d_xfx)
+        .arg(&d_yofs)
+        .arg(&d_yfy)
+        .arg(&src_width)
+        .arg(&dst_width)
+        .arg(&dst_height)
+        .arg(&channels)
+        .launch_2d(
+            dst_width,
+            dst_height,
+            make_config(dst_width, dst_height, block_dim),
+        )
+        .map_err(|e| CudaResizeError::Cuda(e.to_string()))
+}
+
+/// Q14 separable bicubic / lanczos u8 resize (two passes, i16 intermediate).
+///
+/// Tables MUST come from `precompute_contribs` + `build_xsrc_lut` +
+/// `pack_xw_i16` — including the antialias kernel widening — for CPU parity.
+/// The i16 scratch (`src_h × dst_w × channels`) is stream-ordered allocated
+/// per call; with the mempool release threshold raised, steady-state cost
+/// is a pool lookup.
+#[allow(clippy::too_many_arguments)]
+pub fn launch_resize_u8_separable_cuda(
+    ctx: &Arc<CudaContext>,
+    stream: &Arc<CudaStream>,
+    src: &CudaSlice<u8>,
+    dst: &mut CudaSlice<u8>,
+    src_width: u32,
+    src_height: u32,
+    dst_width: u32,
+    dst_height: u32,
+    channels: u32,
+    xsrc: &[u16],
+    xw: &[i16],
+    kx: u32,
+    yofs: &[i32],
+    yw: &[i16],
+    ky: u32,
+    block_dim: Option<(u32, u32)>,
+) -> Result<(), CudaResizeError> {
+    super::check_geometry(src_width, src_height, dst_width, dst_height, block_dim)
+        .map_err(CudaResizeError::Cuda)?;
+    check_dst_len(dst.len(), dst_width, dst_height, channels)?;
+    if kx == 0
+        || ky == 0
+        || xsrc.len() != (dst_width * kx) as usize
+        || xw.len() != (dst_width * kx) as usize
+        || yofs.len() != dst_height as usize
+        || yw.len() != (dst_height * ky) as usize
+    {
+        return Err(CudaResizeError::Cuda(
+            "separable LUT lengths must match dst dims x tap counts".into(),
+        ));
+    }
+
+    let kernel_h = get_kernel(&SEP_H_KERNEL, ctx, SEP_H_SRC, "resize_u8_sep_h")?;
+    let kernel_v = get_kernel(&SEP_V_KERNEL, ctx, SEP_V_SRC, "resize_u8_sep_v")?;
+
+    let d_xsrc = stream.clone_htod(xsrc).map_err(to_cuda_err)?;
+    let d_xw = stream.clone_htod(xw).map_err(to_cuda_err)?;
+    let d_yofs = stream.clone_htod(yofs).map_err(to_cuda_err)?;
+    let d_yw = stream.clone_htod(yw).map_err(to_cuda_err)?;
+
+    // Intermediate: src_h rows of dst_w pixels, i16. Pass 1 writes every
+    // element before pass 2 reads; no zero-fill needed.
+    let inter_len = (src_height as usize) * (dst_width as usize) * (channels as usize);
+    let mut hbuf = unsafe { stream.alloc::<i16>(inter_len) }
+        .map_err(|e| CudaResizeError::Cuda(e.to_string()))?;
+
+    kernel_h
+        .launch_builder(stream)
+        .arg(src)
+        .arg(&mut hbuf)
+        .arg(&d_xsrc)
+        .arg(&d_xw)
+        .arg(&kx)
+        .arg(&src_width)
+        .arg(&dst_width)
+        .arg(&src_height)
+        .arg(&channels)
+        .launch_2d(
+            dst_width,
+            src_height,
+            make_config(dst_width, src_height, block_dim),
+        )
+        .map_err(|e| CudaResizeError::Cuda(e.to_string()))?;
+
+    kernel_v
+        .launch_builder(stream)
+        .arg(&hbuf)
+        .arg(dst)
+        .arg(&d_yofs)
+        .arg(&d_yw)
+        .arg(&ky)
+        .arg(&src_height)
+        .arg(&dst_width)
+        .arg(&dst_height)
+        .arg(&channels)
+        .launch_2d(
+            dst_width,
+            dst_height,
+            make_config(dst_width, dst_height, block_dim),
+        )
+        .map_err(|e| CudaResizeError::Cuda(e.to_string()))
+}

--- a/crates/kornia-imgproc/src/resize/bilinear.rs
+++ b/crates/kornia-imgproc/src/resize/bilinear.rs
@@ -38,10 +38,7 @@ pub(super) fn bilinear_tap(i: usize, scale: f64, src_len: usize) -> (u32, u32) {
 }
 
 /// Per-axis Q14 bilinear LUT: `(ofs, fx, fx1)` with `fx1 = 16384 - fx`.
-pub(super) fn bilinear_axis_lut(
-    src_len: usize,
-    dst_len: usize,
-) -> (Vec<u32>, Vec<u32>, Vec<u32>) {
+pub(super) fn bilinear_axis_lut(src_len: usize, dst_len: usize) -> (Vec<u32>, Vec<u32>, Vec<u32>) {
     let scale = src_len as f64 / dst_len as f64;
     let mut ofs = Vec::with_capacity(dst_len);
     let mut fx = Vec::with_capacity(dst_len);

--- a/crates/kornia-imgproc/src/resize/bilinear.rs
+++ b/crates/kornia-imgproc/src/resize/bilinear.rs
@@ -10,6 +10,51 @@ use rayon::prelude::*;
 
 use super::kernels::{bilinear_row_u8, BilinearXTaps};
 
+/// Q14 fixed-point scale shared by the bilinear taps.
+pub(super) const Q14_SCALE: u32 = 1 << 14;
+
+/// One Q14 bilinear tap for destination index `i` on an axis of length
+/// `src_len` sampled at `scale = src_len / dst_len`: returns `(ofs, fq)`
+/// where `ofs` is the left source index (clamped to `[0, src_len-2]`) and
+/// `fq ∈ [0, 16384]` the Q14 fractional weight of the right neighbor.
+///
+/// BYTE-EXACT CONTRACT: this f64 half-pixel computation is the single source
+/// of the u8 bilinear coordinates — the CPU LUTs and the CUDA `resize_u8`
+/// launcher both call it, so the two backends cannot drift.
+#[inline]
+pub(super) fn bilinear_tap(i: usize, scale: f64, src_len: usize) -> (u32, u32) {
+    let s = (i as f64 + 0.5) * scale - 0.5;
+    let i0 = s.floor() as i64;
+    let f = s - i0 as f64;
+    let (i0, f) = if i0 < 0 {
+        (0i64, 0.0)
+    } else if i0 >= src_len as i64 - 1 {
+        (src_len as i64 - 2, 1.0)
+    } else {
+        (i0, f)
+    };
+    let fq = ((f * Q14_SCALE as f64).round() as u32).min(Q14_SCALE);
+    (i0 as u32, fq)
+}
+
+/// Per-axis Q14 bilinear LUT: `(ofs, fx, fx1)` with `fx1 = 16384 - fx`.
+pub(super) fn bilinear_axis_lut(
+    src_len: usize,
+    dst_len: usize,
+) -> (Vec<u32>, Vec<u32>, Vec<u32>) {
+    let scale = src_len as f64 / dst_len as f64;
+    let mut ofs = Vec::with_capacity(dst_len);
+    let mut fx = Vec::with_capacity(dst_len);
+    let mut fx1 = Vec::with_capacity(dst_len);
+    for i in 0..dst_len {
+        let (o, fq) = bilinear_tap(i, scale, src_len);
+        ofs.push(o);
+        fx.push(fq);
+        fx1.push(Q14_SCALE - fq);
+    }
+    (ofs, fx, fx1)
+}
+
 /// Generic N-channel bilinear u8 resize with precomputed x tables.
 pub(super) fn resize_bilinear_u8_nch<const C: usize>(
     src: &[u8],
@@ -19,30 +64,8 @@ pub(super) fn resize_bilinear_u8_nch<const C: usize>(
     dst_w: usize,
     dst_h: usize,
 ) {
-    const Q: u32 = 14;
-    const SCALE: u32 = 1 << Q;
-    let scale_x = src_w as f64 / dst_w as f64;
     let scale_y = src_h as f64 / dst_h as f64;
-
-    let mut xofs = Vec::<u32>::with_capacity(dst_w);
-    let mut xfx = Vec::<u32>::with_capacity(dst_w);
-    let mut xfx1 = Vec::<u32>::with_capacity(dst_w);
-    for x in 0..dst_w {
-        let sx = (x as f64 + 0.5) * scale_x - 0.5;
-        let xi = sx.floor() as i64;
-        let f = sx - xi as f64;
-        let (xi, f) = if xi < 0 {
-            (0i64, 0.0)
-        } else if xi >= src_w as i64 - 1 {
-            (src_w as i64 - 2, 1.0)
-        } else {
-            (xi, f)
-        };
-        let fq = ((f * SCALE as f64).round() as u32).min(SCALE);
-        xofs.push(xi as u32);
-        xfx.push(fq);
-        xfx1.push(SCALE - fq);
-    }
+    let (xofs, xfx, xfx1) = bilinear_axis_lut(src_w, dst_w);
 
     let src_stride = src_w * C;
     let dst_stride = dst_w * C;
@@ -62,21 +85,12 @@ pub(super) fn resize_bilinear_u8_nch<const C: usize>(
                 .enumerate()
                 .for_each(|(dr, dst_row)| {
                     let y = row_base + dr;
-                    let sy = (y as f64 + 0.5) * scale_y - 0.5;
-                    let yi = sy.floor() as i64;
-                    let f = sy - yi as f64;
-                    let (yi, f) = if yi < 0 {
-                        (0i64, 0.0)
-                    } else if yi >= src_h as i64 - 1 {
-                        (src_h as i64 - 2, 1.0)
-                    } else {
-                        (yi, f)
-                    };
-                    let fy = ((f * SCALE as f64).round() as u32).min(SCALE);
-                    let fy1 = SCALE - fy;
+                    let (yi, fy) = bilinear_tap(y, scale_y, src_h);
+                    let fy1 = Q14_SCALE - fy;
+                    let yi = yi as usize;
 
-                    let row0 = &src[(yi as usize) * src_stride..(yi as usize + 1) * src_stride];
-                    let row1 = &src[(yi as usize + 1) * src_stride..(yi as usize + 2) * src_stride];
+                    let row0 = &src[yi * src_stride..(yi + 1) * src_stride];
+                    let row1 = &src[(yi + 1) * src_stride..(yi + 2) * src_stride];
 
                     bilinear_row_u8::<C>(row0, row1, &x_taps, fy, fy1, dst_row);
                 });

--- a/crates/kornia-imgproc/src/resize/common.rs
+++ b/crates/kornia-imgproc/src/resize/common.rs
@@ -73,13 +73,17 @@ pub(super) fn precompute_contribs(
     let mut offsets = vec![0i32; dst_size];
     let mut weights = vec![0i32; dst_size * ksize];
 
+    // Scratch hoisted out of the loop: two per-column heap allocations here
+    // were the dominant host cost of the GPU separable launchers (the tables
+    // are rebuilt per call), ~1 ms at 1080p.
+    let mut raw = vec![0f64; ksize];
+    let inv_filt_scale = 1.0 / filt_scale;
+
     for i in 0..dst_size {
         let center = (i as f64 + 0.5) * scale - 0.5;
         let left = (center - support).ceil() as i64;
         offsets[i] = left as i32;
 
-        let inv_filt_scale = 1.0 / filt_scale;
-        let mut raw = vec![0f64; ksize];
         let mut sum = 0f64;
         for k in 0..ksize {
             let x = (left + k as i64) as f64 - center;
@@ -87,7 +91,7 @@ pub(super) fn precompute_contribs(
             raw[k] = w;
             sum += w;
         }
-        let mut qw = vec![0i32; ksize];
+        let qw = &mut weights[i * ksize..(i + 1) * ksize];
         let mut qsum = 0i32;
         let norm = if sum.abs() > 1e-12 {
             SCALE as f64 / sum
@@ -110,7 +114,6 @@ pub(super) fn precompute_contribs(
             }
             qw[max_k] += SCALE - qsum;
         }
-        weights[i * ksize..(i + 1) * ksize].copy_from_slice(&qw);
     }
     (offsets, weights, ksize)
 }

--- a/crates/kornia-imgproc/src/resize/common.rs
+++ b/crates/kornia-imgproc/src/resize/common.rs
@@ -2,8 +2,8 @@
 
 /// Which separable kernel to use. `Cubic` is bicubic (a = -0.5), `Lanczos3` is
 /// 3-lobe Lanczos.
-#[derive(Copy, Clone)]
-pub(super) enum FilterKind {
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(crate) enum FilterKind {
     Cubic,
     Lanczos3,
 }

--- a/crates/kornia-imgproc/src/resize/cuda.rs
+++ b/crates/kornia-imgproc/src/resize/cuda.rs
@@ -457,7 +457,12 @@ mod tests {
         let stream = default_stream();
         for &((sw, sh), (dw, dh)) in &[((129, 97), (64, 48)), ((63, 41), (127, 90))] {
             let src = Image::<f32, 3>::new(sized(sw, sh), pattern_f32(sw * sh * 3)).unwrap();
-            for mode in [InterpolationMode::Bilinear, InterpolationMode::Nearest] {
+            for mode in [
+                InterpolationMode::Bilinear,
+                InterpolationMode::Nearest,
+                InterpolationMode::Bicubic,
+                InterpolationMode::Lanczos,
+            ] {
                 let mut cpu_dst = Image::<f32, 3>::from_size_val(sized(dw, dh), 0.0).unwrap();
                 resize(&src, &mut cpu_dst, mode).unwrap();
 
@@ -572,7 +577,12 @@ mod bench_probe {
         }
         stream.synchronize().unwrap();
 
-        for mode in [InterpolationMode::Bilinear, InterpolationMode::Nearest] {
+        for mode in [
+            InterpolationMode::Bilinear,
+            InterpolationMode::Nearest,
+            InterpolationMode::Bicubic,
+            InterpolationMode::Lanczos,
+        ] {
             // DVFS is unlocked on this box: 5 rounds, min = closest to the
             // max-clock condition.
             let mut best = f64::MAX;

--- a/crates/kornia-imgproc/src/resize/cuda.rs
+++ b/crates/kornia-imgproc/src/resize/cuda.rs
@@ -21,7 +21,7 @@ use crate::cuda::resize_u8::{
 use crate::interpolation::InterpolationMode;
 
 use super::bilinear::bilinear_axis_lut;
-use super::common::{build_xsrc_lut, pack_xw_i16, precompute_contribs, FilterKind};
+use super::common::{build_xsrc_lut, pack_xw_i16, precompute_contribs};
 use super::nearest::nearest_axis_lut;
 
 /// Run the CUDA resize for a device-resident f32 pair.
@@ -152,6 +152,7 @@ const U8_LUT_CACHE_CAP: usize = 128;
 
 fn cached_luts(
     key: U8LutKey,
+    stream: &Arc<CudaStream>,
     build: impl FnOnce() -> Result<U8Luts, ImageError>,
 ) -> Result<Arc<U8Luts>, ImageError> {
     let cache = U8_LUT_CACHE.get_or_init(Default::default);
@@ -161,9 +162,22 @@ fn cached_luts(
     // Build + upload outside the lock; a racing duplicate upload is harmless
     // and the entry API keeps the first insertion.
     let built = Arc::new(build()?);
+    // The uploads above are async on THIS call's stream, but the cache is
+    // shared across streams: a later same-geometry call on another stream
+    // has no ordering edge to these copies. Synchronize once before the
+    // entry becomes visible so every cache hit reads completed tables.
+    // Miss-only cost; hits never sync.
+    stream
+        .synchronize()
+        .map_err(|e| ImageError::Cuda(e.to_string()))?;
     let mut map = cache.lock().expect("u8 LUT cache poisoned");
     if map.len() >= U8_LUT_CACHE_CAP {
-        map.clear();
+        // Evict a single arbitrary entry, not the whole map: wholesale
+        // clearing makes >cap working sets stampede (every geometry misses,
+        // rebuilds and re-uploads until the map refills, then clears again).
+        if let Some(k) = map.keys().next().copied() {
+            map.remove(&k);
+        }
     }
     Ok(map.entry(key).or_insert(built).clone())
 }
@@ -197,38 +211,35 @@ pub(super) fn resize_fast_u8_cuda<const C: usize>(
     antialias: bool,
     stream: &Arc<CudaStream>,
 ) -> Result<(), ImageError> {
-    if !(C == 1 || C == 3 || C == 4) {
-        return Err(no_gpu_kernel_err(
-            "resize_fast_u8",
-            "1/3/4-channel u8 images",
-        ));
-    }
     let (src_w, src_h) = dims_u32(src)?;
     let (dst_w, dst_h) = dims_u32(dst)?;
     let ctx = stream.context();
     let (s, d) = device_slices!(src, dst);
     let err = |e: crate::cuda::resize::CudaResizeError| ImageError::Cuda(e.to_string());
 
-    // Branch 1/2: exact-2× RGB fast paths (bilinear only).
-    if interpolation == InterpolationMode::Bilinear
-        && C == 3
-        && src_w == dst_w * 2
-        && src_h == dst_h * 2
-        && src_w >= 2
-        && src_h >= 2
-    {
-        return launch_resize_u8_pyrdown2x_rgb_cuda(ctx, stream, s, d, dst_w, dst_h, None)
-            .map_err(err);
-    }
-    if interpolation == InterpolationMode::Bilinear
-        && C == 3
-        && dst_w == src_w * 2
-        && dst_h == src_h * 2
-        && src_w >= 2
-        && src_h >= 2
-    {
-        return launch_resize_u8_pyrup2x_rgb_cuda(ctx, stream, s, d, src_w, src_h, None)
-            .map_err(err);
+    // The SAME selector the CPU cascade consumes (see `resize_u8_path`):
+    // routing and support errors are decided once, so a device pair can
+    // never take a different kernel — or return a different error variant —
+    // than its host twin.
+    let path = super::resize_u8_path(
+        C,
+        interpolation,
+        src_w as usize,
+        src_h as usize,
+        dst_w as usize,
+        dst_h as usize,
+    )?;
+
+    match path {
+        super::ResizeU8Path::PyrDown2xRgb => {
+            return launch_resize_u8_pyrdown2x_rgb_cuda(ctx, stream, s, d, dst_w, dst_h, None)
+                .map_err(err);
+        }
+        super::ResizeU8Path::PyrUp2xRgb => {
+            return launch_resize_u8_pyrup2x_rgb_cuda(ctx, stream, s, d, src_w, src_h, None)
+                .map_err(err);
+        }
+        _ => {}
     }
 
     let key = U8LutKey {
@@ -247,9 +258,9 @@ pub(super) fn resize_fast_u8_cuda<const C: usize>(
         dst_h,
     };
 
-    match interpolation {
-        InterpolationMode::Nearest => {
-            let luts = cached_luts(key, || {
+    match path {
+        super::ResizeU8Path::Nearest => {
+            let luts = cached_luts(key, stream, || {
                 Ok(U8Luts::Nearest {
                     xmap: htod(stream, &nearest_axis_lut(src_w as usize, dst_w as usize))?,
                     ymap: htod(stream, &nearest_axis_lut(src_h as usize, dst_h as usize))?,
@@ -263,8 +274,8 @@ pub(super) fn resize_fast_u8_cuda<const C: usize>(
             )
             .map_err(err)
         }
-        InterpolationMode::Bilinear => {
-            let luts = cached_luts(key, || {
+        super::ResizeU8Path::Bilinear => {
+            let luts = cached_luts(key, stream, || {
                 let (xofs, xfx, _) = bilinear_axis_lut(src_w as usize, dst_w as usize);
                 let (yofs, yfy, _) = bilinear_axis_lut(src_h as usize, dst_h as usize);
                 Ok(U8Luts::Bilinear {
@@ -288,13 +299,8 @@ pub(super) fn resize_fast_u8_cuda<const C: usize>(
             )
             .map_err(err)
         }
-        InterpolationMode::Bicubic | InterpolationMode::Lanczos => {
-            let luts = cached_luts(key, || {
-                let filt = if interpolation == InterpolationMode::Bicubic {
-                    FilterKind::Cubic
-                } else {
-                    FilterKind::Lanczos3
-                };
+        super::ResizeU8Path::Separable(filt) => {
+            let luts = cached_luts(key, stream, || {
                 let (xofs, xw_q14, kx) =
                     precompute_contribs(src_w as usize, dst_w as usize, filt, antialias);
                 let (yofs, yw_q14, ky) =
@@ -326,6 +332,9 @@ pub(super) fn resize_fast_u8_cuda<const C: usize>(
                 *ky, None,
             )
             .map_err(err)
+        }
+        super::ResizeU8Path::PyrDown2xRgb | super::ResizeU8Path::PyrUp2xRgb => {
+            unreachable!("handled above")
         }
     }
 }
@@ -431,14 +440,25 @@ mod tests {
     fn u8_resize_error_semantics() {
         let stream = default_stream();
 
+        // Unsupported channel count: the error VARIANT must match the CPU
+        // path (the shared selector decides it) — residency-independent.
         let src = Image::<u8, 2>::new(sized(16, 16), pattern_u8(16 * 16 * 2)).unwrap();
         let d_src = src.to_cuda(&stream).unwrap();
         let mut d_dst = Image::<u8, 2>::zeros_cuda(sized(8, 8), &stream).unwrap();
         let err =
             resize_fast_u8_aa(&d_src, &mut d_dst, InterpolationMode::Bilinear, true).unwrap_err();
         assert!(
-            matches!(&err, ImageError::Cuda(msg) if msg.contains("1/3/4-channel")),
+            matches!(err, ImageError::UnsupportedChannelCount(2)),
             "got {err:?}"
+        );
+        let host_src = Image::<u8, 2>::new(sized(16, 16), pattern_u8(16 * 16 * 2)).unwrap();
+        let mut host_dst = Image::<u8, 2>::from_size_val(sized(8, 8), 0).unwrap();
+        let cpu_err =
+            resize_fast_u8_aa(&host_src, &mut host_dst, InterpolationMode::Bilinear, true)
+                .unwrap_err();
+        assert!(
+            matches!(cpu_err, ImageError::UnsupportedChannelCount(2)),
+            "got {cpu_err:?}"
         );
 
         let src3 = Image::<u8, 3>::new(sized(16, 16), pattern_u8(16 * 16 * 3)).unwrap();
@@ -447,6 +467,50 @@ mod tests {
         let err = resize_fast_u8_aa(&d_src3, &mut host_dst, InterpolationMode::Bilinear, true)
             .unwrap_err();
         assert!(matches!(err, ImageError::MixedResidency), "got {err:?}");
+    }
+
+    /// C=2 Nearest must WORK on both residencies (the CPU nearest kernel is
+    /// channel-generic; the GPU generic arm gathers per byte) and agree
+    /// byte-for-byte.
+    #[test]
+    fn u8_nearest_c2_device_matches_cpu() {
+        let stream = default_stream();
+        let src = Image::<u8, 2>::new(sized(37, 23), pattern_u8(37 * 23 * 2)).unwrap();
+        let mut cpu_dst = Image::<u8, 2>::from_size_val(sized(17, 11), 0).unwrap();
+        resize_fast_u8_aa(&src, &mut cpu_dst, InterpolationMode::Nearest, true).unwrap();
+
+        let d_src = src.to_cuda(&stream).unwrap();
+        let mut d_dst = Image::<u8, 2>::zeros_cuda(sized(17, 11), &stream).unwrap();
+        resize_fast_u8_aa(&d_src, &mut d_dst, InterpolationMode::Nearest, true).unwrap();
+        assert_eq!(
+            d_dst.to_host_owned().unwrap().as_slice(),
+            cpu_dst.as_slice()
+        );
+    }
+
+    /// A 1-pixel-wide bilinear source is a typed error on BOTH residencies
+    /// (previously: CPU panicked on the LUT underflow, GPU errored — the
+    /// shared selector now decides once).
+    #[test]
+    fn u8_bilinear_degenerate_source_same_error_both_sides() {
+        let stream = default_stream();
+        let src = Image::<u8, 3>::new(sized(1, 16), pattern_u8(16 * 3)).unwrap();
+        let mut cpu_dst = Image::<u8, 3>::from_size_val(sized(8, 8), 0).unwrap();
+        let cpu_err =
+            resize_fast_u8_aa(&src, &mut cpu_dst, InterpolationMode::Bilinear, true).unwrap_err();
+        assert!(
+            matches!(cpu_err, ImageError::InvalidImageSize(..)),
+            "got {cpu_err:?}"
+        );
+
+        let d_src = src.to_cuda(&stream).unwrap();
+        let mut d_dst = Image::<u8, 3>::zeros_cuda(sized(8, 8), &stream).unwrap();
+        let gpu_err =
+            resize_fast_u8_aa(&d_src, &mut d_dst, InterpolationMode::Bilinear, true).unwrap_err();
+        assert!(
+            matches!(gpu_err, ImageError::InvalidImageSize(..)),
+            "got {gpu_err:?}"
+        );
     }
 
     /// The public `resize`, called with device images, must produce

--- a/crates/kornia-imgproc/src/resize/cuda.rs
+++ b/crates/kornia-imgproc/src/resize/cuda.rs
@@ -539,3 +539,56 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod bench_probe {
+    /// Release-build device-throughput probe:
+    /// `cargo test --release -p kornia-imgproc --features cuda --lib \
+    ///  resize::cuda::bench_probe -- --ignored --nocapture`
+    #[test]
+    #[ignore]
+    fn probe_resize_1080p_to_720p() {
+        use crate::cuda::color::test_utils::{default_stream, pattern_u8};
+        use crate::interpolation::InterpolationMode;
+        use crate::resize::resize_fast_u8_aa;
+        use kornia_image::{Image, ImageSize};
+
+        let stream = default_stream();
+        let src_size = ImageSize {
+            width: 1920,
+            height: 1080,
+        };
+        let dst_size = ImageSize {
+            width: 1280,
+            height: 720,
+        };
+        let src = Image::<u8, 3>::new(src_size, pattern_u8(1920 * 1080 * 3)).unwrap();
+        let d_src = src.to_cuda(&stream).unwrap();
+        let mut d_dst = Image::<u8, 3>::zeros_cuda(dst_size, &stream).unwrap();
+
+        // Clock warmup.
+        for _ in 0..300 {
+            resize_fast_u8_aa(&d_src, &mut d_dst, InterpolationMode::Bilinear, true).unwrap();
+        }
+        stream.synchronize().unwrap();
+
+        for mode in [InterpolationMode::Bilinear, InterpolationMode::Nearest] {
+            // DVFS is unlocked on this box: 5 rounds, min = closest to the
+            // max-clock condition.
+            let mut best = f64::MAX;
+            for _ in 0..5 {
+                for _ in 0..100 {
+                    resize_fast_u8_aa(&d_src, &mut d_dst, mode, true).unwrap();
+                }
+                stream.synchronize().unwrap();
+                let t0 = std::time::Instant::now();
+                for _ in 0..300 {
+                    resize_fast_u8_aa(&d_src, &mut d_dst, mode, true).unwrap();
+                }
+                stream.synchronize().unwrap();
+                best = best.min(t0.elapsed().as_secs_f64() * 1000.0 / 300.0);
+            }
+            println!("{mode:?}: {best:.3} ms/op (min of 5)");
+        }
+    }
+}

--- a/crates/kornia-imgproc/src/resize/cuda.rs
+++ b/crates/kornia-imgproc/src/resize/cuda.rs
@@ -2,9 +2,10 @@
 //! [`resize_fast_u8_aa`](super::resize_fast_u8_aa): route a checked device
 //! pair to the native CUDA resize kernels.
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
 
-use cudarc::driver::CudaStream;
+use cudarc::driver::{CudaSlice, CudaStream};
 use kornia_image::{Image, ImageError};
 
 use crate::cuda::dispatch::{device_slices, dims_u32, no_gpu_kernel_err, untyped_device_err};
@@ -97,6 +98,85 @@ pub(super) fn resize_f32_cuda<const C: usize>(
     .map_err(|e| ImageError::Cuda(e.to_string()))
 }
 
+/// Device-resident coordinate/weight tables for one u8 resize geometry.
+///
+/// Cached because Jetson pageable H2D uploads have a catastrophic latency
+/// tail (~250 µs average per `cuMemcpyHtoDAsync` measured under nsys), and
+/// the lanczos host table build re-evaluates f64 `sin` per tap — together
+/// they dominated the GPU op several times over. A cache hit makes a repeat
+/// resize pure kernel launches, which also keeps it CUDA-Graph-capturable
+/// (a pageable upload inside a capture would fail); warm the cache with one
+/// call before capturing.
+enum U8Luts {
+    Nearest {
+        xmap: CudaSlice<i32>,
+        ymap: CudaSlice<i32>,
+    },
+    Bilinear {
+        xofs: CudaSlice<u32>,
+        xfx: CudaSlice<u32>,
+        yofs: CudaSlice<u32>,
+        yfy: CudaSlice<u32>,
+    },
+    Separable {
+        xsrc: CudaSlice<u16>,
+        xw: CudaSlice<i16>,
+        kx: u32,
+        yofs: CudaSlice<i32>,
+        yw: CudaSlice<i16>,
+        ky: u32,
+    },
+}
+
+/// Cache key: device ordinal + everything that determines table contents.
+/// (`antialias` only matters for the separable modes; the other tags store
+/// `false`.) Channel count does not affect the tables.
+#[derive(PartialEq, Eq, Hash, Clone, Copy)]
+struct U8LutKey {
+    dev: usize,
+    mode: InterpolationMode,
+    antialias: bool,
+    src_w: u32,
+    src_h: u32,
+    dst_w: u32,
+    dst_h: u32,
+}
+
+static U8_LUT_CACHE: OnceLock<Mutex<HashMap<U8LutKey, Arc<U8Luts>>>> = OnceLock::new();
+
+/// Bound on cached geometries. Each entry is a few KB of device memory
+/// (worst case ~100 KB for a wide antialiased lanczos); on overflow the
+/// cache is cleared wholesale — resize-target sets are small and stable in
+/// practice, so eviction is a non-event.
+const U8_LUT_CACHE_CAP: usize = 128;
+
+fn cached_luts(
+    key: U8LutKey,
+    build: impl FnOnce() -> Result<U8Luts, ImageError>,
+) -> Result<Arc<U8Luts>, ImageError> {
+    let cache = U8_LUT_CACHE.get_or_init(Default::default);
+    if let Some(hit) = cache.lock().expect("u8 LUT cache poisoned").get(&key) {
+        return Ok(hit.clone());
+    }
+    // Build + upload outside the lock; a racing duplicate upload is harmless
+    // and the entry API keeps the first insertion.
+    let built = Arc::new(build()?);
+    let mut map = cache.lock().expect("u8 LUT cache poisoned");
+    if map.len() >= U8_LUT_CACHE_CAP {
+        map.clear();
+    }
+    Ok(map.entry(key).or_insert(built).clone())
+}
+
+fn htod<T: cudarc::driver::DeviceRepr>(
+    stream: &Arc<CudaStream>,
+    host: &[T],
+) -> Result<CudaSlice<T>, ImageError> {
+    stream
+        .clone_htod(host)
+        .map_err(|e| ImageError::Cuda(e.to_string()))
+}
+
 /// Run the CUDA u8 resize for a device-resident pair, byte-exact with
 /// [`resize_fast_u8_aa`](super::resize_fast_u8_aa).
 ///
@@ -106,9 +186,10 @@ pub(super) fn resize_f32_cuda<const C: usize>(
 /// would take. Do not reorder one side without the other.
 ///
 /// All coordinate/weight tables are built by the same host functions the CPU
-/// uses (`bilinear_axis_lut`, `nearest_axis_lut`, `precompute_contribs`) and
-/// uploaded; the kernels are integer-only. Output is bit-identical to the
-/// CPU, which the parity tests assert with `assert_eq!`.
+/// uses (`bilinear_axis_lut`, `nearest_axis_lut`, `precompute_contribs`),
+/// uploaded once per geometry (see [`U8Luts`]); the kernels are integer-only.
+/// Output is bit-identical to the CPU, which the parity tests assert with
+/// `assert_eq!`.
 pub(super) fn resize_fast_u8_cuda<const C: usize>(
     src: &Image<u8, C>,
     dst: &mut Image<u8, C>,
@@ -150,41 +231,99 @@ pub(super) fn resize_fast_u8_cuda<const C: usize>(
             .map_err(err);
     }
 
+    let key = U8LutKey {
+        dev: ctx.ordinal(),
+        mode: interpolation,
+        // Only the separable modes read the flag; normalize so nearest and
+        // bilinear share one entry regardless of the caller's antialias.
+        antialias: antialias
+            && matches!(
+                interpolation,
+                InterpolationMode::Bicubic | InterpolationMode::Lanczos
+            ),
+        src_w,
+        src_h,
+        dst_w,
+        dst_h,
+    };
+
     match interpolation {
         InterpolationMode::Nearest => {
-            let xmap = nearest_axis_lut(src_w as usize, dst_w as usize);
-            let ymap = nearest_axis_lut(src_h as usize, dst_h as usize);
+            let luts = cached_luts(key, || {
+                Ok(U8Luts::Nearest {
+                    xmap: htod(stream, &nearest_axis_lut(src_w as usize, dst_w as usize))?,
+                    ymap: htod(stream, &nearest_axis_lut(src_h as usize, dst_h as usize))?,
+                })
+            })?;
+            let U8Luts::Nearest { xmap, ymap } = &*luts else {
+                unreachable!("cache key encodes the mode")
+            };
             launch_resize_u8_nearest_cuda(
-                ctx, stream, s, d, src_w, src_h, dst_w, dst_h, C as u32, &xmap, &ymap, None,
+                ctx, stream, s, d, src_w, src_h, dst_w, dst_h, C as u32, xmap, ymap, None,
             )
             .map_err(err)
         }
         InterpolationMode::Bilinear => {
-            let (xofs, xfx, _) = bilinear_axis_lut(src_w as usize, dst_w as usize);
-            let (yofs, yfy, _) = bilinear_axis_lut(src_h as usize, dst_h as usize);
+            let luts = cached_luts(key, || {
+                let (xofs, xfx, _) = bilinear_axis_lut(src_w as usize, dst_w as usize);
+                let (yofs, yfy, _) = bilinear_axis_lut(src_h as usize, dst_h as usize);
+                Ok(U8Luts::Bilinear {
+                    xofs: htod(stream, &xofs)?,
+                    xfx: htod(stream, &xfx)?,
+                    yofs: htod(stream, &yofs)?,
+                    yfy: htod(stream, &yfy)?,
+                })
+            })?;
+            let U8Luts::Bilinear {
+                xofs,
+                xfx,
+                yofs,
+                yfy,
+            } = &*luts
+            else {
+                unreachable!("cache key encodes the mode")
+            };
             launch_resize_u8_bilinear_cuda(
-                ctx, stream, s, d, src_w, src_h, dst_w, dst_h, C as u32, &xofs, &xfx, &yofs, &yfy,
-                None,
+                ctx, stream, s, d, src_w, src_h, dst_w, dst_h, C as u32, xofs, xfx, yofs, yfy, None,
             )
             .map_err(err)
         }
         InterpolationMode::Bicubic | InterpolationMode::Lanczos => {
-            let filt = if interpolation == InterpolationMode::Bicubic {
-                FilterKind::Cubic
-            } else {
-                FilterKind::Lanczos3
+            let luts = cached_luts(key, || {
+                let filt = if interpolation == InterpolationMode::Bicubic {
+                    FilterKind::Cubic
+                } else {
+                    FilterKind::Lanczos3
+                };
+                let (xofs, xw_q14, kx) =
+                    precompute_contribs(src_w as usize, dst_w as usize, filt, antialias);
+                let (yofs, yw_q14, ky) =
+                    precompute_contribs(src_h as usize, dst_h as usize, filt, antialias);
+                let xsrc = build_xsrc_lut(&xofs, dst_w as usize, kx, src_w as usize);
+                Ok(U8Luts::Separable {
+                    xsrc: htod(stream, &xsrc)?,
+                    xw: htod(stream, &pack_xw_i16(&xw_q14))?,
+                    kx: kx as u32,
+                    yofs: htod(stream, &yofs)?,
+                    // Same i32 → i16 cast the CPU vertical pass applies per tap.
+                    yw: htod(stream, &pack_xw_i16(&yw_q14))?,
+                    ky: ky as u32,
+                })
+            })?;
+            let U8Luts::Separable {
+                xsrc,
+                xw,
+                kx,
+                yofs,
+                yw,
+                ky,
+            } = &*luts
+            else {
+                unreachable!("cache key encodes the mode")
             };
-            let (xofs, xw_q14, kx) =
-                precompute_contribs(src_w as usize, dst_w as usize, filt, antialias);
-            let (yofs, yw_q14, ky) =
-                precompute_contribs(src_h as usize, dst_h as usize, filt, antialias);
-            let xsrc = build_xsrc_lut(&xofs, dst_w as usize, kx, src_w as usize);
-            let xw = pack_xw_i16(&xw_q14);
-            // Same i32 → i16 cast the CPU vertical pass applies per tap.
-            let yw = pack_xw_i16(&yw_q14);
             launch_resize_u8_separable_cuda(
-                ctx, stream, s, d, src_w, src_h, dst_w, dst_h, C as u32, &xsrc, &xw, kx as u32,
-                &yofs, &yw, ky as u32, None,
+                ctx, stream, s, d, src_w, src_h, dst_w, dst_h, C as u32, xsrc, xw, *kx, yofs, yw,
+                *ky, None,
             )
             .map_err(err)
         }

--- a/crates/kornia-imgproc/src/resize/cuda.rs
+++ b/crates/kornia-imgproc/src/resize/cuda.rs
@@ -1,5 +1,6 @@
-//! Device adapter for [`resize`](super::resize): routes a
-//! checked device pair to the native CUDA resize kernels.
+//! Device adapters for [`resize`](super::resize) and
+//! [`resize_fast_u8_aa`](super::resize_fast_u8_aa): route a checked device
+//! pair to the native CUDA resize kernels.
 
 use std::sync::Arc;
 
@@ -11,7 +12,16 @@ use crate::cuda::resize::{
     launch_resize_bicubic_cuda, launch_resize_bilinear_downscale_cuda, launch_resize_lanczos_cuda,
     launch_resize_nearest_downscale_cuda, PixelMapping,
 };
+use crate::cuda::resize_u8::{
+    launch_resize_u8_bilinear_cuda, launch_resize_u8_nearest_cuda,
+    launch_resize_u8_pyrdown2x_rgb_cuda, launch_resize_u8_pyrup2x_rgb_cuda,
+    launch_resize_u8_separable_cuda,
+};
 use crate::interpolation::InterpolationMode;
+
+use super::bilinear::bilinear_axis_lut;
+use super::common::{build_xsrc_lut, pack_xw_i16, precompute_contribs, FilterKind};
+use super::nearest::nearest_axis_lut;
 
 /// Run the CUDA resize for a device-resident f32 pair.
 ///
@@ -87,13 +97,107 @@ pub(super) fn resize_f32_cuda<const C: usize>(
     .map_err(|e| ImageError::Cuda(e.to_string()))
 }
 
+/// Run the CUDA u8 resize for a device-resident pair, byte-exact with
+/// [`resize_fast_u8_aa`](super::resize_fast_u8_aa).
+///
+/// The dispatch cascade below mirrors the CPU cascade in
+/// `resize_fast_u8_aa` BRANCH FOR BRANCH — same guards, same order — so the
+/// kernel a device pair takes is always the twin of the CPU path a host pair
+/// would take. Do not reorder one side without the other.
+///
+/// All coordinate/weight tables are built by the same host functions the CPU
+/// uses (`bilinear_axis_lut`, `nearest_axis_lut`, `precompute_contribs`) and
+/// uploaded; the kernels are integer-only. Output is bit-identical to the
+/// CPU, which the parity tests assert with `assert_eq!`.
+pub(super) fn resize_fast_u8_cuda<const C: usize>(
+    src: &Image<u8, C>,
+    dst: &mut Image<u8, C>,
+    interpolation: InterpolationMode,
+    antialias: bool,
+    stream: &Arc<CudaStream>,
+) -> Result<(), ImageError> {
+    if !(C == 1 || C == 3 || C == 4) {
+        return Err(no_gpu_kernel_err(
+            "resize_fast_u8",
+            "1/3/4-channel u8 images",
+        ));
+    }
+    let (src_w, src_h) = dims_u32(src)?;
+    let (dst_w, dst_h) = dims_u32(dst)?;
+    let ctx = stream.context();
+    let (s, d) = device_slices!(src, dst);
+    let err = |e: crate::cuda::resize::CudaResizeError| ImageError::Cuda(e.to_string());
+
+    // Branch 1/2: exact-2× RGB fast paths (bilinear only).
+    if interpolation == InterpolationMode::Bilinear
+        && C == 3
+        && src_w == dst_w * 2
+        && src_h == dst_h * 2
+        && src_w >= 2
+        && src_h >= 2
+    {
+        return launch_resize_u8_pyrdown2x_rgb_cuda(ctx, stream, s, d, dst_w, dst_h, None)
+            .map_err(err);
+    }
+    if interpolation == InterpolationMode::Bilinear
+        && C == 3
+        && dst_w == src_w * 2
+        && dst_h == src_h * 2
+        && src_w >= 2
+        && src_h >= 2
+    {
+        return launch_resize_u8_pyrup2x_rgb_cuda(ctx, stream, s, d, src_w, src_h, None)
+            .map_err(err);
+    }
+
+    match interpolation {
+        InterpolationMode::Nearest => {
+            let xmap = nearest_axis_lut(src_w as usize, dst_w as usize);
+            let ymap = nearest_axis_lut(src_h as usize, dst_h as usize);
+            launch_resize_u8_nearest_cuda(
+                ctx, stream, s, d, src_w, src_h, dst_w, dst_h, C as u32, &xmap, &ymap, None,
+            )
+            .map_err(err)
+        }
+        InterpolationMode::Bilinear => {
+            let (xofs, xfx, _) = bilinear_axis_lut(src_w as usize, dst_w as usize);
+            let (yofs, yfy, _) = bilinear_axis_lut(src_h as usize, dst_h as usize);
+            launch_resize_u8_bilinear_cuda(
+                ctx, stream, s, d, src_w, src_h, dst_w, dst_h, C as u32, &xofs, &xfx, &yofs, &yfy,
+                None,
+            )
+            .map_err(err)
+        }
+        InterpolationMode::Bicubic | InterpolationMode::Lanczos => {
+            let filt = if interpolation == InterpolationMode::Bicubic {
+                FilterKind::Cubic
+            } else {
+                FilterKind::Lanczos3
+            };
+            let (xofs, xw_q14, kx) =
+                precompute_contribs(src_w as usize, dst_w as usize, filt, antialias);
+            let (yofs, yw_q14, ky) =
+                precompute_contribs(src_h as usize, dst_h as usize, filt, antialias);
+            let xsrc = build_xsrc_lut(&xofs, dst_w as usize, kx, src_w as usize);
+            let xw = pack_xw_i16(&xw_q14);
+            // Same i32 → i16 cast the CPU vertical pass applies per tap.
+            let yw = pack_xw_i16(&yw_q14);
+            launch_resize_u8_separable_cuda(
+                ctx, stream, s, d, src_w, src_h, dst_w, dst_h, C as u32, &xsrc, &xw, kx as u32,
+                &yofs, &yw, ky as u32, None,
+            )
+            .map_err(err)
+        }
+    }
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
-    use crate::cuda::color::test_utils::{default_stream, pattern_f32};
+    use crate::cuda::color::test_utils::{default_stream, pattern_f32, pattern_u8};
     use crate::interpolation::InterpolationMode;
-    use crate::resize::resize;
+    use crate::resize::{resize, resize_fast_u8_aa};
     use kornia_image::{Image, ImageError, ImageSize};
 
     fn sized(w: usize, h: usize) -> ImageSize {
@@ -101,6 +205,109 @@ mod tests {
             width: w,
             height: h,
         }
+    }
+
+    /// Run `resize_fast_u8_aa` on host and device for the same input and
+    /// assert the outputs are bit-identical.
+    fn assert_u8_device_equals_host<const C: usize>(
+        (sw, sh): (usize, usize),
+        (dw, dh): (usize, usize),
+        mode: InterpolationMode,
+        antialias: bool,
+    ) {
+        let stream = default_stream();
+        let src = Image::<u8, C>::new(sized(sw, sh), pattern_u8(sw * sh * C)).unwrap();
+
+        let mut cpu_dst = Image::<u8, C>::from_size_val(sized(dw, dh), 0).unwrap();
+        resize_fast_u8_aa(&src, &mut cpu_dst, mode, antialias).unwrap();
+
+        let d_src = src.to_cuda(&stream).unwrap();
+        let mut d_dst = Image::<u8, C>::zeros_cuda(sized(dw, dh), &stream).unwrap();
+        resize_fast_u8_aa(&d_src, &mut d_dst, mode, antialias).unwrap();
+
+        let back = d_dst.to_host_owned().unwrap();
+        assert_eq!(
+            back.as_slice(),
+            cpu_dst.as_slice(),
+            "{sw}x{sh}->{dw}x{dh} C={C} {mode:?} aa={antialias}: device must be bit-identical to host"
+        );
+    }
+
+    /// Branches 1+2 of the cascade: exact-2× RGB pyrdown/pyrup fast paths.
+    #[test]
+    fn u8_pyr2x_fast_paths_device_equal_host() {
+        // Odd-ish dst dims exercise the tail columns of the CPU NEON kernels.
+        assert_u8_device_equals_host::<3>((130, 98), (65, 49), InterpolationMode::Bilinear, true);
+        assert_u8_device_equals_host::<3>((65, 49), (130, 98), InterpolationMode::Bilinear, true);
+    }
+
+    /// Branch 3: nearest, all supported channel counts, odd sizes, up + down.
+    #[test]
+    fn u8_nearest_device_equals_host() {
+        for &(s, d) in &[((129, 97), (64, 48)), ((63, 41), (127, 90))] {
+            assert_u8_device_equals_host::<1>(s, d, InterpolationMode::Nearest, true);
+            assert_u8_device_equals_host::<3>(s, d, InterpolationMode::Nearest, true);
+            assert_u8_device_equals_host::<4>(s, d, InterpolationMode::Nearest, true);
+        }
+    }
+
+    /// Branch 4: generic Q14 bilinear, non-2× ratios.
+    #[test]
+    fn u8_bilinear_device_equals_host() {
+        for &(s, d) in &[
+            ((129, 97), (64, 48)),
+            ((63, 41), (127, 90)),
+            ((33, 21), (33, 21)),
+        ] {
+            assert_u8_device_equals_host::<1>(s, d, InterpolationMode::Bilinear, true);
+            assert_u8_device_equals_host::<3>(s, d, InterpolationMode::Bilinear, true);
+            assert_u8_device_equals_host::<4>(s, d, InterpolationMode::Bilinear, true);
+        }
+    }
+
+    /// Branch 5: Q14 separable bicubic/lanczos, antialiased (PIL semantics,
+    /// wide kernels) and non-antialiased (OpenCV semantics, fixed taps).
+    #[test]
+    fn u8_separable_device_equals_host() {
+        for mode in [InterpolationMode::Bicubic, InterpolationMode::Lanczos] {
+            for antialias in [true, false] {
+                assert_u8_device_equals_host::<3>((129, 97), (64, 48), mode, antialias);
+                assert_u8_device_equals_host::<1>((63, 41), (127, 90), mode, antialias);
+                assert_u8_device_equals_host::<4>((100, 80), (47, 33), mode, antialias);
+            }
+        }
+    }
+
+    /// Extreme antialiased downscale: tall kernels (ksize grows with the
+    /// scale factor) stress the i32 accumulator bound and the tap loops.
+    #[test]
+    fn u8_separable_extreme_downscale_device_equals_host() {
+        assert_u8_device_equals_host::<3>((1024, 64), (50, 40), InterpolationMode::Lanczos, true);
+        assert_u8_device_equals_host::<3>((1024, 64), (50, 40), InterpolationMode::Bicubic, true);
+    }
+
+    /// u8 device pairs with unsupported channel counts error; mixed
+    /// residency errors — never a silent CPU fallback or transfer.
+    #[test]
+    fn u8_resize_error_semantics() {
+        let stream = default_stream();
+
+        let src = Image::<u8, 2>::new(sized(16, 16), pattern_u8(16 * 16 * 2)).unwrap();
+        let d_src = src.to_cuda(&stream).unwrap();
+        let mut d_dst = Image::<u8, 2>::zeros_cuda(sized(8, 8), &stream).unwrap();
+        let err =
+            resize_fast_u8_aa(&d_src, &mut d_dst, InterpolationMode::Bilinear, true).unwrap_err();
+        assert!(
+            matches!(&err, ImageError::Cuda(msg) if msg.contains("1/3/4-channel")),
+            "got {err:?}"
+        );
+
+        let src3 = Image::<u8, 3>::new(sized(16, 16), pattern_u8(16 * 16 * 3)).unwrap();
+        let d_src3 = src3.to_cuda(&stream).unwrap();
+        let mut host_dst = Image::<u8, 3>::from_size_val(sized(8, 8), 0).unwrap();
+        let err = resize_fast_u8_aa(&d_src3, &mut host_dst, InterpolationMode::Bilinear, true)
+            .unwrap_err();
+        assert!(matches!(err, ImageError::MixedResidency), "got {err:?}");
     }
 
     /// The public `resize`, called with device images, must produce

--- a/crates/kornia-imgproc/src/resize/mod.rs
+++ b/crates/kornia-imgproc/src/resize/mod.rs
@@ -265,6 +265,18 @@ pub fn resize_fast_u8_aa<const C: usize>(
     interpolation: InterpolationMode,
     antialias: bool,
 ) -> Result<(), ImageError> {
+    // Device pairs route to the CUDA u8 kernels (bit-identical output — the
+    // coordinate/weight tables come from the same host builders the CPU
+    // uses). Mixed host/device pairs are a typed error; there is no implicit
+    // transfer in either direction.
+    #[cfg(feature = "cuda")]
+    if let crate::cuda::dispatch::Residency::Device(exec) =
+        crate::cuda::dispatch::pair_residency(src, dst)?
+    {
+        return exec
+            .run(|stream| cuda::resize_fast_u8_cuda(src, dst, interpolation, antialias, stream));
+    }
+
     let (src_w, src_h) = (src.cols(), src.rows());
     let (dst_w, dst_h) = (dst.cols(), dst.rows());
 

--- a/crates/kornia-imgproc/src/resize/mod.rs
+++ b/crates/kornia-imgproc/src/resize/mod.rs
@@ -248,6 +248,81 @@ pub fn resize_fast_u8<const C: usize>(
     resize_fast_u8_aa::<C>(src, dst, interpolation, true)
 }
 
+/// Which u8 kernel a `(mode, geometry, channel count)` combination resolves
+/// to — the SINGLE routing decision consumed by both the CPU cascade
+/// ([`resize_fast_u8_aa`]) and the CUDA cascade
+/// (`cuda::resize_fast_u8_cuda`), so the two sides cannot drift: a device
+/// pair always runs the GPU twin of the kernel a host pair would run.
+/// Kernel-support errors (channel counts, degenerate bilinear sources) are
+/// decided here too, so the error VARIANT is residency-independent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ResizeU8Path {
+    /// Exact-2× RGB box downscale (bilinear fast path).
+    PyrDown2xRgb,
+    /// Exact-2× RGB upscale (bilinear fast path).
+    PyrUp2xRgb,
+    /// Nearest gather (any channel count).
+    Nearest,
+    /// Generic Q14 bilinear (C ∈ {1, 3, 4}, source at least 2×2).
+    Bilinear,
+    /// Two-pass separable Q14 (bicubic / lanczos, C ∈ {1, 3, 4}).
+    Separable(FilterKind),
+}
+
+pub(crate) fn resize_u8_path(
+    channels: usize,
+    mode: InterpolationMode,
+    src_w: usize,
+    src_h: usize,
+    dst_w: usize,
+    dst_h: usize,
+) -> Result<ResizeU8Path, ImageError> {
+    use InterpolationMode as I;
+    Ok(match mode {
+        I::Bilinear
+            if channels == 3
+                && src_w == dst_w * 2
+                && src_h == dst_h * 2
+                && src_w >= 2
+                && src_h >= 2 =>
+        {
+            ResizeU8Path::PyrDown2xRgb
+        }
+        I::Bilinear
+            if channels == 3
+                && dst_w == src_w * 2
+                && dst_h == src_h * 2
+                && src_w >= 2
+                && src_h >= 2 =>
+        {
+            ResizeU8Path::PyrUp2xRgb
+        }
+        I::Nearest => ResizeU8Path::Nearest,
+        I::Bilinear => {
+            if !(channels == 1 || channels == 3 || channels == 4) {
+                return Err(ImageError::UnsupportedChannelCount(channels));
+            }
+            // A 1-pixel axis has no second bilinear tap; previously the CPU
+            // fall-through PANICKED on this (LUT offset underflow) while the
+            // GPU returned a typed error. Both sides now share this error.
+            if src_w < 2 || src_h < 2 {
+                return Err(ImageError::InvalidImageSize(src_w, src_h, 2, 2));
+            }
+            ResizeU8Path::Bilinear
+        }
+        I::Bicubic | I::Lanczos => {
+            if !(channels == 1 || channels == 3 || channels == 4) {
+                return Err(ImageError::UnsupportedChannelCount(channels));
+            }
+            ResizeU8Path::Separable(if mode == I::Bicubic {
+                FilterKind::Cubic
+            } else {
+                FilterKind::Lanczos3
+            })
+        }
+    })
+}
+
 /// Generic fast u8 resize with explicit antialias control.
 ///
 /// `antialias=true` (default via [`resize_fast_u8`]) matches PIL / torchvision
@@ -280,57 +355,47 @@ pub fn resize_fast_u8_aa<const C: usize>(
     let (src_w, src_h) = (src.cols(), src.rows());
     let (dst_w, dst_h) = (dst.cols(), dst.rows());
 
-    if matches!(interpolation, InterpolationMode::Bilinear)
-        && C == 3
-        && src_w == dst_w * 2
-        && src_h == dst_h * 2
-        && src_w >= 2
-        && src_h >= 2
-    {
-        pyramid::pyrdown_2x_rgb_u8(src.as_slice(), dst.as_slice_mut(), src_w, src_h);
-        return Ok(());
+    match resize_u8_path(C, interpolation, src_w, src_h, dst_w, dst_h)? {
+        ResizeU8Path::PyrDown2xRgb => {
+            pyramid::pyrdown_2x_rgb_u8(src.as_slice(), dst.as_slice_mut(), src_w, src_h);
+        }
+        ResizeU8Path::PyrUp2xRgb => {
+            pyramid::pyrup_2x_rgb_u8(src.as_slice(), dst.as_slice_mut(), src_w, src_h);
+        }
+        ResizeU8Path::Nearest => {
+            nearest::resize_nearest_u8::<C>(
+                src.as_slice(),
+                src_w,
+                src_h,
+                dst.as_slice_mut(),
+                dst_w,
+                dst_h,
+            );
+        }
+        ResizeU8Path::Bilinear => {
+            bilinear::resize_bilinear_u8_nch::<C>(
+                src.as_slice(),
+                src_w,
+                src_h,
+                dst.as_slice_mut(),
+                dst_w,
+                dst_h,
+            );
+        }
+        ResizeU8Path::Separable(filt) => {
+            separable::resize_separable_u8::<C>(
+                src.as_slice(),
+                src_w,
+                src_h,
+                dst.as_slice_mut(),
+                dst_w,
+                dst_h,
+                filt,
+                antialias,
+            );
+        }
     }
-
-    if matches!(interpolation, InterpolationMode::Bilinear)
-        && C == 3
-        && dst_w == src_w * 2
-        && dst_h == src_h * 2
-        && src_w >= 2
-        && src_h >= 2
-    {
-        pyramid::pyrup_2x_rgb_u8(src.as_slice(), dst.as_slice_mut(), src_w, src_h);
-        return Ok(());
-    }
-
-    if matches!(interpolation, InterpolationMode::Nearest) && src_w >= 1 && src_h >= 1 {
-        nearest::resize_nearest_u8::<C>(
-            src.as_slice(),
-            src_w,
-            src_h,
-            dst.as_slice_mut(),
-            dst_w,
-            dst_h,
-        );
-        return Ok(());
-    }
-
-    if matches!(interpolation, InterpolationMode::Bilinear)
-        && src_w >= 2
-        && src_h >= 2
-        && (C == 1 || C == 3 || C == 4)
-    {
-        bilinear::resize_bilinear_u8_nch::<C>(
-            src.as_slice(),
-            src_w,
-            src_h,
-            dst.as_slice_mut(),
-            dst_w,
-            dst_h,
-        );
-        return Ok(());
-    }
-
-    resize_fast_impl(src, dst, interpolation, antialias)
+    Ok(())
 }
 
 /// Resize a 1-channel u8 image. Convenience wrapper around [`resize_fast_u8`].
@@ -360,69 +425,6 @@ pub fn resize_fast_rgb_aa(
     antialias: bool,
 ) -> Result<(), ImageError> {
     resize_fast_u8_aa::<3>(src, dst, interpolation, antialias)
-}
-
-/// Slow-path per-interpolation dispatch for cases that didn't take the
-/// fast paths in [`resize_fast_u8_aa`] (primarily bicubic / lanczos and
-/// non-exact-2× bilinear on unusual channel counts).
-fn resize_fast_impl<const C: usize>(
-    src: &Image<u8, C>,
-    dst: &mut Image<u8, C>,
-    interpolation: InterpolationMode,
-    antialias: bool,
-) -> Result<(), ImageError> {
-    if !(C == 1 || C == 3 || C == 4) {
-        return Err(ImageError::UnsupportedChannelCount(C));
-    }
-    let (src_w, src_h) = (src.cols(), src.rows());
-    let (dst_w, dst_h) = (dst.cols(), dst.rows());
-    match interpolation {
-        InterpolationMode::Nearest => {
-            nearest::resize_nearest_u8::<C>(
-                src.as_slice(),
-                src_w,
-                src_h,
-                dst.as_slice_mut(),
-                dst_w,
-                dst_h,
-            );
-        }
-        InterpolationMode::Bilinear => {
-            bilinear::resize_bilinear_u8_nch::<C>(
-                src.as_slice(),
-                src_w,
-                src_h,
-                dst.as_slice_mut(),
-                dst_w,
-                dst_h,
-            );
-        }
-        InterpolationMode::Bicubic => {
-            separable::resize_separable_u8::<C>(
-                src.as_slice(),
-                src_w,
-                src_h,
-                dst.as_slice_mut(),
-                dst_w,
-                dst_h,
-                FilterKind::Cubic,
-                antialias,
-            );
-        }
-        InterpolationMode::Lanczos => {
-            separable::resize_separable_u8::<C>(
-                src.as_slice(),
-                src_w,
-                src_h,
-                dst.as_slice_mut(),
-                dst_w,
-                dst_h,
-                FilterKind::Lanczos3,
-                antialias,
-            );
-        }
-    }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/kornia-imgproc/src/resize/nearest.rs
+++ b/crates/kornia-imgproc/src/resize/nearest.rs
@@ -21,6 +21,7 @@ pub(super) fn nearest_index(i: usize, scale: f64, src_len: usize) -> usize {
 }
 
 /// Per-axis nearest LUT as `i32` (the CUDA kernel's gather index type).
+#[cfg(feature = "cuda")]
 pub(super) fn nearest_axis_lut(src_len: usize, dst_len: usize) -> Vec<i32> {
     let scale = src_len as f64 / dst_len as f64;
     (0..dst_len)

--- a/crates/kornia-imgproc/src/resize/nearest.rs
+++ b/crates/kornia-imgproc/src/resize/nearest.rs
@@ -7,6 +7,27 @@ use rayon::prelude::*;
 
 use super::kernels::nearest_row_u8;
 
+/// Nearest source index for destination index `i` on an axis sampled at
+/// `scale = src_len / dst_len`: `clamp(floor((i + 0.5) * scale))` in f64 —
+/// pixel-center then floor, deliberately NO `- 0.5` (matches OpenCV
+/// `INTER_NEAREST`'s effective u8 behavior).
+///
+/// BYTE-EXACT CONTRACT: single source of the u8 nearest coordinates — the
+/// CPU LUTs and the CUDA `resize_u8` launcher both call it.
+#[inline]
+pub(super) fn nearest_index(i: usize, scale: f64, src_len: usize) -> usize {
+    let v = ((i as f64 + 0.5) * scale).floor() as i64;
+    v.clamp(0, src_len as i64 - 1) as usize
+}
+
+/// Per-axis nearest LUT as `i32` (the CUDA kernel's gather index type).
+pub(super) fn nearest_axis_lut(src_len: usize, dst_len: usize) -> Vec<i32> {
+    let scale = src_len as f64 / dst_len as f64;
+    (0..dst_len)
+        .map(|i| nearest_index(i, scale, src_len) as i32)
+        .collect()
+}
+
 /// Nearest-neighbor u8 resize. Precomputes an `x → src_x` LUT (branch-free
 /// row/col index map) and parallelizes over destination rows.
 pub(super) fn resize_nearest_u8<const C: usize>(
@@ -19,15 +40,10 @@ pub(super) fn resize_nearest_u8<const C: usize>(
 ) {
     let src_stride = src_w * C;
     let dst_stride = dst_w * C;
-    let sx = src_w as f64 / dst_w as f64;
     let sy = src_h as f64 / dst_h as f64;
 
-    let xmap: Vec<usize> = (0..dst_w)
-        .map(|x| {
-            let v = ((x as f64 + 0.5) * sx).floor() as i64;
-            v.clamp(0, src_w as i64 - 1) as usize
-        })
-        .collect();
+    let sx = src_w as f64 / dst_w as f64;
+    let xmap: Vec<usize> = (0..dst_w).map(|x| nearest_index(x, sx, src_w)).collect();
 
     const ROWS_PER_TASK: usize = 16;
     dst.par_chunks_mut(ROWS_PER_TASK * dst_stride)
@@ -39,8 +55,7 @@ pub(super) fn resize_nearest_u8<const C: usize>(
                 .enumerate()
                 .for_each(|(dr, dst_row)| {
                     let y = row_base + dr;
-                    let yi = (((y as f64 + 0.5) * sy).floor() as i64).clamp(0, src_h as i64 - 1)
-                        as usize;
+                    let yi = nearest_index(y, sy, src_h);
                     let src_row = &src[yi * src_stride..(yi + 1) * src_stride];
                     nearest_row_u8::<C>(src_row, &xmap, dst_row);
                 });

--- a/kornia-py/python/kornia_rs/imgproc.pyi
+++ b/kornia-py/python/kornia_rs/imgproc.pyi
@@ -86,9 +86,10 @@ def resize(
 ) -> np.ndarray | Image:
     """``new_size`` is ``(height, width)``; ``interpolation`` is e.g. ``"bilinear"`` / ``"nearest"``.
 
-    A device ``Image`` (f32, 3-channel) runs on the GPU, bit-identical to the
-    CPU f32 path, and returns a device ``Image``. ``antialias`` applies only
-    to the u8 numpy path."""
+    A device ``Image`` (f32 3-channel, or u8 1/3/4-channel) runs on the GPU,
+    bit-identical to the matching CPU path, and returns a device ``Image``.
+    ``antialias`` shapes the u8 bicubic/lanczos kernels (CPU and GPU alike)
+    and is ignored for f32 and for nearest/bilinear."""
     ...
 def warp_affine(
     image: np.ndarray | Image,

--- a/kornia-py/src/cuda_ext/cuda_geometry.rs
+++ b/kornia-py/src/cuda_ext/cuda_geometry.rs
@@ -8,17 +8,25 @@
 //! byte-exact contract.
 
 use super::*;
+use cudarc::driver::{DeviceRepr, ValidAsZeroBits};
 use pyo3::types::PyAnyMethods;
+
+/// Element types the geometry helpers can allocate device outputs for.
+trait GeomElem: DeviceRepr + ValidAsZeroBits + Clone + Default + 'static {}
+impl GeomElem for f32 {}
+impl GeomElem for u8 {}
+
+fn no_device_err(op: &str) -> PyErr {
+    PyValueError::new_err(format!(
+        "{op}: expected a device Image (on a CUDA device); for a host image \
+         pass its numpy array, or move it to a device with .to_cuda(stream)"
+    ))
+}
 
 /// Borrow a device `Image<f32, 3>` out of a unified image, or raise the
 /// uniform "no GPU kernel for this dtype/channels" error.
 fn device_f32c3<'a>(img: &'a PyImageApi, op: &str) -> PyResult<&'a Image<f32, 3>> {
-    let dev = img.as_device().ok_or_else(|| {
-        PyValueError::new_err(format!(
-            "{op}: expected a device Image (on a CUDA device); for a host image \
-             pass its numpy array, or move it to a device with .to_cuda(stream)"
-        ))
-    })?;
+    let dev = img.as_device().ok_or_else(|| no_device_err(op))?;
     match dev {
         Inner::F32C3(src) => Ok(src),
         other => Err(PyValueError::new_err(format!(
@@ -47,21 +55,22 @@ impl PyOut {
     }
 }
 
-/// Borrow a caller-provided `out=` device image mutably, validating dtype,
+/// Borrow a caller-provided `out=` device image mutably, validating dtype
+/// (via `unwrap`, which pattern-matches the expected [`Inner`] variant),
 /// exclusivity (see `as_device_mut`), size, and that it is not the source.
-fn with_out<R>(
+fn with_out_t<T: GeomElem, const C: usize, R>(
     py: Python<'_>,
     out: &Py<PyAny>,
-    src: &Image<f32, 3>,
+    src: &Image<T, C>,
     dst_size: kornia_image::ImageSize,
     op: &str,
-    f: impl FnOnce(&mut Image<f32, 3>) -> PyResult<R>,
+    expect: &str,
+    unwrap: fn(&mut Inner) -> Option<&mut Image<T, C>>,
+    f: impl FnOnce(&mut Image<T, C>) -> PyResult<R>,
 ) -> PyResult<R> {
     let bound = out.bind(py);
     let cell = bound.cast::<PyImageApi>().map_err(|_| {
-        PyValueError::new_err(format!(
-            "{op}: out= must be a device Image (f32, 3-channel)"
-        ))
+        PyValueError::new_err(format!("{op}: out= must be a device Image ({expect})"))
     })?;
     // try_borrow_mut: the input image is already borrowed by the caller, so
     // out=input surfaces here as a borrow conflict — turn it into the same
@@ -75,9 +84,9 @@ fn with_out<R>(
     let dev = api
         .as_device_mut()?
         .ok_or_else(|| PyValueError::new_err(format!("{op}: out= must be a device Image")))?;
-    let Inner::F32C3(dst) = dev else {
+    let Some(dst) = unwrap(dev) else {
         return Err(PyValueError::new_err(format!(
-            "{op}: out= must be a 3-channel f32 device Image"
+            "{op}: out= must be a device Image matching the input ({expect})"
         )));
     };
     if dst.size() != dst_size {
@@ -99,52 +108,154 @@ fn with_out<R>(
     f(dst)
 }
 
+fn with_out<R>(
+    py: Python<'_>,
+    out: &Py<PyAny>,
+    src: &Image<f32, 3>,
+    dst_size: kornia_image::ImageSize,
+    op: &str,
+    f: impl FnOnce(&mut Image<f32, 3>) -> PyResult<R>,
+) -> PyResult<R> {
+    with_out_t(py, out, src, dst_size, op, "f32, 3-channel", unwrap_f32c3, f)
+}
+
+fn unwrap_f32c3(i: &mut Inner) -> Option<&mut Image<f32, 3>> {
+    match i {
+        Inner::F32C3(x) => Some(x),
+        _ => None,
+    }
+}
+fn unwrap_u8c1(i: &mut Inner) -> Option<&mut Image<u8, 1>> {
+    match i {
+        Inner::U8C1(x) => Some(x),
+        _ => None,
+    }
+}
+fn unwrap_u8c3(i: &mut Inner) -> Option<&mut Image<u8, 3>> {
+    match i {
+        Inner::U8C3(x) => Some(x),
+        _ => None,
+    }
+}
+fn unwrap_u8c4(i: &mut Inner) -> Option<&mut Image<u8, 4>> {
+    match i {
+        Inner::U8C4(x) => Some(x),
+        _ => None,
+    }
+}
+
 /// Shared tail: allocate the destination on the source's stream, run `f`
 /// (the public residency-dispatched op), wrap the result.
+fn run_geometry_t<T: GeomElem, const C: usize>(
+    src: &Image<T, C>,
+    cs: kornia_image::ColorSpace,
+    dst_size: kornia_image::ImageSize,
+    wrap: fn(Image<T, C>) -> Inner,
+    f: impl FnOnce(&mut Image<T, C>) -> Result<(), kornia_image::ImageError>,
+) -> PyResult<PyImageApi> {
+    let stream = source_stream(src)?;
+    // SAFETY: every geometry kernel writes each output pixel exactly once
+    // (bounds-guarded grid; warp border cases write 0 rather than skipping),
+    // so the uninitialized destination is fully overwritten.
+    let mut dst = unsafe { Image::<T, C>::uninit_cuda(dst_size, &stream) }.map_err(err)?;
+    f(&mut dst).map_err(err)?;
+    Ok(PyImageApi::from_device(wrap(dst), cs, device_mode::<T>(C)))
+}
+
 fn run_geometry(
     src: &Image<f32, 3>,
     cs: kornia_image::ColorSpace,
     dst_size: kornia_image::ImageSize,
     f: impl FnOnce(&mut Image<f32, 3>) -> Result<(), kornia_image::ImageError>,
 ) -> PyResult<PyImageApi> {
-    let stream = source_stream(src)?;
-    // SAFETY: every geometry kernel writes each output pixel exactly once
-    // (bounds-guarded grid; warp border cases write 0 rather than skipping),
-    // so the uninitialized destination is fully overwritten.
-    let mut dst = unsafe { Image::<f32, 3>::uninit_cuda(dst_size, &stream) }.map_err(err)?;
-    f(&mut dst).map_err(err)?;
-    Ok(PyImageApi::from_device(
-        Inner::F32C3(dst),
-        cs,
-        device_mode::<f32>(3),
-    ))
+    run_geometry_t(src, cs, dst_size, Inner::F32C3, f)
 }
 
-/// Device f32 resize on the half-pixel grid — bit-identical to the CPU
-/// `resize` (see the parity tests in `kornia-imgproc`).
+/// Device resize — f32 C3 on the half-pixel grid, or u8 C1/C3/C4 through the
+/// integer u8 kernel cascade. Both bit-identical to their CPU twins (see the
+/// parity tests in `kornia-imgproc`). `antialias` matches the CPU semantics:
+/// it shapes the u8 bicubic/lanczos kernels and is a no-op for f32 and for
+/// u8 nearest/bilinear.
 pub(crate) fn resize(
     py: Python<'_>,
     img: &PyImageApi,
     new_size: (usize, usize),
     interpolation: &str,
+    antialias: bool,
     out: Option<Py<PyAny>>,
 ) -> PyResult<PyOut> {
     let mode = crate::image::parse_interpolation(interpolation)?;
-    let src = device_f32c3(img, "resize")?;
     let dst_size = kornia_image::ImageSize {
         height: new_size.0,
         width: new_size.1,
     };
-    if let Some(out) = out {
-        with_out(py, &out, src, dst_size, "resize", |dst| {
-            kornia_imgproc::resize::resize(src, dst, mode).map_err(err)
-        })?;
-        return Ok(PyOut::Reused(out));
+
+    /// One u8 channel-count arm: `out=` path or fresh allocation, both
+    /// through the public residency-dispatched `resize_fast_u8_aa`.
+    fn resize_u8<const C: usize>(
+        py: Python<'_>,
+        img: &PyImageApi,
+        src: &Image<u8, C>,
+        dst_size: kornia_image::ImageSize,
+        mode: kornia_imgproc::interpolation::InterpolationMode,
+        antialias: bool,
+        out: Option<Py<PyAny>>,
+        unwrap: fn(&mut Inner) -> Option<&mut Image<u8, C>>,
+        wrap: fn(Image<u8, C>) -> Inner,
+    ) -> PyResult<PyOut> {
+        if let Some(out) = out {
+            with_out_t(
+                py,
+                &out,
+                src,
+                dst_size,
+                "resize",
+                "u8, same channel count as the input",
+                unwrap,
+                |dst| {
+                    kornia_imgproc::resize::resize_fast_u8_aa(src, dst, mode, antialias)
+                        .map_err(err)
+                },
+            )?;
+            return Ok(PyOut::Reused(out));
+        }
+        run_geometry_t(src, img.color_space, dst_size, wrap, |dst| {
+            kornia_imgproc::resize::resize_fast_u8_aa(src, dst, mode, antialias)
+        })
+        .map(PyOut::New)
     }
-    run_geometry(src, img.color_space, dst_size, |dst| {
-        kornia_imgproc::resize::resize(src, dst, mode)
-    })
-    .map(PyOut::New)
+
+    let dev = img.as_device().ok_or_else(|| no_device_err("resize"))?;
+    match dev {
+        Inner::F32C3(src) => {
+            if let Some(out) = out {
+                with_out(py, &out, src, dst_size, "resize", |dst| {
+                    kornia_imgproc::resize::resize(src, dst, mode).map_err(err)
+                })?;
+                return Ok(PyOut::Reused(out));
+            }
+            run_geometry(src, img.color_space, dst_size, |dst| {
+                kornia_imgproc::resize::resize(src, dst, mode)
+            })
+            .map(PyOut::New)
+        }
+        Inner::U8C1(src) => resize_u8::<1>(
+            py, img, src, dst_size, mode, antialias, out, unwrap_u8c1, Inner::U8C1,
+        ),
+        Inner::U8C3(src) => resize_u8::<3>(
+            py, img, src, dst_size, mode, antialias, out, unwrap_u8c3, Inner::U8C3,
+        ),
+        Inner::U8C4(src) => resize_u8::<4>(
+            py, img, src, dst_size, mode, antialias, out, unwrap_u8c4, Inner::U8C4,
+        ),
+        other => Err(PyValueError::new_err(format!(
+            "resize: the GPU path supports f32 3-channel and u8 1/3/4-channel \
+             device images, got {:?} with {} channel(s); convert on the host \
+             or move the image back with .cpu()",
+            other.dtype_enum(),
+            other.channels()
+        ))),
+    }
 }
 
 /// Device f32 warp-affine (forward 2×3 matrix, inverted internally like CPU).

--- a/kornia-py/src/cuda_ext/cuda_geometry.rs
+++ b/kornia-py/src/cuda_ext/cuda_geometry.rs
@@ -9,7 +9,6 @@
 
 use super::*;
 use cudarc::driver::{DeviceRepr, ValidAsZeroBits};
-use pyo3::types::PyAnyMethods;
 
 /// Element types the geometry helpers can allocate device outputs for.
 trait GeomElem: DeviceRepr + ValidAsZeroBits + Clone + Default + 'static {}
@@ -116,7 +115,16 @@ fn with_out<R>(
     op: &str,
     f: impl FnOnce(&mut Image<f32, 3>) -> PyResult<R>,
 ) -> PyResult<R> {
-    with_out_t(py, out, src, dst_size, op, "f32, 3-channel", unwrap_f32c3, f)
+    with_out_t(
+        py,
+        out,
+        src,
+        dst_size,
+        op,
+        "f32, 3-channel",
+        unwrap_f32c3,
+        f,
+    )
 }
 
 fn unwrap_f32c3(i: &mut Inner) -> Option<&mut Image<f32, 3>> {
@@ -240,13 +248,37 @@ pub(crate) fn resize(
             .map(PyOut::New)
         }
         Inner::U8C1(src) => resize_u8::<1>(
-            py, img, src, dst_size, mode, antialias, out, unwrap_u8c1, Inner::U8C1,
+            py,
+            img,
+            src,
+            dst_size,
+            mode,
+            antialias,
+            out,
+            unwrap_u8c1,
+            Inner::U8C1,
         ),
         Inner::U8C3(src) => resize_u8::<3>(
-            py, img, src, dst_size, mode, antialias, out, unwrap_u8c3, Inner::U8C3,
+            py,
+            img,
+            src,
+            dst_size,
+            mode,
+            antialias,
+            out,
+            unwrap_u8c3,
+            Inner::U8C3,
         ),
         Inner::U8C4(src) => resize_u8::<4>(
-            py, img, src, dst_size, mode, antialias, out, unwrap_u8c4, Inner::U8C4,
+            py,
+            img,
+            src,
+            dst_size,
+            mode,
+            antialias,
+            out,
+            unwrap_u8c4,
+            Inner::U8C4,
         ),
         other => Err(PyValueError::new_err(format!(
             "resize: the GPU path supports f32 3-channel and u8 1/3/4-channel \

--- a/kornia-py/src/resize.rs
+++ b/kornia-py/src/resize.rs
@@ -1,9 +1,7 @@
 use pyo3::prelude::*;
 
 use crate::dispatch::cpu_op;
-use crate::image::{
-    alloc_output_pyarray, numpy_as_image, parse_interpolation, to_pyerr, PyImageApi,
-};
+use crate::image::{alloc_output_pyarray, numpy_as_image, parse_interpolation, to_pyerr};
 use kornia_image::ImageSize;
 use kornia_imgproc::resize::resize_fast_rgb_aa;
 
@@ -26,7 +24,7 @@ pub fn resize(
     out: Option<Py<PyAny>>,
 ) -> PyResult<Py<PyAny>> {
     #[cfg(feature = "cuda")]
-    if let Ok(api) = image.cast::<PyImageApi>() {
+    if let Ok(api) = image.cast::<crate::image::PyImageApi>() {
         let img = api.borrow();
         if img.is_device() {
             return crate::cuda_ext::geometry::resize(

--- a/kornia-py/src/resize.rs
+++ b/kornia-py/src/resize.rs
@@ -9,12 +9,12 @@ use kornia_imgproc::resize::resize_fast_rgb_aa;
 
 /// Resize an image.
 ///
-/// Residency-dispatched like the color ops: a device `Image` (f32, 3-channel)
-/// runs the CUDA kernels — bit-identical to the CPU f32 path — and accepts a
-/// preallocated device `out=` (torch-style) so frame loops allocate nothing;
-/// a host `Image` or numpy u8 array runs the CPU fast path. `antialias`
-/// applies only to the u8 CPU path (the f32 paths, CPU and GPU alike, have
-/// never antialiased).
+/// Residency-dispatched like the color ops: a device `Image` (f32 3-channel,
+/// or u8 1/3/4-channel) runs the CUDA kernels — bit-identical to the CPU
+/// twins — and accepts a preallocated device `out=` (torch-style) so frame
+/// loops allocate nothing; a host `Image` or numpy u8 array runs the CPU
+/// fast path. `antialias` shapes the u8 bicubic/lanczos kernels (CPU and
+/// GPU alike); the f32 paths have never antialiased.
 #[pyfunction]
 #[pyo3(signature = (image, new_size, interpolation, antialias=true, out=None))]
 pub fn resize(
@@ -29,8 +29,15 @@ pub fn resize(
     if let Ok(api) = image.cast::<PyImageApi>() {
         let img = api.borrow();
         if img.is_device() {
-            return crate::cuda_ext::geometry::resize(py, &img, new_size, interpolation, out)?
-                .into_py(py);
+            return crate::cuda_ext::geometry::resize(
+                py,
+                &img,
+                new_size,
+                interpolation,
+                antialias,
+                out,
+            )?
+            .into_py(py);
         }
     }
     if out.is_some() {

--- a/kornia-py/tests/test_cuda_geometry.py
+++ b/kornia-py/tests/test_cuda_geometry.py
@@ -49,11 +49,52 @@ class TestDeviceResize:
         assert isinstance(out, np.ndarray)
         assert out.shape == (16, 16, 3)
 
-    def test_wrong_dtype_device_errors(self):
-        a = (np.zeros((16, 16, 3), dtype=np.uint8))
+    def test_wrong_dtype_device_warp_errors(self):
+        # Warps stay f32-only on the device path (resize gained u8 kernels).
+        a = np.zeros((16, 16, 3), dtype=np.uint8)
         d = _dev(a)  # u8 device image
         with pytest.raises(ValueError, match="3-channel f32"):
-            imgproc.resize(d, (8, 8), "bilinear")
+            imgproc.warp_affine(d, [1, 0, 0, 0, 1, 0], (8, 8), "bilinear")
+
+
+class TestDeviceResizeU8:
+    """u8 device resize runs the integer CUDA kernel cascade, bit-identical
+    to the numpy u8 CPU path (same host-built coordinate tables)."""
+
+    def _pattern_u8(self, h, w, c=3):
+        rng = np.random.default_rng(7)
+        return rng.integers(0, 256, size=(h, w, c), dtype=np.uint8)
+
+    @pytest.mark.parametrize("mode", ["nearest", "bilinear", "bicubic", "lanczos"])
+    @pytest.mark.parametrize("antialias", [True, False])
+    def test_matches_numpy_cpu_bit_exact(self, mode, antialias):
+        a = self._pattern_u8(97, 129)
+        cpu = imgproc.resize(a, (48, 64), mode, antialias=antialias)
+        out = imgproc.resize(_dev(a), (48, 64), mode, antialias=antialias)
+        assert "cuda" in str(out.device)
+        np.testing.assert_array_equal(out.cpu().numpy(), cpu)
+
+    def test_pyr2x_fast_paths_bit_exact(self):
+        a = self._pattern_u8(98, 130)
+        for new_size in [(49, 65), (196, 260)]:
+            cpu = imgproc.resize(a, new_size, "bilinear")
+            out = imgproc.resize(_dev(a), new_size, "bilinear")
+            np.testing.assert_array_equal(out.cpu().numpy(), cpu)
+
+    def test_out_reuse_matches_fresh(self):
+        a = self._pattern_u8(64, 64)
+        d = _dev(a)
+        fresh = imgproc.resize(d, (32, 32), "bilinear")
+        out_buf = imgproc.resize(d, (32, 32), "nearest")  # u8 device buffer
+        reused = imgproc.resize(d, (32, 32), "bilinear", out=out_buf)
+        assert reused is out_buf
+        np.testing.assert_array_equal(reused.cpu().numpy(), fresh.cpu().numpy())
+
+    def test_out_dtype_mismatch_rejected(self):
+        a = self._pattern_u8(64, 64)
+        f32_out = imgproc.resize(_dev(_pattern_f32(32, 32)), (32, 32), "bilinear")
+        with pytest.raises(ValueError, match="matching the input"):
+            imgproc.resize(_dev(a), (32, 32), "bilinear", out=f32_out)
 
 
 class TestDeviceWarps:


### PR DESCRIPTION
## What

u8 device images now resize on the GPU, across the **entire** CPU u8 cascade — and the output is **byte-for-byte identical** to the CPU (`assert_eq!`, not tolerances):

| CPU branch | New CUDA kernel |
|---|---|
| pyrdown 2× RGB (box, `(sum+2)>>2`) | `resize_u8_pyrdown2x_rgb` |
| pyrup 2× RGB (nested rounding averages) | `resize_u8_pyrup2x_rgb` |
| nearest (f64 half-pixel floor LUT) | `resize_u8_nearest` (pure gather) |
| generic bilinear Q14 (u64 blend, one Q28 round) | `resize_u8_bilinear` |
| separable bicubic/lanczos Q14, AA + non-AA (i16 intermediate) | `resize_u8_sep_h` + `resize_u8_sep_v` |

**How byte-exactness holds:** the u8 CPU paths precompute coordinates in host f64 and run integer fixed-point pixel loops — no device float expression can mirror that. So the kernels are integer-only, and the coordinate/weight tables are built by the *same host functions the CPU uses* (`bilinear_tap`, `nearest_index`, `precompute_contribs` — extracted as shared single-source builders) and uploaded. CPU and GPU cannot drift by construction.

**Device LUT cache:** nsys showed per-call pageable H2D uploads average ~250 µs on Jetson (8 µs median, 8 ms max tail) — dominating the op. Tables now upload once per (device, mode, antialias, geometry) into a bounded cache; the warm path is pure kernel launches and therefore CUDA-Graph-capturable after one warming call.

Also: Rust `resize_fast_u8_aa` residency dispatch (error-never-fallback, cascade mirrored branch-for-branch); Python `kornia_rs.imgproc.resize` accepts u8 1/3/4-channel device images incl. `out=`; resize launchers no longer panic on NVRTC failure (prep commit consolidates the shadowed compile helpers onto `cuda/mod.rs` — fmad-drift risk).

## Benchmarks (Jetson Orin, 1080p→720p u8 RGB, median, out= reuse)

| op | kornia GPU | VPI-CUDA | cv2 CPU | kornia CPU |
|---|---|---|---|---|
| nearest | **0.22 ms** | 1.18 | 0.70 | 0.39 |
| bilinear | **0.38 ms** | 1.26 | 2.39 | 2.40 |
| bicubic (non-AA, = VPI/cv2 semantics) | **1.20 ms** | 1.32 | 5.30 | 4.78 |
| lanczos AA (no VPI equivalent) | **4.12 ms** | — | 9.33 (non-AA) | 8.14 |

Fastest on every VPI-comparable op. CPU A/B vs main (same-minute, alternating, 2 rounds): all deltas within criterion noise — no regression.

## Tests

- 10 Rust parity tests: all 5 branches × C∈{1,3,4} × AA on/off × odd sizes × extreme downscale (4000→50-class, i32 accumulator bound) — `assert_eq!` on raw bytes.
- Python: u8 device vs numpy CPU bit-exact (4 modes × AA), pyr fast paths, `out=` reuse + dtype-mismatch rejection.
- Known-unrelated: `test_mem_probe_is_sensitive` fails identically with a main-built wheel on this Jetson (environmental `mem_get_info` insensitivity, not this PR — will file separately).

## Follow-ups (not this PR)

- 6+ tap separable kernels scale super-linearly with taps; compile-time tap-count kernel variants are the next lever.
- u8 warps (PR 2 of the roadmap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)