### PR TITLE
feat(imgproc): GPU Gaussian pyramids (f32 + u8) + PyramidPlan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ changes early: `cargo add kornia-imgproc@0.1.15-rc.1` or `pip install --pre korn
 
 ## [Unreleased]
 
+**GPU Gaussian pyramids + `PyramidPlan`.** `pyrdown_f32` (one fused
+5×5-Gaussian+subsample kernel), `pyrup_f32` (polyphase pair), `pyrdown_u8`
+and `pyrup_u8` (separable `[1,4,6,4,1]` integer pairs) now route device
+images to CUDA kernels that are bit-identical (f32) / byte-identical (u8)
+to the CPU paths, including the `reflect_101` borders and 1-pixel-wide
+degenerate sources. `PyramidPlan` preallocates every level buffer so a
+steady-state pyramid build launches kernels only (CUDA-Graph-capturable);
+its levels are bit-identical to `build_pyramid`. Measured 1080p: pyrdown
+u8 RGB 0.62 ms (4.1× OpenCV CPU), 4-level f32 plan 0.68 ms.
+
 **Faster Lanczos-3 warps on CUDA; sub-ULP output change in Lanczos warp/remap
 sampling.** The warp kernels now derive all six tap weights per axis from four
 `sin(πx)` evaluations instead of twelve, using the sinc lattice's periodicity

--- a/crates/kornia-imgproc/src/cuda/dispatch.rs
+++ b/crates/kornia-imgproc/src/cuda/dispatch.rs
@@ -172,24 +172,6 @@ macro_rules! __device_slices {
 /// Extract the typed device slices from a checked device pair.
 pub(crate) use crate::__device_slices as device_slices;
 
-/// One-line residency arm: run `$body(stream)` on the device when the pair
-/// is device-resident, else fall through to the CPU path below the call.
-#[macro_export]
-#[doc(hidden)]
-macro_rules! __try_device {
-    ($src:expr, $dst:expr, $body:expr) => {
-        #[cfg(feature = "cuda")]
-        if let $crate::cuda::dispatch::Residency::Device(exec) =
-            $crate::cuda::dispatch::pair_residency($src, $dst)?
-        {
-            return exec.run($body);
-        }
-    };
-}
-
-/// One-line residency arm (see [`__try_device`]).
-pub(crate) use crate::__try_device as try_device;
-
 /// Checked `usize → u32` image dimensions for the CUDA launchers.
 pub(crate) fn dims_u32<T, const C: usize>(img: &Image<T, C>) -> Result<(u32, u32), ImageError> {
     let w = u32::try_from(img.cols())

--- a/crates/kornia-imgproc/src/cuda/dispatch.rs
+++ b/crates/kornia-imgproc/src/cuda/dispatch.rs
@@ -172,6 +172,24 @@ macro_rules! __device_slices {
 /// Extract the typed device slices from a checked device pair.
 pub(crate) use crate::__device_slices as device_slices;
 
+/// One-line residency arm: run `$body(stream)` on the device when the pair
+/// is device-resident, else fall through to the CPU path below the call.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __try_device {
+    ($src:expr, $dst:expr, $body:expr) => {
+        #[cfg(feature = "cuda")]
+        if let $crate::cuda::dispatch::Residency::Device(exec) =
+            $crate::cuda::dispatch::pair_residency($src, $dst)?
+        {
+            return exec.run($body);
+        }
+    };
+}
+
+/// One-line residency arm (see [`__try_device`]).
+pub(crate) use crate::__try_device as try_device;
+
 /// Checked `usize → u32` image dimensions for the CUDA launchers.
 pub(crate) fn dims_u32<T, const C: usize>(img: &Image<T, C>) -> Result<(u32, u32), ImageError> {
     let w = u32::try_from(img.cols())

--- a/crates/kornia-imgproc/src/cuda/mod.rs
+++ b/crates/kornia-imgproc/src/cuda/mod.rs
@@ -32,6 +32,7 @@ pub mod color;
 /// Native CUDA u8 morphology kernels (dilate / erode, byte-exact with the
 /// CPU ops).
 pub mod morphology;
+pub mod pyramid;
 
 /// Residency-aware dispatch machinery shared by all device-capable ops.
 pub(crate) mod dispatch;

--- a/crates/kornia-imgproc/src/cuda/pyramid.rs
+++ b/crates/kornia-imgproc/src/cuda/pyramid.rs
@@ -1,0 +1,654 @@
+//! CUDA Gaussian-pyramid kernels — textual mirrors of `pyramid.rs`.
+//!
+//! * `pyrdown_f32`: ONE fused 5×5-Gaussian + subsample kernel. The 25
+//!   weights are the same f32 products the CPU precomputes, baked as exact
+//!   bit patterns; interior pixels use direct indexing and the 1-px border
+//!   ring uses `reflect_101` on both axes — branch shapes identical to the
+//!   CPU's split loops, so output is bit-exact under `--fmad=false`.
+//! * `pyrup_f32`: the CPU's polyphase H/V pair (even `(1·p + 6·c + 1·n)/8`,
+//!   odd `(c + n)/2`, border phases special-cased) with an f32 intermediate
+//!   of `dst_w × src_h` — bit-exact.
+//! * `pyrdown_u8`: separable `[1,4,6,4,1]` with a u16 H-intermediate and the
+//!   V-pass `(sum + 128) >> 8` (clamped) — byte-exact.
+//! * `pyrup_u8`: integer polyphase pair (`(p + 6c + n + 4) >> 3`,
+//!   `(c + n + 1) >> 1`) with a u8 intermediate — byte-exact.
+//!
+//! Launchers take caller-provided scratch so `PyramidPlan` can own every
+//! buffer (zero-alloc steady state, graph-capturable); they validate all
+//! slice lengths and channel counts (pub-launcher hygiene).
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use cudarc::driver::{CudaContext, CudaSlice, CudaStream};
+use kornia_tensor::CudaKernel;
+
+use super::{make_config, try_compile_with_l1};
+
+/// Error type for the CUDA pyramid launchers.
+#[derive(Debug, thiserror::Error)]
+pub enum CudaPyramidError {
+    /// CUDA driver / compile / launch error.
+    #[error("CUDA pyramid error: {0}")]
+    Cuda(String),
+    /// A slice is smaller than required.
+    #[error("device slice '{what}' length {got} < required {need}")]
+    SliceTooSmall {
+        /// Which operand was too small.
+        what: &'static str,
+        /// Actual length (elements).
+        got: usize,
+        /// Required length (elements).
+        need: usize,
+    },
+}
+
+fn check_slice(what: &'static str, got: usize, need: usize) -> Result<(), CudaPyramidError> {
+    if got < need {
+        return Err(CudaPyramidError::SliceTooSmall { what, got, need });
+    }
+    Ok(())
+}
+
+/// `reflect_101` device twin (pyramid.rs) — shared preamble for every kernel.
+const REFLECT_101: &str = r#"
+__device__ __forceinline__ int reflect_101(int p, int len) {
+    if (len == 1) return 0;
+    if (p < 0) p = -p;
+    int period = 2 * (len - 1);
+    p %= period;
+    if (p >= len) p = period - p;
+    return p;
+}
+"#;
+
+// ── f32 pyrdown (fused 5x5 + subsample) ──────────────────────────────────────
+
+/// The CPU's 25 precomputed `ky_w * kx_w` f32 products as exact bit patterns.
+const PYRDOWN_W_BITS: [u32; 25] = [
+    0x3b800000, 0x3c800000, 0x3cc00000, 0x3c800000, 0x3b800000, //
+    0x3c800000, 0x3d800000, 0x3dc00000, 0x3d800000, 0x3c800000, //
+    0x3cc00000, 0x3dc00000, 0x3e100000, 0x3dc00000, 0x3cc00000, //
+    0x3c800000, 0x3d800000, 0x3dc00000, 0x3d800000, 0x3c800000, //
+    0x3b800000, 0x3c800000, 0x3cc00000, 0x3c800000, 0x3b800000,
+];
+
+fn pyrdown_f32_src(channels: usize) -> String {
+    let weights: Vec<String> = PYRDOWN_W_BITS
+        .iter()
+        .map(|b| format!("__uint_as_float(0x{b:08x}u)"))
+        .collect();
+    let weights = weights.join(", ");
+    format!(
+        r#"
+#define C {channels}
+{REFLECT_101}
+extern "C" __global__ void pyrdown_f32_c{channels}(
+    const float* __restrict__ src,
+    float* __restrict__       dst,
+    unsigned int src_w,
+    unsigned int src_h,
+    unsigned int dst_w,
+    unsigned int dst_h
+) {{
+    unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x >= dst_w || y >= dst_h) return;
+    const float kw[25] = {{ {weights} }};
+
+    // Same interior test as the CPU's split loops: the 1-px dst border ring
+    // (and everything when dst is tiny) goes through reflect_101.
+    bool interior = (x >= 1u && x + 1u < dst_w && y >= 1u && y + 1u < dst_h);
+    int scx = (int)(x * 2u);
+    int scy = (int)(y * 2u);
+
+    float sum[C];
+    #pragma unroll
+    for (unsigned int ch = 0; ch < C; ++ch) sum[ch] = 0.0f;
+
+    int k_idx = 0;
+    #pragma unroll
+    for (int ky = 0; ky < 5; ++ky) {{
+        int sy = interior ? (scy + ky - 2) : reflect_101(scy + ky - 2, (int)src_h);
+        #pragma unroll
+        for (int kx = 0; kx < 5; ++kx) {{
+            int sx = interior ? (scx + kx - 2) : reflect_101(scx + kx - 2, (int)src_w);
+            size_t si = ((size_t)sy * src_w + (size_t)sx) * C;
+            float w = kw[k_idx];
+            #pragma unroll
+            for (unsigned int ch = 0; ch < C; ++ch) {{
+                sum[ch] += __ldg(&src[si + ch]) * w;
+            }}
+            ++k_idx;
+        }}
+    }}
+    size_t d = ((size_t)y * dst_w + (size_t)x) * C;
+    #pragma unroll
+    for (unsigned int ch = 0; ch < C; ++ch) {{
+        dst[d + ch] = sum[ch];
+    }}
+}}
+"#
+    )
+}
+
+// ── f32 pyrup (polyphase H/V pair) ───────────────────────────────────────────
+
+fn pyrup_h_f32_src(channels: usize) -> String {
+    format!(
+        r#"
+#define C {channels}
+{REFLECT_101}
+// One thread per SOURCE pixel; writes the even and odd output columns with
+// the exact expression groupings of pyrup_horizontal_pass_f32 (border
+// phases special-cased identically).
+extern "C" __global__ void pyrup_h_f32_c{channels}(
+    const float* __restrict__ src,
+    float* __restrict__       dst,
+    unsigned int src_w,
+    unsigned int src_h,
+    unsigned int dst_w
+) {{
+    unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x >= src_w || y >= src_h) return;
+    size_t row = (size_t)y * src_w * C;
+    size_t drow = (size_t)y * dst_w * C;
+
+    #pragma unroll
+    for (unsigned int ch = 0; ch < C; ++ch) {{
+        if (src_w == 1u) {{
+            float v = __ldg(&src[row + ch]);
+            dst[drow + ch] = v;
+            if (C + ch < (size_t)dst_w * C) dst[drow + C + ch] = v;
+            continue;
+        }}
+        float curr = __ldg(&src[row + (size_t)x * C + ch]);
+        if (x == 0u) {{
+            float next = __ldg(&src[row + C + ch]);
+            dst[drow + ch] = (6.0f * curr + 2.0f * next) * 0.125f;
+            dst[drow + C + ch] = (curr + next) * 0.5f;
+        }} else if (x == src_w - 1u) {{
+            float prev = __ldg(&src[row + (size_t)(x - 1u) * C + ch]);
+            dst[drow + (size_t)(2u * x) * C + ch] = (1.0f * prev + 7.0f * curr) * 0.125f;
+            dst[drow + (size_t)(2u * x + 1u) * C + ch] = curr;
+        }} else {{
+            float prev = __ldg(&src[row + (size_t)(x - 1u) * C + ch]);
+            float next = __ldg(&src[row + (size_t)(x + 1u) * C + ch]);
+            dst[drow + (size_t)(2u * x) * C + ch] =
+                (1.0f * prev + 6.0f * curr + 1.0f * next) * 0.125f;
+            dst[drow + (size_t)(2u * x + 1u) * C + ch] = (curr + next) * 0.5f;
+        }}
+    }}
+}}
+"#
+    )
+}
+
+fn pyrup_v_f32_src(channels: usize) -> String {
+    format!(
+        r#"
+#define C {channels}
+{REFLECT_101}
+// One thread per intermediate element (i in [0, dst_w*C), y in [0, src_h));
+// writes the even and odd output rows — pyrup_vertical_pass_f32 mirrored.
+extern "C" __global__ void pyrup_v_f32_c{channels}(
+    const float* __restrict__ buf,
+    float* __restrict__       dst,
+    unsigned int stride_elems,
+    unsigned int src_h
+) {{
+    unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (i >= stride_elems || y >= src_h) return;
+
+    unsigned int top, center, bottom;
+    if (src_h == 1u)      {{ top = 0u; center = 0u; bottom = 0u; }}
+    else if (y == 0u)     {{ top = 0u; center = 0u; bottom = 1u; }}
+    else if (y == src_h - 1u) {{ top = src_h - 2u; center = src_h - 1u; bottom = src_h - 1u; }}
+    else                  {{ top = y - 1u; center = y; bottom = y + 1u; }}
+
+    float t = __ldg(&buf[(size_t)top * stride_elems + i]);
+    float c = __ldg(&buf[(size_t)center * stride_elems + i]);
+    float b = __ldg(&buf[(size_t)bottom * stride_elems + i]);
+
+    float even, odd;
+    if (y == 0u) {{
+        even = (6.0f * c + 2.0f * b) * 0.125f;
+        odd = (c + b) * 0.5f;
+    }} else if (y == src_h - 1u) {{
+        even = (1.0f * t + 7.0f * c) * 0.125f;
+        odd = c;
+    }} else {{
+        even = (1.0f * t + 6.0f * c + 1.0f * b) * 0.125f;
+        odd = (c + b) * 0.5f;
+    }}
+    dst[(size_t)(2u * y) * stride_elems + i] = even;
+    dst[(size_t)(2u * y + 1u) * stride_elems + i] = odd;
+}}
+"#
+    )
+}
+
+// ── u8 pyrdown (separable 1,4,6,4,1 with u16 intermediate) ───────────────────
+
+fn pyrdown_h_u8_src(channels: usize) -> String {
+    format!(
+        r#"
+#define C {channels}
+{REFLECT_101}
+extern "C" __global__ void pyrdown_h_u8_c{channels}(
+    const unsigned char* __restrict__ src,
+    unsigned short* __restrict__      buf,
+    unsigned int src_w,
+    unsigned int src_h,
+    unsigned int dst_w
+) {{
+    unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x >= dst_w || y >= src_h) return;
+    size_t row = (size_t)y * src_w * C;
+    int scx = (int)(x * 2u);
+
+    // Same split as the CPU: the safe interior range [1, (src_w-1)/2) uses
+    // direct indexing; everything else reflects.
+    unsigned int safe_end = (src_w > 2u) ? ((src_w - 1u) / 2u) : 1u;
+    bool interior = (x >= 1u && x < safe_end);
+
+    int xm2, xm1, x0, xp1, xp2;
+    if (interior) {{
+        xm2 = scx - 2; xm1 = scx - 1; x0 = scx; xp1 = scx + 1; xp2 = scx + 2;
+    }} else {{
+        xm2 = reflect_101(scx - 2, (int)src_w);
+        xm1 = reflect_101(scx - 1, (int)src_w);
+        x0  = reflect_101(scx,     (int)src_w);
+        xp1 = reflect_101(scx + 1, (int)src_w);
+        xp2 = reflect_101(scx + 2, (int)src_w);
+    }}
+    size_t d = ((size_t)y * dst_w + (size_t)x) * C;
+    #pragma unroll
+    for (unsigned int ch = 0; ch < C; ++ch) {{
+        unsigned int vm2 = __ldg(&src[row + (size_t)xm2 * C + ch]);
+        unsigned int vm1 = __ldg(&src[row + (size_t)xm1 * C + ch]);
+        unsigned int v0  = __ldg(&src[row + (size_t)x0  * C + ch]);
+        unsigned int vp1 = __ldg(&src[row + (size_t)xp1 * C + ch]);
+        unsigned int vp2 = __ldg(&src[row + (size_t)xp2 * C + ch]);
+        buf[d + ch] = (unsigned short)(vm2 + 4u * vm1 + 6u * v0 + 4u * vp1 + vp2);
+    }}
+}}
+"#
+    )
+}
+
+fn pyrdown_v_u8_src(channels: usize) -> String {
+    format!(
+        r#"
+#define C {channels}
+{REFLECT_101}
+extern "C" __global__ void pyrdown_v_u8_c{channels}(
+    const unsigned short* __restrict__ buf,
+    unsigned char* __restrict__        dst,
+    unsigned int stride_elems,
+    unsigned int src_h,
+    unsigned int dst_h
+) {{
+    unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (i >= stride_elems || y >= dst_h) return;
+    int scy = (int)(y * 2u);
+    int ym2 = reflect_101(scy - 2, (int)src_h);
+    int ym1 = reflect_101(scy - 1, (int)src_h);
+    int y0  = reflect_101(scy,     (int)src_h);
+    int yp1 = reflect_101(scy + 1, (int)src_h);
+    int yp2 = reflect_101(scy + 2, (int)src_h);
+
+    unsigned int vm2 = __ldg(&buf[(size_t)ym2 * stride_elems + i]);
+    unsigned int vm1 = __ldg(&buf[(size_t)ym1 * stride_elems + i]);
+    unsigned int v0  = __ldg(&buf[(size_t)y0  * stride_elems + i]);
+    unsigned int vp1 = __ldg(&buf[(size_t)yp1 * stride_elems + i]);
+    unsigned int vp2 = __ldg(&buf[(size_t)yp2 * stride_elems + i]);
+
+    unsigned int sum = vm2 + 4u * vm1 + 6u * v0 + 4u * vp1 + vp2;
+    unsigned int val = (sum + 128u) >> 8;
+    dst[(size_t)y * stride_elems + i] = (unsigned char)min(val, 255u);
+}}
+"#
+    )
+}
+
+// ── u8 pyrup (integer polyphase pair) ────────────────────────────────────────
+
+fn pyrup_h_u8_src(channels: usize) -> String {
+    format!(
+        r#"
+#define C {channels}
+{REFLECT_101}
+extern "C" __global__ void pyrup_h_u8_c{channels}(
+    const unsigned char* __restrict__ src,
+    unsigned char* __restrict__       buf,
+    unsigned int src_w,
+    unsigned int src_h,
+    unsigned int dst_w
+) {{
+    unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x >= src_w || y >= src_h) return;
+    size_t row = (size_t)y * src_w * C;
+    size_t drow = (size_t)y * dst_w * C;
+    size_t dst_stride = (size_t)dst_w * C;
+
+    int prev_i = reflect_101((int)x - 1, (int)src_w);
+    int next_i = reflect_101((int)x + 1, (int)src_w);
+    #pragma unroll
+    for (unsigned int ch = 0; ch < C; ++ch) {{
+        unsigned int curr = __ldg(&src[row + (size_t)x * C + ch]);
+        unsigned int prev = __ldg(&src[row + (size_t)prev_i * C + ch]);
+        unsigned int next = __ldg(&src[row + (size_t)next_i * C + ch]);
+        buf[drow + (size_t)(2u * x) * C + ch] =
+            (unsigned char)((prev + 6u * curr + next + 4u) >> 3);
+        if ((size_t)(2u * x + 1u) * C + ch < dst_stride) {{
+            buf[drow + (size_t)(2u * x + 1u) * C + ch] =
+                (unsigned char)((curr + next + 1u) >> 1);
+        }}
+    }}
+}}
+"#
+    )
+}
+
+fn pyrup_v_u8_src(channels: usize) -> String {
+    format!(
+        r#"
+#define C {channels}
+{REFLECT_101}
+extern "C" __global__ void pyrup_v_u8_c{channels}(
+    const unsigned char* __restrict__ buf,
+    unsigned char* __restrict__       dst,
+    unsigned int stride_elems,
+    unsigned int src_h
+) {{
+    unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (i >= stride_elems || y >= src_h) return;
+    int yp = reflect_101((int)y - 1, (int)src_h);
+    int yn = reflect_101((int)y + 1, (int)src_h);
+
+    unsigned int c = __ldg(&buf[(size_t)y  * stride_elems + i]);
+    unsigned int p = __ldg(&buf[(size_t)yp * stride_elems + i]);
+    unsigned int n = __ldg(&buf[(size_t)yn * stride_elems + i]);
+
+    dst[(size_t)(2u * y) * stride_elems + i] =
+        (unsigned char)((p + 6u * c + n + 4u) >> 3);
+    dst[(size_t)(2u * y + 1u) * stride_elems + i] =
+        (unsigned char)((c + n + 1u) >> 1);
+}}
+"#
+    )
+}
+
+// ── Kernel cache ─────────────────────────────────────────────────────────────
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+enum PyrKernelKey {
+    DownF32 { channels: u32 },
+    UpHF32 { channels: u32 },
+    UpVF32 { channels: u32 },
+    DownHU8 { channels: u32 },
+    DownVU8 { channels: u32 },
+    UpHU8 { channels: u32 },
+    UpVU8 { channels: u32 },
+}
+
+type PyrKernelCache = Mutex<HashMap<PyrKernelKey, Arc<CudaKernel>>>;
+static PYR_KERNELS: OnceLock<PyrKernelCache> = OnceLock::new();
+const PYR_CACHE_CAP: usize = 32;
+
+fn get_or_compile(
+    ctx: &Arc<CudaContext>,
+    key: PyrKernelKey,
+    name: &str,
+    src_code: impl FnOnce() -> String,
+) -> Result<Arc<CudaKernel>, CudaPyramidError> {
+    let cache = PYR_KERNELS.get_or_init(Default::default);
+    let cached = cache
+        .lock()
+        .expect("pyramid kernel cache poisoned")
+        .get(&key)
+        .cloned();
+    if let Some(hit) = cached {
+        return Ok(hit);
+    }
+    let built =
+        Arc::new(try_compile_with_l1(ctx, &src_code(), name).map_err(CudaPyramidError::Cuda)?);
+    let mut map = cache.lock().expect("pyramid kernel cache poisoned");
+    if map.len() >= PYR_CACHE_CAP {
+        // Evict one entry, not the whole map (stampede guard).
+        if let Some(k) = map.keys().next().copied() {
+            map.remove(&k);
+        }
+    }
+    Ok(map.entry(key).or_insert(built).clone())
+}
+
+// ── Launchers ────────────────────────────────────────────────────────────────
+
+/// Fused f32 pyrdown. `dst` is `ceil(src/2)` in each dimension.
+#[allow(clippy::too_many_arguments)] // mirrors the kernel's parameter surface
+pub fn launch_pyrdown_f32(
+    ctx: &Arc<CudaContext>,
+    stream: &Arc<CudaStream>,
+    src: &CudaSlice<f32>,
+    dst: &mut CudaSlice<f32>,
+    src_w: u32,
+    src_h: u32,
+    dst_w: u32,
+    dst_h: u32,
+    channels: u32,
+) -> Result<(), CudaPyramidError> {
+    super::check_geometry(src_w, src_h, dst_w, dst_h, None).map_err(CudaPyramidError::Cuda)?;
+    if channels == 0 {
+        return Err(CudaPyramidError::Cuda("channels must be at least 1".into()));
+    }
+    check_slice(
+        "src",
+        src.len(),
+        src_w as usize * src_h as usize * channels as usize,
+    )?;
+    check_slice(
+        "dst",
+        dst.len(),
+        dst_w as usize * dst_h as usize * channels as usize,
+    )?;
+    let kernel = get_or_compile(
+        ctx,
+        PyrKernelKey::DownF32 { channels },
+        &format!("pyrdown_f32_c{channels}"),
+        || pyrdown_f32_src(channels as usize),
+    )?;
+    kernel
+        .launch_builder(stream)
+        .arg(src)
+        .arg(dst)
+        .arg(&src_w)
+        .arg(&src_h)
+        .arg(&dst_w)
+        .arg(&dst_h)
+        .launch_2d(dst_w, dst_h, make_config(dst_w, dst_h, None))
+        .map_err(|e| CudaPyramidError::Cuda(e.to_string()))
+}
+
+/// Polyphase f32 pyrup: H pass into `scratch` (`2*src_w × src_h`), V pass
+/// into `dst` (`2*src_w × 2*src_h`).
+#[allow(clippy::too_many_arguments)] // mirrors the kernel's parameter surface
+pub fn launch_pyrup_f32(
+    ctx: &Arc<CudaContext>,
+    stream: &Arc<CudaStream>,
+    src: &CudaSlice<f32>,
+    dst: &mut CudaSlice<f32>,
+    scratch: &mut CudaSlice<f32>,
+    src_w: u32,
+    src_h: u32,
+    channels: u32,
+) -> Result<(), CudaPyramidError> {
+    super::check_geometry(src_w, src_h, src_w, src_h, None).map_err(CudaPyramidError::Cuda)?;
+    if channels == 0 {
+        return Err(CudaPyramidError::Cuda("channels must be at least 1".into()));
+    }
+    let dst_w = src_w * 2;
+    let stride = dst_w as usize * channels as usize;
+    check_slice(
+        "src",
+        src.len(),
+        src_w as usize * src_h as usize * channels as usize,
+    )?;
+    check_slice("scratch", scratch.len(), stride * src_h as usize)?;
+    check_slice("dst", dst.len(), stride * 2 * src_h as usize)?;
+
+    let h = get_or_compile(
+        ctx,
+        PyrKernelKey::UpHF32 { channels },
+        &format!("pyrup_h_f32_c{channels}"),
+        || pyrup_h_f32_src(channels as usize),
+    )?;
+    h.launch_builder(stream)
+        .arg(src)
+        .arg(&mut *scratch)
+        .arg(&src_w)
+        .arg(&src_h)
+        .arg(&dst_w)
+        .launch_2d(src_w, src_h, make_config(src_w, src_h, None))
+        .map_err(|e| CudaPyramidError::Cuda(e.to_string()))?;
+
+    let stride_elems = stride as u32;
+    let v = get_or_compile(
+        ctx,
+        PyrKernelKey::UpVF32 { channels },
+        &format!("pyrup_v_f32_c{channels}"),
+        || pyrup_v_f32_src(channels as usize),
+    )?;
+    v.launch_builder(stream)
+        .arg(&*scratch)
+        .arg(dst)
+        .arg(&stride_elems)
+        .arg(&src_h)
+        .launch_2d(stride_elems, src_h, make_config(stride_elems, src_h, None))
+        .map_err(|e| CudaPyramidError::Cuda(e.to_string()))
+}
+
+/// Separable u8 pyrdown: H pass into a u16 `scratch` (`dst_w × src_h`), V
+/// pass into `dst` (`dst_w × dst_h`).
+#[allow(clippy::too_many_arguments)] // mirrors the kernel's parameter surface
+pub fn launch_pyrdown_u8(
+    ctx: &Arc<CudaContext>,
+    stream: &Arc<CudaStream>,
+    src: &CudaSlice<u8>,
+    dst: &mut CudaSlice<u8>,
+    scratch: &mut CudaSlice<u16>,
+    src_w: u32,
+    src_h: u32,
+    dst_w: u32,
+    dst_h: u32,
+    channels: u32,
+) -> Result<(), CudaPyramidError> {
+    super::check_geometry(src_w, src_h, dst_w, dst_h, None).map_err(CudaPyramidError::Cuda)?;
+    if channels == 0 {
+        return Err(CudaPyramidError::Cuda("channels must be at least 1".into()));
+    }
+    let stride = dst_w as usize * channels as usize;
+    check_slice(
+        "src",
+        src.len(),
+        src_w as usize * src_h as usize * channels as usize,
+    )?;
+    check_slice("scratch", scratch.len(), stride * src_h as usize)?;
+    check_slice("dst", dst.len(), stride * dst_h as usize)?;
+
+    let h = get_or_compile(
+        ctx,
+        PyrKernelKey::DownHU8 { channels },
+        &format!("pyrdown_h_u8_c{channels}"),
+        || pyrdown_h_u8_src(channels as usize),
+    )?;
+    h.launch_builder(stream)
+        .arg(src)
+        .arg(&mut *scratch)
+        .arg(&src_w)
+        .arg(&src_h)
+        .arg(&dst_w)
+        .launch_2d(dst_w, src_h, make_config(dst_w, src_h, None))
+        .map_err(|e| CudaPyramidError::Cuda(e.to_string()))?;
+
+    let stride_elems = stride as u32;
+    let v = get_or_compile(
+        ctx,
+        PyrKernelKey::DownVU8 { channels },
+        &format!("pyrdown_v_u8_c{channels}"),
+        || pyrdown_v_u8_src(channels as usize),
+    )?;
+    v.launch_builder(stream)
+        .arg(&*scratch)
+        .arg(dst)
+        .arg(&stride_elems)
+        .arg(&src_h)
+        .arg(&dst_h)
+        .launch_2d(stride_elems, dst_h, make_config(stride_elems, dst_h, None))
+        .map_err(|e| CudaPyramidError::Cuda(e.to_string()))
+}
+
+/// Integer polyphase u8 pyrup: H pass into a u8 `scratch` (`2*src_w ×
+/// src_h`), V pass into `dst` (`2*src_w × 2*src_h`).
+#[allow(clippy::too_many_arguments)] // mirrors the kernel's parameter surface
+pub fn launch_pyrup_u8(
+    ctx: &Arc<CudaContext>,
+    stream: &Arc<CudaStream>,
+    src: &CudaSlice<u8>,
+    dst: &mut CudaSlice<u8>,
+    scratch: &mut CudaSlice<u8>,
+    src_w: u32,
+    src_h: u32,
+    channels: u32,
+) -> Result<(), CudaPyramidError> {
+    super::check_geometry(src_w, src_h, src_w, src_h, None).map_err(CudaPyramidError::Cuda)?;
+    if channels == 0 {
+        return Err(CudaPyramidError::Cuda("channels must be at least 1".into()));
+    }
+    let dst_w = src_w * 2;
+    let stride = dst_w as usize * channels as usize;
+    check_slice(
+        "src",
+        src.len(),
+        src_w as usize * src_h as usize * channels as usize,
+    )?;
+    check_slice("scratch", scratch.len(), stride * src_h as usize)?;
+    check_slice("dst", dst.len(), stride * 2 * src_h as usize)?;
+
+    let h = get_or_compile(
+        ctx,
+        PyrKernelKey::UpHU8 { channels },
+        &format!("pyrup_h_u8_c{channels}"),
+        || pyrup_h_u8_src(channels as usize),
+    )?;
+    h.launch_builder(stream)
+        .arg(src)
+        .arg(&mut *scratch)
+        .arg(&src_w)
+        .arg(&src_h)
+        .arg(&dst_w)
+        .launch_2d(src_w, src_h, make_config(src_w, src_h, None))
+        .map_err(|e| CudaPyramidError::Cuda(e.to_string()))?;
+
+    let stride_elems = stride as u32;
+    let v = get_or_compile(
+        ctx,
+        PyrKernelKey::UpVU8 { channels },
+        &format!("pyrup_v_u8_c{channels}"),
+        || pyrup_v_u8_src(channels as usize),
+    )?;
+    v.launch_builder(stream)
+        .arg(&*scratch)
+        .arg(dst)
+        .arg(&stride_elems)
+        .arg(&src_h)
+        .launch_2d(stride_elems, src_h, make_config(stride_elems, src_h, None))
+        .map_err(|e| CudaPyramidError::Cuda(e.to_string()))
+}

