### PR TITLE
feat(imgproc): GPU separable filter engine — gaussian/box/sobel/scharr (f32 + u8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,19 @@ real arithmetic, rounding differs). Measured on Jetson AGX Orin (locked
 clocks, 1080p→1080p 3-channel f32): warp-affine lanczos 5.49→4.26 ms,
 warp-perspective lanczos 5.93→4.28 ms sustained.
 
+**GPU separable filters: gaussian, box, sobel, scharr.** New CUDA separable
+engine (`cuda/filter.rs`) with residency dispatch on `gaussian_blur`,
+`box_blur`, `sobel`, `scharr` (f32) and `gaussian_blur_u8`, `box_blur_u8` —
+f32 paths bit-identical to the CPU engine (skip-zero border, sequential
+taps, fmad-free), u8 paths byte-identical to the Q8 striped blur (replicate
+borders) and the 3×3 binomial fast path, with the u8 kernel/sigma routing
+decided by one selector shared with the CPU. Python `gaussian_blur` /
+`box_blur` accept device images; new `imgproc.sobel` (f32, numpy + device).
+Measured 1080p vs OpenCV CPU: gaussian 5×5 u8 RGB 9.2×, box 5×5 9.5×,
+sobel-3 f32 13×. The u8 binomial tails/edges now use the same nested
+halving-add rounding as the SIMD bulk (≤1 LSB shift on border bytes vs
+previous releases).
+
 **u8 color conversions are now byte-for-byte with OpenCV.** Three alignments
 (CPU and CUDA changed together, so device output stays `assert_eq!`-equal to
 host): u8 grayscale now uses cv2's exact Q14 formula

