### PR TITLE
feat(imgproc): u8 CUDA warps (bilinear) + bit-exact CPU perspective backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ changes early: `cargo add kornia-imgproc@0.1.15-rc.1` or `pip install --pre korn
 
 ## [Unreleased]
 
+**u8 CUDA warps (bilinear), bit-identical to the CPU fast paths — which are
+now bit-identical to each other too.** `warp_affine_u8` and
+`warp_perspective_u8` route u8 device images (1/3/4-channel) to new
+integer-only CUDA kernels that mirror the CPU's per-row span math and
+Q16/Q10 fixed-point sampling exactly; `kornia_rs.imgproc.warp_affine` /
+`warp_perspective` accept u8 device images including `out=`. Along the way
+the CPU u8 perspective warp switched from incremental coordinate updates
+(`nx += dnx` per column, with a SIMD reciprocal estimate) to direct
+per-column evaluation with exact IEEE division — scalar, NEON, and AVX2 now
+produce identical bytes instead of agreeing "up to sub-ULP noise". Output
+shifts by at most one Q10 quantum on some pixels relative to earlier
+releases; benchmarks show no measurable CPU cost (the division latency hides
+behind the 4-lane structure).
+
 **u8 CUDA resize — every mode, bit-identical to the CPU fast paths.** Camera
 data is u8; until now the GPU only resized f32 (4× the memory traffic once you
 count the conversion). `resize_fast_u8_aa` (Rust) and `kornia_rs.imgproc.resize`

--- a/crates/kornia-imgproc/src/cuda/mod.rs
+++ b/crates/kornia-imgproc/src/cuda/mod.rs
@@ -14,6 +14,10 @@ pub mod resize_u8;
 /// Native CUDA warp-affine kernels (bilinear and nearest-neighbor).
 pub mod warp_affine;
 
+/// Native CUDA u8 warp-affine kernel (Q16/Q10 fixed point, byte-exact with
+/// the CPU `warp_affine_u8`).
+pub mod warp_affine_u8;
+
 /// Native CUDA warp-perspective kernels (homography, bilinear / nearest / bicubic / Lanczos-3).
 pub mod warp_perspective;
 

--- a/crates/kornia-imgproc/src/cuda/mod.rs
+++ b/crates/kornia-imgproc/src/cuda/mod.rs
@@ -21,6 +21,10 @@ pub mod warp_affine_u8;
 /// Native CUDA warp-perspective kernels (homography, bilinear / nearest / bicubic / Lanczos-3).
 pub mod warp_perspective;
 
+/// Native CUDA u8 warp-perspective kernel (direct rational coords + Q10
+/// fixed point, byte-exact with the CPU `warp_perspective_u8`).
+pub mod warp_perspective_u8;
+
 /// Native CUDA color-space conversion kernels.
 pub mod color;
 

--- a/crates/kornia-imgproc/src/cuda/warp_affine_u8.rs
+++ b/crates/kornia-imgproc/src/cuda/warp_affine_u8.rs
@@ -24,7 +24,8 @@
 //! the same `invert_affine_transform` the CPU path calls, so the f32
 //! inversion arithmetic is shared, not mirrored.
 
-use std::sync::{Arc, OnceLock};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
 
 use cudarc::driver::{CudaContext, CudaSlice, CudaStream};
 use kornia_tensor::CudaKernel;
@@ -32,36 +33,38 @@ use kornia_tensor::CudaKernel;
 use super::resize::CudaResizeError as CudaWarpU8Error;
 use super::{make_config, try_compile_with_l1};
 
-static AFFINE_U8_SRC: &str = r#"
+fn affine_u8_src(channels: usize) -> String {
+    format!(
+        r#"
+#define C {channels}
 // Mirror of warp::span::constrain_span (f32; compiled with --fmad=false so
 // -b/a, ceilf, floorf round exactly like the CPU expressions).
 __device__ __forceinline__ void constrain_span(
     float a, float b, bool ge, float eps, long long* lo, long long* hi
-) {
-    if (fabsf(a) < eps || a == 0.0f) {
+) {{
+    if (fabsf(a) < eps || a == 0.0f) {{
         bool feasible = ge ? (b >= 0.0f) : (b < 0.0f);
-        if (!feasible) { *hi = *lo; }
+        if (!feasible) {{ *hi = *lo; }}
         return;
-    }
+    }}
     float k = -b / a;
-    if (ge) {
-        if (a > 0.0f) { long long v = (long long)ceilf(k);      if (v > *lo) *lo = v; }
-        else          { long long v = (long long)floorf(k) + 1; if (v < *hi) *hi = v; }
-    } else {
-        if (a > 0.0f) { long long v = (long long)ceilf(k);      if (v < *hi) *hi = v; }
-        else          { long long v = (long long)floorf(k) + 1; if (v > *lo) *lo = v; }
-    }
-}
+    if (ge) {{
+        if (a > 0.0f) {{ long long v = (long long)ceilf(k);      if (v > *lo) *lo = v; }}
+        else          {{ long long v = (long long)floorf(k) + 1; if (v < *hi) *hi = v; }}
+    }} else {{
+        if (a > 0.0f) {{ long long v = (long long)ceilf(k);      if (v < *hi) *hi = v; }}
+        else          {{ long long v = (long long)floorf(k) + 1; if (v > *lo) *lo = v; }}
+    }}
+}}
 
-extern "C" __global__ void warp_affine_u8_bilinear(
+extern "C" __global__ void warp_affine_u8_bilinear_c{channels}(
     const unsigned char* __restrict__ src,
     unsigned char* __restrict__       dst,
     float m0, float m1, float m2, float m3, float m4, float m5, // inverse map
     int   dsx_q, int dsy_q,       // host-quantized Q16 increments
     int   src_w, int src_h,
-    unsigned int dst_w, unsigned int dst_h,
-    unsigned int channels
-) {
+    unsigned int dst_w, unsigned int dst_h
+) {{
     // Row prologue: one thread per block-row mirrors the CPU span + Q16
     // anchor computation; blockDim.y <= 8 (see make_config).
     __shared__ int s_xlo[8];
@@ -72,7 +75,7 @@ extern "C" __global__ void warp_affine_u8_bilinear(
     unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
     unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
 
-    if (threadIdx.x == 0 && y < dst_h) {
+    if (threadIdx.x == 0 && y < dst_h) {{
         float y_f = (float)y;
         float sx0 = m1 * y_f + m2;
         float sy0 = m4 * y_f + m5;
@@ -81,10 +84,10 @@ extern "C" __global__ void warp_affine_u8_bilinear(
         long long lo = 0, hi = (long long)dst_w;
         constrain_span(m0, sx0, true, 1e-12f, &lo, &hi);
         constrain_span(m0, sx0 - (float)src_w, false, 1e-12f, &lo, &hi);
-        if (lo < hi) {
+        if (lo < hi) {{
             constrain_span(m3, sy0, true, 1e-12f, &lo, &hi);
             constrain_span(m3, sy0 - (float)src_h, false, 1e-12f, &lo, &hi);
-        }
+        }}
         long long lo_c = min(max(lo, 0ll), (long long)dst_w);
         long long hi_c = min(max(hi, 0ll), (long long)dst_w);
         int xlo = (lo >= hi || lo_c >= hi_c) ? 0 : (int)lo_c;
@@ -94,18 +97,19 @@ extern "C" __global__ void warp_affine_u8_bilinear(
         // Q16 anchors at x_lo — same f32 expression + truncating cast as CPU.
         s_sxq[threadIdx.y] = (int)((sx0 + m0 * (float)xlo) * 65536.0f);
         s_syq[threadIdx.y] = (int)((sy0 + m3 * (float)xlo) * 65536.0f);
-    }
+    }}
     __syncthreads();
 
     if (x >= dst_w || y >= dst_h) return;
 
-    size_t d = ((size_t)y * dst_w + x) * channels;
+    size_t d = ((size_t)y * dst_w + x) * C;
     int xlo = s_xlo[threadIdx.y];
     int xhi = s_xhi[threadIdx.y];
-    if ((int)x < xlo || (int)x >= xhi) {
-        for (unsigned int ch = 0; ch < channels; ++ch) dst[d + ch] = 0;
+    if ((int)x < xlo || (int)x >= xhi) {{
+        #pragma unroll
+    for (unsigned int ch = 0; ch < C; ++ch) dst[d + ch] = 0;
         return;
-    }
+    }}
 
     // Wrapping i32 coordinate, identical to the CPU's repeated wrapping_add.
     unsigned int rel = x - (unsigned int)xlo;
@@ -122,12 +126,13 @@ extern "C" __global__ void warp_affine_u8_bilinear(
     int xi1 = (xi + 1 < src_w) ? xi + 1 : xi;             // replicate far edge
     int yi1 = (yi + 1 < src_h) ? yi + 1 : yi;
 
-    size_t row0 = (size_t)yi * src_w * channels;
-    size_t row1 = (size_t)yi1 * src_w * channels;
-    size_t off0 = (size_t)xi * channels;
-    size_t off1 = (size_t)xi1 * channels;
+    size_t row0 = (size_t)yi * src_w * C;
+    size_t row1 = (size_t)yi1 * src_w * C;
+    size_t off0 = (size_t)xi * C;
+    size_t off1 = (size_t)xi1 * C;
 
-    for (unsigned int ch = 0; ch < channels; ++ch) {
+    #pragma unroll
+    for (unsigned int ch = 0; ch < C; ++ch) {{
         unsigned int p00 = (unsigned int)__ldg(&src[row0 + off0 + ch]);
         unsigned int p01 = (unsigned int)__ldg(&src[row0 + off1 + ch]);
         unsigned int p10 = (unsigned int)__ldg(&src[row1 + off0 + ch]);
@@ -135,11 +140,14 @@ extern "C" __global__ void warp_affine_u8_bilinear(
         unsigned int top = p00 * fx1 + p01 * fx;
         unsigned int bot = p10 * fx1 + p11 * fx;
         dst[d + ch] = (unsigned char)((top * fy1 + bot * fy + (1u << 19)) >> 20);
-    }
+    }}
+}}
+"#
+    )
 }
-"#;
 
-static AFFINE_U8_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
+type PerCKernelCache = Mutex<HashMap<u32, Arc<CudaKernel>>>;
+static AFFINE_U8_KERNELS: OnceLock<PerCKernelCache> = OnceLock::new();
 
 /// Launch the u8 bilinear warp-affine kernel.
 ///
@@ -176,10 +184,27 @@ pub fn launch_warp_affine_u8_bilinear_cuda(
         });
     }
 
-    let kernel = AFFINE_U8_KERNEL
-        .get_or_init(|| try_compile_with_l1(ctx, AFFINE_U8_SRC, "warp_affine_u8_bilinear"))
-        .as_ref()
-        .map_err(|e| CudaWarpU8Error::Cuda(e.clone()))?;
+    // Per-C specialized kernel (scoped-guard cache lookup).
+    let cache = AFFINE_U8_KERNELS.get_or_init(Default::default);
+    let cached = cache
+        .lock()
+        .expect("warp kernel cache poisoned")
+        .get(&channels)
+        .cloned();
+    let kernel = if let Some(hit) = cached {
+        hit
+    } else {
+        let src_code = affine_u8_src(channels as usize);
+        let name = format!("warp_affine_u8_bilinear_c{channels}");
+        let built =
+            Arc::new(try_compile_with_l1(ctx, &src_code, &name).map_err(CudaWarpU8Error::Cuda)?);
+        cache
+            .lock()
+            .expect("warp kernel cache poisoned")
+            .entry(channels)
+            .or_insert(built)
+            .clone()
+    };
 
     // Same Q16 quantization (f32 -> i32 truncating cast) the CPU applies.
     let dsx_q = (m_inv[0] * 65536.0) as i32;
@@ -202,7 +227,6 @@ pub fn launch_warp_affine_u8_bilinear_cuda(
         .arg(&src_h_i)
         .arg(&dst_width)
         .arg(&dst_height)
-        .arg(&channels)
         .launch_2d(
             dst_width,
             dst_height,

--- a/crates/kornia-imgproc/src/cuda/warp_affine_u8.rs
+++ b/crates/kornia-imgproc/src/cuda/warp_affine_u8.rs
@@ -1,0 +1,212 @@
+//! Native CUDA u8 warp-affine (bilinear), byte-exact with `warp_affine_u8`.
+//!
+//! # Exactness strategy
+//!
+//! The CPU u8 path (`warp/affine.rs`) is integer fixed-point per row: a
+//! per-row f32 anchor `sx_q_lo = ((sx0 + dsx*x_lo) * 65536) as i32` at the
+//! valid span's left edge, then Q16 integer increments per column and a Q10
+//! bilinear sampler. The span `[x_lo, x_hi)` is PART of the arithmetic (the
+//! anchor is evaluated at `x_lo`), so a per-pixel f32 validity predicate
+//! cannot reproduce the CPU bytes. Instead the kernel mirrors the CPU row
+//! prologue exactly — one thread per block-row runs the `warp::span`
+//! constraint math (same f32 expressions, `--fmad=false`) into shared
+//! memory, and every thread derives its coordinate as
+//! `sx_q = sx_q_lo + (x - x_lo) * dsx_q` in wrapping 32-bit arithmetic,
+//! identical to the CPU's repeated `wrapping_add`.
+//!
+//! The Q10 sampler transcribes `bilinear_sample_u8_valid`'s scalar form:
+//! `fx = (sx_q & 0xFFFF) >> 6` (truncation), `xi+1` clamped to the last
+//! column/row (BORDER_REPLICATE at the far edge), u32 blend
+//! `(top*fy1 + bot*fy + (1<<19)) >> 20` (round-half-up). Outside the span
+//! the CPU memsets zero; the kernel writes zeros per pixel.
+//!
+//! The launcher takes the ALREADY-INVERTED matrix: the adapter inverts with
+//! the same `invert_affine_transform` the CPU path calls, so the f32
+//! inversion arithmetic is shared, not mirrored.
+
+use std::sync::{Arc, OnceLock};
+
+use cudarc::driver::{CudaContext, CudaSlice, CudaStream};
+use kornia_tensor::CudaKernel;
+
+use super::resize::CudaResizeError as CudaWarpU8Error;
+use super::{make_config, try_compile_with_l1};
+
+static AFFINE_U8_SRC: &str = r#"
+// Mirror of warp::span::constrain_span (f32; compiled with --fmad=false so
+// -b/a, ceilf, floorf round exactly like the CPU expressions).
+__device__ __forceinline__ void constrain_span(
+    float a, float b, bool ge, float eps, long long* lo, long long* hi
+) {
+    if (fabsf(a) < eps || a == 0.0f) {
+        bool feasible = ge ? (b >= 0.0f) : (b < 0.0f);
+        if (!feasible) { *hi = *lo; }
+        return;
+    }
+    float k = -b / a;
+    if (ge) {
+        if (a > 0.0f) { long long v = (long long)ceilf(k);      if (v > *lo) *lo = v; }
+        else          { long long v = (long long)floorf(k) + 1; if (v < *hi) *hi = v; }
+    } else {
+        if (a > 0.0f) { long long v = (long long)ceilf(k);      if (v < *hi) *hi = v; }
+        else          { long long v = (long long)floorf(k) + 1; if (v > *lo) *lo = v; }
+    }
+}
+
+extern "C" __global__ void warp_affine_u8_bilinear(
+    const unsigned char* __restrict__ src,
+    unsigned char* __restrict__       dst,
+    float m0, float m1, float m2, float m3, float m4, float m5, // inverse map
+    int   dsx_q, int dsy_q,       // host-quantized Q16 increments
+    int   src_w, int src_h,
+    unsigned int dst_w, unsigned int dst_h,
+    unsigned int channels
+) {
+    // Row prologue: one thread per block-row mirrors the CPU span + Q16
+    // anchor computation; blockDim.y <= 8 (see make_config).
+    __shared__ int s_xlo[8];
+    __shared__ int s_xhi[8];
+    __shared__ int s_sxq[8];
+    __shared__ int s_syq[8];
+
+    unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+
+    if (threadIdx.x == 0 && y < dst_h) {
+        float y_f = (float)y;
+        float sx0 = m1 * y_f + m2;
+        float sy0 = m4 * y_f + m5;
+
+        // affine_valid_span(axes, dst_w, 1e-12): 0 <= d*x + s0 < upper.
+        long long lo = 0, hi = (long long)dst_w;
+        constrain_span(m0, sx0, true, 1e-12f, &lo, &hi);
+        constrain_span(m0, sx0 - (float)src_w, false, 1e-12f, &lo, &hi);
+        if (lo < hi) {
+            constrain_span(m3, sy0, true, 1e-12f, &lo, &hi);
+            constrain_span(m3, sy0 - (float)src_h, false, 1e-12f, &lo, &hi);
+        }
+        long long lo_c = min(max(lo, 0ll), (long long)dst_w);
+        long long hi_c = min(max(hi, 0ll), (long long)dst_w);
+        int xlo = (lo >= hi || lo_c >= hi_c) ? 0 : (int)lo_c;
+        int xhi = (lo >= hi || lo_c >= hi_c) ? 0 : (int)hi_c;
+        s_xlo[threadIdx.y] = xlo;
+        s_xhi[threadIdx.y] = xhi;
+        // Q16 anchors at x_lo — same f32 expression + truncating cast as CPU.
+        s_sxq[threadIdx.y] = (int)((sx0 + m0 * (float)xlo) * 65536.0f);
+        s_syq[threadIdx.y] = (int)((sy0 + m3 * (float)xlo) * 65536.0f);
+    }
+    __syncthreads();
+
+    if (x >= dst_w || y >= dst_h) return;
+
+    size_t d = ((size_t)y * dst_w + x) * channels;
+    int xlo = s_xlo[threadIdx.y];
+    int xhi = s_xhi[threadIdx.y];
+    if ((int)x < xlo || (int)x >= xhi) {
+        for (unsigned int ch = 0; ch < channels; ++ch) dst[d + ch] = 0;
+        return;
+    }
+
+    // Wrapping i32 coordinate, identical to the CPU's repeated wrapping_add.
+    unsigned int rel = x - (unsigned int)xlo;
+    int sx_q = (int)((unsigned int)s_sxq[threadIdx.y] + rel * (unsigned int)dsx_q);
+    int sy_q = (int)((unsigned int)s_syq[threadIdx.y] + rel * (unsigned int)dsy_q);
+
+    int xi = sx_q >> 16;                                  // arithmetic shift
+    int yi = sy_q >> 16;
+    unsigned int fx = ((unsigned int)(sx_q & 0xFFFF)) >> 6; // Q10, truncation
+    unsigned int fy = ((unsigned int)(sy_q & 0xFFFF)) >> 6;
+    unsigned int fx1 = 1024u - fx;
+    unsigned int fy1 = 1024u - fy;
+
+    int xi1 = (xi + 1 < src_w) ? xi + 1 : xi;             // replicate far edge
+    int yi1 = (yi + 1 < src_h) ? yi + 1 : yi;
+
+    size_t row0 = (size_t)yi * src_w * channels;
+    size_t row1 = (size_t)yi1 * src_w * channels;
+    size_t off0 = (size_t)xi * channels;
+    size_t off1 = (size_t)xi1 * channels;
+
+    for (unsigned int ch = 0; ch < channels; ++ch) {
+        unsigned int p00 = (unsigned int)__ldg(&src[row0 + off0 + ch]);
+        unsigned int p01 = (unsigned int)__ldg(&src[row0 + off1 + ch]);
+        unsigned int p10 = (unsigned int)__ldg(&src[row1 + off0 + ch]);
+        unsigned int p11 = (unsigned int)__ldg(&src[row1 + off1 + ch]);
+        unsigned int top = p00 * fx1 + p01 * fx;
+        unsigned int bot = p10 * fx1 + p11 * fx;
+        dst[d + ch] = (unsigned char)((top * fy1 + bot * fy + (1u << 19)) >> 20);
+    }
+}
+"#;
+
+static AFFINE_U8_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
+
+/// Launch the u8 bilinear warp-affine kernel.
+///
+/// `m_inv` is the INVERSE (dst→src) 2×3 matrix — invert the forward matrix
+/// with `warp::invert_affine_transform` on the host so the f32 inversion is
+/// the same code the CPU path runs. `block_dim.1` must be ≤ 8 (row-prologue
+/// shared-memory arrays); the default config satisfies this.
+#[allow(clippy::too_many_arguments)]
+pub fn launch_warp_affine_u8_bilinear_cuda(
+    ctx: &Arc<CudaContext>,
+    stream: &Arc<CudaStream>,
+    src: &CudaSlice<u8>,
+    dst: &mut CudaSlice<u8>,
+    m_inv: &[f32; 6],
+    src_width: u32,
+    src_height: u32,
+    dst_width: u32,
+    dst_height: u32,
+    channels: u32,
+    block_dim: Option<(u32, u32)>,
+) -> Result<(), CudaWarpU8Error> {
+    super::check_geometry(src_width, src_height, dst_width, dst_height, block_dim)
+        .map_err(CudaWarpU8Error::Cuda)?;
+    if block_dim.is_some_and(|(_, bh)| bh > 8) {
+        return Err(CudaWarpU8Error::Cuda(
+            "warp_affine_u8: block_dim.1 must be <= 8 (row-prologue smem)".into(),
+        ));
+    }
+    let need = (dst_width as usize) * (dst_height as usize) * (channels as usize);
+    if dst.len() < need {
+        return Err(CudaWarpU8Error::SliceTooSmall {
+            got: dst.len(),
+            need,
+        });
+    }
+
+    let kernel = AFFINE_U8_KERNEL
+        .get_or_init(|| try_compile_with_l1(ctx, AFFINE_U8_SRC, "warp_affine_u8_bilinear"))
+        .as_ref()
+        .map_err(|e| CudaWarpU8Error::Cuda(e.clone()))?;
+
+    // Same Q16 quantization (f32 -> i32 truncating cast) the CPU applies.
+    let dsx_q = (m_inv[0] * 65536.0) as i32;
+    let dsy_q = (m_inv[3] * 65536.0) as i32;
+    let (src_w_i, src_h_i) = (src_width as i32, src_height as i32);
+
+    kernel
+        .launch_builder(stream)
+        .arg(src)
+        .arg(dst)
+        .arg(&m_inv[0])
+        .arg(&m_inv[1])
+        .arg(&m_inv[2])
+        .arg(&m_inv[3])
+        .arg(&m_inv[4])
+        .arg(&m_inv[5])
+        .arg(&dsx_q)
+        .arg(&dsy_q)
+        .arg(&src_w_i)
+        .arg(&src_h_i)
+        .arg(&dst_width)
+        .arg(&dst_height)
+        .arg(&channels)
+        .launch_2d(
+            dst_width,
+            dst_height,
+            make_config(dst_width, dst_height, block_dim),
+        )
+        .map_err(|e| CudaWarpU8Error::Cuda(e.to_string()))
+}

--- a/crates/kornia-imgproc/src/cuda/warp_affine_u8.rs
+++ b/crates/kornia-imgproc/src/cuda/warp_affine_u8.rs
@@ -183,6 +183,15 @@ pub fn launch_warp_affine_u8_bilinear_cuda(
             need,
         });
     }
+    // Symmetric source check: the kernel gathers up to src_w*src_h*C-1 and
+    // the adapter is not the only caller of this pub launcher.
+    let src_need = (src_width as usize) * (src_height as usize) * (channels as usize);
+    if src.len() < src_need {
+        return Err(CudaWarpU8Error::SliceTooSmall {
+            got: src.len(),
+            need: src_need,
+        });
+    }
 
     // Per-C specialized kernel (scoped-guard cache lookup).
     let cache = AFFINE_U8_KERNELS.get_or_init(Default::default);

--- a/crates/kornia-imgproc/src/cuda/warp_perspective_u8.rs
+++ b/crates/kornia-imgproc/src/cuda/warp_perspective_u8.rs
@@ -24,7 +24,8 @@
 //! The launcher takes the ALREADY-INVERTED homography: the adapter inverts
 //! with the same `inverse_perspective_matrix` the CPU path calls.
 
-use std::sync::{Arc, OnceLock};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
 
 use cudarc::driver::{CudaContext, CudaSlice, CudaStream};
 use kornia_tensor::CudaKernel;
@@ -32,36 +33,38 @@ use kornia_tensor::CudaKernel;
 use super::resize::CudaResizeError as CudaWarpU8Error;
 use super::{make_config, try_compile_with_l1};
 
-static PERSPECTIVE_U8_SRC: &str = r#"
+fn perspective_u8_src(channels: usize) -> String {
+    format!(
+        r#"
+#define C {channels}
 // Mirror of warp::span::constrain_span (see cuda/warp_affine_u8.rs).
 __device__ __forceinline__ void constrain_span(
     float a, float b, bool ge, float eps, long long* lo, long long* hi
-) {
-    if (fabsf(a) < eps || a == 0.0f) {
+) {{
+    if (fabsf(a) < eps || a == 0.0f) {{
         bool feasible = ge ? (b >= 0.0f) : (b < 0.0f);
-        if (!feasible) { *hi = *lo; }
+        if (!feasible) {{ *hi = *lo; }}
         return;
-    }
+    }}
     float k = -b / a;
-    if (ge) {
-        if (a > 0.0f) { long long v = (long long)ceilf(k);      if (v > *lo) *lo = v; }
-        else          { long long v = (long long)floorf(k) + 1; if (v < *hi) *hi = v; }
-    } else {
-        if (a > 0.0f) { long long v = (long long)ceilf(k);      if (v < *hi) *hi = v; }
-        else          { long long v = (long long)floorf(k) + 1; if (v > *lo) *lo = v; }
-    }
-}
+    if (ge) {{
+        if (a > 0.0f) {{ long long v = (long long)ceilf(k);      if (v > *lo) *lo = v; }}
+        else          {{ long long v = (long long)floorf(k) + 1; if (v < *hi) *hi = v; }}
+    }} else {{
+        if (a > 0.0f) {{ long long v = (long long)ceilf(k);      if (v < *hi) *hi = v; }}
+        else          {{ long long v = (long long)floorf(k) + 1; if (v > *lo) *lo = v; }}
+    }}
+}}
 
-extern "C" __global__ void warp_perspective_u8_bilinear(
+extern "C" __global__ void warp_perspective_u8_bilinear_c{channels}(
     const unsigned char* __restrict__ src,
     unsigned char* __restrict__       dst,
     float m0, float m1, float m2,   // inverse homography, row-major
     float m3, float m4, float m5,
     float m6, float m7, float m8,
     int   src_w, int src_h,
-    unsigned int dst_w, unsigned int dst_h,
-    unsigned int channels
-) {
+    unsigned int dst_w, unsigned int dst_h
+) {{
     // Row prologue: mode 0 = fallback (nd changes sign; bounds-check every
     // pixel on raw params), 1 = uniform positive nd, 2 = uniform negative
     // nd (numerators negated, exactly like the CPU).
@@ -72,7 +75,7 @@ extern "C" __global__ void warp_perspective_u8_bilinear(
     unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
     unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
 
-    if (threadIdx.x == 0 && y < dst_h) {
+    if (threadIdx.x == 0 && y < dst_h) {{
         float y_f = (float)y;
         float nx0 = m1 * y_f + m2;
         float ny0 = m4 * y_f + m5;
@@ -81,11 +84,11 @@ extern "C" __global__ void warp_perspective_u8_bilinear(
         bool uniform_pos = nd0 > 1e-6f && nd_end > 1e-6f;
         bool uniform_neg = nd0 < -1e-6f && nd_end < -1e-6f;
 
-        if (!(uniform_pos || uniform_neg)) {
+        if (!(uniform_pos || uniform_neg)) {{
             s_mode[threadIdx.y] = 0;
             s_xlo[threadIdx.y] = 0;
             s_xhi[threadIdx.y] = (int)dst_w;
-        } else {
+        }} else {{
             float sgn = uniform_pos ? 1.0f : -1.0f;
             float NX0 = sgn * nx0, NY0 = sgn * ny0, ND0 = sgn * nd0;
             float DNX = sgn * m0, DNY = sgn * m3, DND = sgn * m6;
@@ -103,18 +106,19 @@ extern "C" __global__ void warp_perspective_u8_bilinear(
             s_mode[threadIdx.y] = uniform_pos ? 1 : 2;
             s_xlo[threadIdx.y] = empty ? 0 : (int)lo_c;
             s_xhi[threadIdx.y] = empty ? 0 : (int)hi_c;
-        }
-    }
+        }}
+    }}
     __syncthreads();
 
     if (x >= dst_w || y >= dst_h) return;
 
-    size_t d = ((size_t)y * dst_w + x) * channels;
+    size_t d = ((size_t)y * dst_w + x) * C;
     int mode = s_mode[threadIdx.y];
-    if (mode != 0 && ((int)x < s_xlo[threadIdx.y] || (int)x >= s_xhi[threadIdx.y])) {
-        for (unsigned int ch = 0; ch < channels; ++ch) dst[d + ch] = 0;
+    if (mode != 0 && ((int)x < s_xlo[threadIdx.y] || (int)x >= s_xhi[threadIdx.y])) {{
+        #pragma unroll
+    for (unsigned int ch = 0; ch < C; ++ch) dst[d + ch] = 0;
         return;
-    }
+    }}
 
     // Direct per-pixel coordinate — the perspective_coord_at expression
     // tree, on the (possibly negated) row parameters.
@@ -136,10 +140,11 @@ extern "C" __global__ void warp_perspective_u8_bilinear(
     // Bounds-checked Q10 sampler — mirror of warp::common::bilinear_sample_u8.
     int xi = (int)floorf(xf);
     int yi = (int)floorf(yf);
-    if (xi < 0 || xi >= src_w || yi < 0 || yi >= src_h) {
-        for (unsigned int ch = 0; ch < channels; ++ch) dst[d + ch] = 0;
+    if (xi < 0 || xi >= src_w || yi < 0 || yi >= src_h) {{
+        #pragma unroll
+    for (unsigned int ch = 0; ch < C; ++ch) dst[d + ch] = 0;
         return;
-    }
+    }}
     int xi1 = (xi + 1 < src_w) ? xi + 1 : xi;
     int yi1 = (yi + 1 < src_h) ? yi + 1 : yi;
     unsigned int fx = (unsigned int)((xf - (float)xi) * 1024.0f);
@@ -147,12 +152,13 @@ extern "C" __global__ void warp_perspective_u8_bilinear(
     unsigned int fx1 = 1024u - fx;
     unsigned int fy1 = 1024u - fy;
 
-    size_t row0 = (size_t)yi * src_w * channels;
-    size_t row1 = (size_t)yi1 * src_w * channels;
-    size_t off0 = (size_t)xi * channels;
-    size_t off1 = (size_t)xi1 * channels;
+    size_t row0 = (size_t)yi * src_w * C;
+    size_t row1 = (size_t)yi1 * src_w * C;
+    size_t off0 = (size_t)xi * C;
+    size_t off1 = (size_t)xi1 * C;
 
-    for (unsigned int ch = 0; ch < channels; ++ch) {
+    #pragma unroll
+    for (unsigned int ch = 0; ch < C; ++ch) {{
         unsigned int p00 = (unsigned int)__ldg(&src[row0 + off0 + ch]);
         unsigned int p01 = (unsigned int)__ldg(&src[row0 + off1 + ch]);
         unsigned int p10 = (unsigned int)__ldg(&src[row1 + off0 + ch]);
@@ -160,11 +166,14 @@ extern "C" __global__ void warp_perspective_u8_bilinear(
         unsigned int top = p00 * fx1 + p01 * fx;
         unsigned int bot = p10 * fx1 + p11 * fx;
         dst[d + ch] = (unsigned char)((top * fy1 + bot * fy + (1u << 19)) >> 20);
-    }
+    }}
+}}
+"#
+    )
 }
-"#;
 
-static PERSPECTIVE_U8_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
+type PerCKernelCache = Mutex<HashMap<u32, Arc<CudaKernel>>>;
+static PERSPECTIVE_U8_KERNELS: OnceLock<PerCKernelCache> = OnceLock::new();
 
 /// Launch the u8 bilinear warp-perspective kernel.
 ///
@@ -200,12 +209,27 @@ pub fn launch_warp_perspective_u8_bilinear_cuda(
         });
     }
 
-    let kernel = PERSPECTIVE_U8_KERNEL
-        .get_or_init(|| {
-            try_compile_with_l1(ctx, PERSPECTIVE_U8_SRC, "warp_perspective_u8_bilinear")
-        })
-        .as_ref()
-        .map_err(|e| CudaWarpU8Error::Cuda(e.clone()))?;
+    // Per-C specialized kernel (scoped-guard cache lookup).
+    let cache = PERSPECTIVE_U8_KERNELS.get_or_init(Default::default);
+    let cached = cache
+        .lock()
+        .expect("warp kernel cache poisoned")
+        .get(&channels)
+        .cloned();
+    let kernel = if let Some(hit) = cached {
+        hit
+    } else {
+        let src_code = perspective_u8_src(channels as usize);
+        let name = format!("warp_perspective_u8_bilinear_c{channels}");
+        let built =
+            Arc::new(try_compile_with_l1(ctx, &src_code, &name).map_err(CudaWarpU8Error::Cuda)?);
+        cache
+            .lock()
+            .expect("warp kernel cache poisoned")
+            .entry(channels)
+            .or_insert(built)
+            .clone()
+    };
 
     let (src_w_i, src_h_i) = (src_width as i32, src_height as i32);
 
@@ -226,7 +250,6 @@ pub fn launch_warp_perspective_u8_bilinear_cuda(
         .arg(&src_h_i)
         .arg(&dst_width)
         .arg(&dst_height)
-        .arg(&channels)
         .launch_2d(
             dst_width,
             dst_height,

--- a/crates/kornia-imgproc/src/cuda/warp_perspective_u8.rs
+++ b/crates/kornia-imgproc/src/cuda/warp_perspective_u8.rs
@@ -208,6 +208,15 @@ pub fn launch_warp_perspective_u8_bilinear_cuda(
             need,
         });
     }
+    // Symmetric source check: the kernel gathers up to src_w*src_h*C-1 and
+    // the adapter is not the only caller of this pub launcher.
+    let src_need = (src_width as usize) * (src_height as usize) * (channels as usize);
+    if src.len() < src_need {
+        return Err(CudaWarpU8Error::SliceTooSmall {
+            got: src.len(),
+            need: src_need,
+        });
+    }
 
     // Per-C specialized kernel (scoped-guard cache lookup).
     let cache = PERSPECTIVE_U8_KERNELS.get_or_init(Default::default);

--- a/crates/kornia-imgproc/src/cuda/warp_perspective_u8.rs
+++ b/crates/kornia-imgproc/src/cuda/warp_perspective_u8.rs
@@ -1,0 +1,236 @@
+//! Native CUDA u8 warp-perspective (bilinear), byte-exact with
+//! `warp_perspective_u8`.
+//!
+//! # Exactness strategy
+//!
+//! The CPU u8 perspective evaluates the source coordinate DIRECTLY per
+//! column (`nd = nd0 + dnd*x`, `inv_nd = 1.0/nd`, `xf = nx*inv_nd` — see
+//! `warp::kernels::perspective_coord_at`), identically on scalar, NEON, and
+//! AVX2. This kernel reproduces the same expression tree under
+//! `--fmad=false` (plain mul + add, exact IEEE division), the same
+//! truncating Q10 quantization, and the same Q10 integer blend, so device
+//! output is bit-identical to every CPU backend.
+//!
+//! Per row the CPU classifies: uniform-sign `nd` rows get an analytic valid
+//! span (zeros outside), with numerators negated when `nd < 0`; rows where
+//! `nd` changes sign fall back to per-pixel bounds checks on the raw
+//! parameters. One thread per block-row mirrors that classification and the
+//! `warp::span` constraint math (eps = 0) into shared memory. Every sampled
+//! pixel then goes through the bounds-checked sampler — for in-bounds
+//! coordinates it computes the same bytes as the CPU's valid-path sampler,
+//! and at the span's 1-pixel safety margins and on fallback rows it matches
+//! the CPU's `bilinear_sample_u8` (zero outside, replicate at the far edge).
+//!
+//! The launcher takes the ALREADY-INVERTED homography: the adapter inverts
+//! with the same `inverse_perspective_matrix` the CPU path calls.
+
+use std::sync::{Arc, OnceLock};
+
+use cudarc::driver::{CudaContext, CudaSlice, CudaStream};
+use kornia_tensor::CudaKernel;
+
+use super::resize::CudaResizeError as CudaWarpU8Error;
+use super::{make_config, try_compile_with_l1};
+
+static PERSPECTIVE_U8_SRC: &str = r#"
+// Mirror of warp::span::constrain_span (see cuda/warp_affine_u8.rs).
+__device__ __forceinline__ void constrain_span(
+    float a, float b, bool ge, float eps, long long* lo, long long* hi
+) {
+    if (fabsf(a) < eps || a == 0.0f) {
+        bool feasible = ge ? (b >= 0.0f) : (b < 0.0f);
+        if (!feasible) { *hi = *lo; }
+        return;
+    }
+    float k = -b / a;
+    if (ge) {
+        if (a > 0.0f) { long long v = (long long)ceilf(k);      if (v > *lo) *lo = v; }
+        else          { long long v = (long long)floorf(k) + 1; if (v < *hi) *hi = v; }
+    } else {
+        if (a > 0.0f) { long long v = (long long)ceilf(k);      if (v < *hi) *hi = v; }
+        else          { long long v = (long long)floorf(k) + 1; if (v > *lo) *lo = v; }
+    }
+}
+
+extern "C" __global__ void warp_perspective_u8_bilinear(
+    const unsigned char* __restrict__ src,
+    unsigned char* __restrict__       dst,
+    float m0, float m1, float m2,   // inverse homography, row-major
+    float m3, float m4, float m5,
+    float m6, float m7, float m8,
+    int   src_w, int src_h,
+    unsigned int dst_w, unsigned int dst_h,
+    unsigned int channels
+) {
+    // Row prologue: mode 0 = fallback (nd changes sign; bounds-check every
+    // pixel on raw params), 1 = uniform positive nd, 2 = uniform negative
+    // nd (numerators negated, exactly like the CPU).
+    __shared__ int s_xlo[8];
+    __shared__ int s_xhi[8];
+    __shared__ int s_mode[8];
+
+    unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+
+    if (threadIdx.x == 0 && y < dst_h) {
+        float y_f = (float)y;
+        float nx0 = m1 * y_f + m2;
+        float ny0 = m4 * y_f + m5;
+        float nd0 = m7 * y_f + m8;
+        float nd_end = nd0 + m6 * ((float)dst_w - 1.0f);
+        bool uniform_pos = nd0 > 1e-6f && nd_end > 1e-6f;
+        bool uniform_neg = nd0 < -1e-6f && nd_end < -1e-6f;
+
+        if (!(uniform_pos || uniform_neg)) {
+            s_mode[threadIdx.y] = 0;
+            s_xlo[threadIdx.y] = 0;
+            s_xhi[threadIdx.y] = (int)dst_w;
+        } else {
+            float sgn = uniform_pos ? 1.0f : -1.0f;
+            float NX0 = sgn * nx0, NY0 = sgn * ny0, ND0 = sgn * nd0;
+            float DNX = sgn * m0, DNY = sgn * m3, DND = sgn * m6;
+            float sw = (float)src_w, sh = (float)src_h;
+
+            long long lo = 0, hi = (long long)dst_w;
+            constrain_span(DNX, NX0, true, 0.0f, &lo, &hi);
+            constrain_span(DNX - sw * DND, NX0 - sw * ND0, false, 0.0f, &lo, &hi);
+            constrain_span(DNY, NY0, true, 0.0f, &lo, &hi);
+            constrain_span(DNY - sh * DND, NY0 - sh * ND0, false, 0.0f, &lo, &hi);
+
+            long long lo_c = min(max(lo, 0ll), (long long)dst_w);
+            long long hi_c = min(max(hi, 0ll), (long long)dst_w);
+            bool empty = lo_c >= hi_c;
+            s_mode[threadIdx.y] = uniform_pos ? 1 : 2;
+            s_xlo[threadIdx.y] = empty ? 0 : (int)lo_c;
+            s_xhi[threadIdx.y] = empty ? 0 : (int)hi_c;
+        }
+    }
+    __syncthreads();
+
+    if (x >= dst_w || y >= dst_h) return;
+
+    size_t d = ((size_t)y * dst_w + x) * channels;
+    int mode = s_mode[threadIdx.y];
+    if (mode != 0 && ((int)x < s_xlo[threadIdx.y] || (int)x >= s_xhi[threadIdx.y])) {
+        for (unsigned int ch = 0; ch < channels; ++ch) dst[d + ch] = 0;
+        return;
+    }
+
+    // Direct per-pixel coordinate — the perspective_coord_at expression
+    // tree, on the (possibly negated) row parameters.
+    float y_f = (float)y;
+    float sgn = (mode == 2) ? -1.0f : 1.0f;
+    float nx0 = sgn * (m1 * y_f + m2);
+    float ny0 = sgn * (m4 * y_f + m5);
+    float nd0 = sgn * (m7 * y_f + m8);
+    float dnx = sgn * m0, dny = sgn * m3, dnd = sgn * m6;
+
+    float x_f = (float)x;
+    float nx = nx0 + dnx * x_f;
+    float ny = ny0 + dny * x_f;
+    float nd = nd0 + dnd * x_f;
+    float inv_nd = 1.0f / nd;
+    float xf = nx * inv_nd;
+    float yf = ny * inv_nd;
+
+    // Bounds-checked Q10 sampler — mirror of warp::common::bilinear_sample_u8.
+    int xi = (int)floorf(xf);
+    int yi = (int)floorf(yf);
+    if (xi < 0 || xi >= src_w || yi < 0 || yi >= src_h) {
+        for (unsigned int ch = 0; ch < channels; ++ch) dst[d + ch] = 0;
+        return;
+    }
+    int xi1 = (xi + 1 < src_w) ? xi + 1 : xi;
+    int yi1 = (yi + 1 < src_h) ? yi + 1 : yi;
+    unsigned int fx = (unsigned int)((xf - (float)xi) * 1024.0f);
+    unsigned int fy = (unsigned int)((yf - (float)yi) * 1024.0f);
+    unsigned int fx1 = 1024u - fx;
+    unsigned int fy1 = 1024u - fy;
+
+    size_t row0 = (size_t)yi * src_w * channels;
+    size_t row1 = (size_t)yi1 * src_w * channels;
+    size_t off0 = (size_t)xi * channels;
+    size_t off1 = (size_t)xi1 * channels;
+
+    for (unsigned int ch = 0; ch < channels; ++ch) {
+        unsigned int p00 = (unsigned int)__ldg(&src[row0 + off0 + ch]);
+        unsigned int p01 = (unsigned int)__ldg(&src[row0 + off1 + ch]);
+        unsigned int p10 = (unsigned int)__ldg(&src[row1 + off0 + ch]);
+        unsigned int p11 = (unsigned int)__ldg(&src[row1 + off1 + ch]);
+        unsigned int top = p00 * fx1 + p01 * fx;
+        unsigned int bot = p10 * fx1 + p11 * fx;
+        dst[d + ch] = (unsigned char)((top * fy1 + bot * fy + (1u << 19)) >> 20);
+    }
+}
+"#;
+
+static PERSPECTIVE_U8_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
+
+/// Launch the u8 bilinear warp-perspective kernel.
+///
+/// `m_inv` is the INVERSE (dst→src) homography — invert the forward matrix
+/// with `warp::inverse_perspective_matrix` on the host so the f32 inversion
+/// is the same code the CPU path runs. `block_dim.1` must be ≤ 8.
+#[allow(clippy::too_many_arguments)]
+pub fn launch_warp_perspective_u8_bilinear_cuda(
+    ctx: &Arc<CudaContext>,
+    stream: &Arc<CudaStream>,
+    src: &CudaSlice<u8>,
+    dst: &mut CudaSlice<u8>,
+    m_inv: &[f32; 9],
+    src_width: u32,
+    src_height: u32,
+    dst_width: u32,
+    dst_height: u32,
+    channels: u32,
+    block_dim: Option<(u32, u32)>,
+) -> Result<(), CudaWarpU8Error> {
+    super::check_geometry(src_width, src_height, dst_width, dst_height, block_dim)
+        .map_err(CudaWarpU8Error::Cuda)?;
+    if block_dim.is_some_and(|(_, bh)| bh > 8) {
+        return Err(CudaWarpU8Error::Cuda(
+            "warp_perspective_u8: block_dim.1 must be <= 8 (row-prologue smem)".into(),
+        ));
+    }
+    let need = (dst_width as usize) * (dst_height as usize) * (channels as usize);
+    if dst.len() < need {
+        return Err(CudaWarpU8Error::SliceTooSmall {
+            got: dst.len(),
+            need,
+        });
+    }
+
+    let kernel = PERSPECTIVE_U8_KERNEL
+        .get_or_init(|| {
+            try_compile_with_l1(ctx, PERSPECTIVE_U8_SRC, "warp_perspective_u8_bilinear")
+        })
+        .as_ref()
+        .map_err(|e| CudaWarpU8Error::Cuda(e.clone()))?;
+
+    let (src_w_i, src_h_i) = (src_width as i32, src_height as i32);
+
+    kernel
+        .launch_builder(stream)
+        .arg(src)
+        .arg(dst)
+        .arg(&m_inv[0])
+        .arg(&m_inv[1])
+        .arg(&m_inv[2])
+        .arg(&m_inv[3])
+        .arg(&m_inv[4])
+        .arg(&m_inv[5])
+        .arg(&m_inv[6])
+        .arg(&m_inv[7])
+        .arg(&m_inv[8])
+        .arg(&src_w_i)
+        .arg(&src_h_i)
+        .arg(&dst_width)
+        .arg(&dst_height)
+        .arg(&channels)
+        .launch_2d(
+            dst_width,
+            dst_height,
+            make_config(dst_width, dst_height, block_dim),
+        )
+        .map_err(|e| CudaWarpU8Error::Cuda(e.to_string()))
+}

--- a/crates/kornia-imgproc/src/warp/affine.rs
+++ b/crates/kornia-imgproc/src/warp/affine.rs
@@ -376,6 +376,18 @@ pub fn warp_affine_u8<const C: usize>(
     m: &[f32; 6],
 ) -> Result<(), ImageError> {
     use rayon::prelude::*;
+
+    // Device pairs route to the CUDA u8 kernel (bit-identical output — the
+    // kernel mirrors this function's span + Q16/Q10 arithmetic; see
+    // `cuda::warp_affine_u8`). Mixed host/device pairs are a typed error;
+    // there is no implicit transfer in either direction.
+    #[cfg(feature = "cuda")]
+    if let crate::cuda::dispatch::Residency::Device(exec) =
+        crate::cuda::dispatch::pair_residency(src, dst)?
+    {
+        return exec.run(|stream| super::cuda::warp_affine_u8_cuda(src, dst, m, stream));
+    }
+
     let m_inv = invert_affine_transform(m);
     let src_w = src.cols() as i32;
     let src_h = src.rows() as i32;

--- a/crates/kornia-imgproc/src/warp/cuda.rs
+++ b/crates/kornia-imgproc/src/warp/cuda.rs
@@ -17,6 +17,7 @@ use crate::cuda::warp_perspective::{
     launch_warp_perspective_bicubic_cuda, launch_warp_perspective_bilinear_cuda,
     launch_warp_perspective_lanczos_cuda, launch_warp_perspective_nearest_cuda,
 };
+use crate::cuda::warp_perspective_u8::launch_warp_perspective_u8_bilinear_cuda;
 use crate::interpolation::InterpolationMode;
 
 /// Run the CUDA warp-affine for a device-resident f32 pair.
@@ -128,6 +129,34 @@ pub(super) fn warp_affine_u8_cuda<const C: usize>(
     .map_err(|e| ImageError::Cuda(e.to_string()))
 }
 
+/// Run the CUDA u8 warp-perspective (bilinear) for a device-resident pair,
+/// byte-exact with [`warp_perspective_u8`](super::warp_perspective_u8) —
+/// every CPU backend evaluates the coordinate directly per column, and the
+/// kernel mirrors the same expression tree (see `cuda::warp_perspective_u8`).
+pub(super) fn warp_perspective_u8_cuda<const C: usize>(
+    src: &Image<u8, C>,
+    dst: &mut Image<u8, C>,
+    m: &[f32; 9],
+    stream: &Arc<CudaStream>,
+) -> Result<(), ImageError> {
+    if !(C == 1 || C == 3 || C == 4) {
+        return Err(no_gpu_kernel_err(
+            "warp_perspective_u8",
+            "1/3/4-channel u8 images",
+        ));
+    }
+    let (src_w, src_h) = dims_u32(src)?;
+    let (dst_w, dst_h) = dims_u32(dst)?;
+    let ctx = stream.context();
+    let (s, d) = device_slices!(src, dst);
+    let m_inv = super::perspective::inverse_perspective_matrix(m)?;
+
+    launch_warp_perspective_u8_bilinear_cuda(
+        ctx, stream, s, d, &m_inv, src_w, src_h, dst_w, dst_h, C as u32, None,
+    )
+    .map_err(|e| ImageError::Cuda(e.to_string()))
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -194,6 +223,61 @@ mod tests {
         }
         // Odd small size exercises span-clamps and single-warp blocks.
         run::<3>(33, 21, &rot, &stream);
+    }
+
+    /// The public `warp_perspective_u8`, device vs host, bit-identical —
+    /// including the negative-denominator branch and an affine-equivalent
+    /// homography that must take the uniform-nd span path.
+    #[test]
+    fn public_warp_perspective_u8_device_equals_host() {
+        use crate::cuda::color::test_utils::pattern_u8;
+        let stream = default_stream();
+
+        fn run<const C: usize>(
+            w: usize,
+            h: usize,
+            m: &[f32; 9],
+            stream: &std::sync::Arc<cudarc::driver::CudaStream>,
+        ) {
+            let size = ImageSize {
+                width: w,
+                height: h,
+            };
+            let src = Image::<u8, C>::new(size, pattern_u8(w * h * C)).unwrap();
+            let mut cpu_dst = Image::<u8, C>::from_size_val(size, 0).unwrap();
+            crate::warp::warp_perspective_u8(&src, &mut cpu_dst, m).unwrap();
+
+            let d_src = src.to_cuda(stream).unwrap();
+            let mut d_dst = Image::<u8, C>::zeros_cuda(size, stream).unwrap();
+            crate::warp::warp_perspective_u8(&d_src, &mut d_dst, m).unwrap();
+
+            assert_eq!(
+                d_dst.to_host_owned().unwrap().as_slice(),
+                cpu_dst.as_slice(),
+                "{w}x{h} C={C} m={m:?}: device must be bit-identical to host"
+            );
+        }
+
+        // Genuine projective transform (non-zero perspective terms).
+        let proj: [f32; 9] = [
+            0.9, 0.12, 4.0, //
+            -0.08, 1.05, -2.0, //
+            6.0e-4, -4.5e-4, 1.0,
+        ];
+        // Affine-equivalent homography — uniform-nd span path, nd == 1.
+        let affine_h: [f32; 9] = [1.1, 0.1, -3.0, -0.05, 0.95, 2.0, 0.0, 0.0, 1.0];
+        // Negated homography — same geometry, exercises the nd < 0 branch
+        // (xf = nx/nd is invariant, and IEEE negation keeps it bit-exact).
+        let mut neg = proj;
+        for v in neg.iter_mut() {
+            *v = -*v;
+        }
+        for m in [&proj, &affine_h, &neg] {
+            run::<1>(129, 97, m, &stream);
+            run::<3>(129, 97, m, &stream);
+            run::<4>(129, 97, m, &stream);
+        }
+        run::<3>(33, 21, &proj, &stream);
     }
 
     /// The public `warp_affine`, called with device images, must produce

--- a/crates/kornia-imgproc/src/warp/cuda.rs
+++ b/crates/kornia-imgproc/src/warp/cuda.rs
@@ -12,6 +12,7 @@ use crate::cuda::warp_affine::{
     launch_warp_affine_bicubic_cuda, launch_warp_affine_bilinear_cuda,
     launch_warp_affine_lanczos_cuda, launch_warp_affine_nearest_cuda,
 };
+use crate::cuda::warp_affine_u8::launch_warp_affine_u8_bilinear_cuda;
 use crate::cuda::warp_perspective::{
     launch_warp_perspective_bicubic_cuda, launch_warp_perspective_bilinear_cuda,
     launch_warp_perspective_lanczos_cuda, launch_warp_perspective_nearest_cuda,
@@ -95,6 +96,38 @@ pub(super) fn warp_perspective_f32_cuda<const C: usize>(
     .map_err(|e| ImageError::Cuda(e.to_string()))
 }
 
+/// Run the CUDA u8 warp-affine (bilinear) for a device-resident pair,
+/// byte-exact with [`warp_affine_u8`](super::warp_affine_u8).
+///
+/// The forward matrix is inverted here with the same
+/// [`invert_affine_transform`](super::invert_affine_transform) the CPU path
+/// calls — shared code, not mirrored code — and the kernel reproduces the
+/// CPU's per-row span + Q16/Q10 fixed-point arithmetic exactly (see
+/// `cuda::warp_affine_u8`).
+pub(super) fn warp_affine_u8_cuda<const C: usize>(
+    src: &Image<u8, C>,
+    dst: &mut Image<u8, C>,
+    m: &[f32; 6],
+    stream: &Arc<CudaStream>,
+) -> Result<(), ImageError> {
+    if !(C == 1 || C == 3 || C == 4) {
+        return Err(no_gpu_kernel_err(
+            "warp_affine_u8",
+            "1/3/4-channel u8 images",
+        ));
+    }
+    let (src_w, src_h) = dims_u32(src)?;
+    let (dst_w, dst_h) = dims_u32(dst)?;
+    let ctx = stream.context();
+    let (s, d) = device_slices!(src, dst);
+    let m_inv = super::invert_affine_transform(m);
+
+    launch_warp_affine_u8_bilinear_cuda(
+        ctx, stream, s, d, &m_inv, src_w, src_h, dst_w, dst_h, C as u32, None,
+    )
+    .map_err(|e| ImageError::Cuda(e.to_string()))
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -113,6 +146,54 @@ mod tests {
             Image::<f32, 3>::new(size, pattern_f32(w * h * 3)).unwrap(),
             Image::<f32, 3>::from_size_val(size, 0.0).unwrap(),
         )
+    }
+
+    /// The public `warp_affine_u8`, called with device images, must be
+    /// bit-identical to the host path — spans, Q16 anchors, Q10 sampler and
+    /// all. Rotation+scale exercises fractional spans; the flip and the 90°
+    /// rotation pin the exact-integer span boundaries `warp::span` exists
+    /// for; translation by half a pixel exercises the sampler everywhere.
+    #[test]
+    fn public_warp_affine_u8_device_equals_host() {
+        use crate::cuda::color::test_utils::pattern_u8;
+        let stream = default_stream();
+
+        fn run<const C: usize>(
+            w: usize,
+            h: usize,
+            m: &[f32; 6],
+            stream: &std::sync::Arc<cudarc::driver::CudaStream>,
+        ) {
+            let size = ImageSize {
+                width: w,
+                height: h,
+            };
+            let src = Image::<u8, C>::new(size, pattern_u8(w * h * C)).unwrap();
+            let mut cpu_dst = Image::<u8, C>::from_size_val(size, 0).unwrap();
+            crate::warp::warp_affine_u8(&src, &mut cpu_dst, m).unwrap();
+
+            let d_src = src.to_cuda(stream).unwrap();
+            let mut d_dst = Image::<u8, C>::zeros_cuda(size, stream).unwrap();
+            crate::warp::warp_affine_u8(&d_src, &mut d_dst, m).unwrap();
+
+            assert_eq!(
+                d_dst.to_host_owned().unwrap().as_slice(),
+                cpu_dst.as_slice(),
+                "{w}x{h} C={C} m={m:?}: device must be bit-identical to host"
+            );
+        }
+
+        let rot = crate::warp::get_rotation_matrix2d((64.0, 48.0), 37.0, 1.3);
+        let rot90 = crate::warp::get_rotation_matrix2d((64.0, 48.0), 90.0, 1.0);
+        let flip: [f32; 6] = [-1.0, 0.0, 128.0, 0.0, 1.0, 0.0];
+        let half: [f32; 6] = [1.0, 0.0, 0.5, 0.0, 1.0, 0.5];
+        for m in [&rot, &rot90, &flip, &half] {
+            run::<1>(129, 97, m, &stream);
+            run::<3>(129, 97, m, &stream);
+            run::<4>(129, 97, m, &stream);
+        }
+        // Odd small size exercises span-clamps and single-warp blocks.
+        run::<3>(33, 21, &rot, &stream);
     }
 
     /// The public `warp_affine`, called with device images, must produce

--- a/crates/kornia-imgproc/src/warp/cuda.rs
+++ b/crates/kornia-imgproc/src/warp/cuda.rs
@@ -407,3 +407,59 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod bench_probe {
+    /// Release-build device-throughput probe (min of 5 vs unlocked DVFS):
+    /// `cargo test --release ... warp::cuda::bench_probe -- --ignored --nocapture`
+    #[test]
+    #[ignore]
+    fn probe_warps_1080p() {
+        use crate::cuda::color::test_utils::{default_stream, pattern_u8};
+        use kornia_image::{Image, ImageSize};
+
+        let stream = default_stream();
+        let size = ImageSize {
+            width: 1920,
+            height: 1080,
+        };
+        let src = Image::<u8, 3>::new(size, pattern_u8(1920 * 1080 * 3)).unwrap();
+        let d_src = src.to_cuda(&stream).unwrap();
+        let mut d_dst = Image::<u8, 3>::zeros_cuda(size, &stream).unwrap();
+        let aff = crate::warp::get_rotation_matrix2d((960.0, 540.0), 20.0, 1.1);
+        let psp: [f32; 9] = [0.9, 0.12, 40.0, -0.08, 1.05, -20.0, 6.0e-5, -4.5e-5, 1.0];
+
+        for _ in 0..200 {
+            crate::warp::warp_affine_u8(&d_src, &mut d_dst, &aff).unwrap();
+        }
+        stream.synchronize().unwrap();
+
+        let mut best_a = f64::MAX;
+        let mut best_p = f64::MAX;
+        for _ in 0..5 {
+            for _ in 0..50 {
+                crate::warp::warp_affine_u8(&d_src, &mut d_dst, &aff).unwrap();
+            }
+            stream.synchronize().unwrap();
+            let t0 = std::time::Instant::now();
+            for _ in 0..200 {
+                crate::warp::warp_affine_u8(&d_src, &mut d_dst, &aff).unwrap();
+            }
+            stream.synchronize().unwrap();
+            best_a = best_a.min(t0.elapsed().as_secs_f64() * 1000.0 / 200.0);
+
+            for _ in 0..50 {
+                crate::warp::warp_perspective_u8(&d_src, &mut d_dst, &psp).unwrap();
+            }
+            stream.synchronize().unwrap();
+            let t0 = std::time::Instant::now();
+            for _ in 0..200 {
+                crate::warp::warp_perspective_u8(&d_src, &mut d_dst, &psp).unwrap();
+            }
+            stream.synchronize().unwrap();
+            best_p = best_p.min(t0.elapsed().as_secs_f64() * 1000.0 / 200.0);
+        }
+        println!("affine: {best_a:.3} ms/op (min of 5)");
+        println!("perspective: {best_p:.3} ms/op (min of 5)");
+    }
+}

--- a/crates/kornia-imgproc/src/warp/cuda.rs
+++ b/crates/kornia-imgproc/src/warp/cuda.rs
@@ -111,12 +111,6 @@ pub(super) fn warp_affine_u8_cuda<const C: usize>(
     m: &[f32; 6],
     stream: &Arc<CudaStream>,
 ) -> Result<(), ImageError> {
-    if !(C == 1 || C == 3 || C == 4) {
-        return Err(no_gpu_kernel_err(
-            "warp_affine_u8",
-            "1/3/4-channel u8 images",
-        ));
-    }
     let (src_w, src_h) = dims_u32(src)?;
     let (dst_w, dst_h) = dims_u32(dst)?;
     let ctx = stream.context();
@@ -139,12 +133,6 @@ pub(super) fn warp_perspective_u8_cuda<const C: usize>(
     m: &[f32; 9],
     stream: &Arc<CudaStream>,
 ) -> Result<(), ImageError> {
-    if !(C == 1 || C == 3 || C == 4) {
-        return Err(no_gpu_kernel_err(
-            "warp_perspective_u8",
-            "1/3/4-channel u8 images",
-        ));
-    }
     let (src_w, src_h) = dims_u32(src)?;
     let (dst_w, dst_h) = dims_u32(dst)?;
     let ctx = stream.context();
@@ -461,5 +449,47 @@ mod bench_probe {
         }
         println!("affine: {best_a:.3} ms/op (min of 5)");
         println!("perspective: {best_p:.3} ms/op (min of 5)");
+    }
+
+    /// The u8 warp kernels are per-byte generic over C — a 2-channel warp
+    /// must work on BOTH residencies and agree byte-for-byte (the adapter
+    /// previously gated {1,3,4} while the CPU path accepted any C).
+    #[test]
+    fn warp_u8_c2_device_matches_cpu() {
+        use kornia_image::{Image, ImageSize};
+        let stream = crate::cuda::color::test_utils::default_stream();
+        let src = Image::<u8, 2>::new(
+            ImageSize {
+                width: 37,
+                height: 29,
+            },
+            crate::cuda::color::test_utils::pattern_u8(37 * 29 * 2),
+        )
+        .unwrap();
+        let m = [0.9f32, 0.1, 2.0, -0.05, 1.05, -1.0];
+        let mut cpu_dst = Image::<u8, 2>::from_size_val(
+            ImageSize {
+                width: 31,
+                height: 23,
+            },
+            0,
+        )
+        .unwrap();
+        crate::warp::warp_affine_u8(&src, &mut cpu_dst, &m).unwrap();
+
+        let d_src = src.to_cuda(&stream).unwrap();
+        let mut d_dst = Image::<u8, 2>::zeros_cuda(
+            ImageSize {
+                width: 31,
+                height: 23,
+            },
+            &stream,
+        )
+        .unwrap();
+        crate::warp::warp_affine_u8(&d_src, &mut d_dst, &m).unwrap();
+        assert_eq!(
+            d_dst.to_host_owned().unwrap().as_slice(),
+            cpu_dst.as_slice()
+        );
     }
 }

--- a/crates/kornia-imgproc/src/warp/kernels.rs
+++ b/crates/kornia-imgproc/src/warp/kernels.rs
@@ -36,23 +36,28 @@ use super::common::bilinear_sample_u8_valid;
 /// Process a run of `[x_lo, x_hi)` destination columns for one row of a
 /// perspective warp, filling `dst_row` in-place.
 ///
-/// Inputs describe the row-constant perspective state at column `x_lo`:
+/// Inputs describe the row-constant perspective state at column `x = 0`:
 ///
-/// - `nx`, `ny`, `nd`: numerator/denominator at `x = x_lo`.
+/// - `nx0`, `ny0`, `nd0`: numerator/denominator row anchors.
 /// - `dnx`, `dny`, `dnd`: per-column increments.
+///
+/// Every backend evaluates the coordinate DIRECTLY per column —
+/// `nd = nd0 + dnd * x`, `inv_nd = 1.0 / nd` (exact IEEE division),
+/// `xf = nx * inv_nd` — with the identical expression tree, so scalar,
+/// NEON, and AVX2 are **bit-exact** with each other and with the CUDA u8
+/// perspective kernel (which mirrors the same expressions under
+/// `--fmad=false`). The previous incremental form (`nx += dnx` per column,
+/// SIMD reciprocal estimate + refine) drifted a few ulps and made the
+/// backends agree only "up to sub-ULP noise"; direct evaluation removes
+/// both the drift and the approximation.
 ///
 /// Preconditions (the caller is responsible for these):
 ///
 /// - For every `x ∈ [x_lo, x_hi)` the source coordinate
-///   `(nx+dnx*x)/(nd+dnd*x)` is in `[0, src_w)`, and the y coordinate
+///   `(nx0+dnx*x)/(nd0+dnd*x)` is in `[0, src_w)`, and the y coordinate
 ///   analog is in `[0, src_h)`.
 /// - `nd` does not change sign on `[x_lo, x_hi)` (i.e. the row stays on
 ///   one side of the vanishing line).
-///
-/// The scalar fallback is always available and fully portable. The
-/// aarch64/NEON path processes 4 columns per iteration using a 4-lane
-/// reciprocal (estimate + one Newton–Raphson refine); for the 1-3
-/// trailing columns it falls back to the scalar inner loop.
 #[inline]
 #[allow(clippy::too_many_arguments)]
 pub(super) fn process_perspective_span<const C: usize>(
@@ -63,20 +68,20 @@ pub(super) fn process_perspective_span<const C: usize>(
     dst_row: &mut [u8],
     x_lo: usize,
     x_hi: usize,
-    nx: f32,
-    ny: f32,
-    nd: f32,
+    nx0: f32,
+    ny0: f32,
+    nd0: f32,
     dnx: f32,
     dny: f32,
     dnd: f32,
 ) {
     #[cfg(target_arch = "aarch64")]
     // SAFETY: NEON is baseline on aarch64-unknown-linux-gnu. The helper
-    // requires `x_lo ≤ x_hi ≤ dst_row.len() / C` and the perspective-sample-
+    // requires `x_lo ≤ x_hi ≤ dst_row.len() / C` and the perspective-span
     // in-bounds invariants documented above.
     unsafe {
         process_perspective_span_neon::<C>(
-            src, src_w, src_h, src_stride, dst_row, x_lo, x_hi, nx, ny, nd, dnx, dny, dnd,
+            src, src_w, src_h, src_stride, dst_row, x_lo, x_hi, nx0, ny0, nd0, dnx, dny, dnd,
         );
         return;
     }
@@ -84,15 +89,36 @@ pub(super) fn process_perspective_span<const C: usize>(
     if crate::simd::cpu_features().has_avx2 {
         unsafe {
             process_perspective_span_avx2::<C>(
-                src, src_w, src_h, src_stride, dst_row, x_lo, x_hi, nx, ny, nd, dnx, dny, dnd,
+                src, src_w, src_h, src_stride, dst_row, x_lo, x_hi, nx0, ny0, nd0, dnx, dny, dnd,
             );
         }
         return;
     }
     #[allow(unreachable_code)]
     process_perspective_span_scalar::<C>(
-        src, src_w, src_h, src_stride, dst_row, x_lo, x_hi, nx, ny, nd, dnx, dny, dnd,
+        src, src_w, src_h, src_stride, dst_row, x_lo, x_hi, nx0, ny0, nd0, dnx, dny, dnd,
     );
+}
+
+/// Direct per-column perspective sample coordinate. Single source of the
+/// expression tree every backend (and the CUDA u8 kernel) reproduces:
+/// plain mul + add (no FMA), exact division, truncating Q10 quantization.
+#[inline(always)]
+pub(super) fn perspective_coord_at(
+    x: usize,
+    nx0: f32,
+    ny0: f32,
+    nd0: f32,
+    dnx: f32,
+    dny: f32,
+    dnd: f32,
+) -> (f32, f32) {
+    let x_f = x as f32;
+    let nx = nx0 + dnx * x_f;
+    let ny = ny0 + dny * x_f;
+    let nd = nd0 + dnd * x_f;
+    let inv_nd = 1.0 / nd;
+    (nx * inv_nd, ny * inv_nd)
 }
 
 /// Portable scalar implementation — reference for all backends.
@@ -106,17 +132,15 @@ pub(super) fn process_perspective_span_scalar<const C: usize>(
     dst_row: &mut [u8],
     x_lo: usize,
     x_hi: usize,
-    mut nx: f32,
-    mut ny: f32,
-    mut nd: f32,
+    nx0: f32,
+    ny0: f32,
+    nd0: f32,
     dnx: f32,
     dny: f32,
     dnd: f32,
 ) {
     for x in x_lo..x_hi {
-        let inv_nd = 1.0 / nd;
-        let xf = nx * inv_nd;
-        let yf = ny * inv_nd;
+        let (xf, yf) = perspective_coord_at(x, nx0, ny0, nd0, dnx, dny, dnd);
         let xi = xf.floor() as i32;
         let yi = yf.floor() as i32;
         let fx_q10 = ((xf - xi as f32) * 1024.0) as u32;
@@ -125,9 +149,6 @@ pub(super) fn process_perspective_span_scalar<const C: usize>(
         bilinear_sample_u8_valid::<C>(
             src, src_w, src_h, src_stride, xi, yi, fx_q10, fy_q10, dst_pixel,
         );
-        nx += dnx;
-        ny += dny;
-        nd += dnd;
     }
 }
 
@@ -152,9 +173,9 @@ unsafe fn process_perspective_span_neon<const C: usize>(
     dst_row: &mut [u8],
     x_lo: usize,
     x_hi: usize,
-    mut nx: f32,
-    mut ny: f32,
-    mut nd: f32,
+    nx0: f32,
+    ny0: f32,
+    nd0: f32,
     dnx: f32,
     dny: f32,
     dnd: f32,
@@ -167,14 +188,12 @@ unsafe fn process_perspective_span_neon<const C: usize>(
             let dnx_v = vdupq_n_f32(dnx);
             let dny_v = vdupq_n_f32(dny);
             let dnd_v = vdupq_n_f32(dnd);
+            let nx0_v = vdupq_n_f32(nx0);
+            let ny0_v = vdupq_n_f32(ny0);
+            let nd0_v = vdupq_n_f32(nd0);
             let lane_offsets: [f32; 4] = [0.0, 1.0, 2.0, 3.0];
             let lo_v = vld1q_f32(lane_offsets.as_ptr());
-            let mut nx_v = vaddq_f32(vdupq_n_f32(nx), vmulq_f32(dnx_v, lo_v));
-            let mut ny_v = vaddq_f32(vdupq_n_f32(ny), vmulq_f32(dny_v, lo_v));
-            let mut nd_v = vaddq_f32(vdupq_n_f32(nd), vmulq_f32(dnd_v, lo_v));
-            let step_nx = vmulq_n_f32(dnx_v, 4.0);
-            let step_ny = vmulq_n_f32(dny_v, 4.0);
-            let step_nd = vmulq_n_f32(dnd_v, 4.0);
+            let one_v = vdupq_n_f32(1.0);
             let q10_v = vdupq_n_f32(1024.0);
 
             let mut xs = [0i32; 4];
@@ -185,11 +204,17 @@ unsafe fn process_perspective_span_neon<const C: usize>(
             let end = x_lo + n4;
             let mut xi = x_lo;
             while xi < end {
-                // Reciprocal: 1 NR step → ~17-bit precision, sufficient for
-                // image-domain coords (worst-case fractional weight error
-                // below 1 Q10 ULP).
-                let r0 = vrecpeq_f32(nd_v);
-                let inv_nd = vmulq_f32(vrecpsq_f32(nd_v, r0), r0);
+                // Direct per-lane coordinate: x as f32 is exact (columns are
+                // far below 2^24), so `n0 + dn * x` is lane-for-lane the same
+                // rounding as the scalar reference, and `vdivq_f32` is exact
+                // IEEE division — bit-identical to `1.0 / nd` scalar. This
+                // replaced the reciprocal estimate + Newton–Raphson refine
+                // (sub-ULP noise) and the `+= dn` accumulation (drift).
+                let x_f = vaddq_f32(vdupq_n_f32(xi as f32), lo_v);
+                let nx_v = vaddq_f32(nx0_v, vmulq_f32(dnx_v, x_f));
+                let ny_v = vaddq_f32(ny0_v, vmulq_f32(dny_v, x_f));
+                let nd_v = vaddq_f32(nd0_v, vmulq_f32(dnd_v, x_f));
+                let inv_nd = vdivq_f32(one_v, nd_v);
                 let xf = vmulq_f32(nx_v, inv_nd);
                 let yf = vmulq_f32(ny_v, inv_nd);
                 let xi_v = vcvtq_s32_f32(vrndmq_f32(xf));
@@ -209,21 +234,14 @@ unsafe fn process_perspective_span_neon<const C: usize>(
                     );
                 }
 
-                nx_v = vaddq_f32(nx_v, step_nx);
-                ny_v = vaddq_f32(ny_v, step_ny);
-                nd_v = vaddq_f32(nd_v, step_nd);
                 xi += 4;
             }
-            // Pull scalar state from vector lane 0 for the tail.
-            nx = vgetq_lane_f32::<0>(nx_v);
-            ny = vgetq_lane_f32::<0>(ny_v);
-            nd = vgetq_lane_f32::<0>(nd_v);
         }
 
-        // 1-3 trailing columns: scalar tail.
+        // 1-3 trailing columns: scalar tail (same direct evaluation).
         let tail_start = x_lo + n4;
         process_perspective_span_scalar::<C>(
-            src, src_w, src_h, src_stride, dst_row, tail_start, x_hi, nx, ny, nd, dnx, dny, dnd,
+            src, src_w, src_h, src_stride, dst_row, tail_start, x_hi, nx0, ny0, nd0, dnx, dny, dnd,
         );
     }
 }
@@ -249,9 +267,9 @@ unsafe fn process_perspective_span_avx2<const C: usize>(
     dst_row: &mut [u8],
     x_lo: usize,
     x_hi: usize,
-    mut nx: f32,
-    mut ny: f32,
-    mut nd: f32,
+    nx0: f32,
+    ny0: f32,
+    nd0: f32,
     dnx: f32,
     dny: f32,
     dnd: f32,
@@ -263,16 +281,13 @@ unsafe fn process_perspective_span_avx2<const C: usize>(
         let dnx_v = _mm_set1_ps(dnx);
         let dny_v = _mm_set1_ps(dny);
         let dnd_v = _mm_set1_ps(dnd);
+        let nx0_v = _mm_set1_ps(nx0);
+        let ny0_v = _mm_set1_ps(ny0);
+        let nd0_v = _mm_set1_ps(nd0);
         let lane_offsets: [f32; 4] = [0.0, 1.0, 2.0, 3.0];
         let lo_v = _mm_loadu_ps(lane_offsets.as_ptr());
-        let mut nx_v = _mm_add_ps(_mm_set1_ps(nx), _mm_mul_ps(dnx_v, lo_v));
-        let mut ny_v = _mm_add_ps(_mm_set1_ps(ny), _mm_mul_ps(dny_v, lo_v));
-        let mut nd_v = _mm_add_ps(_mm_set1_ps(nd), _mm_mul_ps(dnd_v, lo_v));
-        let step_nx = _mm_mul_ps(dnx_v, _mm_set1_ps(4.0));
-        let step_ny = _mm_mul_ps(dny_v, _mm_set1_ps(4.0));
-        let step_nd = _mm_mul_ps(dnd_v, _mm_set1_ps(4.0));
+        let one_v = _mm_set1_ps(1.0);
         let q10_v = _mm_set1_ps(1024.0);
-        let two = _mm_set1_ps(2.0);
 
         let mut xs = [0i32; 4];
         let mut ys = [0i32; 4];
@@ -282,10 +297,14 @@ unsafe fn process_perspective_span_avx2<const C: usize>(
         let end = x_lo + n4;
         let mut xi = x_lo;
         while xi < end {
-            // Reciprocal: rcp gives ~12-bit estimate; one NR step
-            // r1 = r0 * (2 - nd * r0) lifts to ~24-bit precision.
-            let r0 = _mm_rcp_ps(nd_v);
-            let inv_nd = _mm_mul_ps(r0, _mm_sub_ps(two, _mm_mul_ps(nd_v, r0)));
+            // Direct per-lane coordinate with exact IEEE division — see the
+            // NEON path for the bit-exactness rationale (this replaced the
+            // rcp + Newton–Raphson estimate and the `+= dn` accumulation).
+            let x_f = _mm_add_ps(_mm_set1_ps(xi as f32), lo_v);
+            let nx_v = _mm_add_ps(nx0_v, _mm_mul_ps(dnx_v, x_f));
+            let ny_v = _mm_add_ps(ny0_v, _mm_mul_ps(dny_v, x_f));
+            let nd_v = _mm_add_ps(nd0_v, _mm_mul_ps(dnd_v, x_f));
+            let inv_nd = _mm_div_ps(one_v, nd_v);
             let xf = _mm_mul_ps(nx_v, inv_nd);
             let yf = _mm_mul_ps(ny_v, inv_nd);
             // Floor → i32 (truncating cvt after floor matches NEON's
@@ -307,25 +326,14 @@ unsafe fn process_perspective_span_avx2<const C: usize>(
                 );
             }
 
-            nx_v = _mm_add_ps(nx_v, step_nx);
-            ny_v = _mm_add_ps(ny_v, step_ny);
-            nd_v = _mm_add_ps(nd_v, step_nd);
             xi += 4;
         }
-        // Pull scalar state from vector lane 0 for the tail.
-        let mut tmp = [0f32; 4];
-        _mm_storeu_ps(tmp.as_mut_ptr(), nx_v);
-        nx = tmp[0];
-        _mm_storeu_ps(tmp.as_mut_ptr(), ny_v);
-        ny = tmp[0];
-        _mm_storeu_ps(tmp.as_mut_ptr(), nd_v);
-        nd = tmp[0];
     }
 
-    // 1-3 trailing columns: scalar tail.
+    // 1-3 trailing columns: scalar tail (same direct evaluation).
     let tail_start = x_lo + n4;
     process_perspective_span_scalar::<C>(
-        src, src_w, src_h, src_stride, dst_row, tail_start, x_hi, nx, ny, nd, dnx, dny, dnd,
+        src, src_w, src_h, src_stride, dst_row, tail_start, x_hi, nx0, ny0, nd0, dnx, dny, dnd,
     );
 }
 

--- a/crates/kornia-imgproc/src/warp/perspective.rs
+++ b/crates/kornia-imgproc/src/warp/perspective.rs
@@ -59,7 +59,7 @@ pub(crate) fn invert_homography(m: &[f32; 9]) -> Option<[f32; 9]> {
     Some(inv)
 }
 
-fn inverse_perspective_matrix(m: &[f32; 9]) -> Result<[f32; 9], ImageError> {
+pub(super) fn inverse_perspective_matrix(m: &[f32; 9]) -> Result<[f32; 9], ImageError> {
     invert_homography(m).ok_or(ImageError::CannotComputeDeterminant)
 }
 
@@ -182,6 +182,18 @@ pub fn warp_perspective_u8<const C: usize>(
     m: &[f32; 9],
 ) -> Result<(), ImageError> {
     use rayon::prelude::*;
+
+    // Device pairs route to the CUDA u8 kernel (bit-identical output — the
+    // kernel mirrors this function's direct per-column coordinates and Q10
+    // sampler; see `cuda::warp_perspective_u8`). Mixed host/device pairs are
+    // a typed error; there is no implicit transfer in either direction.
+    #[cfg(feature = "cuda")]
+    if let crate::cuda::dispatch::Residency::Device(exec) =
+        crate::cuda::dispatch::pair_residency(src, dst)?
+    {
+        return exec.run(|stream| super::cuda::warp_perspective_u8_cuda(src, dst, m, stream));
+    }
+
     let inv = inverse_perspective_matrix(m)?;
     let src_w = src.cols() as i32;
     let src_h = src.rows() as i32;
@@ -210,19 +222,14 @@ pub fn warp_perspective_u8<const C: usize>(
             let nd_uniform_neg = nd0 < -1e-6 && nd_end < -1e-6;
 
             if !(nd_uniform_pos || nd_uniform_neg) {
-                // Fallback: per-pixel bounds-checked scalar path.
-                let mut nx = nx0;
-                let mut ny = ny0;
-                let mut nd = nd0;
+                // Fallback: per-pixel bounds-checked scalar path, direct
+                // coordinate evaluation (no `+= dn` drift — the same
+                // expression tree every backend and the CUDA u8 kernel use).
                 for x in 0..dst_w {
-                    let inv_nd = 1.0 / nd;
-                    let xf = nx * inv_nd;
-                    let yf = ny * inv_nd;
+                    let (xf, yf) =
+                        super::kernels::perspective_coord_at(x, nx0, ny0, nd0, dnx, dny, dnd);
                     let dst_pixel = &mut dst_row[x * C..x * C + C];
                     bilinear_sample_u8::<C>(src_slice, src_w, src_h, src_stride, xf, yf, dst_pixel);
-                    nx += dnx;
-                    ny += dny;
-                    nd += dnd;
                 }
                 return;
             }
@@ -280,46 +287,36 @@ pub fn warp_perspective_u8<const C: usize>(
             // float roundoff producing xf = src_w_f exactly (which would
             // overflow xi to src_w and break the valid-sampler's
             // clamp-to-(src_w-1) assumption). The 2 edge pixels per row
-            // are rendered via the scalar bounds-checked sampler.
+            // are rendered via the scalar bounds-checked sampler — with
+            // direct coordinates it produces the same bytes as the valid
+            // sampler whenever the coordinate is in bounds.
             let x_safe_lo = x_lo + 1;
             let x_safe_hi = x_hi.saturating_sub(1);
 
-            let mut nx = nx0 + dnx * x_lo as f32;
-            let mut ny = ny0 + dny * x_lo as f32;
-            let mut nd = nd0 + dnd * x_lo as f32;
+            let edge = |x: usize, dst_row: &mut [u8]| {
+                let (xf, yf) =
+                    super::kernels::perspective_coord_at(x, nx0, ny0, nd0, dnx, dny, dnd);
+                let dst_pixel = &mut dst_row[x * C..x * C + C];
+                bilinear_sample_u8::<C>(src_slice, src_w, src_h, src_stride, xf, yf, dst_pixel);
+            };
 
             if x_safe_lo > x_lo && x_lo < x_hi {
-                let inv_nd = 1.0 / nd;
-                let xf = nx * inv_nd;
-                let yf = ny * inv_nd;
-                let dst_pixel = &mut dst_row[x_lo * C..x_lo * C + C];
-                bilinear_sample_u8::<C>(src_slice, src_w, src_h, src_stride, xf, yf, dst_pixel);
-                nx += dnx;
-                ny += dny;
-                nd += dnd;
+                edge(x_lo, dst_row);
             }
 
             // Dispatch the valid-span inner loop to the best available
-            // backend (NEON on aarch64, scalar elsewhere). Semantics and
-            // numerical behavior are identical across backends (up to
-            // sub-ULP reciprocal-refinement noise).
+            // backend (NEON on aarch64, scalar elsewhere). All backends
+            // evaluate the coordinate directly per column and are
+            // bit-identical (see `process_perspective_span`).
             if x_safe_lo < x_safe_hi {
                 process_perspective_span::<C>(
-                    src_slice, src_w, src_h, src_stride, dst_row, x_safe_lo, x_safe_hi, nx, ny, nd,
-                    dnx, dny, dnd,
+                    src_slice, src_w, src_h, src_stride, dst_row, x_safe_lo, x_safe_hi, nx0, ny0,
+                    nd0, dnx, dny, dnd,
                 );
             }
 
             if x_safe_hi < x_hi && x_safe_hi >= x_safe_lo {
-                // Advance state from x_safe_lo over (x_safe_hi - x_safe_lo)
-                // steps to reach x_safe_hi.
-                let steps = (x_safe_hi - x_safe_lo) as f32;
-                let nd_edge = nd + dnd * steps;
-                let inv_nd = 1.0 / nd_edge;
-                let xf = (nx + dnx * steps) * inv_nd;
-                let yf = (ny + dny * steps) * inv_nd;
-                let dst_pixel = &mut dst_row[x_safe_hi * C..x_safe_hi * C + C];
-                bilinear_sample_u8::<C>(src_slice, src_w, src_h, src_stride, xf, yf, dst_pixel);
+                edge(x_safe_hi, dst_row);
             }
         });
 

--- a/kornia-py/src/cuda_ext/cuda_geometry.rs
+++ b/kornia-py/src/cuda_ext/cuda_geometry.rs
@@ -22,22 +22,6 @@ fn no_device_err(op: &str) -> PyErr {
     ))
 }
 
-/// Borrow a device `Image<f32, 3>` out of a unified image, or raise the
-/// uniform "no GPU kernel for this dtype/channels" error.
-fn device_f32c3<'a>(img: &'a PyImageApi, op: &str) -> PyResult<&'a Image<f32, 3>> {
-    let dev = img.as_device().ok_or_else(|| no_device_err(op))?;
-    match dev {
-        Inner::F32C3(src) => Ok(src),
-        other => Err(PyValueError::new_err(format!(
-            "{op}: the GPU path supports 3-channel f32 device images, got \
-             {:?} with {} channel(s); convert on the host or move the image \
-             back with .cpu()",
-            other.dtype_enum(),
-            other.channels()
-        ))),
-    }
-}
-
 /// A geometry-op result: a freshly allocated device image, or the caller's
 /// `out=` object handed back (torch-style) so frame loops allocate nothing.
 pub(crate) enum PyOut {

--- a/kornia-py/src/cuda_ext/cuda_geometry.rs
+++ b/kornia-py/src/cuda_ext/cuda_geometry.rs
@@ -290,7 +290,94 @@ pub(crate) fn resize(
     }
 }
 
-/// Device f32 warp-affine (forward 2×3 matrix, inverted internally like CPU).
+/// One u8 channel-count warp arm (affine or perspective — `op` is the
+/// public residency-dispatched u8 warp). Matches the numpy u8 path's
+/// semantics: the interpolation string is validated but the u8 warps are
+/// bilinear-only, on host and device alike.
+#[allow(clippy::too_many_arguments)]
+fn warp_u8<const C: usize>(
+    py: Python<'_>,
+    img: &PyImageApi,
+    src: &Image<u8, C>,
+    dst_size: kornia_image::ImageSize,
+    op_name: &'static str,
+    out: Option<Py<PyAny>>,
+    unwrap: fn(&mut Inner) -> Option<&mut Image<u8, C>>,
+    wrap: fn(Image<u8, C>) -> Inner,
+    op: impl Fn(&Image<u8, C>, &mut Image<u8, C>) -> Result<(), kornia_image::ImageError>,
+) -> PyResult<PyOut> {
+    if let Some(out) = out {
+        with_out_t(
+            py,
+            &out,
+            src,
+            dst_size,
+            op_name,
+            "u8, same channel count as the input",
+            unwrap,
+            |dst| op(src, dst).map_err(err),
+        )?;
+        return Ok(PyOut::Reused(out));
+    }
+    run_geometry_t(src, img.color_space, dst_size, wrap, |dst| op(src, dst)).map(PyOut::New)
+}
+
+/// Dispatch a warp over the device image's dtype/channels: f32 C3 keeps the
+/// full interpolation-mode set; u8 C1/C3/C4 run the bilinear u8 kernels.
+macro_rules! warp_arms {
+    ($py:ident, $img:ident, $dst_size:ident, $out:ident, $name:literal,
+     $f32_arm:expr, $u8_op:expr) => {{
+        let dev = $img.as_device().ok_or_else(|| no_device_err($name))?;
+        match dev {
+            Inner::F32C3(src) => $f32_arm(src),
+            Inner::U8C1(src) => warp_u8::<1>(
+                $py,
+                $img,
+                src,
+                $dst_size,
+                $name,
+                $out,
+                unwrap_u8c1,
+                Inner::U8C1,
+                $u8_op,
+            ),
+            Inner::U8C3(src) => warp_u8::<3>(
+                $py,
+                $img,
+                src,
+                $dst_size,
+                $name,
+                $out,
+                unwrap_u8c3,
+                Inner::U8C3,
+                $u8_op,
+            ),
+            Inner::U8C4(src) => warp_u8::<4>(
+                $py,
+                $img,
+                src,
+                $dst_size,
+                $name,
+                $out,
+                unwrap_u8c4,
+                Inner::U8C4,
+                $u8_op,
+            ),
+            other => Err(PyValueError::new_err(format!(
+                concat!(
+                    $name,
+                    ": the GPU path supports f32 3-channel and u8 1/3/4-channel \
+                     device images, got {:?} with {} channel(s)"
+                ),
+                other.dtype_enum(),
+                other.channels()
+            ))),
+        }
+    }};
+}
+
+/// Device warp-affine (forward 2×3 matrix, inverted internally like CPU) —
+/// f32 C3 with the full mode set, or u8 C1/C3/C4 bilinear.
 pub(crate) fn warp_affine(
     py: Python<'_>,
     img: &PyImageApi,
@@ -300,24 +387,34 @@ pub(crate) fn warp_affine(
     out: Option<Py<PyAny>>,
 ) -> PyResult<PyOut> {
     let mode = crate::image::parse_interpolation(interpolation)?;
-    let src = device_f32c3(img, "warp_affine")?;
     let dst_size = kornia_image::ImageSize {
         height: new_size.0,
         width: new_size.1,
     };
-    if let Some(out) = out {
-        with_out(py, &out, src, dst_size, "warp_affine", |dst| {
-            kornia_imgproc::warp::warp_affine(src, dst, &m, mode).map_err(err)
-        })?;
-        return Ok(PyOut::Reused(out));
-    }
-    run_geometry(src, img.color_space, dst_size, |dst| {
-        kornia_imgproc::warp::warp_affine(src, dst, &m, mode)
-    })
-    .map(PyOut::New)
+    warp_arms!(
+        py,
+        img,
+        dst_size,
+        out,
+        "warp_affine",
+        |src: &Image<f32, 3>| {
+            if let Some(out) = out {
+                with_out(py, &out, src, dst_size, "warp_affine", |dst| {
+                    kornia_imgproc::warp::warp_affine(src, dst, &m, mode).map_err(err)
+                })?;
+                return Ok(PyOut::Reused(out));
+            }
+            run_geometry(src, img.color_space, dst_size, |dst| {
+                kornia_imgproc::warp::warp_affine(src, dst, &m, mode)
+            })
+            .map(PyOut::New)
+        },
+        |s: &Image<u8, _>, d: &mut Image<u8, _>| kornia_imgproc::warp::warp_affine_u8(s, d, &m)
+    )
 }
 
-/// Device f32 warp-perspective (forward 3×3 homography).
+/// Device warp-perspective (forward 3×3 homography) — f32 C3 with the full
+/// mode set, or u8 C1/C3/C4 bilinear.
 pub(crate) fn warp_perspective(
     py: Python<'_>,
     img: &PyImageApi,
@@ -327,19 +424,30 @@ pub(crate) fn warp_perspective(
     out: Option<Py<PyAny>>,
 ) -> PyResult<PyOut> {
     let mode = crate::image::parse_interpolation(interpolation)?;
-    let src = device_f32c3(img, "warp_perspective")?;
     let dst_size = kornia_image::ImageSize {
         height: new_size.0,
         width: new_size.1,
     };
-    if let Some(out) = out {
-        with_out(py, &out, src, dst_size, "warp_perspective", |dst| {
-            kornia_imgproc::warp::warp_perspective(src, dst, &m, mode).map_err(err)
-        })?;
-        return Ok(PyOut::Reused(out));
-    }
-    run_geometry(src, img.color_space, dst_size, |dst| {
-        kornia_imgproc::warp::warp_perspective(src, dst, &m, mode)
-    })
-    .map(PyOut::New)
+    warp_arms!(
+        py,
+        img,
+        dst_size,
+        out,
+        "warp_perspective",
+        |src: &Image<f32, 3>| {
+            if let Some(out) = out {
+                with_out(py, &out, src, dst_size, "warp_perspective", |dst| {
+                    kornia_imgproc::warp::warp_perspective(src, dst, &m, mode).map_err(err)
+                })?;
+                return Ok(PyOut::Reused(out));
+            }
+            run_geometry(src, img.color_space, dst_size, |dst| {
+                kornia_imgproc::warp::warp_perspective(src, dst, &m, mode)
+            })
+            .map(PyOut::New)
+        },
+        |s: &Image<u8, _>, d: &mut Image<u8, _>| kornia_imgproc::warp::warp_perspective_u8(
+            s, d, &m
+        )
+    )
 }

--- a/kornia-py/tests/test_cuda_geometry.py
+++ b/kornia-py/tests/test_cuda_geometry.py
@@ -50,10 +50,10 @@ class TestDeviceResize:
         assert out.shape == (16, 16, 3)
 
     def test_wrong_dtype_device_warp_errors(self):
-        # Warps stay f32-only on the device path (resize gained u8 kernels).
-        a = np.zeros((16, 16, 3), dtype=np.uint8)
-        d = _dev(a)  # u8 device image
-        with pytest.raises(ValueError, match="3-channel f32"):
+        # f32 single-channel has no GPU warp kernel — typed error, no fallback.
+        a = np.zeros((16, 16, 1), dtype=np.float32)
+        d = _dev(a)
+        with pytest.raises(ValueError, match="channel"):
             imgproc.warp_affine(d, [1, 0, 0, 0, 1, 0], (8, 8), "bilinear")
 
 
@@ -130,6 +130,40 @@ class TestDeviceWarps:
         out = imgproc.warp_affine(a, m, (16, 16), "nearest")
         assert isinstance(out, np.ndarray)
         np.testing.assert_array_equal(out, a)
+
+
+class TestDeviceWarpsU8:
+    """u8 device warps run the integer CUDA kernels, bit-identical to the
+    numpy u8 CPU path (same span math, same Q16/Q10 fixed point)."""
+
+    def _pattern_u8(self, h, w, c=3):
+        rng = np.random.default_rng(11)
+        return rng.integers(0, 256, size=(h, w, c), dtype=np.uint8)
+
+    def test_affine_matches_numpy_cpu_bit_exact(self):
+        a = self._pattern_u8(97, 129)
+        m = [0.87, -0.5, 40.0, 0.5, 0.87, -10.0]  # rotation + translation
+        cpu = imgproc.warp_affine(a, m, (97, 129), "bilinear")
+        out = imgproc.warp_affine(_dev(a), m, (97, 129), "bilinear")
+        assert "cuda" in str(out.device)
+        np.testing.assert_array_equal(out.cpu().numpy(), cpu)
+
+    def test_perspective_matches_numpy_cpu_bit_exact(self):
+        a = self._pattern_u8(97, 129)
+        m = [0.9, 0.12, 4.0, -0.08, 1.05, -2.0, 6.0e-4, -4.5e-4, 1.0]
+        cpu = imgproc.warp_perspective(a, m, (97, 129), "bilinear")
+        out = imgproc.warp_perspective(_dev(a), m, (97, 129), "bilinear")
+        np.testing.assert_array_equal(out.cpu().numpy(), cpu)
+
+    def test_affine_out_reuse_matches_fresh(self):
+        a = self._pattern_u8(64, 64)
+        d = _dev(a)
+        m = [1.0, 0.0, 3.5, 0.0, 1.0, -2.5]
+        fresh = imgproc.warp_affine(d, m, (64, 64), "bilinear")
+        buf = imgproc.warp_affine(d, m, (64, 64), "bilinear")
+        reused = imgproc.warp_affine(d, m, (64, 64), "bilinear", out=buf)
+        assert reused is buf
+        np.testing.assert_array_equal(reused.cpu().numpy(), fresh.cpu().numpy())
 
 
 class TestOutAndGraph:


### PR DESCRIPTION
## What

Stacked on #1012 (u8 CUDA resize) — review that first; this PR's diff vs its base is warps only.

**u8 CUDA warp-affine + warp-perspective (bilinear), byte-for-byte identical to the CPU u8 paths**, reachable from `warp_affine_u8` / `warp_perspective_u8` (residency dispatch) and Python `warp_affine` / `warp_perspective` (u8 device images, incl. `out=`).

### The affine kernel

The CPU path's span anchor is part of the arithmetic (`sx_q_lo` is evaluated at the span's left edge, then integer-incremented), so per-pixel float predicates can't reproduce the bytes. One thread per block-row mirrors the `warp::span` constraint math (same f32 expressions under `--fmad=false`) into shared memory; each thread derives `sx_q = sx_q_lo + (x−x_lo)·dsx_q` in wrapping 32-bit arithmetic — the CPU's repeated `wrapping_add`, exactly. Forward matrix inverted on the host by the same `invert_affine_transform` the CPU calls (shared code, not mirrored code).

### The perspective kernel — and a CPU exactness upgrade

The CPU u8 perspective used incremental coordinates (`nx += dnx` per column) and a SIMD reciprocal estimate — scalar/NEON/AVX2 agreed only "up to sub-ULP noise", and no GPU kernel could match all of them. **This PR makes the CPU backends bit-identical first**: direct per-column evaluation (`nd = nd0 + dnd·x`, exact IEEE `1.0/nd`) with one shared expression tree (`perspective_coord_at`); NEON/AVX2 keep their 4-lane structure but use exact `vdivq_f32` / `_mm_div_ps`. The CUDA kernel then mirrors that same tree. Parity tests assert bit-identity over projective, affine-equivalent, and negated (nd<0 branch) homographies, C∈{1,3,4}.

**Behavior note:** CPU u8 perspective output shifts by ≤1 Q10 quantum on some pixels vs earlier releases (documented in CHANGELOG). Same-minute A/B on Orin: no measurable CPU perf change (all criterion deltas p>0.05, both rounds) — the divide latency hides behind the 4-lane structure.

## Benchmarks (Jetson Orin, 1080p u8 RGB full-frame, median, out= reuse)

| op | kornia GPU | VPI-CUDA | cv2 CPU | kornia CPU |
|---|---|---|---|---|
| warp-affine | **1.20 ms** | 2.12 | 8.42 | 6.38 |
| warp-perspective | 1.87 ms | **1.69** | 12.00 | 7.90 |

Affine 1.8× faster than VPI; perspective within the fastest-or-tied gate (0.91×) — flagged as a tuning candidate.

## Tests

- Rust: bit-exact parity for affine (rotation+scale, exact 90°, flip — integer span boundaries — half-pixel translation) and perspective (projective / affine-equivalent / negated), C∈{1,3,4}, odd sizes. Full suite green.
- Python: u8 device warps vs numpy CPU bit-exact, `out=` reuse, dtype error paths. 28/28 geometry tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)