### PR TITLE
feat(imgproc): u8 CUDA morphology (dilate/erode), byte-exact + first Python bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ changes early: `cargo add kornia-imgproc@0.1.15-rc.1` or `pip install --pre korn
 
 ## [Unreleased]
 
+**u8 CUDA morphology (dilate / erode), bit-identical to the CPU ops, plus
+first-time Python bindings.** `dilate` / `erode` route u8 device images
+(1/3/4-channel) to a CUDA kernel that samples the exact tap multiset the CPU
+does — same active structuring-element offsets, same border index mapping
+for all five padding modes — so min/max output is byte-for-byte equal
+(`assert_eq!` parity tests over box/cross/ellipse and even-sized kernels).
+The structuring element is cached on-device per geometry (Jetson pageable
+H2D tail; warm path is CUDA-Graph-capturable). New
+`kornia_rs.imgproc.dilate` / `erode` Python functions cover the numpy u8 CPU
+path and u8 device images alike. Non-u8 device pairs error with the typed
+no-GPU-kernel message instead of touching device memory from the CPU.
+
 **u8 CUDA warps (bilinear), bit-identical to the CPU fast paths — which are
 now bit-identical to each other too.** `warp_affine_u8` and
 `warp_perspective_u8` route u8 device images (1/3/4-channel) to new

--- a/crates/kornia-imgproc/src/cuda/mod.rs
+++ b/crates/kornia-imgproc/src/cuda/mod.rs
@@ -28,6 +28,10 @@ pub mod warp_perspective_u8;
 /// Native CUDA color-space conversion kernels.
 pub mod color;
 
+/// Native CUDA u8 morphology kernels (dilate / erode, byte-exact with the
+/// CPU ops).
+pub mod morphology;
+
 /// Residency-aware dispatch machinery shared by all device-capable ops.
 pub(crate) mod dispatch;
 

--- a/crates/kornia-imgproc/src/cuda/morphology.rs
+++ b/crates/kornia-imgproc/src/cuda/morphology.rs
@@ -136,7 +136,7 @@ extern "C" __global__ void morphology_u8(
     }
     let _ = tap_lits; // literals are emitted per-stanza above
 
-    format!(
+    let scalar_kernel = format!(
         r#"
 // Mirrors padding::PaddingMode::map_index (iterative reflect loops match
 // the CPU exactly; pads are tiny).
@@ -198,13 +198,130 @@ extern "C" __global__ void morphology_u8(
 "#,
         neg_min_dx = -min_dx,
         neg_min_dy = -min_dy,
-    )
+    );
+
+    // ── C=1 vector kernel: 4 output pixels per thread ─────────────────────
+    //
+    // Per active row (taps grouped by dy) the kernel loads the aligned u32
+    // words covering the 4-pixel window plus the dx span, normalizes them to
+    // a byte stream starting exactly at `x0 + min_dx` with one __byte_perm
+    // per word, then folds each dx window with __vmaxu4 / __vminu4 —
+    // per-byte-lane u8 min/max over exactly the CPU's tap multiset, so the
+    // result stays byte-exact. Threads whose quad touches a border or the
+    // buffer ends fall back to the scalar bounds-checked taps per lane.
+    use std::collections::BTreeMap;
+    let mut rows: BTreeMap<i32, Vec<i32>> = BTreeMap::new();
+    for pair in taps.chunks_exact(2) {
+        rows.entry(pair[0]).or_default().push(pair[1]);
+    }
+    let span = (max_dx - min_dx) as usize;
+    // Normalized stream words R[0..rn]: highest byte read is span + 3.
+    let rn = (span + 3) / 4 + 1;
+    let wn = rn + 1;
+    let vfold = match op {
+        MorphOp::Dilate => "__vmaxu4",
+        MorphOp::Erode => "__vminu4",
+    };
+    let vinit = match op {
+        MorphOp::Dilate => "0u",
+        MorphOp::Erode => "0xffffffffu",
+    };
+
+    let mut row_blocks = String::new();
+    for (dy, dxs) in &rows {
+        let mut w_loads = String::new();
+        for i in 0..wn {
+            let _ = writeln!(w_loads, "        unsigned int W{i} = __ldg(wp + {i});");
+        }
+        let mut r_norms = String::new();
+        for i in 0..rn {
+            let _ = writeln!(
+                r_norms,
+                "        unsigned int R{i} = __byte_perm(W{i}, W{}, sel_n);",
+                i + 1
+            );
+        }
+        let mut folds = String::new();
+        for dx in dxs {
+            let o = (dx - min_dx) as usize;
+            let (wi, rem) = (o / 4, o % 4);
+            if rem == 0 {
+                let _ = writeln!(folds, "        acc4 = {vfold}(acc4, R{wi});");
+            } else {
+                let sel = 0x3210u32 + 0x1111 * rem as u32;
+                let _ = writeln!(
+                    folds,
+                    "        acc4 = {vfold}(acc4, __byte_perm(R{wi}, R{}, 0x{sel:04x}u));",
+                    wi + 1
+                );
+            }
+        }
+        let _ = write!(
+            row_blocks,
+            "    {{ // row dy = {dy}\n\
+             \x20       const unsigned char* p = src + (ptrdiff_t)(y + ({dy})) * width + x0 + ({min_dx});\n\
+             \x20       unsigned int s = (unsigned int)((size_t)p & 3u);\n\
+             \x20       const unsigned int* wp = (const unsigned int*)(p - s);\n\
+             \x20       unsigned int sel_n = 0x3210u + 0x1111u * s;\n\
+             {w_loads}{r_norms}{folds}    }}\n"
+        );
+    }
+
+    let vector_kernel = format!(
+        r#"
+extern "C" __global__ void morphology_u8_c1v4(
+    const unsigned char* __restrict__ src,
+    unsigned char* __restrict__       dst,
+    const unsigned char* __restrict__ constant_value,
+    int width, int height, unsigned int channels, int border
+) {{
+    int x0 = 4 * (int)(blockIdx.x * blockDim.x + threadIdx.x);
+    unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x0 >= width || y >= (unsigned int)height) return;
+
+    bool vec_ok = x0 >= {neg_min_dx} && x0 + 3 < width - ({max_dx})
+               && (int)y >= {neg_min_dy} && (int)y < height - ({max_dy});
+    // The aligned word loads may reach up to 3 bytes before / after the
+    // window; keep them inside the buffer (corner quads take the scalar
+    // fallback, whose values are identical).
+    long long idx_lo = (long long)((int)y + ({min_dy})) * width + x0 + ({min_dx});
+    long long idx_hi = (long long)((int)y + ({max_dy})) * width + x0 + ({min_dx});
+    vec_ok = vec_ok && idx_lo >= 3
+          && idx_hi + {load_span} <= (long long)width * height;
+
+    if (vec_ok) {{
+        unsigned int acc4 = {vinit};
+{row_blocks}
+        size_t d = (size_t)y * width + x0;
+        dst[d + 0] = (unsigned char)(acc4 & 0xffu);
+        dst[d + 1] = (unsigned char)((acc4 >> 8) & 0xffu);
+        dst[d + 2] = (unsigned char)((acc4 >> 16) & 0xffu);
+        dst[d + 3] = (unsigned char)((acc4 >> 24) & 0xffu);
+        return;
+    }}
+
+    unsigned int ch = 0u; // C == 1
+    for (int lane = 0; lane < 4; ++lane) {{
+        int x = x0 + lane;
+        if (x >= width) break;
+        unsigned int acc = {acc_init};
+{border_stanzas_lane}        dst[(size_t)y * width + x] = (unsigned char)acc;
+    }}
+}}
+"#,
+        neg_min_dx = -min_dx,
+        neg_min_dy = -min_dy,
+        load_span = 4 * wn as i64,
+        border_stanzas_lane = border_stanzas,
+    );
+
+    scalar_kernel + &vector_kernel
 }
 
 /// Compiled specialized kernels, keyed by (taps content, op). Structuring
 /// elements are static per pipeline, so this stays tiny; on overflow the
 /// cache is cleared wholesale.
-type MorphKernelCache = Mutex<HashMap<(Vec<i32>, MorphOp), Arc<CudaKernel>>>;
+type MorphKernelCache = Mutex<HashMap<(Vec<i32>, MorphOp, bool), Arc<CudaKernel>>>;
 static MORPH_KERNELS: OnceLock<MorphKernelCache> = OnceLock::new();
 const MORPH_KERNEL_CACHE_CAP: usize = 64;
 
@@ -258,8 +375,18 @@ pub fn launch_morphology_u8_cuda(
         ));
     }
 
+    // Single-channel images take the 4-pixel-per-thread vector kernel
+    // (same tap multiset per byte lane via __vmaxu4/__vminu4 — byte-exact);
+    // multi-channel and zero-tap elements use the scalar kernel.
+    let vectorized = channels == 1 && !taps.is_empty();
+    let fn_name = if vectorized {
+        "morphology_u8_c1v4"
+    } else {
+        "morphology_u8"
+    };
+
     let cache = MORPH_KERNELS.get_or_init(Default::default);
-    let key = (taps.to_vec(), op);
+    let key = (taps.to_vec(), op, vectorized);
     let cached = cache
         .lock()
         .expect("morph kernel cache poisoned")
@@ -270,8 +397,7 @@ pub fn launch_morphology_u8_cuda(
     } else {
         let src_code = morph_source(taps, op);
         let built = Arc::new(
-            try_compile_with_l1(ctx, &src_code, "morphology_u8")
-                .map_err(CudaMorphologyError::Cuda)?,
+            try_compile_with_l1(ctx, &src_code, fn_name).map_err(CudaMorphologyError::Cuda)?,
         );
         let mut map = cache.lock().expect("morph kernel cache poisoned");
         if map.len() >= MORPH_KERNEL_CACHE_CAP {
@@ -282,6 +408,7 @@ pub fn launch_morphology_u8_cuda(
 
     let border_i = border as i32;
     let (w_i, h_i) = (width as i32, height as i32);
+    let grid_w = if vectorized { width.div_ceil(4) } else { width };
 
     kernel
         .launch_builder(stream)
@@ -292,6 +419,6 @@ pub fn launch_morphology_u8_cuda(
         .arg(&h_i)
         .arg(&channels)
         .arg(&border_i)
-        .launch_2d(width, height, make_config(width, height, block_dim))
+        .launch_2d(grid_w, height, make_config(grid_w, height, block_dim))
         .map_err(|e| CudaMorphologyError::Cuda(e.to_string()))
 }

--- a/crates/kornia-imgproc/src/cuda/morphology.rs
+++ b/crates/kornia-imgproc/src/cuda/morphology.rs
@@ -236,7 +236,7 @@ extern "C" __global__ void morphology_u8(
 
     let span = (max_dx - min_dx) as usize;
     // Normalized stream words R[0..rn]: highest byte read is span + 3.
-    let rn = (span + 3) / 4 + 1;
+    let rn = span.div_ceil(4) + 1;
     let wn = rn + 1;
     let vfold = match op {
         MorphOp::Dilate => "__vmaxu4",
@@ -251,7 +251,7 @@ extern "C" __global__ void morphology_u8(
     let rr_lo = min_dy;
     let rr_hi = max_dy + 3;
     let mut needed: BTreeMap<i32, Vec<usize>> = BTreeMap::new();
-    for (dy, _) in &rows {
+    for dy in rows.keys() {
         let cid = row_class[dy];
         for j in 0..4 {
             let e = needed.entry(dy + j).or_default();
@@ -321,7 +321,7 @@ extern "C" __global__ void morphology_u8(
     let mut out_rows = String::new();
     for j in 0..4 {
         let mut expr = String::from(vinit);
-        for (dy, _) in &rows {
+        for dy in rows.keys() {
             let cid = row_class[dy];
             let k = (dy + j - rr_lo) as usize;
             expr = format!("{vfold}({expr}, H{cid}_{k})");

--- a/crates/kornia-imgproc/src/cuda/morphology.rs
+++ b/crates/kornia-imgproc/src/cuda/morphology.rs
@@ -200,20 +200,40 @@ extern "C" __global__ void morphology_u8(
         neg_min_dy = -min_dy,
     );
 
-    // ── C=1 vector kernel: 4 output pixels per thread ─────────────────────
+    // ── C=1 vector kernel: 4×4 output tile per thread ─────────────────────
     //
-    // Per active row (taps grouped by dy) the kernel loads the aligned u32
-    // words covering the 4-pixel window plus the dx span, normalizes them to
-    // a byte stream starting exactly at `x0 + min_dx` with one __byte_perm
-    // per word, then folds each dx window with __vmaxu4 / __vminu4 —
-    // per-byte-lane u8 min/max over exactly the CPU's tap multiset, so the
-    // result stays byte-exact. Threads whose quad touches a border or the
-    // buffer ends fall back to the scalar bounds-checked taps per lane.
+    // Each thread produces a 4-wide × 4-tall output tile. Per INPUT row
+    // (indices `min_dy ..= max_dy + 3`) the kernel loads the aligned u32
+    // words covering the tile plus the dx span once, normalizes them to a
+    // byte stream anchored at `x0 + min_dx` with one __byte_perm per word,
+    // and computes one horizontal fold per distinct dx-set of the element
+    // (box: one; cross: two). Each output row then folds the horizontal
+    // results of its tap rows vertically — for a 3×3 box that is 6 row
+    // loads + 6 horizontal folds serving 16 outputs, instead of 36 loads.
+    // All folds are __vmaxu4 / __vminu4: per-byte-lane u8 min/max over
+    // exactly the CPU's tap multiset, so the result stays byte-exact.
+    // Tiles touching a border or the buffer ends fall back to the scalar
+    // bounds-checked taps per lane, which compute identical values.
     use std::collections::BTreeMap;
     let mut rows: BTreeMap<i32, Vec<i32>> = BTreeMap::new();
     for pair in taps.chunks_exact(2) {
-        rows.entry(pair[0]).or_default().push(pair[1]);
+        let mut dxs = rows.remove(&pair[0]).unwrap_or_default();
+        dxs.push(pair[1]);
+        rows.insert(pair[0], dxs);
     }
+    // Distinct dx-sets → horizontal-fold classes.
+    let mut classes: Vec<Vec<i32>> = Vec::new();
+    let mut row_class: BTreeMap<i32, usize> = BTreeMap::new();
+    for (dy, dxs) in &rows {
+        let mut key = dxs.clone();
+        key.sort_unstable();
+        let cid = classes.iter().position(|c| *c == key).unwrap_or_else(|| {
+            classes.push(key.clone());
+            classes.len() - 1
+        });
+        row_class.insert(*dy, cid);
+    }
+
     let span = (max_dx - min_dx) as usize;
     // Normalized stream words R[0..rn]: highest byte read is span + 3.
     let rn = (span + 3) / 4 + 1;
@@ -227,8 +247,49 @@ extern "C" __global__ void morphology_u8(
         MorphOp::Erode => "0xffffffffu",
     };
 
+    // Which classes are needed at each input row rr = dy + j (j in 0..4).
+    let rr_lo = min_dy;
+    let rr_hi = max_dy + 3;
+    let mut needed: BTreeMap<i32, Vec<usize>> = BTreeMap::new();
+    for (dy, _) in &rows {
+        let cid = row_class[dy];
+        for j in 0..4 {
+            let e = needed.entry(dy + j).or_default();
+            if !e.contains(&cid) {
+                e.push(cid);
+            }
+        }
+    }
+
+    // Horizontal-fold expression for class `cid` over stream words R{k}_{i}.
+    let hfold_expr = |cid: usize, k: usize| -> String {
+        let mut expr = String::new();
+        for (n, dx) in classes[cid].iter().enumerate() {
+            let o = (dx - min_dx) as usize;
+            let (wi, rem) = (o / 4, o % 4);
+            let window = if rem == 0 {
+                format!("R{k}_{wi}")
+            } else {
+                let sel = 0x3210u32 + 0x1111 * rem as u32;
+                format!("__byte_perm(R{k}_{wi}, R{k}_{}, 0x{sel:04x}u)", wi + 1)
+            };
+            expr = if n == 0 {
+                window
+            } else {
+                format!("{vfold}({expr}, {window})")
+            };
+        }
+        expr
+    };
+
+    // Per-input-row blocks: declare H vars, then load + normalize + fold.
+    let mut h_decls = String::new();
     let mut row_blocks = String::new();
-    for (dy, dxs) in &rows {
+    for (rr, cids) in &needed {
+        let k = (rr - rr_lo) as usize;
+        for cid in cids {
+            let _ = writeln!(h_decls, "    unsigned int H{cid}_{k};");
+        }
         let mut w_loads = String::new();
         for i in 0..wn {
             let _ = writeln!(w_loads, "        unsigned int W{i} = __ldg(wp + {i});");
@@ -237,33 +298,44 @@ extern "C" __global__ void morphology_u8(
         for i in 0..rn {
             let _ = writeln!(
                 r_norms,
-                "        unsigned int R{i} = __byte_perm(W{i}, W{}, sel_n);",
+                "        unsigned int R{k}_{i} = __byte_perm(W{i}, W{}, sel_n);",
                 i + 1
             );
         }
-        let mut folds = String::new();
-        for dx in dxs {
-            let o = (dx - min_dx) as usize;
-            let (wi, rem) = (o / 4, o % 4);
-            if rem == 0 {
-                let _ = writeln!(folds, "        acc4 = {vfold}(acc4, R{wi});");
-            } else {
-                let sel = 0x3210u32 + 0x1111 * rem as u32;
-                let _ = writeln!(
-                    folds,
-                    "        acc4 = {vfold}(acc4, __byte_perm(R{wi}, R{}, 0x{sel:04x}u));",
-                    wi + 1
-                );
-            }
+        let mut h_folds = String::new();
+        for cid in cids {
+            let _ = writeln!(h_folds, "        H{cid}_{k} = {};", hfold_expr(*cid, k));
         }
         let _ = write!(
             row_blocks,
-            "    {{ // row dy = {dy}\n\
-             \x20       const unsigned char* p = src + (ptrdiff_t)(y + ({dy})) * width + x0 + ({min_dx});\n\
+            "    {{ // input row y0 + ({rr})\n\
+             \x20       const unsigned char* p = src + (ptrdiff_t)(y0 + ({rr})) * width + x0 + ({min_dx});\n\
              \x20       unsigned int s = (unsigned int)((size_t)p & 3u);\n\
              \x20       const unsigned int* wp = (const unsigned int*)(p - s);\n\
              \x20       unsigned int sel_n = 0x3210u + 0x1111u * s;\n\
-             {w_loads}{r_norms}{folds}    }}\n"
+             {w_loads}{r_norms}{h_folds}    }}\n"
+        );
+    }
+
+    // Vertical folds + stores per output row.
+    let mut out_rows = String::new();
+    for j in 0..4 {
+        let mut expr = String::from(vinit);
+        for (dy, _) in &rows {
+            let cid = row_class[dy];
+            let k = (dy + j - rr_lo) as usize;
+            expr = format!("{vfold}({expr}, H{cid}_{k})");
+        }
+        let _ = write!(
+            out_rows,
+            "    {{\n\
+             \x20       unsigned int acc4 = {expr};\n\
+             \x20       size_t d = (size_t)(y0 + {j}) * width + x0;\n\
+             \x20       dst[d + 0] = (unsigned char)(acc4 & 0xffu);\n\
+             \x20       dst[d + 1] = (unsigned char)((acc4 >> 8) & 0xffu);\n\
+             \x20       dst[d + 2] = (unsigned char)((acc4 >> 16) & 0xffu);\n\
+             \x20       dst[d + 3] = (unsigned char)((acc4 >> 24) & 0xffu);\n\
+             \x20   }}\n"
         );
     }
 
@@ -276,36 +348,38 @@ extern "C" __global__ void morphology_u8_c1v4(
     int width, int height, unsigned int channels, int border
 ) {{
     int x0 = 4 * (int)(blockIdx.x * blockDim.x + threadIdx.x);
-    unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
-    if (x0 >= width || y >= (unsigned int)height) return;
+    int y0 = 4 * (int)(blockIdx.y * blockDim.y + threadIdx.y);
+    if (x0 >= width || y0 >= height) return;
 
-    bool vec_ok = x0 >= {neg_min_dx} && x0 + 3 < width - ({max_dx})
-               && (int)y >= {neg_min_dy} && (int)y < height - ({max_dy});
+    bool vec_ok = x0 + 3 < width && y0 + 3 < height
+               && x0 >= {neg_min_dx} && x0 + 3 < width - ({max_dx})
+               && y0 >= {neg_min_dy} && y0 + 3 < height - ({max_dy});
     // The aligned word loads may reach up to 3 bytes before / after the
-    // window; keep them inside the buffer (corner quads take the scalar
+    // window; keep them inside the buffer (corner tiles take the scalar
     // fallback, whose values are identical).
-    long long idx_lo = (long long)((int)y + ({min_dy})) * width + x0 + ({min_dx});
-    long long idx_hi = (long long)((int)y + ({max_dy})) * width + x0 + ({min_dx});
+    long long idx_lo = (long long)(y0 + ({rr_lo})) * width + x0 + ({min_dx});
+    long long idx_hi = (long long)(y0 + ({rr_hi})) * width + x0 + ({min_dx});
     vec_ok = vec_ok && idx_lo >= 3
           && idx_hi + {load_span} <= (long long)width * height;
 
     if (vec_ok) {{
-        unsigned int acc4 = {vinit};
+{h_decls}
 {row_blocks}
-        size_t d = (size_t)y * width + x0;
-        dst[d + 0] = (unsigned char)(acc4 & 0xffu);
-        dst[d + 1] = (unsigned char)((acc4 >> 8) & 0xffu);
-        dst[d + 2] = (unsigned char)((acc4 >> 16) & 0xffu);
-        dst[d + 3] = (unsigned char)((acc4 >> 24) & 0xffu);
+{out_rows}
         return;
     }}
 
     unsigned int ch = 0u; // C == 1
-    for (int lane = 0; lane < 4; ++lane) {{
-        int x = x0 + lane;
-        if (x >= width) break;
-        unsigned int acc = {acc_init};
-{border_stanzas_lane}        dst[(size_t)y * width + x] = (unsigned char)acc;
+    for (int jj = 0; jj < 4; ++jj) {{
+        int yy = y0 + jj;
+        if (yy >= height) break;
+        unsigned int y = (unsigned int)yy;
+        for (int lane = 0; lane < 4; ++lane) {{
+            int x = x0 + lane;
+            if (x >= width) break;
+            unsigned int acc = {acc_init};
+{border_stanzas_lane}            dst[(size_t)y * width + x] = (unsigned char)acc;
+        }}
     }}
 }}
 "#,
@@ -408,7 +482,11 @@ pub fn launch_morphology_u8_cuda(
 
     let border_i = border as i32;
     let (w_i, h_i) = (width as i32, height as i32);
-    let grid_w = if vectorized { width.div_ceil(4) } else { width };
+    let (grid_w, grid_h) = if vectorized {
+        (width.div_ceil(4), height.div_ceil(4))
+    } else {
+        (width, height)
+    };
 
     kernel
         .launch_builder(stream)
@@ -419,6 +497,6 @@ pub fn launch_morphology_u8_cuda(
         .arg(&h_i)
         .arg(&channels)
         .arg(&border_i)
-        .launch_2d(grid_w, height, make_config(grid_w, height, block_dim))
+        .launch_2d(grid_w, grid_h, make_config(grid_w, grid_h, block_dim))
         .map_err(|e| CudaMorphologyError::Cuda(e.to_string()))
 }

--- a/crates/kornia-imgproc/src/cuda/morphology.rs
+++ b/crates/kornia-imgproc/src/cuda/morphology.rs
@@ -1,0 +1,297 @@
+//! Native CUDA u8 morphology (dilate / erode), byte-exact with the CPU ops.
+//!
+//! Morphology is a pure integer min/max over the structuring element's
+//! active taps — commutative and association-free — so byte-exactness only
+//! requires sampling the SAME value multiset as the CPU:
+//!
+//! - active taps: the `k_data[i] == 1` offsets of the
+//!   [`Kernel`](crate::morphology::Kernel), relative to the output pixel;
+//! - borders: the CPU pads with `spatial_padding`; the kernel instead maps
+//!   out-of-bounds coordinates per pixel with the same index functions
+//!   (`PaddingMode::map_index` — replicate / reflect / reflect101 / wrap)
+//!   or substitutes the per-channel constant;
+//! - empty-kernel corner: the CPU dilate starts its max at `T::default()`
+//!   and erode's `unwrap_or_default()` yields 0 when no tap is active — the
+//!   kernel writes 0 for zero taps, and dilate folds 0 into its max.
+//!
+//! # Per-structuring-element kernel specialization
+//!
+//! The tap offsets are BAKED INTO THE NVRTC SOURCE as literals and the
+//! compiled kernel is cached per (element hash, op). Three designs were
+//! measured on Orin (3×3 box, 1080p C1): a runtime tap loop over a global
+//! LUT (1.8 ms — serialized dependent loads), the same with shared-memory
+//! staging (2.2 ms — the 8 KB static allocation cut occupancy and fought
+//! the PREFER_L1 carveout), and baked literals with a fully unrolled loop
+//! (fastest — the pixel loads issue independently). Structuring elements
+//! are static per pipeline, so the one-time NVRTC compile (~1 s) amortizes
+//! to zero; interior threads (window in bounds by the tap extents) skip all
+//! border logic.
+
+use std::collections::HashMap;
+use std::fmt::Write as _;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use cudarc::driver::{CudaContext, CudaSlice, CudaStream};
+use kornia_tensor::CudaKernel;
+
+use super::{make_config, try_compile_with_l1};
+
+/// Error type for the CUDA morphology launchers.
+#[derive(Debug, thiserror::Error)]
+pub enum CudaMorphologyError {
+    /// CUDA kernel compilation or launch failure.
+    #[error("CUDA kernel compile/launch error: {0}")]
+    Cuda(String),
+    /// Output device slice is smaller than the required element count.
+    #[error("output slice length {got} < required {need}")]
+    SliceTooSmall {
+        /// Actual slice length (in elements).
+        got: usize,
+        /// Minimum required length (width × height × channels).
+        need: usize,
+    },
+}
+
+/// Which morphological reduction the kernel applies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MorphOp {
+    /// Neighborhood maximum.
+    Dilate,
+    /// Neighborhood minimum.
+    Erode,
+}
+
+/// Border handling, mirroring `padding::PaddingMode` (same index math).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MorphBorder {
+    /// Fill with the per-channel constant value.
+    Constant = 0,
+    /// Clamp to the edge pixel.
+    Replicate = 1,
+    /// Mirror excluding the edge pixel (101 flavor).
+    Reflect101 = 2,
+    /// Mirror including the edge pixel.
+    Reflect = 3,
+    /// Circular wrap.
+    Wrap = 4,
+}
+
+/// Maximum active taps a specialized kernel will bake (a 45×45 box).
+pub const MORPH_MAX_TAPS: usize = 1024;
+
+/// Generate the specialized source for one structuring element + op.
+fn morph_source(taps: &[i32], op: MorphOp) -> String {
+    let ntaps = taps.len() / 2;
+    let (mut min_dy, mut max_dy, mut min_dx, mut max_dx) = (0i32, 0i32, 0i32, 0i32);
+    let mut tap_lits = String::new();
+    for (i, pair) in taps.chunks_exact(2).enumerate() {
+        let (dy, dx) = (pair[0], pair[1]);
+        if i == 0 {
+            (min_dy, max_dy, min_dx, max_dx) = (dy, dy, dx, dx);
+        } else {
+            min_dy = min_dy.min(dy);
+            max_dy = max_dy.max(dy);
+            min_dx = min_dx.min(dx);
+            max_dx = max_dx.max(dx);
+        }
+        let _ = write!(tap_lits, "{{{dy},{dx}}},");
+    }
+    let (acc_init, fold) = match op {
+        MorphOp::Dilate => ("0u", "max"),
+        MorphOp::Erode => ("255u", "min"),
+    };
+    // Zero-tap corner: both CPU ops default to 0 — emit a memset-style body.
+    if ntaps == 0 {
+        return r#"
+extern "C" __global__ void morphology_u8(
+    const unsigned char* __restrict__ src,
+    unsigned char* __restrict__       dst,
+    const unsigned char* __restrict__ constant_value,
+    int width, int height, unsigned int channels, int border
+) {
+    unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x >= (unsigned int)width || y >= (unsigned int)height) return;
+    size_t d = ((size_t)y * width + x) * channels;
+    for (unsigned int ch = 0; ch < channels; ++ch) dst[d + ch] = 0;
+}
+"#
+        .to_string();
+    }
+
+    // Straight-line per-tap stanzas with literal offsets: the compiler folds
+    // `dy*width + dx` into per-tap address math and every load issues
+    // independently. (A `__constant__ TAPS[][2]` array variant measured 3×
+    // slower — per-block constant-cache cold misses.)
+    let mut interior_stanzas = String::new();
+    let mut border_stanzas = String::new();
+    for pair in taps.chunks_exact(2) {
+        let (dy, dx) = (pair[0], pair[1]);
+        let _ = writeln!(
+            interior_stanzas,
+            "        acc = {fold}(acc, (unsigned int)__ldg(base + \
+             ((ptrdiff_t)({dy}) * width + ({dx})) * (ptrdiff_t)channels));"
+        );
+        let _ = writeln!(border_stanzas, "        BORDER_TAP({dy}, {dx});");
+    }
+    let _ = tap_lits; // literals are emitted per-stanza above
+
+    format!(
+        r#"
+// Mirrors padding::PaddingMode::map_index (iterative reflect loops match
+// the CPU exactly; pads are tiny).
+__device__ __forceinline__ int map_index(int i, int len, int mode) {{
+    if (mode == 1) {{ return min(max(i, 0), len - 1); }}
+    if (mode == 2) {{
+        if (len == 1) return 0;
+        while (i < 0 || i >= len) {{ if (i < 0) i = -i; else i = 2 * len - i - 2; }}
+        return i;
+    }}
+    if (mode == 3) {{
+        if (len == 1) return 0;
+        while (i < 0 || i >= len) {{ if (i < 0) i = -i - 1; else i = 2 * len - i - 1; }}
+        return i;
+    }}
+    if (mode == 4) {{ int m = i % len; return m < 0 ? m + len : m; }}
+    return 0;
+}}
+
+#define BORDER_TAP(dy, dx) do {{ \
+    int sy = (int)y + (dy); \
+    int sx = (int)x + (dx); \
+    unsigned int v; \
+    if (sx >= 0 && sx < width && sy >= 0 && sy < height) {{ \
+        v = (unsigned int)__ldg(&src[((size_t)sy * width + sx) * channels + ch]); \
+    }} else if (border == 0) {{ \
+        v = (unsigned int)__ldg(&constant_value[ch]); \
+    }} else {{ \
+        int mx = map_index(sx, width, border); \
+        int my = map_index(sy, height, border); \
+        v = (unsigned int)__ldg(&src[((size_t)my * width + mx) * channels + ch]); \
+    }} \
+    acc = {fold}(acc, v); \
+}} while (0)
+
+extern "C" __global__ void morphology_u8(
+    const unsigned char* __restrict__ src,
+    unsigned char* __restrict__       dst,
+    const unsigned char* __restrict__ constant_value,
+    int width, int height, unsigned int channels, int border
+) {{
+    unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x >= (unsigned int)width || y >= (unsigned int)height) return;
+
+    bool interior = (int)x >= {neg_min_dx} && (int)x < width - ({max_dx})
+                 && (int)y >= {neg_min_dy} && (int)y < height - ({max_dy});
+
+    size_t d = ((size_t)y * width + x) * channels;
+    for (unsigned int ch = 0; ch < channels; ++ch) {{
+        unsigned int acc = {acc_init};
+        if (interior) {{
+            const unsigned char* base = src + d + ch;
+{interior_stanzas}        }} else {{
+{border_stanzas}        }}
+        dst[d + ch] = (unsigned char)acc;
+    }}
+}}
+"#,
+        neg_min_dx = -min_dx,
+        neg_min_dy = -min_dy,
+    )
+}
+
+/// Compiled specialized kernels, keyed by (taps content, op). Structuring
+/// elements are static per pipeline, so this stays tiny; on overflow the
+/// cache is cleared wholesale.
+type MorphKernelCache = Mutex<HashMap<(Vec<i32>, MorphOp), Arc<CudaKernel>>>;
+static MORPH_KERNELS: OnceLock<MorphKernelCache> = OnceLock::new();
+const MORPH_KERNEL_CACHE_CAP: usize = 64;
+
+/// Launch the u8 morphology kernel (dilate or erode), specialized for the
+/// given structuring element.
+///
+/// `taps` are the active element offsets as `(dy, dx)` pairs relative to
+/// the output pixel, at most [`MORPH_MAX_TAPS`]; they are baked into the
+/// kernel source (compiled once per element + op, then cached).
+/// `constant_value` is a device upload of the per-channel constant (read
+/// only for [`MorphBorder::Constant`], but must hold `channels` bytes).
+#[allow(clippy::too_many_arguments)]
+pub fn launch_morphology_u8_cuda(
+    ctx: &Arc<CudaContext>,
+    stream: &Arc<CudaStream>,
+    src: &CudaSlice<u8>,
+    dst: &mut CudaSlice<u8>,
+    width: u32,
+    height: u32,
+    channels: u32,
+    taps: &[i32],
+    constant_value: &CudaSlice<u8>,
+    op: MorphOp,
+    border: MorphBorder,
+    block_dim: Option<(u32, u32)>,
+) -> Result<(), CudaMorphologyError> {
+    super::check_geometry(width, height, width, height, block_dim)
+        .map_err(CudaMorphologyError::Cuda)?;
+    let need = (width as usize) * (height as usize) * (channels as usize);
+    if dst.len() < need {
+        return Err(CudaMorphologyError::SliceTooSmall {
+            got: dst.len(),
+            need,
+        });
+    }
+    if !taps.len().is_multiple_of(2) {
+        return Err(CudaMorphologyError::Cuda(
+            "taps must be (dy, dx) pairs".into(),
+        ));
+    }
+    if taps.len() / 2 > MORPH_MAX_TAPS {
+        return Err(CudaMorphologyError::Cuda(format!(
+            "structuring element has {} active taps; the GPU kernel supports \
+             at most {MORPH_MAX_TAPS} (use the CPU path for larger elements)",
+            taps.len() / 2
+        )));
+    }
+    if constant_value.len() < channels as usize {
+        return Err(CudaMorphologyError::Cuda(
+            "constant_value must hold at least `channels` bytes".into(),
+        ));
+    }
+
+    let cache = MORPH_KERNELS.get_or_init(Default::default);
+    let key = (taps.to_vec(), op);
+    let cached = cache
+        .lock()
+        .expect("morph kernel cache poisoned")
+        .get(&key)
+        .cloned();
+    let kernel = if let Some(hit) = cached {
+        hit
+    } else {
+        let src_code = morph_source(taps, op);
+        let built = Arc::new(
+            try_compile_with_l1(ctx, &src_code, "morphology_u8")
+                .map_err(CudaMorphologyError::Cuda)?,
+        );
+        let mut map = cache.lock().expect("morph kernel cache poisoned");
+        if map.len() >= MORPH_KERNEL_CACHE_CAP {
+            map.clear();
+        }
+        map.entry(key).or_insert(built).clone()
+    };
+
+    let border_i = border as i32;
+    let (w_i, h_i) = (width as i32, height as i32);
+
+    kernel
+        .launch_builder(stream)
+        .arg(src)
+        .arg(dst)
+        .arg(constant_value)
+        .arg(&w_i)
+        .arg(&h_i)
+        .arg(&channels)
+        .arg(&border_i)
+        .launch_2d(width, height, make_config(width, height, block_dim))
+        .map_err(|e| CudaMorphologyError::Cuda(e.to_string()))
+}

--- a/crates/kornia-imgproc/src/cuda/morphology.rs
+++ b/crates/kornia-imgproc/src/cuda/morphology.rs
@@ -331,10 +331,14 @@ extern "C" __global__ void morphology_u8(
             "    {{\n\
              \x20       unsigned int acc4 = {expr};\n\
              \x20       size_t d = (size_t)(y0 + {j}) * width + x0;\n\
-             \x20       dst[d + 0] = (unsigned char)(acc4 & 0xffu);\n\
-             \x20       dst[d + 1] = (unsigned char)((acc4 >> 8) & 0xffu);\n\
-             \x20       dst[d + 2] = (unsigned char)((acc4 >> 16) & 0xffu);\n\
-             \x20       dst[d + 3] = (unsigned char)((acc4 >> 24) & 0xffu);\n\
+             \x20       if (((size_t)(dst + d) & 3u) == 0u) {{\n\
+             \x20           *(unsigned int*)(dst + d) = acc4;\n\
+             \x20       }} else {{\n\
+             \x20           dst[d + 0] = (unsigned char)(acc4 & 0xffu);\n\
+             \x20           dst[d + 1] = (unsigned char)((acc4 >> 8) & 0xffu);\n\
+             \x20           dst[d + 2] = (unsigned char)((acc4 >> 16) & 0xffu);\n\
+             \x20           dst[d + 3] = (unsigned char)((acc4 >> 24) & 0xffu);\n\
+             \x20       }}\n\
              \x20   }}\n"
         );
     }
@@ -397,6 +401,9 @@ extern "C" __global__ void morphology_u8_c1v4(
 /// cache is cleared wholesale.
 type MorphKernelCache = Mutex<HashMap<(Vec<i32>, MorphOp, bool), Arc<CudaKernel>>>;
 static MORPH_KERNELS: OnceLock<MorphKernelCache> = OnceLock::new();
+type SepMorphKey = (i32, i32, i32, i32, MorphOp);
+type SepMorphCache = Mutex<HashMap<SepMorphKey, (Arc<CudaKernel>, Arc<CudaKernel>)>>;
+static SEP_MORPH_KERNELS: OnceLock<SepMorphCache> = OnceLock::new();
 const MORPH_KERNEL_CACHE_CAP: usize = 64;
 
 /// Launch the u8 morphology kernel (dilate or erode), specialized for the
@@ -449,6 +456,79 @@ pub fn launch_morphology_u8_cuda(
         ));
     }
 
+    // FULL-BOX structuring elements on C1 take the separable two-pass fast
+    // path: max/min are associative, so row-fold + column-fold is EXACTLY
+    // the 2D fold (byte-exact; borders map per axis, matching the direct
+    // kernel for every padding mode).
+    if channels == 1 && !taps.is_empty() {
+        let mut ext = (i32::MAX, i32::MIN, i32::MAX, i32::MIN); // dy_lo, dy_hi, dx_lo, dx_hi
+        for pair in taps.chunks_exact(2) {
+            ext.0 = ext.0.min(pair[0]);
+            ext.1 = ext.1.max(pair[0]);
+            ext.2 = ext.2.min(pair[1]);
+            ext.3 = ext.3.max(pair[1]);
+        }
+        let area = ((ext.1 - ext.0 + 1) as usize) * ((ext.3 - ext.2 + 1) as usize);
+        let is_box = taps.len() / 2 == area;
+        let wide_enough = (ext.1 - ext.0 + 1) >= 5 || (ext.3 - ext.2 + 1) >= 5;
+        if is_box && wide_enough {
+            let key = (ext.0, ext.1, ext.2, ext.3, op);
+            let cache = SEP_MORPH_KERNELS.get_or_init(Default::default);
+            let cached = cache
+                .lock()
+                .expect("sep morph cache poisoned")
+                .get(&key)
+                .cloned();
+            let (kh, kv) = if let Some(hit) = cached {
+                hit
+            } else {
+                let src_code = morph_sep_src(ext.2, ext.3, ext.0, ext.1, op);
+                let built_h = Arc::new(
+                    try_compile_with_l1(ctx, &src_code, "morph_sep_h")
+                        .map_err(CudaMorphologyError::Cuda)?,
+                );
+                let built_v = Arc::new(
+                    try_compile_with_l1(ctx, &src_code, "morph_sep_v")
+                        .map_err(CudaMorphologyError::Cuda)?,
+                );
+                let mut map = cache.lock().expect("sep morph cache poisoned");
+                if map.len() >= MORPH_KERNEL_CACHE_CAP {
+                    map.clear();
+                }
+                map.entry(key).or_insert((built_h, built_v)).clone()
+            };
+
+            let tmp_len = (width as usize) * (height as usize);
+            let mut tmp = unsafe { stream.alloc::<u8>(tmp_len) }
+                .map_err(|e| CudaMorphologyError::Cuda(e.to_string()))?;
+
+            let border_i = border as i32;
+            let (w_i, h_i) = (width as i32, height as i32);
+            let grid_w = width.div_ceil(4);
+
+            kh.launch_builder(stream)
+                .arg(src)
+                .arg(&mut tmp)
+                .arg(constant_value)
+                .arg(&w_i)
+                .arg(&h_i)
+                .arg(&border_i)
+                .launch_2d(grid_w, height, make_config(grid_w, height, block_dim))
+                .map_err(|e| CudaMorphologyError::Cuda(e.to_string()))?;
+
+            return kv
+                .launch_builder(stream)
+                .arg(&tmp)
+                .arg(dst)
+                .arg(constant_value)
+                .arg(&w_i)
+                .arg(&h_i)
+                .arg(&border_i)
+                .launch_2d(grid_w, height, make_config(grid_w, height, block_dim))
+                .map_err(|e| CudaMorphologyError::Cuda(e.to_string()));
+        }
+    }
+
     // Single-channel images take the 4-pixel-per-thread vector kernel
     // (same tap multiset per byte lane via __vmaxu4/__vminu4 — byte-exact);
     // multi-channel and zero-tap elements use the scalar kernel.
@@ -499,4 +579,180 @@ pub fn launch_morphology_u8_cuda(
         .arg(&border_i)
         .launch_2d(grid_w, grid_h, make_config(grid_w, grid_h, block_dim))
         .map_err(|e| CudaMorphologyError::Cuda(e.to_string()))
+}
+
+// ── Separable box fast path ───────────────────────────────────────────────────
+
+/// Separable two-pass kernels for FULL BOX structuring elements on C1.
+///
+/// `max`/`min` are associative and commutative, so a box dilate/erode
+/// decomposes EXACTLY into a row pass followed by a column pass — the same
+/// value multiset folds, byte-exact with the direct kernel and the CPU.
+/// Both passes process 4 pixels per thread on u32 words: the row pass
+/// assembles shifted 4-byte windows with `__byte_perm` (as in the direct
+/// C1 kernel), the column pass reads whole words from consecutive rows —
+/// fully coalesced. Borders are handled per pass with the same
+/// `map_index` semantics; the horizontal pass resolves x borders, the
+/// vertical pass y borders, which matches the 2D border sampling of the
+/// direct kernel for every padding mode (each axis' index mapping is
+/// independent).
+fn morph_sep_src(dx_lo: i32, dx_hi: i32, dy_lo: i32, dy_hi: i32, op: MorphOp) -> String {
+    let (vfold, vinit, sfold, sinit) = match op {
+        MorphOp::Dilate => ("__vmaxu4", "0u", "max", "0u"),
+        MorphOp::Erode => ("__vminu4", "0xffffffffu", "min", "255u"),
+    };
+    let span = (dx_hi - dx_lo) as usize;
+    let rn = span.div_ceil(4) + 1;
+    let wn = rn + 1;
+    let mut h_folds = String::new();
+    for dx in dx_lo..=dx_hi {
+        let o = (dx - dx_lo) as usize;
+        let (wi, rem) = (o / 4, o % 4);
+        if rem == 0 {
+            let _ = writeln!(h_folds, "        acc = {vfold}(acc, R{wi});");
+        } else {
+            let sel = 0x3210u32 + 0x1111 * rem as u32;
+            let _ = writeln!(
+                h_folds,
+                "        acc = {vfold}(acc, __byte_perm(R{wi}, R{}, 0x{sel:04x}u));",
+                wi + 1
+            );
+        }
+    }
+    let mut w_loads = String::new();
+    for i in 0..wn {
+        let _ = writeln!(w_loads, "        unsigned int W{i} = __ldg(wp + {i});");
+    }
+    let mut r_norms = String::new();
+    for i in 0..rn {
+        let _ = writeln!(
+            r_norms,
+            "        unsigned int R{i} = __byte_perm(W{i}, W{}, sel_n);",
+            i + 1
+        );
+    }
+    let mut v_folds = String::new();
+    for dy in dy_lo..=dy_hi {
+        let _ = writeln!(
+            v_folds,
+            "        acc = {vfold}(acc, __ldg((const unsigned int*)(tmp + \
+             (size_t)(y + ({dy})) * width) + xw));"
+        );
+    }
+
+    format!(
+        r#"
+__device__ __forceinline__ int map_index(int i, int len, int mode) {{
+    if (mode == 1) {{ return min(max(i, 0), len - 1); }}
+    if (mode == 2) {{
+        if (len == 1) return 0;
+        while (i < 0 || i >= len) {{ if (i < 0) i = -i; else i = 2 * len - i - 2; }}
+        return i;
+    }}
+    if (mode == 3) {{
+        if (len == 1) return 0;
+        while (i < 0 || i >= len) {{ if (i < 0) i = -i - 1; else i = 2 * len - i - 1; }}
+        return i;
+    }}
+    if (mode == 4) {{ int m = i % len; return m < 0 ? m + len : m; }}
+    return 0;
+}}
+
+// Row pass: tmp[y][x] = fold over dx of src[y][x+dx].
+extern "C" __global__ void morph_sep_h(
+    const unsigned char* __restrict__ src,
+    unsigned char* __restrict__       tmp,
+    const unsigned char* __restrict__ constant_value,
+    int width, int height, int border
+) {{
+    int x0 = 4 * (int)(blockIdx.x * blockDim.x + threadIdx.x);
+    int y  = (int)(blockIdx.y * blockDim.y + threadIdx.y);
+    if (x0 >= width || y >= height) return;
+
+    long long idx = (long long)y * width + x0 + ({dx_lo});
+    bool vec_ok = x0 >= {neg_dx_lo} && x0 + 3 < width - ({dx_hi})
+               && idx >= 3
+               && idx + {load_span} <= (long long)width * height;
+    if (vec_ok) {{
+        const unsigned char* p = src + (size_t)y * width + x0 + ({dx_lo});
+        unsigned int s = (unsigned int)((size_t)p & 3u);
+        const unsigned int* wp = (const unsigned int*)(p - s);
+        unsigned int sel_n = 0x3210u + 0x1111u * s;
+{w_loads}{r_norms}        unsigned int acc = {vinit};
+{h_folds}        size_t d = (size_t)y * width + x0;
+        if (((size_t)(tmp + d) & 3u) == 0u) {{
+            *(unsigned int*)(tmp + d) = acc;
+        }} else {{
+            tmp[d + 0] = (unsigned char)(acc & 0xffu);
+            tmp[d + 1] = (unsigned char)((acc >> 8) & 0xffu);
+            tmp[d + 2] = (unsigned char)((acc >> 16) & 0xffu);
+            tmp[d + 3] = (unsigned char)((acc >> 24) & 0xffu);
+        }}
+        return;
+    }}
+    for (int x = x0; x < min(x0 + 4, width); ++x) {{
+        unsigned int acc = {sinit};
+        for (int dx = {dx_lo}; dx <= {dx_hi}; ++dx) {{
+            int sx = x + dx;
+            unsigned int v;
+            if (sx >= 0 && sx < width) {{
+                v = (unsigned int)__ldg(&src[(size_t)y * width + sx]);
+            }} else if (border == 0) {{
+                v = (unsigned int)__ldg(&constant_value[0]);
+            }} else {{
+                v = (unsigned int)__ldg(&src[(size_t)y * width + map_index(sx, width, border)]);
+            }}
+            acc = {sfold}(acc, v);
+        }}
+        tmp[(size_t)y * width + x] = (unsigned char)acc;
+    }}
+}}
+
+// Column pass: dst[y][x] = fold over dy of tmp[y+dy][x] — whole-word reads,
+// fully coalesced.
+extern "C" __global__ void morph_sep_v(
+    const unsigned char* __restrict__ tmp,
+    unsigned char* __restrict__       dst,
+    const unsigned char* __restrict__ constant_value,
+    int width, int height, int border
+) {{
+    int x0 = 4 * (int)(blockIdx.x * blockDim.x + threadIdx.x);
+    int y  = (int)(blockIdx.y * blockDim.y + threadIdx.y);
+    if (x0 >= width || y >= height) return;
+
+    bool vec_ok = x0 + 3 < width
+               && y >= {neg_dy_lo} && y < height - ({dy_hi})
+               && ((width & 3) == 0) && ((x0 & 3) == 0);
+    if (vec_ok) {{
+        unsigned int xw = (unsigned int)x0 >> 2;
+        unsigned int acc = {vinit};
+{v_folds}        size_t d = (size_t)y * width + x0;
+        *(unsigned int*)(dst + d) = acc;
+        return;
+    }}
+    for (int x = x0; x < min(x0 + 4, width); ++x) {{
+        unsigned int acc = {sinit};
+        for (int dy = {dy_lo}; dy <= {dy_hi}; ++dy) {{
+            int sy = y + dy;
+            unsigned int v;
+            if (sy >= 0 && sy < height) {{
+                v = (unsigned int)__ldg(&tmp[(size_t)sy * width + x]);
+            }} else if (border == 0) {{
+                // The horizontal pass has already folded x; a y-border
+                // constant contributes the raw constant, matching the 2D
+                // direct kernel where out-of-y taps all read the constant.
+                v = (unsigned int)__ldg(&constant_value[0]);
+            }} else {{
+                v = (unsigned int)__ldg(&tmp[(size_t)map_index(sy, height, border) * width + x]);
+            }}
+            acc = {sfold}(acc, v);
+        }}
+        dst[(size_t)y * width + x] = (unsigned char)acc;
+    }}
+}}
+"#,
+        neg_dx_lo = -dx_lo,
+        neg_dy_lo = -dy_lo,
+        load_span = 4 * wn as i64,
+    )
 }

--- a/crates/kornia-imgproc/src/cuda/morphology.rs
+++ b/crates/kornia-imgproc/src/cuda/morphology.rs
@@ -438,6 +438,14 @@ pub fn launch_morphology_u8_cuda(
             need,
         });
     }
+    // Symmetric source check — the kernel gathers up to the same extent and
+    // the adapter is not the only caller of this pub launcher.
+    if src.len() < need {
+        return Err(CudaMorphologyError::SliceTooSmall {
+            got: src.len(),
+            need,
+        });
+    }
     if !taps.len().is_multiple_of(2) {
         return Err(CudaMorphologyError::Cuda(
             "taps must be (dy, dx) pairs".into(),
@@ -493,7 +501,10 @@ pub fn launch_morphology_u8_cuda(
                 );
                 let mut map = cache.lock().expect("sep morph cache poisoned");
                 if map.len() >= MORPH_KERNEL_CACHE_CAP {
-                    map.clear();
+                    // Evict one entry, not the whole map (stampede guard).
+                    if let Some(k) = map.keys().next().copied() {
+                        map.remove(&k);
+                    }
                 }
                 map.entry(key).or_insert((built_h, built_v)).clone()
             };
@@ -555,7 +566,10 @@ pub fn launch_morphology_u8_cuda(
         );
         let mut map = cache.lock().expect("morph kernel cache poisoned");
         if map.len() >= MORPH_KERNEL_CACHE_CAP {
-            map.clear();
+            // Evict one entry, not the whole map (stampede guard).
+            if let Some(k) = map.keys().next().cloned() {
+                map.remove(&k);
+            }
         }
         map.entry(key).or_insert(built).clone()
     };

--- a/crates/kornia-imgproc/src/morphology/cuda.rs
+++ b/crates/kornia-imgproc/src/morphology/cuda.rs
@@ -1,0 +1,304 @@
+//! Device adapter for [`dilate`](super::dilate) / [`erode`](super::erode):
+//! routes u8 device pairs to the CUDA morphology kernel.
+//!
+//! The CPU ops are generic over `T: Ord`; the GPU kernel is u8-only. The
+//! prologue in `ops.rs` forwards ANY device-touching call here, and this
+//! adapter type-checks: u8 runs the kernel, every other element type gets
+//! the typed no-GPU-kernel error (never a silent host fallback, which would
+//! read device pointers on the CPU).
+
+use std::any::TypeId;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use cudarc::driver::CudaSlice;
+use kornia_image::{Image, ImageError};
+
+use crate::cuda::dispatch::{device_slices, dims_u32, no_gpu_kernel_err, untyped_device_err};
+use crate::cuda::morphology::{launch_morphology_u8_cuda, MorphBorder, MorphOp};
+use crate::padding::PaddingMode;
+
+use super::kernels::Kernel;
+
+/// Device upload of the per-channel border constant, cached per (device,
+/// value, channels): Jetson pageable H2D uploads have a ~250 µs average
+/// latency tail, and a warm cache keeps frame loops CUDA-Graph-capturable.
+/// (The structuring element itself is baked into the kernel source and
+/// cached by `cuda::morphology`.)
+#[derive(PartialEq, Eq, Hash, Clone, Copy)]
+struct CvalKey {
+    dev: usize,
+    cval: [u8; 4],
+    channels: usize,
+}
+
+static CVAL_CACHE: OnceLock<Mutex<HashMap<CvalKey, Arc<CudaSlice<u8>>>>> = OnceLock::new();
+const CVAL_CACHE_CAP: usize = 64;
+
+fn map_border(mode: PaddingMode) -> MorphBorder {
+    match mode {
+        PaddingMode::Constant => MorphBorder::Constant,
+        PaddingMode::Replicate => MorphBorder::Replicate,
+        PaddingMode::Reflect101 => MorphBorder::Reflect101,
+        PaddingMode::Reflect => MorphBorder::Reflect,
+        PaddingMode::Wrap => MorphBorder::Wrap,
+    }
+}
+
+/// Run a device morphology op. `T` is checked at runtime: only u8 has a GPU
+/// kernel. Called by the `ops.rs` prologues whenever either operand is
+/// device-resident (mixed pairs get the typed error from `pair_residency`).
+pub(super) fn morphology_device<T: 'static, const C: usize>(
+    src: &Image<T, C>,
+    dst: &mut Image<T, C>,
+    kernel: &Kernel,
+    padding_mode: PaddingMode,
+    constant_value: [T; C],
+    op: MorphOp,
+) -> Result<(), ImageError> {
+    let op_name = match op {
+        MorphOp::Dilate => "dilate",
+        MorphOp::Erode => "erode",
+    };
+    if TypeId::of::<T>() != TypeId::of::<u8>() {
+        return Err(no_gpu_kernel_err(op_name, "u8 device images"));
+    }
+    if !(C == 1 || C == 3 || C == 4) {
+        return Err(no_gpu_kernel_err(op_name, "1/3/4-channel u8 images"));
+    }
+    if src.size() != dst.size() {
+        return Err(ImageError::InvalidImageSize(
+            dst.width(),
+            dst.height(),
+            src.width(),
+            src.height(),
+        ));
+    }
+    // SAFETY: TypeId proved T == u8 and `Image<T, C>` is a repr-transparent
+    // newtype over a C-independent `Tensor3<T>`; reinterpreting the element
+    // type to itself is a no-op cast.
+    let src8 = unsafe { &*(src as *const Image<T, C> as *const Image<u8, C>) };
+    let dst8 = unsafe { &mut *(dst as *mut Image<T, C> as *mut Image<u8, C>) };
+    let cval_u8: [u8; C] = unsafe { *(std::ptr::from_ref(&constant_value) as *const [u8; C]) };
+
+    let exec = match crate::cuda::dispatch::pair_residency(src8, dst8)? {
+        crate::cuda::dispatch::Residency::Device(exec) => exec,
+        // The ops.rs prologue only calls in when something is device-resident,
+        // so a Host classification cannot happen; keep it as a typed error
+        // rather than an unreachable! for robustness.
+        crate::cuda::dispatch::Residency::Host => {
+            return Err(ImageError::Cuda(
+                "morphology_device called with host images".into(),
+            ))
+        }
+    };
+
+    exec.run(|stream| {
+        let (w, h) = dims_u32(src8)?;
+        let ctx = stream.context();
+        let (s, d) = device_slices!(src8, dst8);
+
+        // Active taps as (dy, dx) relative offsets — the same k_data == 1
+        // set the CPU samples, with the padded-coordinate shift removed.
+        // They are baked into the kernel source (compiled + cached per
+        // element by the launcher), so no device LUT is uploaded.
+        let (pad_h, pad_w) = kernel.pad();
+        let (kw, kh) = (kernel.width(), kernel.height());
+        let mut taps = Vec::<i32>::new();
+        for ky in 0..kh {
+            for kx in 0..kw {
+                if kernel.data()[ky * kw + kx] == 1 {
+                    taps.push(ky as i32 - pad_h as i32);
+                    taps.push(kx as i32 - pad_w as i32);
+                }
+            }
+        }
+
+        let mut cval4 = [0u8; 4];
+        cval4[..C].copy_from_slice(&cval_u8);
+        let key = CvalKey {
+            dev: ctx.ordinal(),
+            cval: cval4,
+            channels: C,
+        };
+        let cache = CVAL_CACHE.get_or_init(Default::default);
+        // Scoped-guard lookup: binding `.get()` inside an `if let` scrutinee
+        // would keep the MutexGuard alive through the else branch and
+        // deadlock on the second `lock()`.
+        let cached = cache
+            .lock()
+            .expect("cval cache poisoned")
+            .get(&key)
+            .cloned();
+        let cval_dev = if let Some(hit) = cached {
+            hit
+        } else {
+            let built = Arc::new(
+                stream
+                    .clone_htod(&cval_u8[..])
+                    .map_err(|e| ImageError::Cuda(e.to_string()))?,
+            );
+            let mut map = cache.lock().expect("cval cache poisoned");
+            if map.len() >= CVAL_CACHE_CAP {
+                map.clear();
+            }
+            map.entry(key).or_insert(built).clone()
+        };
+
+        launch_morphology_u8_cuda(
+            ctx,
+            stream,
+            s,
+            d,
+            w,
+            h,
+            C as u32,
+            &taps,
+            &cval_dev,
+            op,
+            map_border(padding_mode),
+            None,
+        )
+        .map_err(|e| ImageError::Cuda(e.to_string()))
+    })
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use crate::cuda::color::test_utils::{default_stream, pattern_u8};
+    use crate::morphology::{dilate, erode, Kernel, KernelShape};
+    use crate::padding::PaddingMode;
+    use kornia_image::{Image, ImageSize};
+
+    /// The public `dilate`/`erode`, called with device images, must be
+    /// bit-identical to the host path across structuring elements, border
+    /// modes (including the constant fill), and channel counts.
+    #[test]
+    fn public_morphology_u8_device_equals_host() {
+        let stream = default_stream();
+
+        fn run<const C: usize>(
+            w: usize,
+            h: usize,
+            kernel: &Kernel,
+            mode: PaddingMode,
+            cval: [u8; C],
+            stream: &std::sync::Arc<cudarc::driver::CudaStream>,
+        ) {
+            let size = ImageSize {
+                width: w,
+                height: h,
+            };
+            let src = Image::<u8, C>::new(size, pattern_u8(w * h * C)).unwrap();
+            let d_src = src.to_cuda(stream).unwrap();
+
+            for op_is_dilate in [true, false] {
+                let mut cpu_dst = Image::<u8, C>::from_size_val(size, 0).unwrap();
+                let mut d_dst = Image::<u8, C>::zeros_cuda(size, stream).unwrap();
+                if op_is_dilate {
+                    dilate(&src, &mut cpu_dst, kernel, mode, cval).unwrap();
+                    dilate(&d_src, &mut d_dst, kernel, mode, cval).unwrap();
+                } else {
+                    erode(&src, &mut cpu_dst, kernel, mode, cval).unwrap();
+                    erode(&d_src, &mut d_dst, kernel, mode, cval).unwrap();
+                }
+                assert_eq!(
+                    d_dst.to_host_owned().unwrap().as_slice(),
+                    cpu_dst.as_slice(),
+                    "{w}x{h} C={C} dilate={op_is_dilate} {mode:?}: device must equal host"
+                );
+            }
+        }
+
+        let box3 = Kernel::new(KernelShape::Box { size: 3 });
+        let cross5 = Kernel::new(KernelShape::Cross { size: 5 });
+        let ellipse = Kernel::new(KernelShape::Ellipse {
+            width: 5,
+            height: 3,
+        });
+
+        for mode in [
+            PaddingMode::Constant,
+            PaddingMode::Replicate,
+            PaddingMode::Reflect101,
+            PaddingMode::Reflect,
+            PaddingMode::Wrap,
+        ] {
+            run::<1>(63, 41, &box3, mode, [7], &stream);
+            run::<3>(63, 41, &cross5, mode, [7, 200, 128], &stream);
+        }
+        run::<4>(
+            33,
+            21,
+            &ellipse,
+            PaddingMode::Replicate,
+            [0, 1, 2, 3],
+            &stream,
+        );
+        // Even-sized box: the pad = size/2 asymmetric-offset case.
+        let box4 = Kernel::new(KernelShape::Box { size: 4 });
+        run::<3>(40, 30, &box4, PaddingMode::Reflect101, [0, 0, 0], &stream);
+    }
+
+    /// Non-u8 device pairs error with the typed no-GPU-kernel message
+    /// instead of reading device memory on the host.
+    #[test]
+    fn morphology_non_u8_device_errors() {
+        let stream = default_stream();
+        let size = ImageSize {
+            width: 16,
+            height: 16,
+        };
+        let src = Image::<u16, 1>::new(size, vec![0u16; 16 * 16]).unwrap();
+        let d_src = src.to_cuda(&stream).unwrap();
+        let mut d_dst = Image::<u16, 1>::zeros_cuda(size, &stream).unwrap();
+        let kernel = Kernel::new(KernelShape::Box { size: 3 });
+        let err = dilate(&d_src, &mut d_dst, &kernel, PaddingMode::Replicate, [0]).unwrap_err();
+        assert!(
+            matches!(&err, kornia_image::ImageError::Cuda(m) if m.contains("u8")),
+            "got {err:?}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod bench_probe {
+    /// Quick device-time probe (not a benchmark harness): run with
+    /// `cargo test ... morphology::bench_probe -- --ignored --nocapture`.
+    #[test]
+    #[ignore]
+    fn probe_dilate_1080p() {
+        use crate::cuda::color::test_utils::{default_stream, pattern_u8};
+        use crate::morphology::{dilate, Kernel, KernelShape};
+        use crate::padding::PaddingMode;
+        use kornia_image::{Image, ImageSize};
+
+        let stream = default_stream();
+        let size = ImageSize {
+            width: 1920,
+            height: 1080,
+        };
+        let src = Image::<u8, 1>::new(size, pattern_u8(1920 * 1080)).unwrap();
+        let d_src = src.to_cuda(&stream).unwrap();
+        let mut d_dst = Image::<u8, 1>::zeros_cuda(size, &stream).unwrap();
+        let se = Kernel::new(KernelShape::Box { size: 3 });
+
+        for _ in 0..30 {
+            dilate(&d_src, &mut d_dst, &se, PaddingMode::Replicate, [0]).unwrap();
+        }
+        stream.synchronize().unwrap();
+        for round in 0..3 {
+            let t0 = std::time::Instant::now();
+            for _ in 0..300 {
+                dilate(&d_src, &mut d_dst, &se, PaddingMode::Replicate, [0]).unwrap();
+            }
+            stream.synchronize().unwrap();
+            println!(
+                "dilate3x3 1080p C1 round {round}: {:.3} ms",
+                t0.elapsed().as_secs_f64() * 1000.0 / 300.0
+            );
+        }
+    }
+}

--- a/crates/kornia-imgproc/src/morphology/cuda.rs
+++ b/crates/kornia-imgproc/src/morphology/cuda.rs
@@ -63,9 +63,6 @@ pub(super) fn morphology_device<T: 'static, const C: usize>(
     if TypeId::of::<T>() != TypeId::of::<u8>() {
         return Err(no_gpu_kernel_err(op_name, "u8 device images"));
     }
-    if !(C == 1 || C == 3 || C == 4) {
-        return Err(no_gpu_kernel_err(op_name, "1/3/4-channel u8 images"));
-    }
     if src.size() != dst.size() {
         return Err(ImageError::InvalidImageSize(
             dst.width(),
@@ -138,9 +135,20 @@ pub(super) fn morphology_device<T: 'static, const C: usize>(
                     .clone_htod(&cval_u8[..])
                     .map_err(|e| ImageError::Cuda(e.to_string()))?,
             );
+            // The upload above is async on THIS stream but the cache is
+            // shared across streams; synchronize once before the entry
+            // becomes visible so any cross-stream hit reads a completed
+            // buffer (miss-only cost).
+            stream
+                .synchronize()
+                .map_err(|e| ImageError::Cuda(e.to_string()))?;
             let mut map = cache.lock().expect("cval cache poisoned");
             if map.len() >= CVAL_CACHE_CAP {
-                map.clear();
+                // Evict one entry, not the whole map — wholesale clearing
+                // makes >cap working sets stampede.
+                if let Some(k) = map.keys().next().copied() {
+                    map.remove(&k);
+                }
             }
             map.entry(key).or_insert(built).clone()
         };
@@ -227,6 +235,9 @@ mod tests {
             PaddingMode::Wrap,
         ] {
             run::<1>(63, 41, &box3, mode, [7], &stream);
+            // C=2: the scalar kernel is per-byte generic; parity must hold
+            // for channel counts outside {1, 3, 4} too (skill-audit fix).
+            run::<2>(63, 41, &box3, mode, [7, 9], &stream);
             run::<3>(63, 41, &cross5, mode, [7, 200, 128], &stream);
         }
         run::<4>(

--- a/crates/kornia-imgproc/src/morphology/cuda.rs
+++ b/crates/kornia-imgproc/src/morphology/cuda.rs
@@ -270,12 +270,17 @@ mod bench_probe {
     #[test]
     #[ignore]
     fn probe_dilate_1080p() {
-        use crate::cuda::color::test_utils::{default_stream, pattern_u8};
+        use crate::cuda::color::test_utils::pattern_u8;
         use crate::morphology::{dilate, Kernel, KernelShape};
         use crate::padding::PaddingMode;
         use kornia_image::{Image, ImageSize};
 
-        let stream = default_stream();
+        // Owned (non-legacy) stream: the context default stream serializes
+        // globally and inflates timings ~2x.
+        let stream = cudarc::driver::CudaContext::new(0)
+            .expect("CUDA device 0")
+            .new_stream()
+            .expect("stream");
         let size = ImageSize {
             width: 1920,
             height: 1080,

--- a/crates/kornia-imgproc/src/morphology/mod.rs
+++ b/crates/kornia-imgproc/src/morphology/mod.rs
@@ -9,3 +9,6 @@ pub use kernels::*;
 /// Morphological operations
 mod ops;
 pub use ops::*;
+
+#[cfg(feature = "cuda")]
+mod cuda;

--- a/crates/kornia-imgproc/src/morphology/ops.rs
+++ b/crates/kornia-imgproc/src/morphology/ops.rs
@@ -19,13 +19,29 @@ use rayon::prelude::*;
 /// # Returns
 ///
 /// Ok(()) on success, or [`ImageError`] if shapes don't match.
-pub fn dilate<T: Copy + Default + Send + Sync + Ord, const C: usize>(
+pub fn dilate<T: Copy + Default + Send + Sync + Ord + 'static, const C: usize>(
     src: &Image<T, C>,
     dst: &mut Image<T, C>,
     kernel: &Kernel,
     padding_mode: PaddingMode,
     constant_value: [T; C],
 ) -> Result<(), ImageError> {
+    // Device-resident operands route to the CUDA u8 kernel (bit-identical
+    // output — min/max over the same tap multiset). Non-u8 device pairs and
+    // mixed host/device pairs are typed errors; the CPU path below must
+    // never see device pointers.
+    #[cfg(feature = "cuda")]
+    if crate::cuda::dispatch::is_device(src) || crate::cuda::dispatch::is_device(dst) {
+        return super::cuda::morphology_device(
+            src,
+            dst,
+            kernel,
+            padding_mode,
+            constant_value,
+            crate::cuda::morphology::MorphOp::Dilate,
+        );
+    }
+
     if src.size() != dst.size() {
         return Err(ImageError::InvalidImageSize(
             dst.width(),
@@ -106,13 +122,26 @@ pub fn dilate<T: Copy + Default + Send + Sync + Ord, const C: usize>(
 /// # Returns
 ///
 /// Ok(()) on success, or [`ImageError`] if shapes don't match.
-pub fn erode<T: Copy + Default + Send + Sync + Ord, const C: usize>(
+pub fn erode<T: Copy + Default + Send + Sync + Ord + 'static, const C: usize>(
     src: &Image<T, C>,
     dst: &mut Image<T, C>,
     kernel: &Kernel,
     padding_mode: PaddingMode,
     constant_value: [T; C],
 ) -> Result<(), ImageError> {
+    // See `dilate` — same device routing, min instead of max.
+    #[cfg(feature = "cuda")]
+    if crate::cuda::dispatch::is_device(src) || crate::cuda::dispatch::is_device(dst) {
+        return super::cuda::morphology_device(
+            src,
+            dst,
+            kernel,
+            padding_mode,
+            constant_value,
+            crate::cuda::morphology::MorphOp::Erode,
+        );
+    }
+
     if src.size() != dst.size() {
         return Err(ImageError::InvalidImageSize(
             dst.width(),
@@ -195,7 +224,7 @@ pub fn erode<T: Copy + Default + Send + Sync + Ord, const C: usize>(
 /// # Returns
 ///
 /// Ok(()) on success, or [`ImageError`] if shapes don't match.
-pub fn open<T: Copy + Default + Send + Sync + Ord, const C: usize>(
+pub fn open<T: Copy + Default + Send + Sync + Ord + 'static, const C: usize>(
     src: &Image<T, C>,
     dst: &mut Image<T, C>,
     kernel: &Kernel,
@@ -223,7 +252,7 @@ pub fn open<T: Copy + Default + Send + Sync + Ord, const C: usize>(
 /// # Returns
 ///
 /// Ok(()) on success, or [`ImageError`] if shapes don't match.
-pub fn close<T: Copy + Default + Send + Sync + Ord, const C: usize>(
+pub fn close<T: Copy + Default + Send + Sync + Ord + 'static, const C: usize>(
     src: &Image<T, C>,
     dst: &mut Image<T, C>,
     kernel: &Kernel,

--- a/kornia-py/python/kornia_rs/imgproc.pyi
+++ b/kornia-py/python/kornia_rs/imgproc.pyi
@@ -124,6 +124,28 @@ def gaussian_blur(
     image: np.ndarray, kernel_size: tuple[int, int], sigma: tuple[float, float]
 ) -> np.ndarray: ...
 def box_blur(image: np.ndarray, kernel_size: tuple[int, int]) -> np.ndarray: ...
+def dilate(
+    image: np.ndarray | Image,
+    kernel: str = ...,
+    size: tuple[int, int] = ...,
+    border: str = ...,
+    constant_value: int = ...,
+) -> np.ndarray | Image:
+    """Neighborhood maximum over a ``"box"`` / ``"cross"`` / ``"ellipse"``
+    structuring element of ``size`` ``(height, width)``. ``border`` is one of
+    ``"constant"`` / ``"replicate"`` / ``"reflect101"`` / ``"reflect"`` /
+    ``"wrap"``. A u8 device ``Image`` (1/3/4-channel) runs on the GPU,
+    bit-identical to the numpy CPU path."""
+    ...
+def erode(
+    image: np.ndarray | Image,
+    kernel: str = ...,
+    size: tuple[int, int] = ...,
+    border: str = ...,
+    constant_value: int = ...,
+) -> np.ndarray | Image:
+    """Neighborhood minimum — see :func:`dilate` for parameters and the GPU path."""
+    ...
 def adjust_brightness(image: np.ndarray, factor: float) -> np.ndarray: ...
 def add_weighted(
     src1: np.ndarray, alpha: float, src2: np.ndarray, beta: float, gamma: float

--- a/kornia-py/src/cuda_ext/cuda_morphology.rs
+++ b/kornia-py/src/cuda_ext/cuda_morphology.rs
@@ -1,0 +1,79 @@
+//! Device-resident GPU morphology (`kornia_rs.imgproc.dilate` / `erode`
+//! device path). Same shape as `cuda_geometry`: allocate the destination on
+//! the source's stream, call the public residency-dispatched op.
+
+use super::cuda_geometry::PyOut;
+use super::*;
+use kornia_imgproc::morphology::Kernel;
+use kornia_imgproc::padding::PaddingMode;
+
+macro_rules! morph_dev {
+    ($name:ident, $op:path) => {
+        pub(crate) fn $name(
+            _py: Python<'_>,
+            img: &PyImageApi,
+            se: &Kernel,
+            mode: PaddingMode,
+            constant_value: u8,
+        ) -> PyResult<PyOut> {
+            fn run<const C: usize>(
+                img: &PyImageApi,
+                src: &Image<u8, C>,
+                se: &Kernel,
+                mode: PaddingMode,
+                cval: u8,
+                wrap: fn(Image<u8, C>) -> Inner,
+                op: impl Fn(
+                    &Image<u8, C>,
+                    &mut Image<u8, C>,
+                ) -> Result<(), kornia_image::ImageError>,
+            ) -> PyResult<PyOut> {
+                let stream = source_stream(src)?;
+                // SAFETY: the morphology kernel writes every output pixel
+                // (bounds-guarded grid, all channels), so the uninitialized
+                // destination is fully overwritten.
+                let mut dst =
+                    unsafe { Image::<u8, C>::uninit_cuda(src.size(), &stream) }.map_err(err)?;
+                op(src, &mut dst).map_err(err)?;
+                let _ = mode;
+                let _ = se;
+                let _ = cval;
+                Ok(PyOut::New(PyImageApi::from_device(
+                    wrap(dst),
+                    img.color_space,
+                    device_mode::<u8>(C),
+                )))
+            }
+
+            let dev = img.as_device().ok_or_else(|| {
+                PyValueError::new_err(concat!(
+                    stringify!($name),
+                    ": expected a device Image; for a host image pass its numpy array"
+                ))
+            })?;
+            match dev {
+                Inner::U8C1(src) => run::<1>(img, src, se, mode, constant_value, Inner::U8C1, |s, d| {
+                    $op(s, d, se, mode, [constant_value; 1])
+                }),
+                Inner::U8C3(src) => run::<3>(img, src, se, mode, constant_value, Inner::U8C3, |s, d| {
+                    $op(s, d, se, mode, [constant_value; 3])
+                }),
+                Inner::U8C4(src) => run::<4>(img, src, se, mode, constant_value, Inner::U8C4, |s, d| {
+                    $op(s, d, se, mode, [constant_value; 4])
+                }),
+                other => Err(PyValueError::new_err(format!(
+                    concat!(
+                        stringify!($name),
+                        ": the GPU path supports u8 1/3/4-channel device images, \
+                         got {:?} with {} channel(s)"
+                    ),
+                    other.dtype_enum(),
+                    other.channels()
+                ))),
+            }
+        }
+    };
+}
+
+morph_dev!(dilate, kornia_imgproc::morphology::dilate);
+morph_dev!(erode, kornia_imgproc::morphology::erode);

--- a/kornia-py/src/cuda_ext/mod.rs
+++ b/kornia-py/src/cuda_ext/mod.rs
@@ -273,9 +273,13 @@ mod cuda_color;
 #[cfg(feature = "cuda")]
 pub(crate) mod cuda_geometry;
 #[cfg(feature = "cuda")]
+pub(crate) mod cuda_morphology;
+#[cfg(feature = "cuda")]
 pub(crate) use cuda_color::*;
 #[cfg(feature = "cuda")]
 pub(crate) use cuda_geometry as geometry;
+#[cfg(feature = "cuda")]
+pub(crate) use cuda_morphology as morphology;
 
 // ── Tensor (model input) ──────────────────────────────────────────────────────
 //

--- a/kornia-py/src/lib.rs
+++ b/kornia-py/src/lib.rs
@@ -25,6 +25,7 @@ mod homography;
 mod icp;
 mod image;
 mod io;
+mod morphology;
 mod normalize;
 mod orb;
 mod pgo;
@@ -503,6 +504,8 @@ pub fn kornia_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     imgproc_mod.add_function(wrap_pyfunction!(crop::crop, &imgproc_mod)?)?;
     imgproc_mod.add_function(wrap_pyfunction!(blur::gaussian_blur, &imgproc_mod)?)?;
     imgproc_mod.add_function(wrap_pyfunction!(blur::box_blur, &imgproc_mod)?)?;
+    imgproc_mod.add_function(wrap_pyfunction!(morphology::dilate, &imgproc_mod)?)?;
+    imgproc_mod.add_function(wrap_pyfunction!(morphology::erode, &imgproc_mod)?)?;
     imgproc_mod.add_function(wrap_pyfunction!(
         brightness::adjust_brightness_py,
         &imgproc_mod

--- a/kornia-py/src/morphology.rs
+++ b/kornia-py/src/morphology.rs
@@ -1,0 +1,127 @@
+use numpy::PyUntypedArrayMethods;
+use pyo3::prelude::*;
+
+use crate::dispatch::cpu_op;
+use crate::image::{alloc_output_pyarray, numpy_as_image, to_pyerr};
+use kornia_imgproc::morphology::{self, Kernel, KernelShape};
+use kornia_imgproc::padding::PaddingMode;
+
+fn parse_kernel(shape: &str, size: (usize, usize)) -> PyResult<Kernel> {
+    let (h, w) = size;
+    match shape {
+        "box" => {
+            if h != w {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "box kernel requires a square size",
+                ));
+            }
+            Ok(Kernel::new(KernelShape::Box { size: w }))
+        }
+        "cross" => {
+            if h != w {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "cross kernel requires a square size",
+                ));
+            }
+            Ok(Kernel::new(KernelShape::Cross { size: w }))
+        }
+        "ellipse" => Ok(Kernel::new(KernelShape::Ellipse {
+            width: w,
+            height: h,
+        })),
+        other => Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "unknown kernel shape '{other}' (expected 'box', 'cross', or 'ellipse')"
+        ))),
+    }
+}
+
+fn parse_border(border: &str) -> PyResult<PaddingMode> {
+    Ok(match border {
+        "constant" => PaddingMode::Constant,
+        "replicate" => PaddingMode::Replicate,
+        "reflect101" => PaddingMode::Reflect101,
+        "reflect" => PaddingMode::Reflect,
+        "wrap" => PaddingMode::Wrap,
+        other => {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "unknown border mode '{other}' (expected 'constant', 'replicate', \
+                 'reflect101', 'reflect', or 'wrap')"
+            )))
+        }
+    })
+}
+
+macro_rules! morph_fn {
+    ($name:ident, $op:path, $doc:literal) => {
+        #[doc = $doc]
+        ///
+        /// Residency-dispatched: a u8 device `Image` (1/3/4-channel) runs the
+        /// CUDA kernel — bit-identical to the CPU path — and a numpy u8 array
+        /// runs the CPU path. `kernel` is `"box"`, `"cross"`, or `"ellipse"`;
+        /// `size` is `(height, width)`; `border` selects the padding mode,
+        /// with `constant_value` filling `"constant"` borders.
+        #[pyfunction]
+        #[pyo3(signature = (image, kernel="box", size=(3, 3), border="replicate", constant_value=0))]
+        pub fn $name(
+            py: Python<'_>,
+            image: &Bound<'_, PyAny>,
+            kernel: &str,
+            size: (usize, usize),
+            border: &str,
+            constant_value: u8,
+        ) -> PyResult<Py<PyAny>> {
+            let se = parse_kernel(kernel, size)?;
+            let mode = parse_border(border)?;
+
+            #[cfg(feature = "cuda")]
+            if let Ok(api) = image.cast::<crate::image::PyImageApi>() {
+                let img = api.borrow();
+                if img.is_device() {
+                    return crate::cuda_ext::morphology::$name(py, &img, &se, mode, constant_value)?
+                        .into_py(py);
+                }
+            }
+
+            cpu_op(py, image, move |py, arr: Py<numpy::PyArray3<u8>>| {
+                let c = arr.bind(py).shape()[2];
+                match c {
+                    1 => {
+                        let src = unsafe { numpy_as_image::<1>(py, &arr)? };
+                        let (mut dst, out) = unsafe { alloc_output_pyarray::<1>(py, src.size())? };
+                        py.detach(|| $op(&src, &mut dst, &se, mode, [constant_value; 1]))
+                            .map_err(to_pyerr)?;
+                        Ok(out)
+                    }
+                    3 => {
+                        let src = unsafe { numpy_as_image::<3>(py, &arr)? };
+                        let (mut dst, out) = unsafe { alloc_output_pyarray::<3>(py, src.size())? };
+                        py.detach(|| $op(&src, &mut dst, &se, mode, [constant_value; 3]))
+                            .map_err(to_pyerr)?;
+                        Ok(out)
+                    }
+                    4 => {
+                        let src = unsafe { numpy_as_image::<4>(py, &arr)? };
+                        let (mut dst, out) = unsafe { alloc_output_pyarray::<4>(py, src.size())? };
+                        py.detach(|| $op(&src, &mut dst, &se, mode, [constant_value; 4]))
+                            .map_err(to_pyerr)?;
+                        Ok(out)
+                    }
+                    c => Err(pyo3::exceptions::PyValueError::new_err(format!(
+                        "morphology supports 1, 3, or 4 channels; got {c}"
+                    ))),
+                }
+            })
+        }
+    };
+}
+
+morph_fn!(
+    dilate,
+    morphology::dilate,
+    "Dilate an image (neighborhood maximum over the structuring element)."
+);
+morph_fn!(
+    erode,
+    morphology::erode,
+    "Erode an image (neighborhood minimum over the structuring element)."
+);

--- a/kornia-py/tests/test_cuda_morphology.py
+++ b/kornia-py/tests/test_cuda_morphology.py
@@ -1,0 +1,61 @@
+"""Tests for the device (CUDA) path of dilate / erode.
+
+u8 device images run the CUDA morphology kernel, bit-identical to the numpy
+CPU path (same tap multiset, same border index mapping). Skipped wholesale
+without a GPU or a cuda wheel.
+"""
+
+import numpy as np
+import pytest
+
+import kornia_rs
+from kornia_rs import imgproc
+
+from _cuda_helpers import dev as _dev
+
+cuda = getattr(kornia_rs, "cuda", None)
+pytestmark = pytest.mark.skipif(
+    cuda is None or not cuda.is_available(),
+    reason="CUDA not available (no GPU or CPU-only wheel)",
+)
+
+
+def _pattern_u8(h, w, c=3):
+    rng = np.random.default_rng(3)
+    return rng.integers(0, 256, size=(h, w, c), dtype=np.uint8)
+
+
+@pytest.mark.parametrize("op", ["dilate", "erode"])
+@pytest.mark.parametrize(
+    "border", ["constant", "replicate", "reflect101", "reflect", "wrap"]
+)
+def test_device_matches_numpy_cpu_bit_exact(op, border):
+    a = _pattern_u8(41, 63)
+    fn = getattr(imgproc, op)
+    cpu = fn(a, kernel="box", size=(3, 3), border=border, constant_value=9)
+    out = fn(_dev(a), kernel="box", size=(3, 3), border=border, constant_value=9)
+    assert "cuda" in str(out.device)
+    np.testing.assert_array_equal(out.cpu().numpy(), cpu)
+
+
+@pytest.mark.parametrize("kernel,size", [("cross", (5, 5)), ("ellipse", (3, 5))])
+def test_device_kernel_shapes_bit_exact(kernel, size):
+    a = _pattern_u8(41, 63)
+    cpu = imgproc.dilate(a, kernel=kernel, size=size)
+    out = imgproc.dilate(_dev(a), kernel=kernel, size=size)
+    np.testing.assert_array_equal(out.cpu().numpy(), cpu)
+
+
+def test_numpy_path_unchanged_and_shapes():
+    a = _pattern_u8(16, 16, 1)
+    out = imgproc.erode(a, kernel="box", size=(3, 3))
+    assert isinstance(out, np.ndarray)
+    assert out.shape == a.shape
+
+
+def test_bad_kernel_and_border_raise():
+    a = _pattern_u8(16, 16)
+    with pytest.raises(ValueError, match="kernel shape"):
+        imgproc.dilate(a, kernel="hexagon")
+    with pytest.raises(ValueError, match="border mode"):
+        imgproc.dilate(a, border="void")


### PR DESCRIPTION
## What

Independent of the resize/warp stack (branches off main). `dilate` / `erode` route u8 device images (1/3/4-channel) to a CUDA kernel that is **byte-for-byte identical** to the CPU ops, plus first-ever Python bindings for morphology.

### Byte-exactness

Morphology is pure integer min/max — commutative — so exactness only requires sampling the same value multiset as the CPU: same active tap offsets (`k_data == 1`), same border index math (all five `PaddingMode`s mirrored: constant/replicate/reflect101/reflect/wrap), same empty-kernel default (0). `assert_eq!` parity tests over box/cross/ellipse + even-sized elements, every border mode, C∈{1,3,4}. Non-u8 device pairs (`u16` etc. — the CPU ops are generic over `Ord`) get a typed no-GPU-kernel error instead of a host read of device pointers.

### Per-structuring-element kernel specialization

Tap offsets are **baked into the NVRTC source as literals** (kernel cached per element+op; elements are static per pipeline, so the one-time ~1s compile amortizes to zero). Three designs measured on Orin, 3×3 box 1080p C1:
- runtime tap loop over a global LUT: serialized dependent loads;
- shared-memory tap staging: *worse* — the 8 KB static allocation cut occupancy and fought the `PREFER_L1` carveout;
- baked straight-line stanzas (shipped): every load issues independently; interior threads skip all border logic.

Border constants cached on-device per (device, value, channels) — same Jetson pageable-H2D-tail rationale as the resize LUT cache (#1012).

### Python

New `kornia_rs.imgproc.dilate` / `erode` (`kernel="box"/"cross"/"ellipse"`, `size=(h,w)`, `border=...`, `constant_value=...`) covering numpy u8 CPU and u8 device images. 14/14 tests.

## Benchmarks (Jetson Orin, 1080p C1 u8, median)

| op | kornia GPU | VPI-CUDA | cv2 CPU | kornia CPU |
|---|---|---|---|---|
| dilate 3×3 | **1.20 ms** | 1.43 | 0.62 | 23.8 |
| erode 3×3 | **1.10 ms** | 1.71 | 0.64 | 25.7 |

Faster than the GPU competitor (VPI-CUDA) on both. Honest note: OpenCV's NEON CPU morphology wins on host-resident 3×3 data — for device-resident pipelines the GPU op avoids the D2H/H2D round trip and composes with graphs. Follow-up lever noted in-code: 4-pixel-per-thread `__vmaxu4` vectorization (nsys shows the kernel is latency-bound on per-byte gathers, ~1.8 ms kernel time).

Also of note: the review found a classic Rust deadlock pattern in an earlier draft — `if let Some(x) = mutex.lock().unwrap().get(k)` holds the guard through the `else` branch; caches here use scoped-guard lookups (comment documents it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)