### PR TITLE
feat(kornia-py): device arms for every CUDA-backed color conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ real arithmetic, rounding differs). Measured on Jetson AGX Orin (locked
 clocks, 1080p→1080p 3-channel f32): warp-affine lanczos 5.49→4.26 ms,
 warp-perspective lanczos 5.93→4.28 ms sustained.
 
+**Python: every color conversion with a CUDA kernel now accepts a device
+`Image`.** Previously ~10 GPU color paths existed in the Rust crates but the
+Python surface raised "no GPU kernel for a device Image": HLS, Luv, XYZ,
+linear-RGB (f32 pairs), planar YUV (u8 **and** f32 pairs), plus the f32 arms
+of YCbCr, sepia and gray (`imgproc.gray_from_rgb` on an f32 device image now
+returns a device gray f32 image). u8 arms stay bit-exact with the CPU path;
+f32 arms follow the existing tolerance contract. Covered by device-vs-CPU
+parity tests and a memory-leak loop over the new arms.
+
 **u8 CUDA morphology (dilate / erode), bit-identical to the CPU ops, plus
 first-time Python bindings.** `dilate` / `erode` route u8 device images
 (1/3/4-channel) to a CUDA kernel that samples the exact tap multiset the CPU

--- a/kornia-py/src/color.rs
+++ b/kornia-py/src/color.rs
@@ -183,14 +183,30 @@ py_f32_3to3!(
     crate::cuda_ext::rgb_from_hsv,
     "HSV f32 → RGB f32."
 );
-py_f32_3to3!(hls_from_rgb, color::hls_from_rgb, "RGB f32 → HLS f32.");
-py_f32_3to3!(rgb_from_hls, color::rgb_from_hls, "HLS f32 → RGB f32.");
+py_f32_3to3!(
+    hls_from_rgb,
+    color::hls_from_rgb,
+    crate::cuda_ext::hls_from_rgb,
+    "RGB f32 → HLS f32."
+);
+py_f32_3to3!(
+    rgb_from_hls,
+    color::rgb_from_hls,
+    crate::cuda_ext::rgb_from_hls,
+    "HLS f32 → RGB f32."
+);
 py_f32_3to3!(
     xyz_from_rgb,
     color::xyz_from_rgb,
+    crate::cuda_ext::xyz_from_rgb,
     "RGB f32 → CIE XYZ f32 (D65)."
 );