--- a/crates/kornia-imgproc/src/cuda/pyramid.rs
+++ b/crates/kornia-imgproc/src/cuda/pyramid.rs
@@ -403,11 +403,12 @@ type PyrKernelCache = Mutex<HashMap<PyrKernelKey, Arc<CudaKernel>>>;
 static PYR_KERNELS: OnceLock<PyrKernelCache> = OnceLock::new();
 const PYR_CACHE_CAP: usize = 32;
 
+/// `make` renders `(kernel_name, source)` and runs ONLY on a cache miss —
+/// steady-state launches allocate nothing host-side.
 fn get_or_compile(
     ctx: &Arc<CudaContext>,
     key: PyrKernelKey,
-    name: &str,
-    src_code: impl FnOnce() -> String,
+    make: impl FnOnce() -> (String, String),
 ) -> Result<Arc<CudaKernel>, CudaPyramidError> {
     let cache = PYR_KERNELS.get_or_init(Default::default);
     let cached = cache
@@ -418,8 +419,9 @@ fn get_or_compile(
     if let Some(hit) = cached {
         return Ok(hit);
     }
+    let (name, src_code) = make();
     let built =
-        Arc::new(try_compile_with_l1(ctx, &src_code(), name).map_err(CudaPyramidError::Cuda)?);
+        Arc::new(try_compile_with_l1(ctx, &src_code, &name).map_err(CudaPyramidError::Cuda)?);
     let mut map = cache.lock().expect("pyramid kernel cache poisoned");
     if map.len() >= PYR_CACHE_CAP {
         // Evict one entry, not the whole map (stampede guard).
@@ -459,12 +461,12 @@ pub fn launch_pyrdown_f32(
         dst.len(),
         dst_w as usize * dst_h as usize * channels as usize,
     )?;
-    let kernel = get_or_compile(
-        ctx,
-        PyrKernelKey::DownF32 { channels },
-        &format!("pyrdown_f32_c{channels}"),
-        || pyrdown_f32_src(channels as usize),
-    )?;
+    let kernel = get_or_compile(ctx, PyrKernelKey::DownF32 { channels }, || {
+        (
+            format!("pyrdown_f32_c{channels}"),
+            pyrdown_f32_src(channels as usize),
+        )
+    })?;
     kernel
         .launch_builder(stream)
         .arg(src)
@@ -504,12 +506,12 @@ pub fn launch_pyrup_f32(
     check_slice("scratch", scratch.len(), stride * src_h as usize)?;
     check_slice("dst", dst.len(), stride * 2 * src_h as usize)?;
 
-    let h = get_or_compile(
-        ctx,
-        PyrKernelKey::UpHF32 { channels },
-        &format!("pyrup_h_f32_c{channels}"),
-        || pyrup_h_f32_src(channels as usize),
-    )?;
+    let h = get_or_compile(ctx, PyrKernelKey::UpHF32 { channels }, || {
+        (
+            format!("pyrup_h_f32_c{channels}"),
+            pyrup_h_f32_src(channels as usize),
+        )
+    })?;
     h.launch_builder(stream)
         .arg(src)
         .arg(&mut *scratch)
@@ -520,12 +522,12 @@ pub fn launch_pyrup_f32(
         .map_err(|e| CudaPyramidError::Cuda(e.to_string()))?;
 
     let stride_elems = stride as u32;
-    let v = get_or_compile(
-        ctx,
-        PyrKernelKey::UpVF32 { channels },
-        &format!("pyrup_v_f32_c{channels}"),
-        || pyrup_v_f32_src(channels as usize),
-    )?;
+    let v = get_or_compile(ctx, PyrKernelKey::UpVF32 { channels }, || {
+        (
+            format!("pyrup_v_f32_c{channels}"),
+            pyrup_v_f32_src(channels as usize),
+        )
+    })?;
     v.launch_builder(stream)
         .arg(&*scratch)
         .arg(dst)
@@ -563,12 +565,12 @@ pub fn launch_pyrdown_u8(
     check_slice("scratch", scratch.len(), stride * src_h as usize)?;
     check_slice("dst", dst.len(), stride * dst_h as usize)?;
 
-    let h = get_or_compile(
-        ctx,
-        PyrKernelKey::DownHU8 { channels },
-        &format!("pyrdown_h_u8_c{channels}"),
-        || pyrdown_h_u8_src(channels as usize),
-    )?;
+    let h = get_or_compile(ctx, PyrKernelKey::DownHU8 { channels }, || {
+        (
+            format!("pyrdown_h_u8_c{channels}"),
+            pyrdown_h_u8_src(channels as usize),
+        )
+    })?;
     h.launch_builder(stream)
         .arg(src)
         .arg(&mut *scratch)
@@ -579,12 +581,12 @@ pub fn launch_pyrdown_u8(
         .map_err(|e| CudaPyramidError::Cuda(e.to_string()))?;
 
     let stride_elems = stride as u32;
-    let v = get_or_compile(
-        ctx,
-        PyrKernelKey::DownVU8 { channels },
-        &format!("pyrdown_v_u8_c{channels}"),
-        || pyrdown_v_u8_src(channels as usize),
-    )?;
+    let v = get_or_compile(ctx, PyrKernelKey::DownVU8 { channels }, || {
+        (
+            format!("pyrdown_v_u8_c{channels}"),
+            pyrdown_v_u8_src(channels as usize),
+        )
+    })?;
     v.launch_builder(stream)
         .arg(&*scratch)
         .arg(dst)
@@ -622,12 +624,12 @@ pub fn launch_pyrup_u8(
     check_slice("scratch", scratch.len(), stride * src_h as usize)?;
     check_slice("dst", dst.len(), stride * 2 * src_h as usize)?;
 
-    let h = get_or_compile(
-        ctx,
-        PyrKernelKey::UpHU8 { channels },
-        &format!("pyrup_h_u8_c{channels}"),
-        || pyrup_h_u8_src(channels as usize),
-    )?;
+    let h = get_or_compile(ctx, PyrKernelKey::UpHU8 { channels }, || {
+        (
+            format!("pyrup_h_u8_c{channels}"),
+            pyrup_h_u8_src(channels as usize),
+        )
+    })?;
     h.launch_builder(stream)
         .arg(src)
         .arg(&mut *scratch)
@@ -638,12 +640,12 @@ pub fn launch_pyrup_u8(
         .map_err(|e| CudaPyramidError::Cuda(e.to_string()))?;
 
     let stride_elems = stride as u32;
-    let v = get_or_compile(
-        ctx,
-        PyrKernelKey::UpVU8 { channels },
-        &format!("pyrup_v_u8_c{channels}"),
-        || pyrup_v_u8_src(channels as usize),
-    )?;
+    let v = get_or_compile(ctx, PyrKernelKey::UpVU8 { channels }, || {
+        (
+            format!("pyrup_v_u8_c{channels}"),
+            pyrup_v_u8_src(channels as usize),
+        )
+    })?;
     v.launch_builder(stream)
         .arg(&*scratch)
         .arg(dst)

--- a/crates/kornia-imgproc/src/filter/ops.rs
+++ b/crates/kornia-imgproc/src/filter/ops.rs
@@ -5,8 +5,7 @@ use rayon::{
 };
 
 use super::{fast_horizontal_filter, kernels, separable_filter};
-#[cfg(feature = "cuda")]
-use crate::cuda::dispatch::try_device;
+use crate::try_device;
 
 /// Which u8 gaussian-blur kernel a `(kernel, sigma)` combination resolves to
 /// — the single decision shared by the CPU fast-path branch and the CUDA

--- a/crates/kornia-imgproc/src/filter/ops.rs
+++ b/crates/kornia-imgproc/src/filter/ops.rs
@@ -5,19 +5,8 @@ use rayon::{
 };
 
 use super::{fast_horizontal_filter, kernels, separable_filter};
-
-/// One-line residency arm: run `$body(stream)` on the device when the pair
-/// is device-resident, else fall through to the CPU path below the call.
-macro_rules! try_device {
-    ($src:expr, $dst:expr, $body:expr) => {
-        #[cfg(feature = "cuda")]
-        if let crate::cuda::dispatch::Residency::Device(exec) =
-            crate::cuda::dispatch::pair_residency($src, $dst)?
-        {
-            return exec.run($body);
-        }
-    };
-}
+#[cfg(feature = "cuda")]
+use crate::cuda::dispatch::try_device;
 
 /// Which u8 gaussian-blur kernel a `(kernel, sigma)` combination resolves to
 /// — the single decision shared by the CPU fast-path branch and the CUDA

--- a/crates/kornia-imgproc/src/lib.rs
+++ b/crates/kornia-imgproc/src/lib.rs
@@ -1,5 +1,24 @@
 #![deny(missing_docs)]
 #![doc = env!("CARGO_PKG_DESCRIPTION")]
+/// One-line residency arm: run `$body(stream)` on the device when the pair
+/// is device-resident, else fall through to the CPU path below the call.
+/// Defined at crate root (not inside the cfg-gated `cuda` module) so
+/// non-CUDA builds can still see the macro — its expansion is what gates.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __try_device {
+    ($src:expr, $dst:expr, $body:expr) => {
+        #[cfg(feature = "cuda")]
+        if let $crate::cuda::dispatch::Residency::Device(exec) =
+            $crate::cuda::dispatch::pair_residency($src, $dst)?
+        {
+            return exec.run($body);
+        }
+    };
+}
+/// One-line residency arm (see [`__try_device`]).
+pub(crate) use crate::__try_device as try_device;
+
 /// image undistortion module.
 pub mod calibration;
 

--- a/crates/kornia-imgproc/src/pyramid.rs
+++ b/crates/kornia-imgproc/src/pyramid.rs
@@ -223,6 +223,13 @@ pub fn pyrup_f32<const C: usize>(
         ));
     }
 
+    #[cfg(feature = "cuda")]
+    if let crate::cuda::dispatch::Residency::Device(exec) =
+        crate::cuda::dispatch::pair_residency(src, dst)?
+    {
+        return exec.run(|stream| cuda_adapters::pyrup_f32_cuda(src, dst, stream));
+    }
+
     // Intermediate buffer for horizontal pass, pyrup_horizontal writes here
     let mut buffer = vec![0.0f32; dst.width() * src.height() * C];
     pyrup_horizontal_pass_f32::<C>(src, &mut buffer, dst.width());
@@ -315,6 +322,13 @@ pub fn pyrdown_f32<const C: usize>(
             dst.width(),
             dst.height(),
         ));
+    }
+
+    #[cfg(feature = "cuda")]
+    if let crate::cuda::dispatch::Residency::Device(exec) =
+        crate::cuda::dispatch::pair_residency(src, dst)?
+    {
+        return exec.run(|stream| cuda_adapters::pyrdown_f32_cuda(src, dst, stream));
     }
 
     let src_width = src.width();
@@ -464,6 +478,13 @@ pub fn pyrdown_u8<const C: usize>(
             dst.width(),
             dst.height(),
         ));
+    }
+
+    #[cfg(feature = "cuda")]
+    if let crate::cuda::dispatch::Residency::Device(exec) =
+        crate::cuda::dispatch::pair_residency(src, dst)?
+    {
+        return exec.run(|stream| cuda_adapters::pyrdown_u8_cuda(src, dst, stream));
     }
 
     let buffer_width = dst.width();
@@ -794,6 +815,13 @@ pub fn pyrup_u8<const C: usize>(
     }
 
     // Intermediate buffer for horizontal pass
+    #[cfg(feature = "cuda")]
+    if let crate::cuda::dispatch::Residency::Device(exec) =
+        crate::cuda::dispatch::pair_residency(src, dst)?
+    {
+        return exec.run(|stream| cuda_adapters::pyrup_u8_cuda(src, dst, stream));
+    }
+
     let mut buffer = vec![0u8; dst.width() * src.height() * C];
     pyrup_horizontal_pass_u8::<C>(src, &mut buffer, dst.width());
 
@@ -1417,5 +1445,388 @@ mod tests {
         }
 
         Ok(())
+    }
+}
+
+// ── CUDA adapters + PyramidPlan ──────────────────────────────────────────────
+
+#[cfg(feature = "cuda")]
+mod cuda_adapters {
+    use super::*;
+    use crate::cuda::dispatch::{device_slices, dims_u32, untyped_device_err};
+    use crate::cuda::pyramid::{
+        launch_pyrdown_f32, launch_pyrdown_u8, launch_pyrup_f32, launch_pyrup_u8,
+    };
+    use cudarc::driver::CudaStream;
+    use std::sync::Arc;
+
+    fn err(e: impl std::fmt::Display) -> ImageError {
+        ImageError::Cuda(e.to_string())
+    }
+
+    pub(super) fn pyrdown_f32_cuda<const C: usize>(
+        src: &Image<f32, C>,
+        dst: &mut Image<f32, C>,
+        stream: &Arc<CudaStream>,
+    ) -> Result<(), ImageError> {
+        let (sw, sh) = dims_u32(src)?;
+        let (dw, dh) = dims_u32(dst)?;
+        let ctx = stream.context();
+        let (s, d) = device_slices!(src, dst);
+        launch_pyrdown_f32(ctx, stream, s, d, sw, sh, dw, dh, C as u32).map_err(err)
+    }
+
+    pub(super) fn pyrup_f32_cuda<const C: usize>(
+        src: &Image<f32, C>,
+        dst: &mut Image<f32, C>,
+        stream: &Arc<CudaStream>,
+    ) -> Result<(), ImageError> {
+        let (sw, sh) = dims_u32(src)?;
+        let ctx = stream.context();
+        let (s, d) = device_slices!(src, dst);
+        let n = (sw as usize * 2) * sh as usize * C;
+        let mut scratch = unsafe { stream.alloc::<f32>(n) }.map_err(err)?;
+        launch_pyrup_f32(ctx, stream, s, d, &mut scratch, sw, sh, C as u32).map_err(err)
+    }
+
+    pub(super) fn pyrdown_u8_cuda<const C: usize>(
+        src: &Image<u8, C>,
+        dst: &mut Image<u8, C>,
+        stream: &Arc<CudaStream>,
+    ) -> Result<(), ImageError> {
+        let (sw, sh) = dims_u32(src)?;
+        let (dw, dh) = dims_u32(dst)?;
+        let ctx = stream.context();
+        let (s, d) = device_slices!(src, dst);
+        let n = dw as usize * sh as usize * C;
+        let mut scratch = unsafe { stream.alloc::<u16>(n) }.map_err(err)?;
+        launch_pyrdown_u8(ctx, stream, s, d, &mut scratch, sw, sh, dw, dh, C as u32).map_err(err)
+    }
+
+    pub(super) fn pyrup_u8_cuda<const C: usize>(
+        src: &Image<u8, C>,
+        dst: &mut Image<u8, C>,
+        stream: &Arc<CudaStream>,
+    ) -> Result<(), ImageError> {
+        let (sw, sh) = dims_u32(src)?;
+        let ctx = stream.context();
+        let (s, d) = device_slices!(src, dst);
+        let n = (sw as usize * 2) * sh as usize * C;
+        let mut scratch = unsafe { stream.alloc::<u8>(n) }.map_err(err)?;
+        launch_pyrup_u8(ctx, stream, s, d, &mut scratch, sw, sh, C as u32).map_err(err)
+    }
+}
+
+/// Device Gaussian pyramid with every buffer (levels AND pass scratch)
+/// preallocated — the steady state allocates nothing, so `run` is a pure
+/// kernel-launch sequence (CUDA-Graph-capturable).
+#[cfg(feature = "cuda")]
+pub struct PyramidPlan<const C: usize> {
+    levels: Vec<Image<f32, C>>,
+    scratch: Vec<cudarc::driver::CudaSlice<u16>>, // unused for f32; kept sized 0
+    stream: std::sync::Arc<cudarc::driver::CudaStream>,
+}
+
+#[cfg(feature = "cuda")]
+impl<const C: usize> PyramidPlan<C> {
+    /// Allocate a plan producing `max_level` downsampled levels of `size`
+    /// (level 0 buffer holds a copy of the input; levels shrink by 2×).
+    pub fn new(
+        stream: &std::sync::Arc<cudarc::driver::CudaStream>,
+        size: ImageSize,
+        max_level: usize,
+    ) -> Result<Self, ImageError> {
+        let mut levels = Vec::with_capacity(max_level + 1);
+        let (mut w, mut h) = (size.width, size.height);
+        for _ in 0..=max_level {
+            levels.push(Image::<f32, C>::zeros_cuda(
+                ImageSize {
+                    width: w,
+                    height: h,
+                },
+                stream,
+            )?);
+            w = w.div_ceil(2);
+            h = h.div_ceil(2);
+        }
+        Ok(Self {
+            levels,
+            scratch: Vec::new(),
+            stream: stream.clone(),
+        })
+    }
+
+    /// Run the pyramid: `src` must match level 0's size and residency.
+    /// After return, [`Self::levels`] holds the Gaussian pyramid.
+    pub fn run(&mut self, src: &Image<f32, C>) -> Result<(), ImageError> {
+        let _ = &self.scratch;
+        if src.size() != self.levels[0].size() {
+            return Err(ImageError::InvalidImageSize(
+                self.levels[0].width(),
+                self.levels[0].height(),
+                src.width(),
+                src.height(),
+            ));
+        }
+        // Level 0 = copy of src (device-to-device, stream-ordered).
+        {
+            let s0 = src
+                .0
+                .as_cudaslice()
+                .ok_or_else(|| ImageError::Cuda("plan src not device-resident".into()))?;
+            let d0 = self.levels[0]
+                .0
+                .as_cudaslice_mut()
+                .ok_or_else(|| ImageError::Cuda("plan level not device-resident".into()))?;
+            self.stream
+                .memcpy_dtod(s0, d0)
+                .map_err(|e| ImageError::Cuda(e.to_string()))?;
+        }
+        for i in 1..self.levels.len() {
+            let (prev, rest) = self.levels.split_at_mut(i);
+            let src_lvl = &prev[i - 1];
+            let dst_lvl = &mut rest[0];
+            let (sw, sh) = (src_lvl.width() as u32, src_lvl.height() as u32);
+            let (dw, dh) = (dst_lvl.width() as u32, dst_lvl.height() as u32);
+            let ctx = self.stream.context();
+            let s = src_lvl
+                .0
+                .as_cudaslice()
+                .ok_or_else(|| ImageError::Cuda("plan level not device-resident".into()))?;
+            let d = dst_lvl
+                .0
+                .as_cudaslice_mut()
+                .ok_or_else(|| ImageError::Cuda("plan level not device-resident".into()))?;
+            crate::cuda::pyramid::launch_pyrdown_f32(
+                ctx,
+                &self.stream,
+                s,
+                d,
+                sw,
+                sh,
+                dw,
+                dh,
+                C as u32,
+            )
+            .map_err(|e| ImageError::Cuda(e.to_string()))?;
+        }
+        Ok(())
+    }
+
+    /// The pyramid levels (level 0 = full resolution).
+    pub fn levels(&self) -> &[Image<f32, C>] {
+        &self.levels
+    }
+}
+
+#[cfg(all(test, feature = "cuda"))]
+mod cuda_tests {
+    use super::*;
+    use crate::cuda::color::test_utils::{default_stream, pattern_f32, pattern_u8};
+
+    fn sz(w: usize, h: usize) -> ImageSize {
+        ImageSize {
+            width: w,
+            height: h,
+        }
+    }
+
+    /// f32 pyrdown/pyrup device output must be BIT-identical to the CPU
+    /// (fused 5x5 weights, polyphase expressions, fmad-free), including the
+    /// reflect_101 border ring and degenerate 1-wide/1-tall sources.
+    #[test]
+    fn f32_pyramid_device_equals_host_bitexact() {
+        let stream = default_stream();
+        for (w, h) in [(64usize, 48usize), (67, 43), (5, 4), (1, 7), (8, 1)] {
+            let src = Image::<f32, 3>::new(sz(w, h), pattern_f32(w * h * 3)).unwrap();
+            let d_src = src.to_cuda(&stream).unwrap();
+
+            // pyrdown
+            let (dw, dh) = (w.div_ceil(2), h.div_ceil(2));
+            let mut cpu = Image::<f32, 3>::from_size_val(sz(dw, dh), 0.0).unwrap();
+            pyrdown_f32(&src, &mut cpu).unwrap();
+            let mut d_dst = Image::<f32, 3>::zeros_cuda(sz(dw, dh), &stream).unwrap();
+            pyrdown_f32(&d_src, &mut d_dst).unwrap();
+            let back = d_dst.to_host_owned().unwrap();
+            for (i, (a, b)) in back.as_slice().iter().zip(cpu.as_slice()).enumerate() {
+                assert!(
+                    a.to_bits() == b.to_bits(),
+                    "pyrdown {w}x{h} elem {i}: {a} vs {b}"
+                );
+            }
+
+            // pyrup
+            let (uw, uh) = (w * 2, h * 2);
+            let mut cpu = Image::<f32, 3>::from_size_val(sz(uw, uh), 0.0).unwrap();
+            pyrup_f32(&src, &mut cpu).unwrap();
+            let mut d_dst = Image::<f32, 3>::zeros_cuda(sz(uw, uh), &stream).unwrap();
+            pyrup_f32(&d_src, &mut d_dst).unwrap();
+            let back = d_dst.to_host_owned().unwrap();
+            for (i, (a, b)) in back.as_slice().iter().zip(cpu.as_slice()).enumerate() {
+                assert!(
+                    a.to_bits() == b.to_bits(),
+                    "pyrup {w}x{h} elem {i}: {a} vs {b}"
+                );
+            }
+        }
+    }
+
+    /// u8 pyrdown/pyrup must be byte-exact vs the CPU separable paths.
+    #[test]
+    fn u8_pyramid_device_equals_host_byte_exact() {
+        let stream = default_stream();
+        for (w, h) in [(64usize, 48usize), (67, 43), (5, 4), (1, 7), (8, 1)] {
+            let src = Image::<u8, 3>::new(sz(w, h), pattern_u8(w * h * 3)).unwrap();
+            let d_src = src.to_cuda(&stream).unwrap();
+
+            let (dw, dh) = (w.div_ceil(2), h.div_ceil(2));
+            let mut cpu = Image::<u8, 3>::from_size_val(sz(dw, dh), 0).unwrap();
+            pyrdown_u8(&src, &mut cpu).unwrap();
+            let mut d_dst = Image::<u8, 3>::zeros_cuda(sz(dw, dh), &stream).unwrap();
+            pyrdown_u8(&d_src, &mut d_dst).unwrap();
+            assert_eq!(
+                d_dst.to_host_owned().unwrap().as_slice(),
+                cpu.as_slice(),
+                "pyrdown_u8 {w}x{h}"
+            );
+
+            let (uw, uh) = (w * 2, h * 2);
+            let mut cpu = Image::<u8, 3>::from_size_val(sz(uw, uh), 0).unwrap();
+            pyrup_u8(&src, &mut cpu).unwrap();
+            let mut d_dst = Image::<u8, 3>::zeros_cuda(sz(uw, uh), &stream).unwrap();
+            pyrup_u8(&d_src, &mut d_dst).unwrap();
+            assert_eq!(
+                d_dst.to_host_owned().unwrap().as_slice(),
+                cpu.as_slice(),
+                "pyrup_u8 {w}x{h}"
+            );
+        }
+    }
+
+    /// PyramidPlan levels must be bit-identical to the CPU build_pyramid.
+    #[test]
+    fn pyramid_plan_matches_cpu_build_pyramid() {
+        let stream = default_stream();
+        let (w, h) = (97usize, 61usize);
+        let src = Image::<f32, 1>::new(sz(w, h), pattern_f32(w * h)).unwrap();
+        let cpu_levels = build_pyramid(&src, 3).unwrap();
+
+        let d_src = src.to_cuda(&stream).unwrap();
+        let mut plan = PyramidPlan::<1>::new(&stream, sz(w, h), 3).unwrap();
+        plan.run(&d_src).unwrap();
+        // Reuse: second run must produce the same result from the same input.
+        plan.run(&d_src).unwrap();
+
+        assert_eq!(plan.levels().len(), cpu_levels.len());
+        for (li, (gpu_lvl, cpu_lvl)) in plan.levels().iter().zip(&cpu_levels).enumerate() {
+            let back = gpu_lvl.to_host_owned().unwrap();
+            for (i, (a, b)) in back.as_slice().iter().zip(cpu_lvl.as_slice()).enumerate() {
+                assert!(
+                    a.to_bits() == b.to_bits(),
+                    "plan level {li} elem {i}: {a} vs {b}"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(all(test, feature = "cuda"))]
+mod cuda_probe {
+    use super::*;
+    use crate::cuda::color::test_utils::{default_stream, pattern_f32, pattern_u8};
+
+    /// Sustained 1080p probes + single launches for ncu (ignored).
+    #[test]
+    #[ignore]
+    fn probe_pyramid_1080p() {
+        let stream = default_stream();
+        let sz = ImageSize {
+            width: 1920,
+            height: 1080,
+        };
+        let dsz = ImageSize {
+            width: 960,
+            height: 540,
+        };
+        let f = Image::<f32, 1>::new(sz, pattern_f32(1920 * 1080)).unwrap();
+        let u = Image::<u8, 3>::new(sz, pattern_u8(1920 * 1080 * 3)).unwrap();
+        let df = f.to_cuda(&stream).unwrap();
+        let du = u.to_cuda(&stream).unwrap();
+        let mut df_d = Image::<f32, 1>::zeros_cuda(dsz, &stream).unwrap();
+        let mut du_d = Image::<u8, 3>::zeros_cuda(dsz, &stream).unwrap();
+
+        for (name, f_run) in [("pyrdown_f32 C1", true), ("pyrdown_u8 C3", false)] {
+            let mut best = f64::MAX;
+            for _ in 0..30 {
+                if f_run {
+                    pyrdown_f32(&df, &mut df_d).unwrap();
+                } else {
+                    pyrdown_u8(&du, &mut du_d).unwrap();
+                }
+            }
+            stream.synchronize().unwrap();
+            for _ in 0..5 {
+                let t0 = std::time::Instant::now();
+                for _ in 0..100 {
+                    if f_run {
+                        pyrdown_f32(&df, &mut df_d).unwrap();
+                    } else {
+                        pyrdown_u8(&du, &mut du_d).unwrap();
+                    }
+                }
+                stream.synchronize().unwrap();
+                best = best.min(t0.elapsed().as_secs_f64() * 1000.0 / 100.0);
+            }
+            println!("{name}: {best:.3} ms (min of 5x100)");
+        }
+
+        // plan: 4-level f32 pyramid sustained
+        let mut plan = PyramidPlan::<1>::new(&stream, sz, 3).unwrap();
+        for _ in 0..20 {
+            plan.run(&df).unwrap();
+        }
+        stream.synchronize().unwrap();
+        let mut best = f64::MAX;
+        for _ in 0..5 {
+            let t0 = std::time::Instant::now();
+            for _ in 0..100 {
+                plan.run(&df).unwrap();
+            }
+            stream.synchronize().unwrap();
+            best = best.min(t0.elapsed().as_secs_f64() * 1000.0 / 100.0);
+        }
+        println!("PyramidPlan 4-level f32 C1 1080p: {best:.3} ms (min of 5x100)");
+    }
+
+    /// One launch per kernel for ncu (ignored).
+    #[test]
+    #[ignore]
+    fn ncu_single_launches() {
+        let stream = default_stream();
+        let sz = ImageSize {
+            width: 1920,
+            height: 1080,
+        };
+        let dsz = ImageSize {
+            width: 960,
+            height: 540,
+        };
+        let usz = ImageSize {
+            width: 3840,
+            height: 2160,
+        };
+        let f = Image::<f32, 1>::new(sz, pattern_f32(1920 * 1080)).unwrap();
+        let u = Image::<u8, 3>::new(sz, pattern_u8(1920 * 1080 * 3)).unwrap();
+        let df = f.to_cuda(&stream).unwrap();
+        let du = u.to_cuda(&stream).unwrap();
+        let mut d1 = Image::<f32, 1>::zeros_cuda(dsz, &stream).unwrap();
+        let mut d2 = Image::<u8, 3>::zeros_cuda(dsz, &stream).unwrap();
+        let mut u1 = Image::<f32, 1>::zeros_cuda(usz, &stream).unwrap();
+        let mut u2 = Image::<u8, 3>::zeros_cuda(usz, &stream).unwrap();
+        pyrdown_f32(&df, &mut d1).unwrap();
+        pyrdown_u8(&du, &mut d2).unwrap();
+        pyrup_f32(&df, &mut u1).unwrap();
+        pyrup_u8(&du, &mut u2).unwrap();
+        stream.synchronize().unwrap();
     }
 }

--- a/crates/kornia-imgproc/src/pyramid.rs
+++ b/crates/kornia-imgproc/src/pyramid.rs
@@ -224,10 +224,11 @@ pub fn pyrup_f32<const C: usize>(
     }
 
     #[cfg(feature = "cuda")]
-    if let crate::cuda::dispatch::Residency::Device(exec) =
-        crate::cuda::dispatch::pair_residency(src, dst)?
     {
-        return exec.run(|stream| cuda_adapters::pyrup_f32_cuda(src, dst, stream));
+        use crate::cuda::dispatch::try_device;
+        try_device!(src, dst, |stream| cuda_adapters::pyrup_f32_cuda(
+            src, dst, stream
+        ));
     }
 
     // Intermediate buffer for horizontal pass, pyrup_horizontal writes here
@@ -325,10 +326,11 @@ pub fn pyrdown_f32<const C: usize>(
     }
 
     #[cfg(feature = "cuda")]
-    if let crate::cuda::dispatch::Residency::Device(exec) =
-        crate::cuda::dispatch::pair_residency(src, dst)?
     {
-        return exec.run(|stream| cuda_adapters::pyrdown_f32_cuda(src, dst, stream));
+        use crate::cuda::dispatch::try_device;
+        try_device!(src, dst, |stream| cuda_adapters::pyrdown_f32_cuda(
+            src, dst, stream
+        ));
     }
 
     let src_width = src.width();
@@ -481,10 +483,11 @@ pub fn pyrdown_u8<const C: usize>(
     }
 
     #[cfg(feature = "cuda")]
-    if let crate::cuda::dispatch::Residency::Device(exec) =
-        crate::cuda::dispatch::pair_residency(src, dst)?
     {
-        return exec.run(|stream| cuda_adapters::pyrdown_u8_cuda(src, dst, stream));
+        use crate::cuda::dispatch::try_device;
+        try_device!(src, dst, |stream| cuda_adapters::pyrdown_u8_cuda(
+            src, dst, stream
+        ));
     }
 
     let buffer_width = dst.width();
@@ -816,10 +819,11 @@ pub fn pyrup_u8<const C: usize>(
 
     // Intermediate buffer for horizontal pass
     #[cfg(feature = "cuda")]
-    if let crate::cuda::dispatch::Residency::Device(exec) =
-        crate::cuda::dispatch::pair_residency(src, dst)?
     {
-        return exec.run(|stream| cuda_adapters::pyrup_u8_cuda(src, dst, stream));
+        use crate::cuda::dispatch::try_device;
+        try_device!(src, dst, |stream| cuda_adapters::pyrup_u8_cuda(
+            src, dst, stream
+        ));
     }
 
     let mut buffer = vec![0u8; dst.width() * src.height() * C];
@@ -1523,7 +1527,6 @@ mod cuda_adapters {
 #[cfg(feature = "cuda")]
 pub struct PyramidPlan<const C: usize> {
     levels: Vec<Image<f32, C>>,
-    scratch: Vec<cudarc::driver::CudaSlice<u16>>, // unused for f32; kept sized 0
     stream: std::sync::Arc<cudarc::driver::CudaStream>,
 }
 
@@ -1551,7 +1554,6 @@ impl<const C: usize> PyramidPlan<C> {
         }
         Ok(Self {
             levels,
-            scratch: Vec::new(),
             stream: stream.clone(),
         })
     }
@@ -1559,7 +1561,6 @@ impl<const C: usize> PyramidPlan<C> {
     /// Run the pyramid: `src` must match level 0's size and residency.
     /// After return, [`Self::levels`] holds the Gaussian pyramid.
     pub fn run(&mut self, src: &Image<f32, C>) -> Result<(), ImageError> {
-        let _ = &self.scratch;
         if src.size() != self.levels[0].size() {
             return Err(ImageError::InvalidImageSize(
                 self.levels[0].width(),
@@ -1582,33 +1583,12 @@ impl<const C: usize> PyramidPlan<C> {
                 .memcpy_dtod(s0, d0)
                 .map_err(|e| ImageError::Cuda(e.to_string()))?;
         }
+        // Levels are device-resident by construction, so call the adapter
+        // directly (no per-level residency re-check) — one shared path to
+        // the launcher instead of open-coding slice extraction here.
         for i in 1..self.levels.len() {
             let (prev, rest) = self.levels.split_at_mut(i);
-            let src_lvl = &prev[i - 1];
-            let dst_lvl = &mut rest[0];
-            let (sw, sh) = (src_lvl.width() as u32, src_lvl.height() as u32);
-            let (dw, dh) = (dst_lvl.width() as u32, dst_lvl.height() as u32);
-            let ctx = self.stream.context();
-            let s = src_lvl
-                .0
-                .as_cudaslice()
-                .ok_or_else(|| ImageError::Cuda("plan level not device-resident".into()))?;
-            let d = dst_lvl
-                .0
-                .as_cudaslice_mut()
-                .ok_or_else(|| ImageError::Cuda("plan level not device-resident".into()))?;
-            crate::cuda::pyramid::launch_pyrdown_f32(
-                ctx,
-                &self.stream,
-                s,
-                d,
-                sw,
-                sh,
-                dw,
-                dh,
-                C as u32,
-            )
-            .map_err(|e| ImageError::Cuda(e.to_string()))?;
+            cuda_adapters::pyrdown_f32_cuda(&prev[i - 1], &mut rest[0], &self.stream)?;
         }
         Ok(())
     }
@@ -1755,47 +1735,36 @@ mod cuda_probe {
         let mut df_d = Image::<f32, 1>::zeros_cuda(dsz, &stream).unwrap();
         let mut du_d = Image::<u8, 3>::zeros_cuda(dsz, &stream).unwrap();
 
-        for (name, f_run) in [("pyrdown_f32 C1", true), ("pyrdown_u8 C3", false)] {
-            let mut best = f64::MAX;
+        let bench_min = |name: &str, mut op: Box<dyn FnMut() + '_>| {
             for _ in 0..30 {
-                if f_run {
-                    pyrdown_f32(&df, &mut df_d).unwrap();
-                } else {
-                    pyrdown_u8(&du, &mut du_d).unwrap();
-                }
+                op();
             }
             stream.synchronize().unwrap();
+            let mut best = f64::MAX;
             for _ in 0..5 {
                 let t0 = std::time::Instant::now();
                 for _ in 0..100 {
-                    if f_run {
-                        pyrdown_f32(&df, &mut df_d).unwrap();
-                    } else {
-                        pyrdown_u8(&du, &mut du_d).unwrap();
-                    }
+                    op();
                 }
                 stream.synchronize().unwrap();
                 best = best.min(t0.elapsed().as_secs_f64() * 1000.0 / 100.0);
             }
             println!("{name}: {best:.3} ms (min of 5x100)");
-        }
+        };
 
-        // plan: 4-level f32 pyramid sustained
+        bench_min(
+            "pyrdown_f32 C1",
+            Box::new(|| pyrdown_f32(&df, &mut df_d).unwrap()),
+        );
+        bench_min(
+            "pyrdown_u8 C3",
+            Box::new(|| pyrdown_u8(&du, &mut du_d).unwrap()),
+        );
         let mut plan = PyramidPlan::<1>::new(&stream, sz, 3).unwrap();
-        for _ in 0..20 {
-            plan.run(&df).unwrap();
-        }
-        stream.synchronize().unwrap();
-        let mut best = f64::MAX;
-        for _ in 0..5 {
-            let t0 = std::time::Instant::now();
-            for _ in 0..100 {
-                plan.run(&df).unwrap();
-            }
-            stream.synchronize().unwrap();
-            best = best.min(t0.elapsed().as_secs_f64() * 1000.0 / 100.0);
-        }
-        println!("PyramidPlan 4-level f32 C1 1080p: {best:.3} ms (min of 5x100)");
+        bench_min(
+            "PyramidPlan 4-level f32 C1 1080p",
+            Box::new(|| plan.run(&df).unwrap()),
+        );
     }
 
     /// One launch per kernel for ncu (ignored).

--- a/crates/kornia-imgproc/src/pyramid.rs
+++ b/crates/kornia-imgproc/src/pyramid.rs
@@ -225,7 +225,7 @@ pub fn pyrup_f32<const C: usize>(
 
     #[cfg(feature = "cuda")]
     {
-        use crate::cuda::dispatch::try_device;
+        use crate::try_device;
         try_device!(src, dst, |stream| cuda_adapters::pyrup_f32_cuda(
             src, dst, stream
         ));
@@ -327,7 +327,7 @@ pub fn pyrdown_f32<const C: usize>(
 
     #[cfg(feature = "cuda")]
     {
-        use crate::cuda::dispatch::try_device;
+        use crate::try_device;
         try_device!(src, dst, |stream| cuda_adapters::pyrdown_f32_cuda(
             src, dst, stream
         ));
@@ -484,7 +484,7 @@ pub fn pyrdown_u8<const C: usize>(
 
     #[cfg(feature = "cuda")]
     {
-        use crate::cuda::dispatch::try_device;
+        use crate::try_device;
         try_device!(src, dst, |stream| cuda_adapters::pyrdown_u8_cuda(
             src, dst, stream
         ));
@@ -820,7 +820,7 @@ pub fn pyrup_u8<const C: usize>(
     // Intermediate buffer for horizontal pass
     #[cfg(feature = "cuda")]
     {
-        use crate::cuda::dispatch::try_device;
+        use crate::try_device;
         try_device!(src, dst, |stream| cuda_adapters::pyrup_u8_cuda(
             src, dst, stream
         ));


### PR DESCRIPTION
## What (roadmap PR 5)

CUDA pyramids, byte-to-byte with the CPU:

| op | contract | verified |
|---|---|---|
| pyrdown_f32 (fused 5×5+subsample) | **bit-exact** | `to_bits()` equality, odd + 1-wide/1-tall sources |
| pyrup_f32 (polyphase pair) | **bit-exact** | same |
| pyrdown_u8 (`[1,4,6,4,1]`, u16 mid, `(sum+128)>>8`) | **byte-exact** | `assert_eq!` |
| pyrup_u8 (`(p+6c+n+4)>>3` / `(c+n+1)>>1`) | **byte-exact** | `assert_eq!` |
| `PyramidPlan` | bit-exact vs `build_pyramid` | asserted incl. plan reuse |

`PyramidPlan` preallocates every level; steady-state `run()` = one dtod copy + N launches (graph-capturable — the substrate for PR 12 FAST/ORB and PR 15 pipeline B).

## nv profile (ncu basic, locked clocks)

u8 H-pass **89% mem-pipe** (envelope); f32 fused down compute-bound at 83% sm / 92% occ (the fmad-free 25-tap price of bit-exactness); V-passes compute-bound on `reflect_101`'s per-thread modulo — indices are uniform per row, branch-arithmetic replacement filed as a follow-up task with the counter evidence.

## Bench (1080p, locked clocks, sustained)

| op | kornia GPU | cv2 CPU | × |
|---|---|---|---|
| pyrdown u8 C3 | **0.624 ms** | 2.53 | **4.1** |
| pyrup u8 C3 | ~1.9 ms (4K write) | 20.6 | **~10** |
| pyrdown f32 C1 | 0.342 ms | 0.53 | 1.5 |
| 4-level f32 plan | **0.682 ms** | — | — |

(VPI's python surface exposes no pyramid builder to compare.)

378 lib tests green, clippy `-D warnings` clean. Python bindings for pyrdown/pyrup: follow-up (no existing py pyramid surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)