--- a/crates/kornia-imgproc/src/cuda/filter.rs
+++ b/crates/kornia-imgproc/src/cuda/filter.rs
@@ -57,16 +57,22 @@ fn check_slice(what: &'static str, got: usize, need: usize) -> Result<(), CudaFi
 
 // ── f32 kernels ──────────────────────────────────────────────────────────────
 
+/// Shared `#pragma unroll` prelude: baked tap counts get an unrolled literal
+/// bound; 0 means the runtime-loop fallback.
+fn unroll_prelude(ktaps: usize, runtime_var: &str) -> (String, String) {
+    if ktaps > 0 {
+        ("#pragma unroll".to_string(), format!("{ktaps}u"))
+    } else {
+        (String::new(), runtime_var.to_string())
+    }
+}
+
 /// f32 horizontal/vertical pass source. `horizontal` picks the axis; taps are
 /// applied in ascending order with plain multiply-add (`--fmad=false` at
 /// compile keeps the expression tree identical to the CPU's `acc += v * k`).
 /// Out-of-bounds taps are skipped — the CPU engine's constant-zero border.
 fn sep_f32_src(channels: usize, ktaps: usize, horizontal: bool) -> String {
-    let (loop_head, bound) = if ktaps > 0 {
-        ("#pragma unroll".to_string(), format!("{ktaps}u"))
-    } else {
-        (String::new(), "ktaps".to_string())
-    };
+    let (loop_head, bound) = unroll_prelude(ktaps, "ktaps");
     let axis = if horizontal { "h" } else { "v" };
     let coord = if horizontal {
         r#"
@@ -127,11 +133,7 @@ extern "C" __global__ void sep_filter_f32_{axis}_c{channels}_k{ktaps}(
 /// u8 Q8 pass source. Mirrors `hpass_u8_row`/the striped V-pass: replicate-
 /// clamped taps, `(acc + 128) >> 8` rounding, u8 output per pass.
 fn sep_u8q8_src(channels: usize, ktaps: usize, horizontal: bool) -> String {
-    let (loop_head, bound) = if ktaps > 0 {
-        ("#pragma unroll".to_string(), format!("{ktaps}u"))
-    } else {
-        (String::new(), "ktaps".to_string())
-    };
+    let (loop_head, bound) = unroll_prelude(ktaps, "ktaps");
     let axis = if horizontal { "h" } else { "v" };
     let coord = if horizontal {
         r#"
@@ -230,8 +232,7 @@ extern "C" __global__ void binomial3_u8_{axis}_c{channels}(
         unsigned int a = (unsigned int)__ldg(&src[ia + ch]);
         unsigned int b = (unsigned int)__ldg(&src[ib + ch]);
         unsigned int d = (unsigned int)__ldg(&src[id + ch]);
-        dst[((size_t)y * cols + (size_t)x) * C + ch] =
-            (unsigned char)rhadd_u8(rhadd_u8(a, b), rhadd_u8(b, d));
+        dst[ib + ch] = (unsigned char)rhadd_u8(rhadd_u8(a, b), rhadd_u8(b, d));
     }}
 }}
 "#
@@ -240,19 +241,38 @@ extern "C" __global__ void binomial3_u8_{axis}_c{channels}(
 
 // ── Kernel cache ─────────────────────────────────────────────────────────────
 
-type SepKernelCache = Mutex<HashMap<(u32, u32, bool, u8), Arc<CudaKernel>>>;
+/// Cache key: each kernel family carries exactly its real parameters — no
+/// don't-care fields, no numeric discriminants.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+enum SepKernelKey {
+    F32 {
+        channels: u32,
+        baked_taps: u32,
+        horizontal: bool,
+    },
+    U8Q8 {
+        channels: u32,
+        baked_taps: u32,
+        horizontal: bool,
+    },
+    Binomial {
+        channels: u32,
+        horizontal: bool,
+    },
+    Magnitude,
+}
+
+type SepKernelCache = Mutex<HashMap<SepKernelKey, Arc<CudaKernel>>>;
 static SEP_FILTER_KERNELS: OnceLock<SepKernelCache> = OnceLock::new();
 const SEP_FILTER_CACHE_CAP: usize = 64;
 
-const VAR_F32: u8 = 0;
-const VAR_U8Q8: u8 = 1;
-const VAR_BINOMIAL: u8 = 2;
-
+/// `src_code` is a closure so the multi-KB kernel source is only rendered on
+/// a cache miss — steady-state launches skip the `format!` entirely.
 fn get_or_compile(
     ctx: &Arc<CudaContext>,
-    key: (u32, u32, bool, u8),
+    key: SepKernelKey,
     name: &str,
-    src_code: &str,
+    src_code: impl FnOnce() -> String,
 ) -> Result<Arc<CudaKernel>, CudaFilterError> {
     let cache = SEP_FILTER_KERNELS.get_or_init(Default::default);
     let cached = cache
@@ -263,7 +283,8 @@ fn get_or_compile(
     if let Some(hit) = cached {
         return Ok(hit);
     }
-    let built = Arc::new(try_compile_with_l1(ctx, src_code, name).map_err(CudaFilterError::Cuda)?);
+    let built =
+        Arc::new(try_compile_with_l1(ctx, &src_code(), name).map_err(CudaFilterError::Cuda)?);
     let mut map = cache
         .lock()
         .expect("separable filter kernel cache poisoned");
@@ -286,6 +307,34 @@ fn baked(k: u32) -> u32 {
 
 // ── Launchers ────────────────────────────────────────────────────────────────
 
+#[allow(clippy::too_many_arguments)]
+fn validate_separable<T, U>(
+    src: &CudaSlice<T>,
+    dst: &CudaSlice<T>,
+    scratch: &CudaSlice<T>,
+    kx: &CudaSlice<U>,
+    kx_len: u32,
+    ky: &CudaSlice<U>,
+    ky_len: u32,
+    cols: u32,
+    rows: u32,
+    channels: u32,
+) -> Result<(), CudaFilterError> {
+    super::check_geometry(cols, rows, cols, rows, None).map_err(CudaFilterError::Cuda)?;
+    if channels == 0 || kx_len == 0 || ky_len == 0 {
+        return Err(CudaFilterError::Cuda(
+            "channels and tap counts must be at least 1".into(),
+        ));
+    }
+    let n = cols as usize * rows as usize * channels as usize;
+    check_slice("src", src.len(), n)?;
+    check_slice("dst", dst.len(), n)?;
+    check_slice("scratch", scratch.len(), n)?;
+    check_slice("kx", kx.len(), kx_len as usize)?;
+    check_slice("ky", ky.len(), ky_len as usize)?;
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)] // mirrors the kernel's parameter surface
 fn launch_sep_f32_pass(
     ctx: &Arc<CudaContext>,
@@ -302,8 +351,14 @@ fn launch_sep_f32_pass(
     let kb = baked(ktaps);
     let axis = if horizontal { "h" } else { "v" };
     let name = format!("sep_filter_f32_{axis}_c{channels}_k{kb}");
-    let src_code = sep_f32_src(channels as usize, kb as usize, horizontal);
-    let kernel = get_or_compile(ctx, (channels, kb, horizontal, VAR_F32), &name, &src_code)?;
+    let key = SepKernelKey::F32 {
+        channels,
+        baked_taps: kb,
+        horizontal,
+    };
+    let kernel = get_or_compile(ctx, key, &name, || {
+        sep_f32_src(channels as usize, kb as usize, horizontal)
+    })?;
     kernel
         .launch_builder(stream)
         .arg(src)
@@ -336,18 +391,9 @@ pub fn launch_separable_filter_f32(
     rows: u32,
     channels: u32,
 ) -> Result<(), CudaFilterError> {
-    super::check_geometry(cols, rows, cols, rows, None).map_err(CudaFilterError::Cuda)?;
-    if channels == 0 || kx_len == 0 || ky_len == 0 {
-        return Err(CudaFilterError::Cuda(
-            "channels and tap counts must be at least 1".into(),
-        ));
-    }
-    let n = cols as usize * rows as usize * channels as usize;
-    check_slice("src", src.len(), n)?;
-    check_slice("dst", dst.len(), n)?;
-    check_slice("scratch", scratch.len(), n)?;
-    check_slice("kx", kx.len(), kx_len as usize)?;
-    check_slice("ky", ky.len(), ky_len as usize)?;
+    validate_separable(
+        src, dst, scratch, kx, kx_len, ky, ky_len, cols, rows, channels,
+    )?;
 
     launch_sep_f32_pass(
         ctx, stream, src, scratch, kx, kx_len, cols, rows, channels, true,
@@ -373,8 +419,14 @@ fn launch_sep_u8q8_pass(
     let kb = baked(ktaps);
     let axis = if horizontal { "h" } else { "v" };
     let name = format!("sep_filter_u8_{axis}_c{channels}_k{kb}");
-    let src_code = sep_u8q8_src(channels as usize, kb as usize, horizontal);
-    let kernel = get_or_compile(ctx, (channels, kb, horizontal, VAR_U8Q8), &name, &src_code)?;
+    let key = SepKernelKey::U8Q8 {
+        channels,
+        baked_taps: kb,
+        horizontal,
+    };
+    let kernel = get_or_compile(ctx, key, &name, || {
+        sep_u8q8_src(channels as usize, kb as usize, horizontal)
+    })?;
     kernel
         .launch_builder(stream)
         .arg(src)
@@ -406,18 +458,9 @@ pub fn launch_separable_blur_u8q8(
     rows: u32,
     channels: u32,
 ) -> Result<(), CudaFilterError> {
-    super::check_geometry(cols, rows, cols, rows, None).map_err(CudaFilterError::Cuda)?;
-    if channels == 0 || kx_len == 0 || ky_len == 0 {
-        return Err(CudaFilterError::Cuda(
-            "channels and tap counts must be at least 1".into(),
-        ));
-    }
-    let n = cols as usize * rows as usize * channels as usize;
-    check_slice("src", src.len(), n)?;
-    check_slice("dst", dst.len(), n)?;
-    check_slice("scratch", scratch.len(), n)?;
-    check_slice("kx", kx.len(), kx_len as usize)?;
-    check_slice("ky", ky.len(), ky_len as usize)?;
+    validate_separable(
+        src, dst, scratch, kx, kx_len, ky, ky_len, cols, rows, channels,
+    )?;
 
     launch_sep_u8q8_pass(
         ctx, stream, src, scratch, kx, kx_len, cols, rows, channels, true,
@@ -451,9 +494,12 @@ pub fn launch_binomial3_u8(
 
     let h_kernel = get_or_compile(
         ctx,
-        (channels, 3, true, VAR_BINOMIAL),
+        SepKernelKey::Binomial {
+            channels,
+            horizontal: true,
+        },
         &format!("binomial3_u8_h_c{channels}"),
-        &binomial3_src(channels as usize, true),
+        || binomial3_src(channels as usize, true),
     )?;
     h_kernel
         .launch_builder(stream)
@@ -466,9 +512,12 @@ pub fn launch_binomial3_u8(
 
     let v_kernel = get_or_compile(
         ctx,
-        (channels, 3, false, VAR_BINOMIAL),
+        SepKernelKey::Binomial {
+            channels,
+            horizontal: false,
+        },
         &format!("binomial3_u8_v_c{channels}"),
-        &binomial3_src(channels as usize, false),
+        || binomial3_src(channels as usize, false),
     )?;
     v_kernel
         .launch_builder(stream)
@@ -514,9 +563,9 @@ pub fn launch_gradient_magnitude_f32(
     check_slice("dst", dst.len(), n)?;
     let kernel = get_or_compile(
         ctx,
-        (0, 0, false, 3),
+        SepKernelKey::Magnitude,
         "gradient_magnitude_f32",
-        MAGNITUDE_SRC,
+        || MAGNITUDE_SRC.to_string(),
     )?;
     let n_u32 = u32::try_from(n).map_err(|_| CudaFilterError::Cuda("n exceeds u32".into()))?;
     let cfg = cudarc::driver::LaunchConfig {

--- a/crates/kornia-imgproc/src/cuda/filter.rs
+++ b/crates/kornia-imgproc/src/cuda/filter.rs
@@ -1,0 +1,535 @@
+//! CUDA separable-filter engine (f32 skip-zero + u8 Q8 + 3×3 binomial u8).
+//!
+//! Three kernel families, each the textual mirror of a CPU path:
+//!
+//! * **f32 H/V pair** — mirrors `filter/separable_filter.rs`: taps applied in
+//!   sequential order with plain `acc += v * k` (compiled `--fmad=false`), and
+//!   out-of-bounds taps SKIPPED (constant-zero border, no renormalize). The
+//!   intermediate is a full f32 image, matching the CPU `temp` buffer.
+//!   Bit-exact with the CPU engine by construction.
+//! * **u8 Q8 H/V pair** — mirrors `filter/ops.rs::separable_blur_u8_striped`:
+//!   host-quantized `quantize_kernel_256` weights, replicate-clamped borders,
+//!   `(acc + 128) >> 8` rounding per pass with a u8 intermediate.
+//! * **u8 3×3 binomial** — mirrors the `[1,2,1]/4` fast path's halving-add
+//!   nesting `rhadd(rhadd(a,b), rhadd(b,d))` with replicate borders.
+//!
+//! House rules per the codebase: per-C NVRTC codegen with baked tap counts
+//! (runtime-loop fallback above [`SEP_FILTER_MAX_BAKED_TAPS`]), scoped-guard
+//! kernel caches with single-entry eviction, no shared-memory tiling
+//! (occupancy beats staging on Orin — measured repeatedly), and pub launchers
+//! that validate everything the kernels assume.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use cudarc::driver::{CudaContext, CudaSlice, CudaStream};
+use kornia_tensor::CudaKernel;
+
+use super::{make_config, try_compile_with_l1};
+
+/// Above this tap count the runtime-loop kernel variant is used.
+pub const SEP_FILTER_MAX_BAKED_TAPS: u32 = 32;
+
+/// Error type for the CUDA filter launchers.
+#[derive(Debug, thiserror::Error)]
+pub enum CudaFilterError {
+    /// CUDA driver / compile / launch error.
+    #[error("CUDA filter error: {0}")]
+    Cuda(String),
+    /// A slice is smaller than required.
+    #[error("device slice '{what}' length {got} < required {need}")]
+    SliceTooSmall {
+        /// Which operand was too small.
+        what: &'static str,
+        /// Actual length (elements).
+        got: usize,
+        /// Required length (elements).
+        need: usize,
+    },
+}
+
+fn check_slice(what: &'static str, got: usize, need: usize) -> Result<(), CudaFilterError> {
+    if got < need {
+        return Err(CudaFilterError::SliceTooSmall { what, got, need });
+    }
+    Ok(())
+}
+
+// ── f32 kernels ──────────────────────────────────────────────────────────────
+
+/// f32 horizontal/vertical pass source. `horizontal` picks the axis; taps are
+/// applied in ascending order with plain multiply-add (`--fmad=false` at
+/// compile keeps the expression tree identical to the CPU's `acc += v * k`).
+/// Out-of-bounds taps are skipped — the CPU engine's constant-zero border.
+fn sep_f32_src(channels: usize, ktaps: usize, horizontal: bool) -> String {
+    let (loop_head, bound) = if ktaps > 0 {
+        ("#pragma unroll".to_string(), format!("{ktaps}u"))
+    } else {
+        (String::new(), "ktaps".to_string())
+    };
+    let axis = if horizontal { "h" } else { "v" };
+    let coord = if horizontal {
+        r#"
+        int t = (int)x + (int)ti - half;
+        bool inb = (t >= 0 && t < (int)cols);
+        size_t si = inb ? (((size_t)y * cols + (size_t)t) * C) : 0;
+"#
+    } else {
+        r#"
+        int t = (int)y + (int)ti - half;
+        bool inb = (t >= 0 && t < (int)rows);
+        size_t si = inb ? (((size_t)t * cols + (size_t)x) * C) : 0;
+"#
+    };
+    format!(
+        r#"
+#define C {channels}
+extern "C" __global__ void sep_filter_f32_{axis}_c{channels}_k{ktaps}(
+    const float* __restrict__ src,
+    float* __restrict__       dst,
+    const float* __restrict__ taps,
+    unsigned int ktaps,
+    unsigned int cols,
+    unsigned int rows
+) {{
+    unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x >= cols || y >= rows) return;
+    int half = (int)(ktaps / 2u);
+
+    float acc[C];
+    #pragma unroll
+    for (unsigned int ch = 0; ch < C; ++ch) acc[ch] = 0.0f;
+
+    {loop_head}
+    for (unsigned int ti = 0; ti < {bound}; ++ti) {{
+        float k = __ldg(&taps[ti]);
+{coord}
+        if (inb) {{
+            #pragma unroll
+            for (unsigned int ch = 0; ch < C; ++ch) {{
+                acc[ch] += __ldg(&src[si + ch]) * k;
+            }}
+        }}
+    }}
+    size_t d = ((size_t)y * cols + (size_t)x) * C;
+    #pragma unroll
+    for (unsigned int ch = 0; ch < C; ++ch) {{
+        dst[d + ch] = acc[ch];
+    }}
+}}
+"#
+    )
+}
+
+// ── u8 Q8 kernels ────────────────────────────────────────────────────────────
+
+/// u8 Q8 pass source. Mirrors `hpass_u8_row`/the striped V-pass: replicate-
+/// clamped taps, `(acc + 128) >> 8` rounding, u8 output per pass.
+fn sep_u8q8_src(channels: usize, ktaps: usize, horizontal: bool) -> String {
+    let (loop_head, bound) = if ktaps > 0 {
+        ("#pragma unroll".to_string(), format!("{ktaps}u"))
+    } else {
+        (String::new(), "ktaps".to_string())
+    };
+    let axis = if horizontal { "h" } else { "v" };
+    let coord = if horizontal {
+        r#"
+        int t = min(max((int)x + (int)ti - half, 0), (int)cols - 1);
+        size_t si = ((size_t)y * cols + (size_t)t) * C;
+"#
+    } else {
+        r#"
+        int t = min(max((int)y + (int)ti - half, 0), (int)rows - 1);
+        size_t si = ((size_t)t * cols + (size_t)x) * C;
+"#
+    };
+    format!(
+        r#"
+#define C {channels}
+extern "C" __global__ void sep_filter_u8_{axis}_c{channels}_k{ktaps}(
+    const unsigned char* __restrict__ src,
+    unsigned char* __restrict__       dst,
+    const unsigned char* __restrict__ taps,
+    unsigned int ktaps,
+    unsigned int cols,
+    unsigned int rows
+) {{
+    unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x >= cols || y >= rows) return;
+    int half = (int)(ktaps / 2u);
+
+    unsigned int acc[C];
+    #pragma unroll
+    for (unsigned int ch = 0; ch < C; ++ch) acc[ch] = 0u;
+
+    {loop_head}
+    for (unsigned int ti = 0; ti < {bound}; ++ti) {{
+        unsigned int k = (unsigned int)__ldg(&taps[ti]);
+{coord}
+        #pragma unroll
+        for (unsigned int ch = 0; ch < C; ++ch) {{
+            acc[ch] += (unsigned int)__ldg(&src[si + ch]) * k;
+        }}
+    }}
+    size_t d = ((size_t)y * cols + (size_t)x) * C;
+    #pragma unroll
+    for (unsigned int ch = 0; ch < C; ++ch) {{
+        dst[d + ch] = (unsigned char)((acc[ch] + 128u) >> 8);
+    }}
+}}
+"#
+    )
+}
+
+// ── u8 3×3 binomial kernels ──────────────────────────────────────────────────
+
+/// `[1,2,1]/4` pass via the same halving-add nesting the CPU NEON bulk uses:
+/// `rhadd(rhadd(a, b), rhadd(b, d))` with `rhadd(x, y) = (x + y + 1) >> 1`,
+/// replicate borders. One source per axis.
+fn binomial3_src(channels: usize, horizontal: bool) -> String {
+    let axis = if horizontal { "h" } else { "v" };
+    let coord = if horizontal {
+        r#"
+    int xm = max((int)x - 1, 0);
+    int xp = min((int)x + 1, (int)cols - 1);
+    size_t ia = ((size_t)y * cols + (size_t)xm) * C;
+    size_t ib = ((size_t)y * cols + (size_t)x) * C;
+    size_t id = ((size_t)y * cols + (size_t)xp) * C;
+"#
+    } else {
+        r#"
+    int ym = max((int)y - 1, 0);
+    int yp = min((int)y + 1, (int)rows - 1);
+    size_t ia = ((size_t)ym * cols + (size_t)x) * C;
+    size_t ib = ((size_t)y * cols + (size_t)x) * C;
+    size_t id = ((size_t)yp * cols + (size_t)x) * C;
+"#
+    };
+    format!(
+        r#"
+#define C {channels}
+__device__ __forceinline__ unsigned int rhadd_u8(unsigned int a, unsigned int b)
+{{
+    return (a + b + 1u) >> 1;
+}}
+
+extern "C" __global__ void binomial3_u8_{axis}_c{channels}(
+    const unsigned char* __restrict__ src,
+    unsigned char* __restrict__       dst,
+    unsigned int cols,
+    unsigned int rows
+) {{
+    unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x >= cols || y >= rows) return;
+{coord}
+    #pragma unroll
+    for (unsigned int ch = 0; ch < C; ++ch) {{
+        unsigned int a = (unsigned int)__ldg(&src[ia + ch]);
+        unsigned int b = (unsigned int)__ldg(&src[ib + ch]);
+        unsigned int d = (unsigned int)__ldg(&src[id + ch]);
+        dst[((size_t)y * cols + (size_t)x) * C + ch] =
+            (unsigned char)rhadd_u8(rhadd_u8(a, b), rhadd_u8(b, d));
+    }}
+}}
+"#
+    )
+}
+
+// ── Kernel cache ─────────────────────────────────────────────────────────────
+
+type SepKernelCache = Mutex<HashMap<(u32, u32, bool, u8), Arc<CudaKernel>>>;
+static SEP_FILTER_KERNELS: OnceLock<SepKernelCache> = OnceLock::new();
+const SEP_FILTER_CACHE_CAP: usize = 64;
+
+const VAR_F32: u8 = 0;
+const VAR_U8Q8: u8 = 1;
+const VAR_BINOMIAL: u8 = 2;
+
+fn get_or_compile(
+    ctx: &Arc<CudaContext>,
+    key: (u32, u32, bool, u8),
+    name: &str,
+    src_code: &str,
+) -> Result<Arc<CudaKernel>, CudaFilterError> {
+    let cache = SEP_FILTER_KERNELS.get_or_init(Default::default);
+    let cached = cache
+        .lock()
+        .expect("separable filter kernel cache poisoned")
+        .get(&key)
+        .cloned();
+    if let Some(hit) = cached {
+        return Ok(hit);
+    }
+    let built = Arc::new(try_compile_with_l1(ctx, src_code, name).map_err(CudaFilterError::Cuda)?);
+    let mut map = cache
+        .lock()
+        .expect("separable filter kernel cache poisoned");
+    if map.len() >= SEP_FILTER_CACHE_CAP {
+        // Evict one entry, not the whole map (stampede guard).
+        if let Some(k) = map.keys().next().copied() {
+            map.remove(&k);
+        }
+    }
+    Ok(map.entry(key).or_insert(built).clone())
+}
+
+fn baked(k: u32) -> u32 {
+    if k <= SEP_FILTER_MAX_BAKED_TAPS {
+        k
+    } else {
+        0
+    }
+}
+
+// ── Launchers ────────────────────────────────────────────────────────────────
+
+#[allow(clippy::too_many_arguments)] // mirrors the kernel's parameter surface
+fn launch_sep_f32_pass(
+    ctx: &Arc<CudaContext>,
+    stream: &Arc<CudaStream>,
+    src: &CudaSlice<f32>,
+    dst: &mut CudaSlice<f32>,
+    taps: &CudaSlice<f32>,
+    ktaps: u32,
+    cols: u32,
+    rows: u32,
+    channels: u32,
+    horizontal: bool,
+) -> Result<(), CudaFilterError> {
+    let kb = baked(ktaps);
+    let axis = if horizontal { "h" } else { "v" };
+    let name = format!("sep_filter_f32_{axis}_c{channels}_k{kb}");
+    let src_code = sep_f32_src(channels as usize, kb as usize, horizontal);
+    let kernel = get_or_compile(ctx, (channels, kb, horizontal, VAR_F32), &name, &src_code)?;
+    kernel
+        .launch_builder(stream)
+        .arg(src)
+        .arg(dst)
+        .arg(taps)
+        .arg(&ktaps)
+        .arg(&cols)
+        .arg(&rows)
+        .launch_2d(cols, rows, make_config(cols, rows, None))
+        .map_err(|e| CudaFilterError::Cuda(e.to_string()))
+}
+
+/// f32 separable filter: H pass into a caller-provided f32 scratch, V pass
+/// into `dst`. Bit-exact with `filter/separable_filter.rs::separable_filter`
+/// (skip-zero border, sequential taps, `--fmad=false`).
+///
+/// `scratch` must hold `cols * rows * channels` f32 (same as src/dst).
+#[allow(clippy::too_many_arguments)] // mirrors the kernel's parameter surface
+pub fn launch_separable_filter_f32(
+    ctx: &Arc<CudaContext>,
+    stream: &Arc<CudaStream>,
+    src: &CudaSlice<f32>,
+    dst: &mut CudaSlice<f32>,
+    scratch: &mut CudaSlice<f32>,
+    kx: &CudaSlice<f32>,
+    kx_len: u32,
+    ky: &CudaSlice<f32>,
+    ky_len: u32,
+    cols: u32,
+    rows: u32,
+    channels: u32,
+) -> Result<(), CudaFilterError> {
+    super::check_geometry(cols, rows, cols, rows, None).map_err(CudaFilterError::Cuda)?;
+    if channels == 0 || kx_len == 0 || ky_len == 0 {
+        return Err(CudaFilterError::Cuda(
+            "channels and tap counts must be at least 1".into(),
+        ));
+    }
+    let n = cols as usize * rows as usize * channels as usize;
+    check_slice("src", src.len(), n)?;
+    check_slice("dst", dst.len(), n)?;
+    check_slice("scratch", scratch.len(), n)?;
+    check_slice("kx", kx.len(), kx_len as usize)?;
+    check_slice("ky", ky.len(), ky_len as usize)?;
+
+    launch_sep_f32_pass(
+        ctx, stream, src, scratch, kx, kx_len, cols, rows, channels, true,
+    )?;
+    launch_sep_f32_pass(
+        ctx, stream, scratch, dst, ky, ky_len, cols, rows, channels, false,
+    )
+}
+
+#[allow(clippy::too_many_arguments)] // mirrors the kernel's parameter surface
+fn launch_sep_u8q8_pass(
+    ctx: &Arc<CudaContext>,
+    stream: &Arc<CudaStream>,
+    src: &CudaSlice<u8>,
+    dst: &mut CudaSlice<u8>,
+    taps: &CudaSlice<u8>,
+    ktaps: u32,
+    cols: u32,
+    rows: u32,
+    channels: u32,
+    horizontal: bool,
+) -> Result<(), CudaFilterError> {
+    let kb = baked(ktaps);
+    let axis = if horizontal { "h" } else { "v" };
+    let name = format!("sep_filter_u8_{axis}_c{channels}_k{kb}");
+    let src_code = sep_u8q8_src(channels as usize, kb as usize, horizontal);
+    let kernel = get_or_compile(ctx, (channels, kb, horizontal, VAR_U8Q8), &name, &src_code)?;
+    kernel
+        .launch_builder(stream)
+        .arg(src)
+        .arg(dst)
+        .arg(taps)
+        .arg(&ktaps)
+        .arg(&cols)
+        .arg(&rows)
+        .launch_2d(cols, rows, make_config(cols, rows, None))
+        .map_err(|e| CudaFilterError::Cuda(e.to_string()))
+}
+
+/// u8 Q8 separable blur: H pass into a u8 scratch, V pass into `dst`.
+/// Byte-exact with `separable_blur_u8_striped` (replicate borders,
+/// `(acc + 128) >> 8` per pass, u8 intermediate). Taps are the
+/// `quantize_kernel_256` weights, uploaded by the adapter.
+#[allow(clippy::too_many_arguments)] // mirrors the kernel's parameter surface
+pub fn launch_separable_blur_u8q8(
+    ctx: &Arc<CudaContext>,
+    stream: &Arc<CudaStream>,
+    src: &CudaSlice<u8>,
+    dst: &mut CudaSlice<u8>,
+    scratch: &mut CudaSlice<u8>,
+    kx: &CudaSlice<u8>,
+    kx_len: u32,
+    ky: &CudaSlice<u8>,
+    ky_len: u32,
+    cols: u32,
+    rows: u32,
+    channels: u32,
+) -> Result<(), CudaFilterError> {
+    super::check_geometry(cols, rows, cols, rows, None).map_err(CudaFilterError::Cuda)?;
+    if channels == 0 || kx_len == 0 || ky_len == 0 {
+        return Err(CudaFilterError::Cuda(
+            "channels and tap counts must be at least 1".into(),
+        ));
+    }
+    let n = cols as usize * rows as usize * channels as usize;
+    check_slice("src", src.len(), n)?;
+    check_slice("dst", dst.len(), n)?;
+    check_slice("scratch", scratch.len(), n)?;
+    check_slice("kx", kx.len(), kx_len as usize)?;
+    check_slice("ky", ky.len(), ky_len as usize)?;
+
+    launch_sep_u8q8_pass(
+        ctx, stream, src, scratch, kx, kx_len, cols, rows, channels, true,
+    )?;
+    launch_sep_u8q8_pass(
+        ctx, stream, scratch, dst, ky, ky_len, cols, rows, channels, false,
+    )
+}
+
+/// u8 3×3 binomial blur (`[1,2,1]/4` per axis via nested halving-adds,
+/// replicate borders) — the GPU twin of the CPU binomial fast path.
+#[allow(clippy::too_many_arguments)] // mirrors the kernel's parameter surface
+pub fn launch_binomial3_u8(
+    ctx: &Arc<CudaContext>,
+    stream: &Arc<CudaStream>,
+    src: &CudaSlice<u8>,
+    dst: &mut CudaSlice<u8>,
+    scratch: &mut CudaSlice<u8>,
+    cols: u32,
+    rows: u32,
+    channels: u32,
+) -> Result<(), CudaFilterError> {
+    super::check_geometry(cols, rows, cols, rows, None).map_err(CudaFilterError::Cuda)?;
+    if channels == 0 {
+        return Err(CudaFilterError::Cuda("channels must be at least 1".into()));
+    }
+    let n = cols as usize * rows as usize * channels as usize;
+    check_slice("src", src.len(), n)?;
+    check_slice("dst", dst.len(), n)?;
+    check_slice("scratch", scratch.len(), n)?;
+
+    let h_kernel = get_or_compile(
+        ctx,
+        (channels, 3, true, VAR_BINOMIAL),
+        &format!("binomial3_u8_h_c{channels}"),
+        &binomial3_src(channels as usize, true),
+    )?;
+    h_kernel
+        .launch_builder(stream)
+        .arg(src)
+        .arg(&mut *scratch)
+        .arg(&cols)
+        .arg(&rows)
+        .launch_2d(cols, rows, make_config(cols, rows, None))
+        .map_err(|e| CudaFilterError::Cuda(e.to_string()))?;
+
+    let v_kernel = get_or_compile(
+        ctx,
+        (channels, 3, false, VAR_BINOMIAL),
+        &format!("binomial3_u8_v_c{channels}"),
+        &binomial3_src(channels as usize, false),
+    )?;
+    v_kernel
+        .launch_builder(stream)
+        .arg(&*scratch)
+        .arg(dst)
+        .arg(&cols)
+        .arg(&rows)
+        .launch_2d(cols, rows, make_config(cols, rows, None))
+        .map_err(|e| CudaFilterError::Cuda(e.to_string()))
+}
+
+// ── sobel/scharr magnitude ───────────────────────────────────────────────────
+
+static MAGNITUDE_SRC: &str = r#"
+extern "C" __global__ void gradient_magnitude_f32(
+    const float* __restrict__ gx,
+    const float* __restrict__ gy,
+    float* __restrict__       dst,
+    unsigned int n
+) {
+    unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= n) return;
+    float a = __ldg(&gx[i]);
+    float b = __ldg(&gy[i]);
+    // Same expression tree as the CPU's (gx*gx + gy*gy).sqrt() under
+    // --fmad=false.
+    dst[i] = sqrtf(a * a + b * b);
+}
+"#;
+
+/// `dst[i] = sqrt(gx[i]^2 + gy[i]^2)` — the CPU magnitude fold of
+/// `sobel`/`scharr`, mirrored under `--fmad=false`.
+pub fn launch_gradient_magnitude_f32(
+    ctx: &Arc<CudaContext>,
+    stream: &Arc<CudaStream>,
+    gx: &CudaSlice<f32>,
+    gy: &CudaSlice<f32>,
+    dst: &mut CudaSlice<f32>,
+    n: usize,
+) -> Result<(), CudaFilterError> {
+    check_slice("gx", gx.len(), n)?;
+    check_slice("gy", gy.len(), n)?;
+    check_slice("dst", dst.len(), n)?;
+    let kernel = get_or_compile(
+        ctx,
+        (0, 0, false, 3),
+        "gradient_magnitude_f32",
+        MAGNITUDE_SRC,
+    )?;
+    let n_u32 = u32::try_from(n).map_err(|_| CudaFilterError::Cuda("n exceeds u32".into()))?;
+    let cfg = cudarc::driver::LaunchConfig {
+        block_dim: (256, 1, 1),
+        grid_dim: (n_u32.div_ceil(256), 1, 1),
+        shared_mem_bytes: 0,
+    };
+    kernel
+        .launch_builder(stream)
+        .arg(gx)
+        .arg(gy)
+        .arg(dst)
+        .arg(&n_u32)
+        .launch_cfg(cfg)
+        .map_err(|e| CudaFilterError::Cuda(e.to_string()))
+}

--- a/crates/kornia-imgproc/src/cuda/mod.rs
+++ b/crates/kornia-imgproc/src/cuda/mod.rs
@@ -9,6 +9,7 @@ pub mod resize;
 
 /// Native CUDA u8 resize kernels (integer LUT-driven, byte-exact with the
 /// CPU u8 fast paths).
+pub mod filter;
 pub mod resize_u8;
 
 /// Native CUDA warp-affine kernels (bilinear and nearest-neighbor).

--- a/crates/kornia-imgproc/src/filter/cuda.rs
+++ b/crates/kornia-imgproc/src/filter/cuda.rs
@@ -23,94 +23,80 @@ use crate::cuda::filter::{
     launch_separable_filter_f32,
 };
 
-// ── tap-table device cache ───────────────────────────────────────────────────
+// ── tap-table device caches ──────────────────────────────────────────────────
+//
+// One typed map per dtype: lookups clone exactly the wanted Arc, no enum
+// round-trip. (A shared generic device-table cache usable by resize's weight
+// tables too is tracked as a follow-up.)
 
 #[derive(Clone, PartialEq, Eq, Hash)]
 struct TapKey {
     dev: usize,
-    /// Tap values as raw bit patterns (f32 taps) or widened bytes (u8 taps),
-    /// so one map serves both dtypes without float-Eq issues.
+    /// Tap values as raw bit patterns, so f32 keys hash/compare exactly.
     bits: Vec<u32>,
-    is_u8: bool,
 }
 
-enum TapTable {
-    F32(Arc<CudaSlice<f32>>),
-    U8(Arc<CudaSlice<u8>>),
-}
-
-type TapCache = Mutex<HashMap<TapKey, TapTable>>;
-static TAP_CACHE: OnceLock<TapCache> = OnceLock::new();
+type TapCache<T> = Mutex<HashMap<TapKey, Arc<CudaSlice<T>>>>;
+static TAP_CACHE_F32: OnceLock<TapCache<f32>> = OnceLock::new();
+static TAP_CACHE_U8: OnceLock<TapCache<u8>> = OnceLock::new();
 const TAP_CACHE_CAP: usize = 128;
 
 fn err_cuda(e: impl std::fmt::Display) -> ImageError {
     ImageError::Cuda(e.to_string())
 }
 
-fn insert_tap(key: TapKey, built: TapTable, stream: &Arc<CudaStream>) -> Result<(), ImageError> {
-    // Uploads are async on THIS stream but the cache is shared across
-    // streams; synchronize once before the entry becomes visible.
-    stream.synchronize().map_err(err_cuda)?;
-    let mut map = TAP_CACHE
-        .get_or_init(Default::default)
+/// Get-or-upload a tap table. The upload is async on `stream`; synchronize
+/// once before the entry becomes visible so cross-stream hits always read
+/// completed tables (miss-only cost). Evicts one entry at cap.
+fn cached_taps<T: cudarc::driver::DeviceRepr + Clone>(
+    cache: &'static OnceLock<TapCache<T>>,
+    stream: &Arc<CudaStream>,
+    taps: &[T],
+    bits: Vec<u32>,
+) -> Result<Arc<CudaSlice<T>>, ImageError> {
+    let key = TapKey {
+        dev: stream.context().ordinal(),
+        bits,
+    };
+    let map = cache.get_or_init(Default::default);
+    if let Some(hit) = map
         .lock()
-        .expect("filter tap cache poisoned");
+        .expect("filter tap cache poisoned")
+        .get(&key)
+        .cloned()
+    {
+        return Ok(hit);
+    }
+    let built = Arc::new(stream.clone_htod(taps).map_err(err_cuda)?);
+    stream.synchronize().map_err(err_cuda)?;
+    let mut map = map.lock().expect("filter tap cache poisoned");
     if map.len() >= TAP_CACHE_CAP {
         if let Some(k) = map.keys().next().cloned() {
             map.remove(&k);
         }
     }
-    map.entry(key).or_insert(built);
-    Ok(())
+    Ok(map.entry(key).or_insert(built).clone())
 }
 
 fn cached_taps_f32(
     stream: &Arc<CudaStream>,
     taps: &[f32],
 ) -> Result<Arc<CudaSlice<f32>>, ImageError> {
-    let key = TapKey {
-        dev: stream.context().ordinal(),
-        bits: taps.iter().map(|t| t.to_bits()).collect(),
-        is_u8: false,
-    };
-    if let Some(TapTable::F32(hit)) = TAP_CACHE
-        .get_or_init(Default::default)
-        .lock()
-        .expect("filter tap cache poisoned")
-        .get(&key)
-        .map(|t| match t {
-            TapTable::F32(a) => TapTable::F32(a.clone()),
-            TapTable::U8(a) => TapTable::U8(a.clone()),
-        })
-    {
-        return Ok(hit);
-    }
-    let built = Arc::new(stream.clone_htod(taps).map_err(err_cuda)?);
-    insert_tap(key, TapTable::F32(built.clone()), stream)?;
-    Ok(built)
+    cached_taps(
+        &TAP_CACHE_F32,
+        stream,
+        taps,
+        taps.iter().map(|t| t.to_bits()).collect(),
+    )
 }
 
 fn cached_taps_u8(stream: &Arc<CudaStream>, taps: &[u8]) -> Result<Arc<CudaSlice<u8>>, ImageError> {
-    let key = TapKey {
-        dev: stream.context().ordinal(),
-        bits: taps.iter().map(|&t| t as u32).collect(),
-        is_u8: true,
-    };
-    if let Some(TapTable::U8(hit)) = TAP_CACHE
-        .get_or_init(Default::default)
-        .lock()
-        .expect("filter tap cache poisoned")
-        .get(&key)
-        .map(|t| match t {
-            TapTable::F32(a) => TapTable::F32(a.clone()),
-            TapTable::U8(a) => TapTable::U8(a.clone()),
-        })
-    {
-        return Ok(hit);
-    }
-    let built = Arc::new(stream.clone_htod(taps).map_err(err_cuda)?);
-    insert_tap(key, TapTable::U8(built.clone()), stream)?;
-    Ok(built)
+    cached_taps(
+        &TAP_CACHE_U8,
+        stream,
+        taps,
+        taps.iter().map(|&t| t as u32).collect(),
+    )
 }
 
 // ── adapters ─────────────────────────────────────────────────────────────────

--- a/crates/kornia-imgproc/src/filter/cuda.rs
+++ b/crates/kornia-imgproc/src/filter/cuda.rs
@@ -1,0 +1,338 @@
+//! Device adapters for the separable-filter ops (residency-dispatch arms).
+//!
+//! The 1D tap tables are built by the SAME host functions the CPU paths use
+//! (`filter/kernels.rs`, `quantize_kernel_256`) and uploaded once per
+//! parameter set through a small device cache (Jetson pageable H2D has a
+//! ~250 µs latency tail; the cache synchronizes its uploading stream before
+//! an entry becomes visible, so cross-stream hits always read completed
+//! tables, and evicts one entry at cap).
+//!
+//! Scratch buffers are per-call stream-ordered allocations (mempool-cheap;
+//! not CUDA-graph-capturable — same documented limitation as the morphology
+//! separable path; a Plan object is the follow-up for both).
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use cudarc::driver::{CudaSlice, CudaStream};
+use kornia_image::{Image, ImageError};
+
+use crate::cuda::dispatch::{device_slices, dims_u32, untyped_device_err};
+use crate::cuda::filter::{
+    launch_binomial3_u8, launch_gradient_magnitude_f32, launch_separable_blur_u8q8,
+    launch_separable_filter_f32,
+};
+
+// ── tap-table device cache ───────────────────────────────────────────────────
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct TapKey {
+    dev: usize,
+    /// Tap values as raw bit patterns (f32 taps) or widened bytes (u8 taps),
+    /// so one map serves both dtypes without float-Eq issues.
+    bits: Vec<u32>,
+    is_u8: bool,
+}
+
+enum TapTable {
+    F32(Arc<CudaSlice<f32>>),
+    U8(Arc<CudaSlice<u8>>),
+}
+
+type TapCache = Mutex<HashMap<TapKey, TapTable>>;
+static TAP_CACHE: OnceLock<TapCache> = OnceLock::new();
+const TAP_CACHE_CAP: usize = 128;
+
+fn err_cuda(e: impl std::fmt::Display) -> ImageError {
+    ImageError::Cuda(e.to_string())
+}
+
+fn insert_tap(key: TapKey, built: TapTable, stream: &Arc<CudaStream>) -> Result<(), ImageError> {
+    // Uploads are async on THIS stream but the cache is shared across
+    // streams; synchronize once before the entry becomes visible.
+    stream.synchronize().map_err(err_cuda)?;
+    let mut map = TAP_CACHE
+        .get_or_init(Default::default)
+        .lock()
+        .expect("filter tap cache poisoned");
+    if map.len() >= TAP_CACHE_CAP {
+        if let Some(k) = map.keys().next().cloned() {
+            map.remove(&k);
+        }
+    }
+    map.entry(key).or_insert(built);
+    Ok(())
+}
+
+fn cached_taps_f32(
+    stream: &Arc<CudaStream>,
+    taps: &[f32],
+) -> Result<Arc<CudaSlice<f32>>, ImageError> {
+    let key = TapKey {
+        dev: stream.context().ordinal(),
+        bits: taps.iter().map(|t| t.to_bits()).collect(),
+        is_u8: false,
+    };
+    if let Some(TapTable::F32(hit)) = TAP_CACHE
+        .get_or_init(Default::default)
+        .lock()
+        .expect("filter tap cache poisoned")
+        .get(&key)
+        .map(|t| match t {
+            TapTable::F32(a) => TapTable::F32(a.clone()),
+            TapTable::U8(a) => TapTable::U8(a.clone()),
+        })
+    {
+        return Ok(hit);
+    }
+    let built = Arc::new(stream.clone_htod(taps).map_err(err_cuda)?);
+    insert_tap(key, TapTable::F32(built.clone()), stream)?;
+    Ok(built)
+}
+
+fn cached_taps_u8(stream: &Arc<CudaStream>, taps: &[u8]) -> Result<Arc<CudaSlice<u8>>, ImageError> {
+    let key = TapKey {
+        dev: stream.context().ordinal(),
+        bits: taps.iter().map(|&t| t as u32).collect(),
+        is_u8: true,
+    };
+    if let Some(TapTable::U8(hit)) = TAP_CACHE
+        .get_or_init(Default::default)
+        .lock()
+        .expect("filter tap cache poisoned")
+        .get(&key)
+        .map(|t| match t {
+            TapTable::F32(a) => TapTable::F32(a.clone()),
+            TapTable::U8(a) => TapTable::U8(a.clone()),
+        })
+    {
+        return Ok(hit);
+    }
+    let built = Arc::new(stream.clone_htod(taps).map_err(err_cuda)?);
+    insert_tap(key, TapTable::U8(built.clone()), stream)?;
+    Ok(built)
+}
+
+// ── adapters ─────────────────────────────────────────────────────────────────
+
+/// Device twin of `separable_filter` for f32 images — bit-exact (skip-zero
+/// border, sequential taps, `--fmad=false` kernels).
+pub(super) fn separable_filter_f32_cuda<const C: usize>(
+    src: &Image<f32, C>,
+    dst: &mut Image<f32, C>,
+    kernel_x: &[f32],
+    kernel_y: &[f32],
+    stream: &Arc<CudaStream>,
+) -> Result<(), ImageError> {
+    let (cols, rows) = dims_u32(src)?;
+    let ctx = stream.context();
+    let (s, d) = device_slices!(src, dst);
+    let kx = cached_taps_f32(stream, kernel_x)?;
+    let ky = cached_taps_f32(stream, kernel_y)?;
+    let n = cols as usize * rows as usize * C;
+    let mut scratch = unsafe { stream.alloc::<f32>(n) }.map_err(err_cuda)?;
+    launch_separable_filter_f32(
+        ctx,
+        stream,
+        s,
+        d,
+        &mut scratch,
+        &kx,
+        kernel_x.len() as u32,
+        &ky,
+        kernel_y.len() as u32,
+        cols,
+        rows,
+        C as u32,
+    )
+    .map_err(err_cuda)
+}
+
+/// Device twin of the u8 Q8 striped blur (replicate borders, Q8 per pass).
+pub(super) fn separable_blur_u8_cuda<const C: usize>(
+    src: &Image<u8, C>,
+    dst: &mut Image<u8, C>,
+    ikx: &[u8],
+    iky: &[u8],
+    stream: &Arc<CudaStream>,
+) -> Result<(), ImageError> {
+    let (cols, rows) = dims_u32(src)?;
+    let ctx = stream.context();
+    let (s, d) = device_slices!(src, dst);
+    let kx = cached_taps_u8(stream, ikx)?;
+    let ky = cached_taps_u8(stream, iky)?;
+    let n = cols as usize * rows as usize * C;
+    let mut scratch = unsafe { stream.alloc::<u8>(n) }.map_err(err_cuda)?;
+    launch_separable_blur_u8q8(
+        ctx,
+        stream,
+        s,
+        d,
+        &mut scratch,
+        &kx,
+        ikx.len() as u32,
+        &ky,
+        iky.len() as u32,
+        cols,
+        rows,
+        C as u32,
+    )
+    .map_err(err_cuda)
+}
+
+/// Device twin of the u8 3×3 binomial fast path (nested halving-adds).
+pub(super) fn binomial3_u8_cuda<const C: usize>(
+    src: &Image<u8, C>,
+    dst: &mut Image<u8, C>,
+    stream: &Arc<CudaStream>,
+) -> Result<(), ImageError> {
+    let (cols, rows) = dims_u32(src)?;
+    let ctx = stream.context();
+    let (s, d) = device_slices!(src, dst);
+    let n = cols as usize * rows as usize * C;
+    let mut scratch = unsafe { stream.alloc::<u8>(n) }.map_err(err_cuda)?;
+    launch_binomial3_u8(ctx, stream, s, d, &mut scratch, cols, rows, C as u32).map_err(err_cuda)
+}
+
+/// Device twin of `sobel`/`scharr`: two separable passes into gx/gy scratch,
+/// then the magnitude fold — every stage bit-exact with its CPU twin.
+pub(super) fn gradient_magnitude_f32_cuda<const C: usize>(
+    src: &Image<f32, C>,
+    dst: &mut Image<f32, C>,
+    kernel_a: &[f32],
+    kernel_b: &[f32],
+    stream: &Arc<CudaStream>,
+) -> Result<(), ImageError> {
+    let (cols, rows) = dims_u32(src)?;
+    let ctx = stream.context();
+    let (s, d) = device_slices!(src, dst);
+    let ka = cached_taps_f32(stream, kernel_a)?;
+    let kb = cached_taps_f32(stream, kernel_b)?;
+    let n = cols as usize * rows as usize * C;
+    let mut scratch = unsafe { stream.alloc::<f32>(n) }.map_err(err_cuda)?;
+    let mut gx = unsafe { stream.alloc::<f32>(n) }.map_err(err_cuda)?;
+    let mut gy = unsafe { stream.alloc::<f32>(n) }.map_err(err_cuda)?;
+    // gx: kernel_a horizontal, kernel_b vertical; gy: swapped — the same
+    // (kernel_x, kernel_y) pairing the CPU sobel/scharr use.
+    launch_separable_filter_f32(
+        ctx,
+        stream,
+        s,
+        &mut gx,
+        &mut scratch,
+        &ka,
+        kernel_a.len() as u32,
+        &kb,
+        kernel_b.len() as u32,
+        cols,
+        rows,
+        C as u32,
+    )
+    .map_err(err_cuda)?;
+    launch_separable_filter_f32(
+        ctx,
+        stream,
+        s,
+        &mut gy,
+        &mut scratch,
+        &kb,
+        kernel_b.len() as u32,
+        &ka,
+        kernel_a.len() as u32,
+        cols,
+        rows,
+        C as u32,
+    )
+    .map_err(err_cuda)?;
+    launch_gradient_magnitude_f32(ctx, stream, &gx, &gy, d, n).map_err(err_cuda)
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use crate::cuda::color::test_utils::{default_stream, pattern_f32, pattern_u8};
+    use crate::filter::{box_blur, box_blur_u8, gaussian_blur, gaussian_blur_u8, scharr, sobel};
+    use kornia_image::{Image, ImageSize};
+
+    fn sized(w: usize, h: usize) -> ImageSize {
+        ImageSize {
+            width: w,
+            height: h,
+        }
+    }
+
+    /// Every f32 separable op must be bit-identical to its CPU twin
+    /// (skip-zero border, sequential taps, fmad=false).
+    #[test]
+    fn f32_filters_device_equal_host_bitexact() {
+        let stream = default_stream();
+        let (w, h) = (67, 43);
+        let src = Image::<f32, 3>::new(sized(w, h), pattern_f32(w * h * 3)).unwrap();
+        let d_src = src.to_cuda(&stream).unwrap();
+
+        type OpFn = fn(&Image<f32, 3>, &mut Image<f32, 3>) -> Result<(), kornia_image::ImageError>;
+        let cases: &[(&str, OpFn)] = &[
+            ("box_blur5x3", |s, d| box_blur(s, d, (5, 3))),
+            ("gaussian5", |s, d| gaussian_blur(s, d, (5, 5), (1.5, 1.5))),
+            ("sobel3", |s, d| sobel(s, d, 3)),
+            ("scharr3", |s, d| scharr(s, d, 3)),
+        ];
+        for (name, op) in cases {
+            let mut cpu = Image::<f32, 3>::from_size_val(sized(w, h), 0.0).unwrap();
+            op(&src, &mut cpu).unwrap();
+            let mut d_dst = Image::<f32, 3>::zeros_cuda(sized(w, h), &stream).unwrap();
+            op(&d_src, &mut d_dst).unwrap();
+            let back = d_dst.to_host_owned().unwrap();
+            for (i, (a, b)) in back.as_slice().iter().zip(cpu.as_slice()).enumerate() {
+                assert!(a.to_bits() == b.to_bits(), "{name} elem {i}: {a} vs {b}");
+            }
+        }
+    }
+
+    /// u8 blurs must be byte-exact vs the CPU paths for BOTH selector
+    /// branches (binomial 3x3 and general Q8) and both u8 ops.
+    #[test]
+    fn u8_blurs_device_equal_host_byte_exact() {
+        let stream = default_stream();
+        for (w, h) in [(64usize, 48usize), (67, 43)] {
+            let src = Image::<u8, 1>::new(sized(w, h), pattern_u8(w * h)).unwrap();
+            let src3 = Image::<u8, 3>::new(sized(w, h), pattern_u8(w * h * 3)).unwrap();
+            let d_src = src.to_cuda(&stream).unwrap();
+            let d_src3 = src3.to_cuda(&stream).unwrap();
+
+            // Binomial branch (k=3, sigma 1.0).
+            let mut cpu = Image::<u8, 1>::from_size_val(sized(w, h), 0).unwrap();
+            gaussian_blur_u8(&src, &mut cpu, (3, 3), (1.0, 1.0)).unwrap();
+            let mut d_dst = Image::<u8, 1>::zeros_cuda(sized(w, h), &stream).unwrap();
+            gaussian_blur_u8(&d_src, &mut d_dst, (3, 3), (1.0, 1.0)).unwrap();
+            assert_eq!(
+                d_dst.to_host_owned().unwrap().as_slice(),
+                cpu.as_slice(),
+                "binomial {w}x{h}"
+            );
+
+            // General Q8 branch (k=5).
+            let mut cpu = Image::<u8, 3>::from_size_val(sized(w, h), 0).unwrap();
+            gaussian_blur_u8(&src3, &mut cpu, (5, 5), (2.0, 2.0)).unwrap();
+            let mut d_dst = Image::<u8, 3>::zeros_cuda(sized(w, h), &stream).unwrap();
+            gaussian_blur_u8(&d_src3, &mut d_dst, (5, 5), (2.0, 2.0)).unwrap();
+            assert_eq!(
+                d_dst.to_host_owned().unwrap().as_slice(),
+                cpu.as_slice(),
+                "gaussian q8 {w}x{h}"
+            );
+
+            // box_blur_u8 (always Q8).
+            let mut cpu = Image::<u8, 3>::from_size_val(sized(w, h), 0).unwrap();
+            box_blur_u8(&src3, &mut cpu, (3, 5)).unwrap();
+            let mut d_dst = Image::<u8, 3>::zeros_cuda(sized(w, h), &stream).unwrap();
+            box_blur_u8(&d_src3, &mut d_dst, (3, 5)).unwrap();
+            assert_eq!(
+                d_dst.to_host_owned().unwrap().as_slice(),
+                cpu.as_slice(),
+                "box q8 {w}x{h}"
+            );
+        }
+    }
+}

--- a/crates/kornia-imgproc/src/filter/mod.rs
+++ b/crates/kornia-imgproc/src/filter/mod.rs
@@ -5,6 +5,9 @@
 /// Filter kernels
 pub mod kernels;
 
+#[cfg(feature = "cuda")]
+mod cuda;
+
 /// Filter operations
 mod ops;
 pub use ops::*;

--- a/crates/kornia-imgproc/src/filter/ops.rs
+++ b/crates/kornia-imgproc/src/filter/ops.rs
@@ -6,6 +6,26 @@ use rayon::{
 
 use super::{fast_horizontal_filter, kernels, separable_filter};
 
+/// Which u8 gaussian-blur kernel a `(kernel, sigma)` combination resolves to
+/// — the single decision shared by the CPU fast-path branch and the CUDA
+/// adapter, so the two sides route identically (see the one-selector rule
+/// applied to resize in `resize::resize_u8_path`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BlurU8Path {
+    /// `[1,2,1]/4` nested halving-adds (k=3, sigma ≈ 1).
+    Binomial3,
+    /// General Q8 two-pass with `quantize_kernel_256` weights.
+    GeneralQ8,
+}
+
+pub(crate) fn blur_u8_path(kx: usize, ky: usize, sx: f32, sy: f32) -> BlurU8Path {
+    if kx == 3 && ky == 3 && (0.6..=1.2).contains(&sx) && (0.6..=1.2).contains(&sy) {
+        BlurU8Path::Binomial3
+    } else {
+        BlurU8Path::GeneralQ8
+    }
+}
+
 /// Blur an image using a box blur filter
 ///
 /// # Arguments
@@ -22,6 +42,14 @@ pub fn box_blur<const C: usize>(
 ) -> Result<(), ImageError> {
     let kernel_x = kernels::box_blur_kernel_1d(kernel_size.0);
     let kernel_y = kernels::box_blur_kernel_1d(kernel_size.1);
+    #[cfg(feature = "cuda")]
+    if let crate::cuda::dispatch::Residency::Device(exec) =
+        crate::cuda::dispatch::pair_residency(src, dst)?
+    {
+        return exec.run(|stream| {
+            super::cuda::separable_filter_f32_cuda(src, dst, &kernel_x, &kernel_y, stream)
+        });
+    }
     separable_filter(src, dst, &kernel_x, &kernel_y)?;
     Ok(())
 }
@@ -54,6 +82,13 @@ pub fn box_blur_u8<const C: usize>(
     let ikx = quantize_kernel_256(&kernels::box_blur_kernel_1d(kx));
     let iky = quantize_kernel_256(&kernels::box_blur_kernel_1d(ky));
 
+    #[cfg(feature = "cuda")]
+    if let crate::cuda::dispatch::Residency::Device(exec) =
+        crate::cuda::dispatch::pair_residency(src, dst)?
+    {
+        return exec
+            .run(|stream| super::cuda::separable_blur_u8_cuda(src, dst, &ikx, &iky, stream));
+    }
     separable_blur_u8_striped(
         src.as_slice(),
         dst.as_slice_mut(),
@@ -127,6 +162,14 @@ pub fn gaussian_blur<const C: usize>(
 
     let kernel_x = kernels::gaussian_kernel_1d(kernel_x, sigma_x);
     let kernel_y = kernels::gaussian_kernel_1d(kernel_y, sigma_y);
+    #[cfg(feature = "cuda")]
+    if let crate::cuda::dispatch::Residency::Device(exec) =
+        crate::cuda::dispatch::pair_residency(src, dst)?
+    {
+        return exec.run(|stream| {
+            super::cuda::separable_filter_f32_cuda(src, dst, &kernel_x, &kernel_y, stream)
+        });
+    }
     separable_filter(src, dst, &kernel_x, &kernel_y)?;
 
     Ok(())
@@ -148,6 +191,15 @@ pub fn sobel<const C: usize>(
 ) -> Result<(), ImageError> {
     // get the sobel kernels
     let (kernel_x, kernel_y) = kernels::sobel_kernel_1d(kernel_size)?;
+
+    #[cfg(feature = "cuda")]
+    if let crate::cuda::dispatch::Residency::Device(exec) =
+        crate::cuda::dispatch::pair_residency(src, dst)?
+    {
+        return exec.run(|stream| {
+            super::cuda::gradient_magnitude_f32_cuda(src, dst, &kernel_x, &kernel_y, stream)
+        });
+    }
 
     // apply the sobel filter using separable filter
     let mut gx = Image::<f32, C>::from_size_val(src.size(), 0.0)?;
@@ -183,6 +235,15 @@ pub fn scharr<const C: usize>(
     kernel_size: usize,
 ) -> Result<(), ImageError> {
     let (kernel_x, kernel_y) = kernels::scharr_kernel_1d(kernel_size)?;
+
+    #[cfg(feature = "cuda")]
+    if let crate::cuda::dispatch::Residency::Device(exec) =
+        crate::cuda::dispatch::pair_residency(src, dst)?
+    {
+        return exec.run(|stream| {
+            super::cuda::gradient_magnitude_f32_cuda(src, dst, &kernel_x, &kernel_y, stream)
+        });
+    }
 
     let mut gx = Image::<f32, C>::from_size_val(src.size(), 0.0)?;
     separable_filter(src, &mut gx, &kernel_x, &kernel_y)?;
@@ -614,13 +675,28 @@ pub fn gaussian_blur_u8<const C: usize>(
     }
 
     let ((kx, ky), (sx, sy)) = resolve_gaussian_params(kernel_size, sigma)?;
+    let path = blur_u8_path(kx, ky, sx, sy);
+
+    #[cfg(feature = "cuda")]
+    if let crate::cuda::dispatch::Residency::Device(exec) =
+        crate::cuda::dispatch::pair_residency(src, dst)?
+    {
+        return exec.run(|stream| match path {
+            BlurU8Path::Binomial3 => super::cuda::binomial3_u8_cuda(src, dst, stream),
+            BlurU8Path::GeneralQ8 => {
+                let ikx = quantize_kernel_256(&kernels::gaussian_kernel_1d(kx, sx));
+                let iky = quantize_kernel_256(&kernels::gaussian_kernel_1d(ky, sy));
+                super::cuda::separable_blur_u8_cuda(src, dst, &ikx, &iky, stream)
+            }
+        });
+    }
 
     // Binomial fast path for k=3, sigma in the [1,2,1]/4 range (sigma≈0.7–1.2).
     // The [1,2,1]/4 separable kernel (one H-pass + one V-pass of halving-adds) is
     // within ±4% of a true Gaussian at sigma=1.0 and stays entirely in u8
     // (no vmull/widen/pack). cv2.GaussianBlur((3,3), 1.0) uses the same kernel.
     // Uses the [1,2,1]/4 separable NEON/AVX2 helpers (identical arithmetic).
-    if kx == 3 && ky == 3 && (0.6..=1.2).contains(&sx) && (0.6..=1.2).contains(&sy) {
+    if path == BlurU8Path::Binomial3 {
         #[cfg(target_arch = "aarch64")]
         {
             gaussian_blur_3x3_binomial_u8::<C>(
@@ -1154,7 +1230,7 @@ fn hpass_binomial_row<const C: usize>(src: &[u8], dst: &mut [u8], cols: usize) {
         let b = a;
         // Clamp right neighbor: when cols==1, stride==C, so right neighbor is self.
         let d = if stride > C { src[C + c] as u16 } else { b };
-        dst[c] = ((a + 2 * b + d + 2) >> 2) as u8;
+        dst[c] = ((((a + b + 1) >> 1) + ((b + d + 1) >> 1) + 1) >> 1) as u8;
     }
 
     // Middle bytes: compute (src[i-C] + 2*src[i] + src[i+C] + 2) / 4 per byte.
@@ -1176,7 +1252,7 @@ fn hpass_binomial_row<const C: usize>(src: &[u8], dst: &mut [u8], cols: usize) {
             let a = src[i - C] as u16;
             let b = src[i] as u16;
             let d = src[i + C] as u16;
-            dst[i] = ((a + 2 * b + d + 2) >> 2) as u8;
+            dst[i] = ((((a + b + 1) >> 1) + ((b + d + 1) >> 1) + 1) >> 1) as u8;
             i += 1;
         }
     }
@@ -1191,7 +1267,7 @@ fn hpass_binomial_row<const C: usize>(src: &[u8], dst: &mut [u8], cols: usize) {
         };
         let b = src[stride - C + c] as u16;
         let d = b;
-        dst[stride - C + c] = ((a + 2 * b + d + 2) >> 2) as u8;
+        dst[stride - C + c] = ((((a + b + 1) >> 1) + ((b + d + 1) >> 1) + 1) >> 1) as u8;
     }
 }
 
@@ -1217,7 +1293,7 @@ fn vpass_binomial_row(top: &[u8], mid: &[u8], bot: &[u8], dst: &mut [u8]) {
             let a = top[i] as u16;
             let b = mid[i] as u16;
             let d = bot[i] as u16;
-            dst[i] = ((a + 2 * b + d + 2) >> 2) as u8;
+            dst[i] = ((((a + b + 1) >> 1) + ((b + d + 1) >> 1) + 1) >> 1) as u8;
             i += 1;
         }
     }
@@ -1568,7 +1644,7 @@ unsafe fn hpass_binomial_row_avx2<const C: usize>(src: &[u8], dst: &mut [u8], co
         let b = a;
         // Clamp right neighbor: when cols==1, stride==C, so right neighbor is self.
         let d = if stride > C { src[C + c] as u16 } else { b };
-        dst[c] = ((a + 2 * b + d + 2) >> 2) as u8;
+        dst[c] = ((((a + b + 1) >> 1) + ((b + d + 1) >> 1) + 1) >> 1) as u8;
     }
 
     let mut i = C;
@@ -1586,7 +1662,7 @@ unsafe fn hpass_binomial_row_avx2<const C: usize>(src: &[u8], dst: &mut [u8], co
         let a = src[i - C] as u16;
         let b = src[i] as u16;
         let d = src[i + C] as u16;
-        dst[i] = ((a + 2 * b + d + 2) >> 2) as u8;
+        dst[i] = ((((a + b + 1) >> 1) + ((b + d + 1) >> 1) + 1) >> 1) as u8;
         i += 1;
     }
 
@@ -1600,7 +1676,7 @@ unsafe fn hpass_binomial_row_avx2<const C: usize>(src: &[u8], dst: &mut [u8], co
         };
         let b = src[stride - C + c] as u16;
         let d = b;
-        dst[stride - C + c] = ((a + 2 * b + d + 2) >> 2) as u8;
+        dst[stride - C + c] = ((((a + b + 1) >> 1) + ((b + d + 1) >> 1) + 1) >> 1) as u8;
     }
 }
 
@@ -1625,7 +1701,7 @@ unsafe fn vpass_binomial_row_avx2(top: &[u8], mid: &[u8], bot: &[u8], dst: &mut 
         let a = top[i] as u16;
         let b = mid[i] as u16;
         let d = bot[i] as u16;
-        dst[i] = ((a + 2 * b + d + 2) >> 2) as u8;
+        dst[i] = ((((a + b + 1) >> 1) + ((b + d + 1) >> 1) + 1) >> 1) as u8;
         i += 1;
     }
 }

--- a/crates/kornia-imgproc/src/filter/ops.rs
+++ b/crates/kornia-imgproc/src/filter/ops.rs
@@ -6,6 +6,19 @@ use rayon::{
 
 use super::{fast_horizontal_filter, kernels, separable_filter};
 
+/// One-line residency arm: run `$body(stream)` on the device when the pair
+/// is device-resident, else fall through to the CPU path below the call.
+macro_rules! try_device {
+    ($src:expr, $dst:expr, $body:expr) => {
+        #[cfg(feature = "cuda")]
+        if let crate::cuda::dispatch::Residency::Device(exec) =
+            crate::cuda::dispatch::pair_residency($src, $dst)?
+        {
+            return exec.run($body);
+        }
+    };
+}
+
 /// Which u8 gaussian-blur kernel a `(kernel, sigma)` combination resolves to
 /// — the single decision shared by the CPU fast-path branch and the CUDA
 /// adapter, so the two sides route identically (see the one-selector rule
@@ -42,14 +55,9 @@ pub fn box_blur<const C: usize>(
 ) -> Result<(), ImageError> {
     let kernel_x = kernels::box_blur_kernel_1d(kernel_size.0);
     let kernel_y = kernels::box_blur_kernel_1d(kernel_size.1);
-    #[cfg(feature = "cuda")]
-    if let crate::cuda::dispatch::Residency::Device(exec) =
-        crate::cuda::dispatch::pair_residency(src, dst)?
-    {
-        return exec.run(|stream| {
-            super::cuda::separable_filter_f32_cuda(src, dst, &kernel_x, &kernel_y, stream)
-        });
-    }
+    try_device!(src, dst, |stream| super::cuda::separable_filter_f32_cuda(
+        src, dst, &kernel_x, &kernel_y, stream
+    ));
     separable_filter(src, dst, &kernel_x, &kernel_y)?;
     Ok(())
 }
@@ -82,13 +90,9 @@ pub fn box_blur_u8<const C: usize>(
     let ikx = quantize_kernel_256(&kernels::box_blur_kernel_1d(kx));
     let iky = quantize_kernel_256(&kernels::box_blur_kernel_1d(ky));
 
-    #[cfg(feature = "cuda")]
-    if let crate::cuda::dispatch::Residency::Device(exec) =
-        crate::cuda::dispatch::pair_residency(src, dst)?
-    {
-        return exec
-            .run(|stream| super::cuda::separable_blur_u8_cuda(src, dst, &ikx, &iky, stream));
-    }
+    try_device!(src, dst, |stream| super::cuda::separable_blur_u8_cuda(
+        src, dst, &ikx, &iky, stream
+    ));
     separable_blur_u8_striped(
         src.as_slice(),
         dst.as_slice_mut(),
@@ -162,14 +166,9 @@ pub fn gaussian_blur<const C: usize>(
 
     let kernel_x = kernels::gaussian_kernel_1d(kernel_x, sigma_x);
     let kernel_y = kernels::gaussian_kernel_1d(kernel_y, sigma_y);
-    #[cfg(feature = "cuda")]
-    if let crate::cuda::dispatch::Residency::Device(exec) =
-        crate::cuda::dispatch::pair_residency(src, dst)?
-    {
-        return exec.run(|stream| {
-            super::cuda::separable_filter_f32_cuda(src, dst, &kernel_x, &kernel_y, stream)
-        });
-    }
+    try_device!(src, dst, |stream| super::cuda::separable_filter_f32_cuda(
+        src, dst, &kernel_x, &kernel_y, stream
+    ));
     separable_filter(src, dst, &kernel_x, &kernel_y)?;
 
     Ok(())
@@ -192,14 +191,9 @@ pub fn sobel<const C: usize>(
     // get the sobel kernels
     let (kernel_x, kernel_y) = kernels::sobel_kernel_1d(kernel_size)?;
 
-    #[cfg(feature = "cuda")]
-    if let crate::cuda::dispatch::Residency::Device(exec) =
-        crate::cuda::dispatch::pair_residency(src, dst)?
-    {
-        return exec.run(|stream| {
-            super::cuda::gradient_magnitude_f32_cuda(src, dst, &kernel_x, &kernel_y, stream)
-        });
-    }
+    try_device!(src, dst, |stream| super::cuda::gradient_magnitude_f32_cuda(
+        src, dst, &kernel_x, &kernel_y, stream
+    ));
 
     // apply the sobel filter using separable filter
     let mut gx = Image::<f32, C>::from_size_val(src.size(), 0.0)?;
@@ -236,14 +230,9 @@ pub fn scharr<const C: usize>(
 ) -> Result<(), ImageError> {
     let (kernel_x, kernel_y) = kernels::scharr_kernel_1d(kernel_size)?;
 
-    #[cfg(feature = "cuda")]
-    if let crate::cuda::dispatch::Residency::Device(exec) =
-        crate::cuda::dispatch::pair_residency(src, dst)?
-    {
-        return exec.run(|stream| {
-            super::cuda::gradient_magnitude_f32_cuda(src, dst, &kernel_x, &kernel_y, stream)
-        });
-    }
+    try_device!(src, dst, |stream| super::cuda::gradient_magnitude_f32_cuda(
+        src, dst, &kernel_x, &kernel_y, stream
+    ));
 
     let mut gx = Image::<f32, C>::from_size_val(src.size(), 0.0)?;
     separable_filter(src, &mut gx, &kernel_x, &kernel_y)?;
@@ -677,19 +666,14 @@ pub fn gaussian_blur_u8<const C: usize>(
     let ((kx, ky), (sx, sy)) = resolve_gaussian_params(kernel_size, sigma)?;
     let path = blur_u8_path(kx, ky, sx, sy);
 
-    #[cfg(feature = "cuda")]
-    if let crate::cuda::dispatch::Residency::Device(exec) =
-        crate::cuda::dispatch::pair_residency(src, dst)?
-    {
-        return exec.run(|stream| match path {
-            BlurU8Path::Binomial3 => super::cuda::binomial3_u8_cuda(src, dst, stream),
-            BlurU8Path::GeneralQ8 => {
-                let ikx = quantize_kernel_256(&kernels::gaussian_kernel_1d(kx, sx));
-                let iky = quantize_kernel_256(&kernels::gaussian_kernel_1d(ky, sy));
-                super::cuda::separable_blur_u8_cuda(src, dst, &ikx, &iky, stream)
-            }
-        });
-    }
+    try_device!(src, dst, |stream| match path {
+        BlurU8Path::Binomial3 => super::cuda::binomial3_u8_cuda(src, dst, stream),
+        BlurU8Path::GeneralQ8 => {
+            let ikx = quantize_kernel_256(&kernels::gaussian_kernel_1d(kx, sx));
+            let iky = quantize_kernel_256(&kernels::gaussian_kernel_1d(ky, sy));
+            super::cuda::separable_blur_u8_cuda(src, dst, &ikx, &iky, stream)
+        }
+    });
 
     // Binomial fast path for k=3, sigma in the [1,2,1]/4 range (sigma≈0.7–1.2).
     // The [1,2,1]/4 separable kernel (one H-pass + one V-pass of halving-adds) is

--- a/kornia-py/src/blur.rs
+++ b/kornia-py/src/blur.rs
@@ -28,7 +28,6 @@ pub fn gaussian_blur(
         }
     }
     cpu_op(py, image, move |py, arr: Py<numpy::PyArray3<u8>>| {
-        let _ = arr.bind(py).shape();
         let src = unsafe { numpy_as_image::<3>(py, &arr)? };
         let (mut dst, out) = unsafe { alloc_output_pyarray::<3>(py, src.size())? };
         py.detach(|| filter::gaussian_blur_u8(&src, &mut dst, kernel_size, sigma))
@@ -54,7 +53,6 @@ pub fn box_blur(
         }
     }
     cpu_op(py, image, move |py, arr: Py<numpy::PyArray3<u8>>| {
-        let _ = arr.bind(py).shape();
         let src = unsafe { numpy_as_image::<3>(py, &arr)? };
         let (mut dst, out) = unsafe { alloc_output_pyarray::<3>(py, src.size())? };
         py.detach(|| filter::box_blur_u8(&src, &mut dst, kernel_size))

--- a/kornia-py/src/blur.rs
+++ b/kornia-py/src/blur.rs
@@ -1,31 +1,103 @@
+use numpy::PyUntypedArrayMethods;
 use pyo3::prelude::*;
 
-use crate::image::{alloc_output_pyarray, numpy_as_image, to_pyerr, PyImage};
+use crate::dispatch::cpu_op;
+use crate::image::{
+    alloc_output_pyarray, alloc_output_pyarray_f32, numpy_as_image, numpy_as_image_f32, to_pyerr,
+};
 use kornia_imgproc::filter;
 
+/// Gaussian blur.
+///
+/// Residency-dispatched: a device `Image` (u8 1/3/4-channel or f32
+/// 1/3-channel) runs the CUDA separable kernels — byte-exact (u8) /
+/// bit-exact (f32) with the CPU paths — and a numpy u8 array runs the CPU
+/// path.
 #[pyfunction]
 pub fn gaussian_blur(
     py: Python<'_>,
-    image: PyImage,
+    image: &Bound<'_, PyAny>,
     kernel_size: (usize, usize),
     sigma: (f32, f32),
-) -> PyResult<PyImage> {
-    let src = unsafe { numpy_as_image::<3>(py, &image)? };
-    let (mut dst, out) = unsafe { alloc_output_pyarray::<3>(py, src.size())? };
-
-    py.detach(|| filter::gaussian_blur_u8(&src, &mut dst, kernel_size, sigma))
-        .map_err(to_pyerr)?;
-
-    Ok(out)
+) -> PyResult<Py<PyAny>> {
+    #[cfg(feature = "cuda")]
+    if let Ok(api) = image.cast::<crate::image::PyImageApi>() {
+        let img = api.borrow();
+        if img.is_device() {
+            return crate::cuda_ext::filter::gaussian_blur(&img, kernel_size, sigma)?.into_py(py);
+        }
+    }
+    cpu_op(py, image, move |py, arr: Py<numpy::PyArray3<u8>>| {
+        let _ = arr.bind(py).shape();
+        let src = unsafe { numpy_as_image::<3>(py, &arr)? };
+        let (mut dst, out) = unsafe { alloc_output_pyarray::<3>(py, src.size())? };
+        py.detach(|| filter::gaussian_blur_u8(&src, &mut dst, kernel_size, sigma))
+            .map_err(to_pyerr)?;
+        Ok(out)
+    })
 }
 
+/// Box blur.
+///
+/// Residency-dispatched like [`gaussian_blur`].
 #[pyfunction]
-pub fn box_blur(py: Python<'_>, image: PyImage, kernel_size: (usize, usize)) -> PyResult<PyImage> {
-    let src = unsafe { numpy_as_image::<3>(py, &image)? };
-    let (mut dst, out) = unsafe { alloc_output_pyarray::<3>(py, src.size())? };
+pub fn box_blur(
+    py: Python<'_>,
+    image: &Bound<'_, PyAny>,
+    kernel_size: (usize, usize),
+) -> PyResult<Py<PyAny>> {
+    #[cfg(feature = "cuda")]
+    if let Ok(api) = image.cast::<crate::image::PyImageApi>() {
+        let img = api.borrow();
+        if img.is_device() {
+            return crate::cuda_ext::filter::box_blur(&img, kernel_size)?.into_py(py);
+        }
+    }
+    cpu_op(py, image, move |py, arr: Py<numpy::PyArray3<u8>>| {
+        let _ = arr.bind(py).shape();
+        let src = unsafe { numpy_as_image::<3>(py, &arr)? };
+        let (mut dst, out) = unsafe { alloc_output_pyarray::<3>(py, src.size())? };
+        py.detach(|| filter::box_blur_u8(&src, &mut dst, kernel_size))
+            .map_err(to_pyerr)?;
+        Ok(out)
+    })
+}
 
-    py.detach(|| filter::box_blur_u8(&src, &mut dst, kernel_size))
-        .map_err(to_pyerr)?;
-
-    Ok(out)
+/// Sobel gradient magnitude (f32).
+///
+/// Residency-dispatched: an f32 device `Image` (1/3-channel) runs the CUDA
+/// separable kernels + magnitude fold — bit-exact with the CPU path — and a
+/// numpy f32 array runs the CPU path.
+#[pyfunction]
+#[pyo3(signature = (image, kernel_size=3))]
+pub fn sobel(py: Python<'_>, image: &Bound<'_, PyAny>, kernel_size: usize) -> PyResult<Py<PyAny>> {
+    #[cfg(feature = "cuda")]
+    if let Ok(api) = image.cast::<crate::image::PyImageApi>() {
+        let img = api.borrow();
+        if img.is_device() {
+            return crate::cuda_ext::filter::sobel(&img, kernel_size)?.into_py(py);
+        }
+    }
+    cpu_op(py, image, move |py, arr: Py<numpy::PyArray3<f32>>| {
+        let c = arr.bind(py).shape()[2];
+        match c {
+            1 => {
+                let src = unsafe { numpy_as_image_f32::<1>(py, &arr)? };
+                let (mut dst, out) = unsafe { alloc_output_pyarray_f32::<1>(py, src.size())? };
+                py.detach(|| filter::sobel(&src, &mut dst, kernel_size))
+                    .map_err(to_pyerr)?;
+                Ok(out)
+            }
+            3 => {
+                let src = unsafe { numpy_as_image_f32::<3>(py, &arr)? };
+                let (mut dst, out) = unsafe { alloc_output_pyarray_f32::<3>(py, src.size())? };
+                py.detach(|| filter::sobel(&src, &mut dst, kernel_size))
+                    .map_err(to_pyerr)?;
+                Ok(out)
+            }
+            c => Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "sobel supports 1 or 3 channels; got {c}"
+            ))),
+        }
+    })
 }

--- a/kornia-py/src/cuda_ext/cuda_filter.rs
+++ b/kornia-py/src/cuda_ext/cuda_filter.rs
@@ -1,0 +1,107 @@
+//! Device-resident GPU separable filters (`kornia_rs.imgproc.gaussian_blur` /
+//! `box_blur` / `sobel` device paths). Same shape as `cuda_morphology`:
+//! allocate the destination on the source's stream and call the public
+//! residency-dispatched op — routing and byte-exactness live in the crate.
+
+use super::cuda_geometry::PyOut;
+use super::*;
+
+fn run_u8<const C: usize>(
+    img: &PyImageApi,
+    src: &Image<u8, C>,
+    wrap: fn(Image<u8, C>) -> Inner,
+    op: impl Fn(&Image<u8, C>, &mut Image<u8, C>) -> Result<(), kornia_image::ImageError>,
+) -> PyResult<PyOut> {
+    let stream = source_stream(src)?;
+    // SAFETY: the filter kernels write every output pixel (bounds-guarded
+    // grid, all channels), so the uninitialized destination is fully
+    // overwritten.
+    let mut dst = unsafe { Image::<u8, C>::uninit_cuda(src.size(), &stream) }.map_err(err)?;
+    op(src, &mut dst).map_err(err)?;
+    Ok(PyOut::New(PyImageApi::from_device(
+        wrap(dst),
+        img.color_space,
+        device_mode::<u8>(C),
+    )))
+}
+
+fn run_f32<const C: usize>(
+    img: &PyImageApi,
+    src: &Image<f32, C>,
+    wrap: fn(Image<f32, C>) -> Inner,
+    op: impl Fn(&Image<f32, C>, &mut Image<f32, C>) -> Result<(), kornia_image::ImageError>,
+) -> PyResult<PyOut> {
+    let stream = source_stream(src)?;
+    // SAFETY: as above.
+    let mut dst = unsafe { Image::<f32, C>::uninit_cuda(src.size(), &stream) }.map_err(err)?;
+    op(src, &mut dst).map_err(err)?;
+    Ok(PyOut::New(PyImageApi::from_device(
+        wrap(dst),
+        img.color_space,
+        device_mode::<f32>(C),
+    )))
+}
+
+macro_rules! blur_dev {
+    ($name:ident, $op_u8:path, $op_f32:path, ($($arg:ident: $ty:ty),*)) => {
+        pub(crate) fn $name(img: &PyImageApi, $($arg: $ty),*) -> PyResult<PyOut> {
+            let dev = img.as_device().ok_or_else(|| {
+                PyValueError::new_err(concat!(
+                    stringify!($name),
+                    ": expected a device Image; for a host image pass its numpy array"
+                ))
+            })?;
+            match dev {
+                Inner::U8C1(src) => run_u8::<1>(img, src, Inner::U8C1, |s, d| $op_u8(s, d, $($arg),*)),
+                Inner::U8C3(src) => run_u8::<3>(img, src, Inner::U8C3, |s, d| $op_u8(s, d, $($arg),*)),
+                Inner::U8C4(src) => run_u8::<4>(img, src, Inner::U8C4, |s, d| $op_u8(s, d, $($arg),*)),
+                Inner::F32C1(src) => run_f32::<1>(img, src, Inner::F32C1, |s, d| $op_f32(s, d, $($arg),*)),
+                Inner::F32C3(src) => run_f32::<3>(img, src, Inner::F32C3, |s, d| $op_f32(s, d, $($arg),*)),
+                other => Err(PyValueError::new_err(format!(
+                    concat!(
+                        stringify!($name),
+                        ": the GPU path supports u8 1/3/4-channel and f32 1/3-channel \
+                         device images, got {:?} with {} channel(s)"
+                    ),
+                    other.dtype_enum(),
+                    other.channels()
+                ))),
+            }
+        }
+    };
+}
+
+blur_dev!(
+    gaussian_blur,
+    kornia_imgproc::filter::gaussian_blur_u8,
+    kornia_imgproc::filter::gaussian_blur,
+    (kernel_size: (usize, usize), sigma: (f32, f32))
+);
+blur_dev!(
+    box_blur,
+    kornia_imgproc::filter::box_blur_u8,
+    kornia_imgproc::filter::box_blur,
+    (kernel_size: (usize, usize))
+);
+
+/// Sobel magnitude — f32 device images only (the crate op is f32).
+pub(crate) fn sobel(img: &PyImageApi, kernel_size: usize) -> PyResult<PyOut> {
+    let dev = img.as_device().ok_or_else(|| {
+        PyValueError::new_err(
+            "sobel: expected a device Image; for a host image pass its numpy array",
+        )
+    })?;
+    match dev {
+        Inner::F32C1(src) => run_f32::<1>(img, src, Inner::F32C1, |s, d| {
+            kornia_imgproc::filter::sobel(s, d, kernel_size)
+        }),
+        Inner::F32C3(src) => run_f32::<3>(img, src, Inner::F32C3, |s, d| {
+            kornia_imgproc::filter::sobel(s, d, kernel_size)
+        }),
+        other => Err(PyValueError::new_err(format!(
+            "sobel: the GPU path supports f32 1/3-channel device images, got {:?} with {} channel(s)",
+            other.dtype_enum(),
+            other.channels()
+        ))),
+    }
+}

--- a/kornia-py/src/cuda_ext/cuda_filter.rs
+++ b/kornia-py/src/cuda_ext/cuda_filter.rs
@@ -6,39 +6,25 @@
 use super::cuda_geometry::PyOut;
 use super::*;
 
-fn run_u8<const C: usize>(
+fn run<T, const C: usize>(
     img: &PyImageApi,
-    src: &Image<u8, C>,
-    wrap: fn(Image<u8, C>) -> Inner,
-    op: impl Fn(&Image<u8, C>, &mut Image<u8, C>) -> Result<(), kornia_image::ImageError>,
-) -> PyResult<PyOut> {
+    src: &Image<T, C>,
+    wrap: fn(Image<T, C>) -> Inner,
+    op: impl Fn(&Image<T, C>, &mut Image<T, C>) -> Result<(), kornia_image::ImageError>,
+) -> PyResult<PyOut>
+where
+    T: cudarc::driver::DeviceRepr + cudarc::driver::ValidAsZeroBits + Clone + Default + 'static,
+{
     let stream = source_stream(src)?;
     // SAFETY: the filter kernels write every output pixel (bounds-guarded
     // grid, all channels), so the uninitialized destination is fully
     // overwritten.
-    let mut dst = unsafe { Image::<u8, C>::uninit_cuda(src.size(), &stream) }.map_err(err)?;
+    let mut dst = unsafe { Image::<T, C>::uninit_cuda(src.size(), &stream) }.map_err(err)?;
     op(src, &mut dst).map_err(err)?;
     Ok(PyOut::New(PyImageApi::from_device(
         wrap(dst),
         img.color_space,
-        device_mode::<u8>(C),
-    )))
-}
-
-fn run_f32<const C: usize>(
-    img: &PyImageApi,
-    src: &Image<f32, C>,
-    wrap: fn(Image<f32, C>) -> Inner,
-    op: impl Fn(&Image<f32, C>, &mut Image<f32, C>) -> Result<(), kornia_image::ImageError>,
-) -> PyResult<PyOut> {
-    let stream = source_stream(src)?;
-    // SAFETY: as above.
-    let mut dst = unsafe { Image::<f32, C>::uninit_cuda(src.size(), &stream) }.map_err(err)?;
-    op(src, &mut dst).map_err(err)?;
-    Ok(PyOut::New(PyImageApi::from_device(
-        wrap(dst),
-        img.color_space,
-        device_mode::<f32>(C),
+        device_mode::<T>(C),
     )))
 }
 
@@ -52,11 +38,11 @@ macro_rules! blur_dev {
                 ))
             })?;
             match dev {
-                Inner::U8C1(src) => run_u8::<1>(img, src, Inner::U8C1, |s, d| $op_u8(s, d, $($arg),*)),
-                Inner::U8C3(src) => run_u8::<3>(img, src, Inner::U8C3, |s, d| $op_u8(s, d, $($arg),*)),
-                Inner::U8C4(src) => run_u8::<4>(img, src, Inner::U8C4, |s, d| $op_u8(s, d, $($arg),*)),
-                Inner::F32C1(src) => run_f32::<1>(img, src, Inner::F32C1, |s, d| $op_f32(s, d, $($arg),*)),
-                Inner::F32C3(src) => run_f32::<3>(img, src, Inner::F32C3, |s, d| $op_f32(s, d, $($arg),*)),
+                Inner::U8C1(src) => run::<u8, 1>(img, src, Inner::U8C1, |s, d| $op_u8(s, d, $($arg),*)),
+                Inner::U8C3(src) => run::<u8, 3>(img, src, Inner::U8C3, |s, d| $op_u8(s, d, $($arg),*)),
+                Inner::U8C4(src) => run::<u8, 4>(img, src, Inner::U8C4, |s, d| $op_u8(s, d, $($arg),*)),
+                Inner::F32C1(src) => run::<f32, 1>(img, src, Inner::F32C1, |s, d| $op_f32(s, d, $($arg),*)),
+                Inner::F32C3(src) => run::<f32, 3>(img, src, Inner::F32C3, |s, d| $op_f32(s, d, $($arg),*)),
                 other => Err(PyValueError::new_err(format!(
                     concat!(
                         stringify!($name),
@@ -92,10 +78,10 @@ pub(crate) fn sobel(img: &PyImageApi, kernel_size: usize) -> PyResult<PyOut> {
         )
     })?;
     match dev {
-        Inner::F32C1(src) => run_f32::<1>(img, src, Inner::F32C1, |s, d| {
+        Inner::F32C1(src) => run::<f32, 1>(img, src, Inner::F32C1, |s, d| {
             kornia_imgproc::filter::sobel(s, d, kernel_size)
         }),
-        Inner::F32C3(src) => run_f32::<3>(img, src, Inner::F32C3, |s, d| {
+        Inner::F32C3(src) => run::<f32, 3>(img, src, Inner::F32C3, |s, d| {
             kornia_imgproc::filter::sobel(s, d, kernel_size)
         }),
         other => Err(PyValueError::new_err(format!(

--- a/kornia-py/src/cuda_ext/mod.rs
+++ b/kornia-py/src/cuda_ext/mod.rs
@@ -274,14 +274,16 @@ where
 #[cfg(feature = "cuda")]
 mod cuda_color;
 #[cfg(feature = "cuda")]
-pub(crate) mod cuda_geometry;
+pub(crate) mod cuda_filter;
 #[cfg(feature = "cuda")]
+pub(crate) mod cuda_geometry;
 pub(crate) mod cuda_morphology;
 #[cfg(feature = "cuda")]
 pub(crate) use cuda_color::*;
 #[cfg(feature = "cuda")]
-pub(crate) use cuda_geometry as geometry;
+pub(crate) use cuda_filter as filter;
 #[cfg(feature = "cuda")]
+pub(crate) use cuda_geometry as geometry;
 pub(crate) use cuda_morphology as morphology;
 
 // ── Tensor (model input) ──────────────────────────────────────────────────────

--- a/kornia-py/src/lib.rs
+++ b/kornia-py/src/lib.rs
@@ -504,6 +504,7 @@ pub fn kornia_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     imgproc_mod.add_function(wrap_pyfunction!(crop::crop, &imgproc_mod)?)?;
     imgproc_mod.add_function(wrap_pyfunction!(blur::gaussian_blur, &imgproc_mod)?)?;
     imgproc_mod.add_function(wrap_pyfunction!(blur::box_blur, &imgproc_mod)?)?;
+    imgproc_mod.add_function(wrap_pyfunction!(blur::sobel, &imgproc_mod)?)?;
     imgproc_mod.add_function(wrap_pyfunction!(morphology::dilate, &imgproc_mod)?)?;
     imgproc_mod.add_function(wrap_pyfunction!(morphology::erode, &imgproc_mod)?)?;
     imgproc_mod.add_function(wrap_pyfunction!(


### PR DESCRIPTION
## What (roadmap PR 4)

CUDA separable-filter engine + residency dispatch for `gaussian_blur`, `box_blur`, `sobel`, `scharr` (f32) and `gaussian_blur_u8`, `box_blur_u8`. Unblocks the dependency chain: pyramids (PR 5) → median/bilateral GPU (PR 9) → Canny GPU (PR 11) → FAST/ORB (PR 12).

**Exactness** (the contract, per kernel family):
- f32: **bit-exact** vs the CPU engine — `to_bits()`-equality asserted for all four ops (skip-zero border, sequential taps, `--fmad=false`).
- u8 Q8: **byte-exact** vs `separable_blur_u8_striped` (same `quantize_kernel_256` weights, replicate borders, `(acc+128)>>8` per pass, u8 intermediate).
- u8 3×3 binomial: **byte-exact** vs the `[1,2,1]/4` fast path — after unifying the CPU's scalar tails on the nested halving-add its own SIMD bulk computes (they previously disagreed by rounding, making CPU output position-dependent within a row; ≤1 LSB shift on border bytes, changelog'd).
- Routing decided once: `blur_u8_path` selector shared by CPU branch + CUDA adapter (the one-selector rule from the #1012 review).

**Skill compliance built-in**: launcher validation of every buffer/param, tap-table device cache with cross-stream fence + evict-one, no smem tiling, per-C codegen with baked-tap variants (runtime fallback >32 taps), 8-arg launchers documented.

**Python**: `gaussian_blur`/`box_blur` accept device images; new `imgproc.sobel` (f32, numpy + device). Parity verified from python (u8 byte-equal, sobel bitwise-equal).

## Bench (1080p, locked clocks, sustained)

| op | kornia GPU | cv2 CPU | ×cv2 | VPI-CUDA |
|---|---|---|---|---|
| gaussian 5×5 u8 RGB | **0.664 ms** | 6.10 | **9.2** | n/a (C1 only) |
| gaussian 3×3 u8 RGB (binomial) | 0.535 | 1.97 | 3.7 | n/a |
| box 5×5 u8 RGB | **0.664 ms** | 6.27 | **9.5** | n/a |
| sobel-3 f32 C1 | **1.335 ms** | 17.45 | **13.1** | (no sobel) |
| gaussian 5×5 u8 C1 | 0.863 | — | — | 0.521 |

C3 blurs run ~2.4× VPI per byte (VPI can't do interleaved C3 at all); VPI's C1 gaussian beats our C1 path 1.65× — a `__dp4a` word-vectorized C1 variant is filed as follow-up (task tracked).

376 lib tests green (incl. the new bit/byte parity suites), 41 python tests green, clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)