-py_f32_3to3!(rgb_from_xyz, color::rgb_from_xyz, "CIE XYZ f32 → RGB f32.");
+py_f32_3to3!(
+    rgb_from_xyz,
+    color::rgb_from_xyz,
+    crate::cuda_ext::rgb_from_xyz,
+    "CIE XYZ f32 → RGB f32."
+);
 py_f32_3to3!(
     lab_from_rgb,
     color::lab_from_rgb,
@@ -206,21 +222,25 @@ py_f32_3to3!(
 py_f32_3to3!(
     luv_from_rgb,
     color::luv_from_rgb,
+    crate::cuda_ext::luv_from_rgb,
     "RGB f32 → CIE L*u*v* f32."
 );
 py_f32_3to3!(
     rgb_from_luv,
     color::rgb_from_luv,
+    crate::cuda_ext::rgb_from_luv,
     "CIE L*u*v* f32 → RGB f32."
 );
 py_f32_3to3!(
     linear_rgb_from_rgb,
     color::linear_rgb_from_rgb,
+    crate::cuda_ext::linear_rgb_from_rgb,
     "sRGB f32 → linear-RGB f32 (gamma expand)."
 );
 py_f32_3to3!(
     rgb_from_linear_rgb,
     color::rgb_from_linear_rgb,
+    crate::cuda_ext::rgb_from_linear_rgb,
     "linear-RGB f32 → sRGB f32 (gamma compress)."
 );
 py_f32_3to3!(
@@ -238,9 +258,15 @@ py_f32_3to3!(
 py_f32_3to3!(
     yuv_from_rgb,
     color::yuv_from_rgb,
+    crate::cuda_ext::yuv_from_rgb,
     "RGB f32 → YUV f32 (planar, full range)."
 );
-py_f32_3to3!(rgb_from_yuv, color::rgb_from_yuv, "YUV f32 → RGB f32.");
+py_f32_3to3!(
+    rgb_from_yuv,
+    color::rgb_from_yuv,
+    crate::cuda_ext::rgb_from_yuv,
+    "YUV f32 → RGB f32."
+);
 py_f32_3to3!(
     sepia_from_rgb,
     color::sepia_from_rgb_f32,

--- a/kornia-py/src/cuda_ext/cuda_color.rs
+++ b/kornia-py/src/cuda_ext/cuda_color.rs
@@ -88,13 +88,70 @@ macro_rules! conv_fn {
     };
 }
 
-conv_fn!(
-    /// RGB8 → Gray8 (BT.601, bit-exact vs the CPU path).
-    gray_from_rgb, U8C3, Rgb8, u8, 1, U8C1, Gray8, ColorSpace::Gray
+/// Dtype-dispatching sibling of `conv_fn!`: the same conversion exists for a
+/// u8 and an f32 device source (different `ConvertColor` pairs), so route on
+/// the source's `Inner` variant instead of demanding one.
+macro_rules! conv_fn_dual {
+    ($(#[$meta:meta])* $pyname:ident, $dcs:expr,
+     u8: ($svar8:ident, $snt8:ty, $dc8:literal, $dvar8:ident, $dnt8:ty),
+     f32: ($svarf:ident, $sntf:ty, $dcf:literal, $dvarf:ident, $dntf:ty)) => {
+        $(#[$meta])*
+        #[pyfunction]
+        pub fn $pyname(img: &PyImageApi) -> PyResult<PyImageApi> {
+            let dev = img.as_device().ok_or_else(|| {
+                PyValueError::new_err(concat!(
+                    stringify!($pyname),
+                    ": expected a device Image (on a CUDA device); for a host image pass \
+                     its numpy array, or move it to a device with .to_cuda(stream)"
+                ))
+            })?;
+            match dev {
+                Inner::$svar8(src) => {
+                    let stream = source_stream(src)?;
+                    // SAFETY: the ConvertColor kernel writes every output pixel (one
+                    // thread per pixel, bounds-guarded), so the uninitialized
+                    // destination is fully overwritten before any read.
+                    let mut dst =
+                        unsafe { Image::<u8, $dc8>::uninit_cuda(src.size(), &stream) }.map_err(err)?;
+                    convert_pair!(src, $snt8, &mut dst, $dnt8)?;
+                    Ok(PyImageApi::from_device(
+                        Inner::$dvar8(dst),
+                        $dcs,
+                        device_mode::<u8>($dc8),
+                    ))
+                }
+                Inner::$svarf(src) => {
+                    let stream = source_stream(src)?;
+                    // SAFETY: as above.
+                    let mut dst =
+                        unsafe { Image::<f32, $dcf>::uninit_cuda(src.size(), &stream) }.map_err(err)?;
+                    convert_pair!(src, $sntf, &mut dst, $dntf)?;
+                    Ok(PyImageApi::from_device(
+                        Inner::$dvarf(dst),
+                        $dcs,
+                        device_mode::<f32>($dcf),
+                    ))
+                }
+                _ => Err(PyValueError::new_err(concat!(
+                    stringify!($pyname),
+                    ": wrong input dtype/channels for this conversion"
+                ))),
+            }
+        }
+    };
+}
+
+conv_fn_dual!(
+    /// RGB → Gray (BT.601; u8 bit-exact vs the CPU path, f32 mirrored math).
+    gray_from_rgb, ColorSpace::Gray,
+    u8: (U8C3, Rgb8, 1, U8C1, Gray8),
+    f32: (F32C3, Rgbf32, 1, F32C1, Grayf32)
 );
-conv_fn!(
-    /// Gray8 → RGB8 broadcast.
-    rgb_from_gray, U8C1, Gray8, u8, 3, U8C3, Rgb8, ColorSpace::Rgb
+conv_fn_dual!(
+    /// Gray → RGB broadcast (u8 and f32).
+    rgb_from_gray, ColorSpace::Rgb,
+    u8: (U8C1, Gray8, 3, U8C3, Rgb8),
+    f32: (F32C1, Grayf32, 3, F32C3, Rgbf32)
 );
 conv_fn!(
     /// RGB8 → BGR8 channel swap (symmetric).
@@ -107,13 +164,29 @@ conv_fn!(
 // RGBA8/BGRA8 → RGB8 are provided by `rgb_from_rgba_bg`/`rgb_from_bgra_bg`
 // (below) instead of `conv_fn!`, so the device path can honor the `background`
 // alpha-composite argument like the CPU path rather than only dropping alpha.
-conv_fn!(
-    /// RGB8 → YCbCr8 (full-range Q14, bit-exact vs the CPU path).
-    ycbcr_from_rgb, U8C3, Rgb8, u8, 3, U8C3, YCbCr8, ColorSpace::YCbCr
+conv_fn_dual!(
+    /// RGB → YCbCr (full range; u8 Q14 bit-exact vs the CPU path, f32 mirrored).
+    ycbcr_from_rgb, ColorSpace::YCbCr,
+    u8: (U8C3, Rgb8, 3, U8C3, YCbCr8),
+    f32: (F32C3, Rgbf32, 3, F32C3, YCbCrf32)
 );
-conv_fn!(
-    /// YCbCr8 → RGB8.
-    rgb_from_ycbcr, U8C3, YCbCr8, u8, 3, U8C3, Rgb8, ColorSpace::Rgb
+conv_fn_dual!(
+    /// YCbCr → RGB (u8 and f32).
+    rgb_from_ycbcr, ColorSpace::Rgb,
+    u8: (U8C3, YCbCr8, 3, U8C3, Rgb8),
+    f32: (F32C3, YCbCrf32, 3, F32C3, Rgbf32)
+);
+conv_fn_dual!(
+    /// RGB → planar YUV (full range; u8 and f32).
+    yuv_from_rgb, ColorSpace::Yuv,
+    u8: (U8C3, Rgb8, 3, U8C3, Yuv8),
+    f32: (F32C3, Rgbf32, 3, F32C3, Yuvf32)
+);
+conv_fn_dual!(
+    /// Planar YUV → RGB (u8 and f32).
+    rgb_from_yuv, ColorSpace::Rgb,
+    u8: (U8C3, Yuv8, 3, U8C3, Rgb8),
+    f32: (F32C3, Yuvf32, 3, F32C3, Rgbf32)
 );
 conv_fn!(
     /// RGB f32 → HSV f32 (kornia conventions, [0,255] scale).
@@ -131,22 +204,80 @@ conv_fn!(
     /// Lab f32 → RGB f32.
     rgb_from_lab, F32C3, Labf32, f32, 3, F32C3, Rgbf32, ColorSpace::Rgb
 );
+conv_fn!(
+    /// RGB f32 → HLS f32.
+    hls_from_rgb, F32C3, Rgbf32, f32, 3, F32C3, Hlsf32, ColorSpace::Hls
+);
+conv_fn!(
+    /// HLS f32 → RGB f32.
+    rgb_from_hls, F32C3, Hlsf32, f32, 3, F32C3, Rgbf32, ColorSpace::Rgb
+);
+conv_fn!(
+    /// RGB f32 → CIE Luv f32.
+    luv_from_rgb, F32C3, Rgbf32, f32, 3, F32C3, Luvf32, ColorSpace::Luv
+);
+conv_fn!(
+    /// Luv f32 → RGB f32.
+    rgb_from_luv, F32C3, Luvf32, f32, 3, F32C3, Rgbf32, ColorSpace::Rgb
+);
+conv_fn!(
+    /// RGB f32 → CIE XYZ f32 (D65).
+    xyz_from_rgb, F32C3, Rgbf32, f32, 3, F32C3, Xyzf32, ColorSpace::Xyz
+);
+conv_fn!(
+    /// XYZ f32 → RGB f32.
+    rgb_from_xyz, F32C3, Xyzf32, f32, 3, F32C3, Rgbf32, ColorSpace::Rgb
+);
+conv_fn!(
+    /// sRGB f32 → linear-RGB f32 (gamma expand).
+    linear_rgb_from_rgb, F32C3, Rgbf32, f32, 3, F32C3, LinearRgbf32, ColorSpace::LinearRgb
+);
+conv_fn!(
+    /// linear-RGB f32 → sRGB f32 (gamma compress).
+    rgb_from_linear_rgb, F32C3, LinearRgbf32, f32, 3, F32C3, Rgbf32, ColorSpace::Rgb
+);
 
-/// Sepia tone on RGB8 (Q8 fixed point, bit-exact vs the CPU path).
+/// Sepia tone on RGB (u8 Q8 fixed point bit-exact vs the CPU path; f32
+/// mirrored float math). Direct fns rather than `ConvertColor` — they
+/// device-dispatch internally.
 #[pyfunction]
 pub fn sepia_from_rgb(img: &PyImageApi) -> PyResult<PyImageApi> {
-    let src = device_src!(img, "sepia_from_rgb", U8C3);
-    // Allocate the destination on the source's own stream/device (see `conv_fn!`).
-    let stream = source_stream(src)?;
-    // SAFETY: the sepia kernel writes every output pixel, so the uninitialized
-    // destination is fully overwritten before any read.
-    let mut dst = unsafe { Image::<u8, 3>::uninit_cuda(src.size(), &stream) }.map_err(err)?;
-    color::sepia_from_rgb_u8(src, &mut dst).map_err(err)?;
-    Ok(PyImageApi::from_device(
-        Inner::U8C3(dst),
-        ColorSpace::Rgb,
-        device_mode::<u8>(3),
-    ))
+    let dev = img.as_device().ok_or_else(|| {
+        PyValueError::new_err(
+            "sepia_from_rgb: expected a device Image (on a CUDA device); for a host image pass \
+             its numpy array, or move it to a device with .to_cuda(stream)",
+        )
+    })?;
+    match dev {
+        Inner::U8C3(src) => {
+            let stream = source_stream(src)?;
+            // SAFETY: the sepia kernel writes every output pixel, so the
+            // uninitialized destination is fully overwritten before any read.
+            let mut dst =
+                unsafe { Image::<u8, 3>::uninit_cuda(src.size(), &stream) }.map_err(err)?;
+            color::sepia_from_rgb_u8(src, &mut dst).map_err(err)?;
+            Ok(PyImageApi::from_device(
+                Inner::U8C3(dst),
+                ColorSpace::Rgb,
+                device_mode::<u8>(3),
+            ))
+        }
+        Inner::F32C3(src) => {
+            let stream = source_stream(src)?;
+            // SAFETY: as above.
+            let mut dst =
+                unsafe { Image::<f32, 3>::uninit_cuda(src.size(), &stream) }.map_err(err)?;
+            color::sepia_from_rgb_f32(src, &mut dst).map_err(err)?;
+            Ok(PyImageApi::from_device(
+                Inner::F32C3(dst),
+                ColorSpace::Rgb,
+                device_mode::<f32>(3),
+            ))
+        }
+        _ => Err(PyValueError::new_err(
+            "sepia_from_rgb: wrong input dtype/channels for this conversion",
+        )),
+    }
 }
 
 /// Apply one of the 21 OpenCV colormaps to a Gray8 image (name as in

--- a/kornia-py/src/cuda_ext/mod.rs
+++ b/kornia-py/src/cuda_ext/mod.rs
@@ -30,7 +30,10 @@ use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 
 #[cfg(feature = "cuda")]
-use kornia_image::color_spaces::{Bgr8, Bgra8, Gray8, Hsvf32, Labf32, Rgb8, Rgba8, Rgbf32, YCbCr8};
+use kornia_image::color_spaces::{
+    Bgr8, Bgra8, Gray8, Grayf32, Hlsf32, Hsvf32, Labf32, LinearRgbf32, Luvf32, Rgb8, Rgba8, Rgbf32,
+    Xyzf32, YCbCr8, YCbCrf32, Yuv8, Yuvf32,
+};
 #[cfg(feature = "cuda")]
 use kornia_image::Image;
 #[cfg(feature = "cuda")]

--- a/kornia-py/tests/test_cuda_memory.py
+++ b/kornia-py/tests/test_cuda_memory.py
@@ -256,3 +256,24 @@ def test_no_leak_full_pipeline():
         del dev, gray, rgb, cap
 
     assert_no_leak(body)
+
+
+def test_no_leak_new_color_device_arms():
+    """The dual-dtype / f32 arms wired 2026-07-18 (hls/luv/xyz/linear/yuv/
+    f32-ycbcr/f32-sepia/f32-gray) allocate fresh device destinations — chain a
+    representative set and assert steady-state."""
+    dev = _dev(_rgbf())
+    dev8 = _dev(_rgb())
+
+    def body():
+        hls = kornia_rs.imgproc.hls_from_rgb(dev)
+        luv = kornia_rs.imgproc.luv_from_rgb(dev)
+        xyz = kornia_rs.imgproc.rgb_from_xyz(kornia_rs.imgproc.xyz_from_rgb(dev))
+        lin = kornia_rs.imgproc.linear_rgb_from_rgb(dev)
+        yuvf = kornia_rs.imgproc.rgb_from_yuv(kornia_rs.imgproc.yuv_from_rgb(dev))
+        yuv8 = kornia_rs.imgproc.yuv_from_rgb(dev8)
+        sep = kornia_rs.imgproc.sepia_from_rgb(dev)
+        gray = kornia_rs.imgproc.gray_from_rgb(dev)
+        del hls, luv, xyz, lin, yuvf, yuv8, sep, gray
+
+    assert_no_leak(body)

--- a/kornia-py/tests/test_image_device.py
+++ b/kornia-py/tests/test_image_device.py
@@ -278,3 +278,60 @@ def test_cuda_color_op_on_unified_image():
     assert gray.device == "cuda:0" and gray.channels == 1
     cpu_gray = np.asarray(kornia_rs.imgproc.gray_from_rgb(a)).squeeze()
     np.testing.assert_array_equal(gray.numpy().squeeze(-1), cpu_gray)
+
+
+# ── device arms wired 2026-07-18: every color op with a CUDA kernel must accept
+# a device Image and match the CPU path (u8 bit-exact; f32 tolerance) ─────────
+
+_F32_3TO3_OPS = [
+    "hsv_from_rgb", "rgb_from_hsv",
+    "hls_from_rgb", "rgb_from_hls",
+    "lab_from_rgb", "rgb_from_lab",
+    "luv_from_rgb", "rgb_from_luv",
+    "xyz_from_rgb", "rgb_from_xyz",
+    "linear_rgb_from_rgb", "rgb_from_linear_rgb",
+    "ycbcr_from_rgb", "rgb_from_ycbcr",
+    "yuv_from_rgb", "rgb_from_yuv",
+    "sepia_from_rgb",
+]
+
+
+# f32 color is a tolerance contract (not bit-exact): transcendental-heavy ops
+# (lab/luv: cbrt + powf) accumulate more ULP drift between host libm and the
+# CUDA math library than the rational ones.
+_F32_ATOL = {"lab_from_rgb": 5e-2, "rgb_from_lab": 5e-2, "luv_from_rgb": 5e-2, "rgb_from_luv": 5e-2}
+
+
+@pytest.mark.parametrize("op", _F32_3TO3_OPS)
+def test_cuda_f32_color_op_matches_cpu(op):
+    a = _rgbf()
+    fn = getattr(kornia_rs.imgproc, op)
+    dev = fn(_dev(a))
+    assert dev.device == "cuda:0" and dev.channels == 3
+    cpu = np.asarray(fn(a))
+    np.testing.assert_allclose(dev.numpy(), cpu, atol=_F32_ATOL.get(op, 1e-3))
+
+
+@pytest.mark.parametrize("op", ["ycbcr_from_rgb", "rgb_from_ycbcr", "yuv_from_rgb", "rgb_from_yuv"])
+def test_cuda_u8_color_op_device_arm(op):
+    # CPU<->GPU bit-exactness for the u8 kernels is asserted in the imgproc
+    # crate tests; here we pin the python surface: a u8 device Image is
+    # accepted (was "no GPU kernel"/"wrong dtype" before the dual-dtype arms),
+    # stays on device with the right shape/dtype, and is deterministic.
+    a = _rgb()
+    fn = getattr(kornia_rs.imgproc, op)
+    dev = fn(_dev(a))
+    assert dev.device == "cuda:0" and dev.channels == 3
+    out = dev.numpy()
+    assert out.dtype == np.uint8 and out.shape == a.shape
+    np.testing.assert_array_equal(out, fn(_dev(a)).numpy())
+
+
+def test_cuda_f32_gray_arms():
+    a = _rgbf()
+    gray = kornia_rs.imgproc.gray_from_rgb(_dev(a))
+    assert gray.device == "cuda:0" and gray.channels == 1
+    cpu = np.asarray(kornia_rs.imgproc.gray_from_rgb_f32(a))
+    np.testing.assert_allclose(gray.numpy(), cpu, atol=1e-3)
+    back = kornia_rs.imgproc.rgb_from_gray(gray)
+    assert back.device == "cuda:0" and back.channels == 3


### PR DESCRIPTION
## What

The all-kernel ncu sweep found ~10 color conversions whose CUDA kernels exist and dispatch fine from Rust, but whose Python functions raised `no GPU kernel for a device Image` / `wrong input dtype`: **HLS, Luv, XYZ, linear-RGB (f32 pairs), planar YUV (u8 + f32 pairs), and the f32 arms of YCbCr, sepia, gray**.

Pure binding work — no kernel changes:

- `conv_fn_dual!`: dtype-dispatching sibling of `conv_fn!` — one python function routes `U8C3`/`F32C3` (and `U8C1`/`F32C1` for gray) device sources to their own `ConvertColor` pairs, mirroring how the CPU path already serves both dtypes. Applied to `ycbcr_from_rgb`/`rgb_from_ycbcr`, `yuv_from_rgb`/`rgb_from_yuv`, `gray_from_rgb`/`rgb_from_gray`.
- New f32 `conv_fn!` entries: `hls`/`luv`/`xyz`/`linear_rgb` both directions; `sepia_from_rgb` device arm goes dual via the direct fns.
- `py_f32_3to3!` entries in `color.rs` gain their `$dev` paths.

Python device-op coverage goes from 27 → 41 of the CUDA color/geometry surface (`gray_from_rgb` on an f32 device image now returns a device gray f32 image).

## Tests

- Parametrized device-vs-CPU parity for all 17 f32 3→3 ops — per-op tolerance (5e-2 for cbrt/powf-heavy lab/luv, 1e-3 elsewhere) per the documented f32 tolerance contract; u8 bit-exactness is already pinned by the imgproc crate's `assert_eq!` tests.
- Device-arm acceptance + determinism for u8 yuv/ycbcr; f32 gray arms.
- Leak loop chaining the new arms (`test_no_leak_new_color_device_arms`).
- 56 passed; sole failure is the known-environmental `test_mem_probe_is_sensitive` (fails identically on main-built wheels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)