### PR TITLE
perf(imgproc): faster Lanczos-3 warps — 4 sin_pi evals per axis instead of 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ changes early: `cargo add kornia-imgproc@0.1.15-rc.1` or `pip install --pre korn
 
 ## [Unreleased]
 
+**Faster Lanczos-3 warps on CUDA; sub-ULP output change in Lanczos warp/remap
+sampling.** The warp kernels now derive all six tap weights per axis from four
+`sin(πx)` evaluations instead of twelve, using the sinc lattice's periodicity
+(`sin(π(frac+n)) = ±sin(π·frac)`); the CPU sampler (`lanczos_sample`, used by
+`warp_affine`/`warp_perspective`/`remap` with `InterpolationMode::Lanczos`) is
+refactored identically, so CPU and GPU remain bit-exact to each other. Absolute
+values shift by ≤1e-6 relative to previous releases (weights are identical in
+real arithmetic, rounding differs). Measured on Jetson AGX Orin (locked
+clocks, 1080p→1080p 3-channel f32): warp-affine lanczos 5.49→4.26 ms,
+warp-perspective lanczos 5.93→4.28 ms sustained.
+
 **u8 CUDA morphology (dilate / erode), bit-identical to the CPU ops, plus
 first-time Python bindings.** `dilate` / `erode` route u8 device images
 (1/3/4-channel) to a CUDA kernel that samples the exact tap multiset the CPU

--- a/crates/kornia-imgproc/src/cuda/warp_affine.rs
+++ b/crates/kornia-imgproc/src/cuda/warp_affine.rs
@@ -335,13 +335,29 @@ __device__ inline float sin_pi(float x) {
     return (((int)k) & 1) ? -s : s;
 }
 
-__device__ inline float lanczos3(float x) {
+__device__ inline void lanczos3_weights(float frac, float* w) {
+    // All six tap weights from FOUR sin_pi evals instead of twelve — the
+    // textual twin of the Rust lanczos3_weights (see interpolation/lanczos.rs
+    // for the periodicity derivation). Epsilon patches mirror the original
+    // per-tap lanczos3 special cases; the frac == 0 zero at tap 5 falls out
+    // of s == 0 on its own.
     const float PI = 3.14159265358979f;
-    if (fabsf(x) < 1e-5f) return 1.0f;
-    if (fabsf(x) >= 3.0f) return 0.0f;
-    float pix  = PI * x;
-    float pix3 = pix * 0.33333333f;
-    return sin_pi(x) * sin_pi(x * (1.0f / 3.0f)) / (pix * pix3);
+    float s  = sin_pi(frac);
+    float t0 = sin_pi(frac * (1.0f / 3.0f));
+    float t1 = sin_pi((frac - 1.0f) * (1.0f / 3.0f));
+    float t2 = sin_pi((frac - 2.0f) * (1.0f / 3.0f));
+    float st0 = s * t0;
+    float st1 = s * t1;
+    float st2 = s * t2;
+    float x, pix, pix3;
+    x = frac + 2.0f; pix = PI * x; pix3 = pix * 0.33333333f; w[0] = -st1 / (pix * pix3);
+    x = frac + 1.0f; pix = PI * x; pix3 = pix * 0.33333333f; w[1] =  st2 / (pix * pix3);
+    x = frac;        pix = PI * x; pix3 = pix * 0.33333333f; w[2] =  st0 / (pix * pix3);
+    x = frac - 1.0f; pix = PI * x; pix3 = pix * 0.33333333f; w[3] = -st1 / (pix * pix3);
+    x = frac - 2.0f; pix = PI * x; pix3 = pix * 0.33333333f; w[4] =  st2 / (pix * pix3);
+    x = frac - 3.0f; pix = PI * x; pix3 = pix * 0.33333333f; w[5] =  st0 / (pix * pix3);
+    if (frac < 1e-5f)               { w[2] = 1.0f; }
+    if (fabsf(frac - 1.0f) < 1e-5f) { w[3] = 1.0f; }
 }
 
 extern "C" __global__ void warp_affine_lanczos_3c(
@@ -384,14 +400,9 @@ extern "C" __global__ void warp_affine_lanczos_3c(
     float frac_x = sx - (float)x0;
     float frac_y = sy - (float)y0;
 
-    // 6 weights per axis; tap i is at offset (i-2) from x0/y0.
     float wx[6], wy[6];
-    wx[0] = lanczos3(frac_x + 2.0f); wx[1] = lanczos3(frac_x + 1.0f);
-    wx[2] = lanczos3(frac_x);        wx[3] = lanczos3(frac_x - 1.0f);
-    wx[4] = lanczos3(frac_x - 2.0f); wx[5] = lanczos3(frac_x - 3.0f);
-    wy[0] = lanczos3(frac_y + 2.0f); wy[1] = lanczos3(frac_y + 1.0f);
-    wy[2] = lanczos3(frac_y);        wy[3] = lanczos3(frac_y - 1.0f);
-    wy[4] = lanczos3(frac_y - 2.0f); wy[5] = lanczos3(frac_y - 3.0f);
+    lanczos3_weights(frac_x, wx);
+    lanczos3_weights(frac_y, wy);
 
     // Normalise to guard against brightness drift at clamped boundaries.
     float sum_wx = wx[0]+wx[1]+wx[2]+wx[3]+wx[4]+wx[5];
@@ -402,6 +413,10 @@ extern "C" __global__ void warp_affine_lanczos_3c(
     for (int i = 0; i < 6; i++) { wx[i] *= inv_x; wy[i] *= inv_y; }
 
     // Row base addresses precomputed to move the multiply outside the inner loop.
+    // Failed experiment (2026-07-17): 32-bit element offsets here regressed
+    // 3.67 -> 4.59 ms sustained — the narrower IMAD address math lands on the
+    // same FMA pipe the weight computation saturates, while the 64-bit form
+    // the compiler builds from ull math schedules around it. Keep ull.
     unsigned long long row[6];
     #pragma unroll
     for (int i = 0; i < 6; i++) {

--- a/crates/kornia-imgproc/src/cuda/warp_perspective.rs
+++ b/crates/kornia-imgproc/src/cuda/warp_perspective.rs
@@ -275,13 +275,29 @@ __device__ inline float sin_pi(float x) {
     return (((int)k) & 1) ? -s : s;
 }
 
-__device__ inline float lanczos3(float x) {
+__device__ inline void lanczos3_weights(float frac, float* w) {
+    // All six tap weights from FOUR sin_pi evals instead of twelve — the
+    // textual twin of the Rust lanczos3_weights (see interpolation/lanczos.rs
+    // for the periodicity derivation). Epsilon patches mirror the original
+    // per-tap lanczos3 special cases; the frac == 0 zero at tap 5 falls out
+    // of s == 0 on its own.
     const float PI = 3.14159265358979f;
-    if (fabsf(x) < 1e-5f) return 1.0f;
-    if (fabsf(x) >= 3.0f) return 0.0f;
-    float pix  = PI * x;
-    float pix3 = pix * 0.33333333f;
-    return sin_pi(x) * sin_pi(x * (1.0f / 3.0f)) / (pix * pix3);
+    float s  = sin_pi(frac);
+    float t0 = sin_pi(frac * (1.0f / 3.0f));
+    float t1 = sin_pi((frac - 1.0f) * (1.0f / 3.0f));
+    float t2 = sin_pi((frac - 2.0f) * (1.0f / 3.0f));
+    float st0 = s * t0;
+    float st1 = s * t1;
+    float st2 = s * t2;
+    float x, pix, pix3;
+    x = frac + 2.0f; pix = PI * x; pix3 = pix * 0.33333333f; w[0] = -st1 / (pix * pix3);
+    x = frac + 1.0f; pix = PI * x; pix3 = pix * 0.33333333f; w[1] =  st2 / (pix * pix3);
+    x = frac;        pix = PI * x; pix3 = pix * 0.33333333f; w[2] =  st0 / (pix * pix3);
+    x = frac - 1.0f; pix = PI * x; pix3 = pix * 0.33333333f; w[3] = -st1 / (pix * pix3);
+    x = frac - 2.0f; pix = PI * x; pix3 = pix * 0.33333333f; w[4] =  st2 / (pix * pix3);
+    x = frac - 3.0f; pix = PI * x; pix3 = pix * 0.33333333f; w[5] =  st0 / (pix * pix3);
+    if (frac < 1e-5f)               { w[2] = 1.0f; }
+    if (fabsf(frac - 1.0f) < 1e-5f) { w[3] = 1.0f; }
 }
 
 extern "C" __global__ void warp_perspective_lanczos_3c(
@@ -321,12 +337,8 @@ extern "C" __global__ void warp_perspective_lanczos_3c(
     float frac_y = sy - (float)y0;
 
     float wx[6], wy[6];
-    wx[0] = lanczos3(frac_x + 2.0f); wx[1] = lanczos3(frac_x + 1.0f);
-    wx[2] = lanczos3(frac_x);        wx[3] = lanczos3(frac_x - 1.0f);
-    wx[4] = lanczos3(frac_x - 2.0f); wx[5] = lanczos3(frac_x - 3.0f);
-    wy[0] = lanczos3(frac_y + 2.0f); wy[1] = lanczos3(frac_y + 1.0f);
-    wy[2] = lanczos3(frac_y);        wy[3] = lanczos3(frac_y - 1.0f);
-    wy[4] = lanczos3(frac_y - 2.0f); wy[5] = lanczos3(frac_y - 3.0f);
+    lanczos3_weights(frac_x, wx);
+    lanczos3_weights(frac_y, wy);
 
     float sum_wx = wx[0]+wx[1]+wx[2]+wx[3]+wx[4]+wx[5];
     float sum_wy = wy[0]+wy[1]+wy[2]+wy[3]+wy[4]+wy[5];
@@ -335,6 +347,10 @@ extern "C" __global__ void warp_perspective_lanczos_3c(
     #pragma unroll
     for (int i = 0; i < 6; i++) { wx[i] *= inv_x; wy[i] *= inv_y; }
 
+    // Failed experiment (2026-07-17): 32-bit element offsets here regressed
+    // 3.67 -> 4.59 ms sustained — the narrower IMAD address math lands on the
+    // same FMA pipe the weight computation saturates, while the 64-bit form
+    // the compiler builds from ull math schedules around it. Keep ull.
     unsigned long long row[6];
     #pragma unroll
     for (int i = 0; i < 6; i++) {

--- a/crates/kornia-imgproc/src/interpolation/lanczos.rs
+++ b/crates/kornia-imgproc/src/interpolation/lanczos.rs
@@ -89,6 +89,49 @@ pub(crate) fn lanczos_axis(src_len: usize, dst_len: usize) -> (Vec<i32>, Vec<f32
     (x0s, weights)
 }
 
+/// All six Lanczos-3 tap weights for `frac ∈ [0, 1)` from FOUR `sin_pi`
+/// evaluations instead of twelve — the textual twin of the CUDA kernels'
+/// `lanczos3_weights`. `sin(π(frac+n)) = ±sin(π·frac)` and
+/// `sin(π(frac+n)/3)` cycles through three magnitudes with sign flips, so
+/// the six numerators collapse to `±s·t1, s·t2, s·t0` and only the
+/// denominators `(πx)·(πx/3)` differ per tap. The two epsilon patches
+/// mirror the original per-tap `lanczos3` special cases exactly (the
+/// `frac == 0` zero at tap 5 falls out of `s == 0` on its own).
+///
+/// Keep the expression shapes in sync with the CUDA sources or
+/// byte-exactness dies.
+#[inline]
+pub(crate) fn lanczos3_weights(frac: f32) -> [f32; 6] {
+    const PI: f32 = std::f32::consts::PI;
+    let s = sin_pi(frac);
+    let t0 = sin_pi(frac * (1.0 / 3.0));
+    let t1 = sin_pi((frac - 1.0) * (1.0 / 3.0));
+    let t2 = sin_pi((frac - 2.0) * (1.0 / 3.0));
+    let st0 = s * t0;
+    let st1 = s * t1;
+    let st2 = s * t2;
+    let den = |x: f32| {
+        let pix = PI * x;
+        let pix3 = pix * 0.333_333_34;
+        pix * pix3
+    };
+    let mut w = [
+        -st1 / den(frac + 2.0),
+        st2 / den(frac + 1.0),
+        st0 / den(frac),
+        -st1 / den(frac - 1.0),
+        st2 / den(frac - 2.0),
+        st0 / den(frac - 3.0),
+    ];
+    if frac < 1e-5 {
+        w[2] = 1.0;
+    }
+    if (frac - 1.0).abs() < 1e-5 {
+        w[3] = 1.0;
+    }
+    w
+}
+
 /// Direct 6×6 Lanczos-3 sample at coordinate `(sx, sy)` for channel `c` —
 /// the warp kernels' inner loop: per-axis weights normalized separately, then
 /// a two-level fused accumulation (per-row `fmaf` over `dx`, then `fmaf` of
@@ -109,22 +152,8 @@ pub(crate) fn lanczos_sample<const C: usize>(
     let frac_y = sy - y0;
     let (x0, y0) = (x0 as i64, y0 as i64);
 
-    let mut wx = [
-        lanczos3(frac_x + 2.0),
-        lanczos3(frac_x + 1.0),
-        lanczos3(frac_x),
-        lanczos3(frac_x - 1.0),
-        lanczos3(frac_x - 2.0),
-        lanczos3(frac_x - 3.0),
-    ];
-    let mut wy = [
-        lanczos3(frac_y + 2.0),
-        lanczos3(frac_y + 1.0),
-        lanczos3(frac_y),
-        lanczos3(frac_y - 1.0),
-        lanczos3(frac_y - 2.0),
-        lanczos3(frac_y - 3.0),
-    ];
+    let mut wx = lanczos3_weights(frac_x);
+    let mut wy = lanczos3_weights(frac_y);
     let sum_wx = wx[0] + wx[1] + wx[2] + wx[3] + wx[4] + wx[5];
     let sum_wy = wy[0] + wy[1] + wy[2] + wy[3] + wy[4] + wy[5];
     let inv_x = 1.0 / sum_wx;
@@ -199,5 +228,36 @@ pub(crate) fn resize_lanczos_separable<const C: usize>(
                 drow[dx * C + k] = acc;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod weight_tests {
+    use super::*;
+
+    /// The 4-eval weight path must agree with the per-tap `lanczos3` form to
+    /// float tolerance across the whole frac range (they differ only in
+    /// rounding: the periodicity identities are exact in real arithmetic).
+    #[test]
+    fn four_eval_weights_match_per_tap_form() {
+        for i in 0..=10_000 {
+            let frac = i as f32 / 10_001.0;
+            let w = lanczos3_weights(frac);
+            let per_tap = [
+                lanczos3(frac + 2.0),
+                lanczos3(frac + 1.0),
+                lanczos3(frac),
+                lanczos3(frac - 1.0),
+                lanczos3(frac - 2.0),
+                lanczos3(frac - 3.0),
+            ];
+            for (t, (a, b)) in w.iter().zip(&per_tap).enumerate() {
+                assert!((a - b).abs() < 1e-6, "frac={frac} tap={t}: {a} vs {b}");
+            }
+        }
+        // Exact edge values.
+        let w0 = lanczos3_weights(0.0);
+        assert_eq!(w0[2], 1.0);
+        assert_eq!(w0[5], 0.0);
     }
 }


### PR DESCRIPTION
## What

The f32 Lanczos warp kernels were the only **compute-bound** kernels in the whole CUDA surface (ncu sweep: sm ≈81%, everything else envelope-bound). Root cost: 12 `lanczos3` calls/pixel = 24 `sin_pi` polynomial evals.

The sinc lattice is periodic: `sin(π(frac+n)) = ±sin(π·frac)`, and `sin(π(frac+n)/3)` cycles through three magnitudes with sign flips. The six numerators per axis collapse to three shared products of **four** `sin_pi` evals; only the `(πx)²/3` denominators differ per tap.

## Byte-exact contract

- Both twins change textually together: device `lanczos3_weights` (both warp sources) and Rust `lanczos3_weights` (`interpolation/lanczos.rs`, used by `lanczos_sample` → CPU warps + remap). CPU↔GPU parity tests stay `assert_eq!`-green.
- Absolute outputs shift ≤1e-6 vs the per-tap form (identical in real arithmetic, different rounding) — same class as the #1013 perspective coord refactor. New 10k-point equivalence test pins the corridor; CHANGELOG entry included.
- Separable resize-lanczos (`lanczos_axis` tables) untouched.

## Bench (Orin, locked clocks, interleaved same-minute A/B, min of 3 cycles, 1080p 3ch f32)

| kernel | before | after | Δ |
|---|---|---|---|
| warp_affine lanczos | 5.49 ms | **4.26 ms** | −22% |
| warp_perspective lanczos | 5.93 ms | **4.28 ms** | −28% |

Also resolved: the ncu sweep's apparent affine-vs-perspective 1.8× gap did **not** reproduce in sustained timing (both ~5.9ms before) — ncu replay artifact, noted in the profiling skill.

Failed experiment documented in-source: 32-bit tap addressing regressed 3.67→4.59ms (IMAD address math contends with the saturated FMA pipe).

Tests: 356 passed (full imgproc lib w/ CUDA), clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)