### PR TITLE
perf(imgproc): color-kernel sweep — branchless HSV hue, close f32-HSV headroom investigation

### DIFF
--- a/crates/kornia-imgproc/src/cuda/color/hsv_hls.rs
+++ b/crates/kornia-imgproc/src/cuda/color/hsv_hls.rs
@@ -29,6 +29,12 @@ __device__ __forceinline__ float hue_deg(
     return h;
 }
 
+// Branchless hue: all three sector expressions are predicated selects on
+// one reciprocal-free divide each; the r-sector fmodf is dropped because
+// (g - b) / delta is always in [-1, 1], where fmodf(x, 6) == x. Warp
+// divergence (3-way branch with divide + fmodf per path) was the dominant
+// cost of the previous form — ~18 GB/s effective vs the ~55 GB/s platform
+// envelope for this access pattern.
 extern "C" __global__ void hsv_from_rgb_f32(
     const float* __restrict__ src, float* __restrict__ dst, unsigned int npixels)
 {
@@ -41,10 +47,17 @@ extern "C" __global__ void hsv_from_rgb_f32(
     float maxv = fmaxf(fmaxf(r, g), b);
     float minv = fminf(fminf(r, g), b);
     float delta = maxv - minv;
-    float h = (delta == 0.0f) ? 0.0f : hue_deg(r, g, b, maxv, delta);
-    float s = (maxv == 0.0f) ? 0.0f : (delta / maxv) * 255.0f;
+    float safe = (delta == 0.0f) ? 1.0f : delta;
+    float hr = (g - b) / safe;              // in [-1, 1]; fmod(x,6) == x
+    float hg = ((b - r) / safe) + 2.0f;
+    float hb = ((r - g) / safe) + 4.0f;
+    float h6 = (maxv == r) ? hr : (maxv == g) ? hg : hb;
+    float h = 60.0f * h6;
+    if (h < 0.0f) h += 360.0f;
+    if (delta == 0.0f) h = 0.0f;
+    float sat = (maxv == 0.0f) ? 0.0f : (delta / maxv) * 255.0f;
     dst[si]      = h * DEG_TO_BYTE;
-    dst[si + 1u] = s;
+    dst[si + 1u] = sat;
     dst[si + 2u] = maxv * 255.0f;
 }
 

--- a/crates/kornia-imgproc/src/cuda/color/hsv_hls.rs
+++ b/crates/kornia-imgproc/src/cuda/color/hsv_hls.rs
@@ -35,6 +35,17 @@ __device__ __forceinline__ float hue_deg(
 // divergence (3-way branch with divide + fmodf per path) was the dominant
 // cost of the previous form — ~18 GB/s effective vs the ~55 GB/s platform
 // envelope for this access pattern.
+//
+// Closed perf investigation (ncu, locked clocks): the scalar float3 access
+// does fetch 3x excessive sectors (67% of total), but L1 absorbs the
+// overlap (65% hit rate) and the kernel sits at ~85% of the measured
+// ~55 GB/s f32-C3 streaming envelope — Orin's EMC is SoC-shared and the
+// 204 GB/s spec is not reachable by a lone GPU stream. A 4px/thread
+// float4-vectorized variant (3 aligned float4 loads/stores, named-register
+// unpack, no spill) cut sectors 3x yet measured 1.20 ms vs 1.06 ms scalar
+// sustained at 1080p: quartering the thread count removes the warps that
+// hide LPDDR5 latency. Occupancy beats access-pattern perfection on this
+// part; keep the 1px scalar form.
 extern "C" __global__ void hsv_from_rgb_f32(
     const float* __restrict__ src, float* __restrict__ dst, unsigned int npixels)
 {
@@ -484,5 +495,36 @@ mod tests {
             let diff = max_abs_diff(&gpu, &cpu);
             assert!(diff <= 1e-3, "{name} max diff {diff} > 1e-3");
         }
+    }
+}
+
+#[cfg(test)]
+mod probe_tests {
+    use super::*;
+    use crate::cuda::color::test_utils::{default_stream, pattern_u8};
+
+    /// Sustained 1080p hsv_from_rgb_f32 probe (ignored; run under locked clocks).
+    #[test]
+    #[ignore]
+    fn probe_hsv_f32_1080p() {
+        let stream = default_stream();
+        let n = 1920 * 1080;
+        let rgb: Vec<f32> = pattern_u8(n * 3).into_iter().map(|b| b as f32).collect();
+        let d_src = stream.clone_htod(&rgb).unwrap();
+        let mut d_dst = stream.alloc_zeros::<f32>(n * 3).unwrap();
+        for _ in 0..50 {
+            launch_hsv_from_rgb_f32(&stream, &d_src, &mut d_dst, n).unwrap();
+        }
+        stream.synchronize().unwrap();
+        let mut best = f64::MAX;
+        for _ in 0..5 {
+            let t0 = std::time::Instant::now();
+            for _ in 0..100 {
+                launch_hsv_from_rgb_f32(&stream, &d_src, &mut d_dst, n).unwrap();
+            }
+            stream.synchronize().unwrap();
+            best = best.min(t0.elapsed().as_secs_f64() * 1000.0 / 100.0);
+        }
+        println!("hsv_from_rgb_f32 1080p: {best:.3} ms (min of 5x100)");
     }
 }


### PR DESCRIPTION
## What

Color-conversion kernel optimization sweep (task: 10x-per-op goal, color family).

- **Branchless hue** in the f32 HSV forward kernel: the 3-way max-channel branch (each path with its own divide, one with `fmodf`) becomes predicated selects on three reciprocal-free divides; the r-sector `fmodf` is dropped outright since `(g−b)/delta ∈ [−1,1]` where `fmod(x,6) == x`. CPU↔GPU parity tests unchanged and green (19/19).
- **Closes the f32-HSV "4x headroom" investigation** with ncu evidence (locked clocks), documented in-source:
  - The scalar float3 access pattern does fetch 3× excessive sectors (67% of total), but L1 absorbs the neighbor-channel overlap (65% hit rate).
  - ncu's "Memory Throughput" on the Orin iGPU reports the **L1/LSU pipe, not DRAM** — there are no dram__ metrics on this part (EMC is SoC-shared).
  - The kernel runs at ~85% of the *measured* ~55 GB/s f32-C3 streaming envelope; the 204 GB/s spec figure is shared-EMC theoretical and unreachable by a lone GPU stream, so the projected headroom never existed.
  - A float4-vectorized 4px/thread variant (3 aligned float4 loads/stores, named-register unpack, no local-memory spill) removed the excessive sectors and **still regressed 13%** (1.20 vs 1.06 ms sustained 1080p): quartering thread count removes the warps that hide LPDDR5 latency. Fourth confirmation of the Orin occupancy-over-ILP rule.
- Adds an ignored sustained 1080p probe test (`probe_hsv_f32_1080p`) for future A/Bs.

## Bench (Orin, jetson_clocks locked, sustained 1080p, vs cv2 CPU)

| op | gpu ms | cv2 ms | ×cv2 |
|---|---|---|---|
| gray_from_rgb | 0.100 | 0.819 | 8.2 |
| bgr_from_rgb | 0.237 | 0.453 | 1.9 |
| rgba_from_rgb | 0.465 | 1.579 | 3.4 |
| hsv_from_rgb | 1.023 | 3.344 | 3.3 |
| lab_from_rgb | 1.045 | 29.673 | **28.4** ✓ |
| ycbcr_from_rgb | 0.245 | 3.182 | **13.0** ✓ |
| sepia_from_rgb | 0.252 | — | — |

cv2 CPU column is noisy run-to-run (hsv baseline measured 2.6–4.7 ms across runs); kornia column is stable ±3%. u8 swizzles/gray sit on the ~80 GB/s u8 streaming envelope; f32 C3 ops sit on the ~55 GB/s envelope — remaining gaps to 10× are DRAM-physics, same class as the warp/VPI parity finding in #1015.

🤖 Generated with [Claude Code](https://claude.com/claude-code)