### PR TITLE
docs(examples): cuda-fusion example — composing FKL-style fused kernels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ changes early: `cargo add kornia-imgproc@0.1.15-rc.1` or `pip install --pre korn
 
 ## [Unreleased]
 
+**`cuda-fusion` example + docs.** New runnable example
+(`examples/cuda_fusion`) showing the FKL-style kernel-fusion API:
+composing the DNN-preprocess chain and a novel resize→normalize→gray
+chain from the stage library, printing the generated CUDA source, and a
+sustained benchmark (~0.13 ms/frame, 1080p → 640×640 CHW on Orin). The
+README documents pipeline composition, batching, the custom-`FusedStage`
+recipe, and the f32-intermediate precision contract.
+
 **Connected-component labeling (CPU and CUDA), label-exact with OpenCV's
 SAUF.** New `connected_components` for u8 single-channel masks
 (`kornia_rs.imgproc.connected_components` in Python, returning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ changes early: `cargo add kornia-imgproc@0.1.15-rc.1` or `pip install --pre korn
 ## [Unreleased]
 
 **`cuda-fusion` example + docs.** New runnable example
-(`examples/cuda_fusion`) showing the FKL-style kernel-fusion API:
+(`examples/cuda_fusion`) showing the kernel-fusion API (build/exec model
+borrowed from the Fused Kernel Library; scoped to linear per-pixel
+transform chains — documented explicitly as narrower than FKL):
 composing the DNN-preprocess chain and a novel resize→normalize→gray
 chain from the stage library, printing the generated CUDA source, and a
 sustained benchmark (~0.13 ms/frame, 1080p → 640×640 CHW on Orin). The

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3262,6 +3262,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-fusion"
+version = "0.1.0"
+dependencies = [
+ "cudarc 0.19.8",
+ "kornia-imgproc",
+]
+
+[[package]]
 name = "cuda-imgproc"
 version = "0.1.0"
 dependencies = [

--- a/examples/cuda_fusion/Cargo.toml
+++ b/examples/cuda_fusion/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "cuda-fusion"
+version = "0.1.0"
+authors = ["Edgar Riba <edgar.riba@gmail.com>"]
+license = "Apache-2.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+cudarc = { version = "0.19", default-features = false, features = [
+  "cuda-version-from-build-system",
+  "driver",
+  "fallback-dynamic-loading",
+  "fallback-latest",
+  "nvrtc",
+  "std",
+] }
+kornia-imgproc = { path = "../../crates/kornia-imgproc", features = ["cuda"] }

--- a/examples/cuda_fusion/README.md
+++ b/examples/cuda_fusion/README.md
@@ -1,12 +1,21 @@
-# CUDA kernel fusion (FKL-style)
+# CUDA kernel fusion
 
 Compose per-op stages into **one generated CUDA kernel** where
 intermediates flow through registers — no global-memory round trips
-between ops. The design follows the [Fused Kernel Library]
-(https://github.com/Libraries-Openly-Fused) build/exec model, but composes
-at **runtime** via NVRTC (compiled once per pipeline shape, then cached;
-measured at exact performance parity with FKL's compile-time templates on
-Jetson AGX Orin).
+between ops. The build/exec stage split and the `__grid_constant__`
+parameter-blob technique are borrowed from the [Fused Kernel Library]
+(https://github.com/Libraries-Openly-Fused) (Amoros / Nuñez / Peña);
+composition here happens at **runtime** via NVRTC (compiled once per
+pipeline shape, then cached).
+
+**Scope — this is NOT a general FKL equivalent.** The current engine
+composes *linear, per-output-pixel transform chains only*: one `Source`
+stage (single input buffer) → `Map` stages passing a `float3` value in
+registers → one `Sink` stage (single output buffer). No multi-input
+stages, no reductions, no other inter-stage value types yet. FKL's
+template machinery composes considerably more (arbitrary value types,
+multi-operand operations, reduction patterns). Within this transform-chain
+scope, per-stage code is arbitrary CUDA.
 
 ```bash
 cargo run -p cuda-fusion --release
@@ -15,10 +24,11 @@ cargo run -p cuda-fusion --release
 The example composes:
 
 1. the DNN-preprocess chain `resize → normalize(ImageNet) → planar CHW`
-   (≈0.13 ms/frame for 1080p → 640×640 on Orin — one kernel, one u8 read,
-   one f32 write);
-2. a **novel** chain `resize → normalize → gray → single-plane write` that
-   exists nowhere as hand-written kernel code;
+   (≈0.13 ms/frame for 1080p → 640×640 on Jetson AGX Orin — one kernel,
+   one u8 read, one f32 write);
+2. a chain with no hand-written kernel anywhere in the library
+   (`resize → normalize → gray → single-plane write`), generated from the
+   same stage library;
 3. prints the generated CUDA source so you can see exactly what runs.
 
 ## Composing a pipeline
@@ -65,24 +75,21 @@ reads: zero registers, warp-broadcast), so chains don't pay register cost
 for carrying state. Same-shape pipelines with different parameter values
 share one compiled kernel — params are data, shapes are code.
 
-## FKL head-to-head (the paper's pipeline)
+## Benchmark vs the FKL binary — one pipeline only
 
-The example also runs FusedKernelLibrary's flagship pipeline —
-`bilinear resize → Mul(1/255) → SplitWrite planar` — in single and
-batch-4 form, matching FKL's own benchmark harness (their
-`executeOperations<TransformDPP<>>` example). Measured same-minute
-against the FKL C++ binary compiled on the same Jetson AGX Orin
-(sm_87, locked clocks):
+For the one pipeline both implementations express (bilinear resize →
+Mul(1/255) → planar split; FKL's `TransformDPP` example), measured
+same-minute against the FKL C++ binary compiled on the same Jetson AGX
+Orin (sm_87, locked clocks):
 
-| pipeline (1080p → 640×640) | kornia fused | FKL (C++ templates) |
+| 1080p → 640×640 | this engine | FKL |
 |---|---|---|
 | single | 0.13–0.14 ms | 0.12–0.13 ms |
 | batch-4 | 0.49–0.50 ms | 0.49 ms |
 
-Runtime NVRTC composition matches compile-time template fusion at
-steady state — the composed kernels are the same shape; only the
-composition mechanism differs (and ours composes at runtime, e.g. from
-Python-driven pipeline definitions).
+This says the *generated kernel* for this chain is as good as FKL's
+template-instantiated one — it says nothing about the many pipeline
+shapes FKL can express and this engine cannot (see Scope above).
 
 ## Precision contract
 

--- a/examples/cuda_fusion/README.md
+++ b/examples/cuda_fusion/README.md
@@ -1,0 +1,73 @@
+# CUDA kernel fusion (FKL-style)
+
+Compose per-op stages into **one generated CUDA kernel** where
+intermediates flow through registers — no global-memory round trips
+between ops. The design follows the [Fused Kernel Library]
+(https://github.com/Libraries-Openly-Fused) build/exec model, but composes
+at **runtime** via NVRTC (compiled once per pipeline shape, then cached;
+measured at exact performance parity with FKL's compile-time templates on
+Jetson AGX Orin).
+
+```bash
+cargo run -p cuda-fusion --release
+```
+
+The example composes:
+
+1. the DNN-preprocess chain `resize → normalize(ImageNet) → planar CHW`
+   (≈0.13 ms/frame for 1080p → 640×640 on Orin — one kernel, one u8 read,
+   one f32 write);
+2. a **novel** chain `resize → normalize → gray → single-plane write` that
+   exists nowhere as hand-written kernel code;
+3. prints the generated CUDA source so you can see exactly what runs.
+
+## Composing a pipeline
+
+```rust
+use kornia_imgproc::cuda::fusion::*;
+
+let read = ReadU8RgbBilinear { src_w, src_h, dst_w, dst_h }; // Source
+let norm = Normalize { scale, bias };                        // Map
+let pipe = FusedPipeline::build(&ctx, &[&read, &norm, &WriteChwF32], dst_w, dst_h)?;
+pipe.launch(&stream, &d_src, &mut d_dst)?;                   // one kernel
+```
+
+Stages must be `Source, Map..., Sink`. Batched variants
+(`build_batched`/`launch_batched`) add a `blockIdx.z` prologue so one
+launch processes N images (bit-identical to N single launches).
+
+## Writing your own stage
+
+Implement `FusedStage`: pack parameters into the blob and emit a CUDA
+snippet that transforms the register value `float3 v`:
+
+```rust
+struct Saturate { gain: f32 }
+
+impl FusedStage for Saturate {
+    fn name(&self) -> String { "saturate".into() }
+    fn build(&self, idx: usize, p: &mut ParamPacker, i: &str, o: &str)
+        -> Result<(String, String), FusionError>
+    {
+        let g = p.f32(idx, "gain", self.gain)?; // -> constant-bank macro
+        Ok((String::new(), format!(
+            "float3 {o}; float m = ({i}.x + {i}.y + {i}.z) * (1.0f/3.0f);\n\
+             {o}.x = m + ({i}.x - m) * {g};\n\
+             {o}.y = m + ({i}.y - m) * {g};\n\
+             {o}.z = m + ({i}.z - m) * {g};\n"
+        )))
+    }
+}
+```
+
+Parameters live in a single `__grid_constant__` POD blob (constant-bank
+reads: zero registers, warp-broadcast), so chains don't pay register cost
+for carrying state. Same-shape pipelines with different parameter values
+share one compiled kernel — params are data, shapes are code.
+
+## Precision contract
+
+Fused chains keep intermediates in f32 registers, so output is NOT
+byte-equal to running the u8 ops separately through buffers — it is a
+documented higher-precision contract (no intermediate quantization), the
+same one the hand-fused `Preprocessor` uses.

--- a/examples/cuda_fusion/README.md
+++ b/examples/cuda_fusion/README.md
@@ -91,6 +91,19 @@ This says the *generated kernel* for this chain is as good as FKL's
 template-instantiated one — it says nothing about the many pipeline
 shapes FKL can express and this engine cannot (see Scope above).
 
+## Roadmap
+
+The engine is planned to grow toward general pipeline composition in the
+spirit of FKL and GStreamer:
+
+- typed inter-stage values (`float`, `float3`, `float4`, packed u8) with
+  build-time compatibility checking;
+- multi-input stages (two-image ops: add_weighted, masking) via the same
+  per-image pointer blob the batch path already uses;
+- reduction sinks (histograms, statistics) as a second grid contract;
+- longer term: branching pipeline graphs (GStreamer-style tees/muxes)
+  and a Python surface for runtime-composed chains.
+
 ## Precision contract
 
 Fused chains keep intermediates in f32 registers, so output is NOT

--- a/examples/cuda_fusion/README.md
+++ b/examples/cuda_fusion/README.md
@@ -65,6 +65,25 @@ reads: zero registers, warp-broadcast), so chains don't pay register cost
 for carrying state. Same-shape pipelines with different parameter values
 share one compiled kernel — params are data, shapes are code.
 
+## FKL head-to-head (the paper's pipeline)
+
+The example also runs FusedKernelLibrary's flagship pipeline —
+`bilinear resize → Mul(1/255) → SplitWrite planar` — in single and
+batch-4 form, matching FKL's own benchmark harness (their
+`executeOperations<TransformDPP<>>` example). Measured same-minute
+against the FKL C++ binary compiled on the same Jetson AGX Orin
+(sm_87, locked clocks):
+
+| pipeline (1080p → 640×640) | kornia fused | FKL (C++ templates) |
+|---|---|---|
+| single | 0.13–0.14 ms | 0.12–0.13 ms |
+| batch-4 | 0.49–0.50 ms | 0.49 ms |
+
+Runtime NVRTC composition matches compile-time template fusion at
+steady state — the composed kernels are the same shape; only the
+composition mechanism differs (and ours composes at runtime, e.g. from
+Python-driven pipeline definitions).
+
 ## Precision contract
 
 Fused chains keep intermediates in f32 registers, so output is NOT

--- a/examples/cuda_fusion/src/main.rs
+++ b/examples/cuda_fusion/src/main.rs
@@ -1,5 +1,8 @@
-//! FKL-style kernel fusion: compose per-op stages into ONE generated CUDA
-//! kernel where intermediates stay in registers.
+//! Kernel fusion: compose per-op transform stages into ONE generated CUDA
+//! kernel where intermediates stay in registers. Build/exec split and the
+//! grid_constant parameter blob follow the Fused Kernel Library's design;
+//! scope is linear per-pixel transform chains (see README — NOT a general
+//! FKL equivalent).
 //!
 //! ```bash
 //! cargo run -p cuda-fusion --release

--- a/examples/cuda_fusion/src/main.rs
+++ b/examples/cuda_fusion/src/main.rs
@@ -1,0 +1,98 @@
+//! FKL-style kernel fusion: compose per-op stages into ONE generated CUDA
+//! kernel where intermediates stay in registers.
+//!
+//! ```bash
+//! cargo run -p cuda-fusion --release
+//! ```
+//!
+//! Demonstrates:
+//! 1. the standard DNN-preprocess chain (resize → normalize → CHW write);
+//! 2. a NOVEL chain (resize → normalize → gray → single-plane write) that
+//!    exists nowhere as hand-written kernel code — the engine generates it
+//!    from the same stage library;
+//! 3. printing the generated CUDA source;
+//! 4. a sustained benchmark of the fused kernel.
+
+use cudarc::driver::CudaContext;
+use kornia_imgproc::cuda::fusion::{
+    FusedPipeline, Normalize, ReadU8RgbBilinear, RgbToGray, WriteC1F32, WriteChwF32,
+};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let ctx = CudaContext::new(0)?;
+    let stream = ctx.new_stream()?;
+
+    let (sw, sh) = (1920u32, 1080u32);
+    let (dw, dh) = (640u32, 640u32);
+
+    // Fake camera frame (u8 HWC RGB).
+    let host: Vec<u8> = (0..(sw * sh * 3) as usize)
+        .map(|i| ((i * 2654435761usize) >> 24) as u8)
+        .collect();
+    let d_src = stream.clone_htod(&host)?;
+
+    // ── 1. DNN preprocess: resize → normalize(ImageNet) → planar CHW ────
+    let read = ReadU8RgbBilinear {
+        src_w: sw,
+        src_h: sh,
+        dst_w: dw,
+        dst_h: dh,
+    };
+    let norm = Normalize {
+        scale: [
+            1.0 / 255.0 / 0.229,
+            1.0 / 255.0 / 0.224,
+            1.0 / 255.0 / 0.225,
+        ],
+        bias: [-0.485 / 0.229, -0.456 / 0.224, -0.406 / 0.225],
+    };
+    let pipe = FusedPipeline::build(&ctx, &[&read, &norm, &WriteChwF32], dw, dh)?;
+    let mut d_out = stream.alloc_zeros::<f32>((3 * dw * dh) as usize)?;
+    pipe.launch(&stream, &d_src, &mut d_out)?;
+    stream.synchronize()?;
+    println!("preprocess chain: OK ({}x{} -> CHW {}x{})", sw, sh, dw, dh);
+
+    // ── 2. Novel composition: same stages, different chain ──────────────
+    let gray_pipe = FusedPipeline::build(
+        &ctx,
+        &[
+            &read,
+            &Normalize {
+                scale: [1.0 / 255.0; 3],
+                bias: [0.0; 3],
+            },
+            &RgbToGray,
+            &WriteC1F32,
+        ],
+        dw,
+        dh,
+    )?;
+    let mut d_gray = stream.alloc_zeros::<f32>((dw * dh) as usize)?;
+    gray_pipe.launch(&stream, &d_src, &mut d_gray)?;
+    stream.synchronize()?;
+    println!("novel gray chain: OK (no hand-written kernel exists for this)");
+
+    // ── 3. The generated CUDA source ────────────────────────────────────
+    println!("\n──── generated kernel (gray chain) ────");
+    println!("{}", gray_pipe.generated_source());
+
+    // ── 4. Sustained benchmark ──────────────────────────────────────────
+    for _ in 0..50 {
+        pipe.launch(&stream, &d_src, &mut d_out)?;
+    }
+    stream.synchronize()?;
+    let mut best = f64::INFINITY;
+    for _ in 0..5 {
+        let t = std::time::Instant::now();
+        for _ in 0..200 {
+            pipe.launch(&stream, &d_src, &mut d_out)?;
+        }
+        stream.synchronize()?;
+        best = best.min(t.elapsed().as_secs_f64() / 200.0);
+    }
+    println!(
+        "fused preprocess sustained: {:.3} ms/frame (1080p -> 640x640 CHW, one kernel)",
+        best * 1e3
+    );
+    Ok(())
+}

--- a/examples/cuda_fusion/src/main.rs
+++ b/examples/cuda_fusion/src/main.rs
@@ -76,7 +76,66 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\n──── generated kernel (gray chain) ────");
     println!("{}", gray_pipe.generated_source());
 
-    // ── 4. Sustained benchmark ──────────────────────────────────────────
+    // ── 4. The FKL paper pipeline, for the head-to-head comparison ─────
+    // FusedKernelLibrary's flagship example (README/paper): bilinear
+    // resize → Mul(1/255) → SplitWrite to planar f32. Ours: same chain
+    // via Normalize{scale: 1/255, bias: 0} + WriteChwF32. Single and
+    // batch-4, matching the FKL benchmark harness shape.
+    let fkl_norm = Normalize {
+        scale: [1.0 / 255.0; 3],
+        bias: [0.0; 3],
+    };
+    let fkl_pipe = FusedPipeline::build(&ctx, &[&read, &fkl_norm, &WriteChwF32], dw, dh)?;
+    let mut d_fkl = stream.alloc_zeros::<f32>((3 * dw * dh) as usize)?;
+    for _ in 0..50 {
+        fkl_pipe.launch(&stream, &d_src, &mut d_fkl)?;
+    }
+    stream.synchronize()?;
+    let mut best_fkl = f64::INFINITY;
+    for _ in 0..5 {
+        let t = std::time::Instant::now();
+        for _ in 0..100 {
+            fkl_pipe.launch(&stream, &d_src, &mut d_fkl)?;
+        }
+        stream.synchronize()?;
+        best_fkl = best_fkl.min(t.elapsed().as_secs_f64() / 100.0);
+    }
+
+    let batch = 4usize;
+    let d_srcs: Vec<_> = (0..batch)
+        .map(|_| stream.clone_htod(&host))
+        .collect::<Result<_, _>>()?;
+    let src_refs: Vec<&cudarc::driver::CudaSlice<u8>> = d_srcs.iter().collect();
+    let bpipe = FusedPipeline::build_batched(
+        &ctx,
+        &[&read, &fkl_norm, &WriteChwF32],
+        dw,
+        dh,
+        batch as u32,
+        (3 * dw * dh) as usize,
+    )?;
+    let mut d_bout = stream.alloc_zeros::<f32>(batch * (3 * dw * dh) as usize)?;
+    for _ in 0..50 {
+        bpipe.launch_batched(&stream, &src_refs, &mut d_bout)?;
+    }
+    stream.synchronize()?;
+    let mut best_b = f64::INFINITY;
+    for _ in 0..5 {
+        let t = std::time::Instant::now();
+        for _ in 0..100 {
+            bpipe.launch_batched(&stream, &src_refs, &mut d_bout)?;
+        }
+        stream.synchronize()?;
+        best_b = best_b.min(t.elapsed().as_secs_f64() / 100.0);
+    }
+    println!(
+        "FKL-paper pipeline (resize -> mul 1/255 -> planar split):
+  single: {:.3} ms   batch-4: {:.3} ms   (compare with the FKL C++ binary — see README)",
+        best_fkl * 1e3,
+        best_b * 1e3
+    );
+
+    // ── 5. Sustained benchmark ──────────────────────────────────────────
     for _ in 0..50 {
         pipe.launch(&stream, &d_src, &mut d_out)?;
     }


### PR DESCRIPTION
## Summary

Runnable example + documentation for the kernel-fusion engine shipped in #1016.

- **Compose**: `FusedPipeline::build(&ctx, &[&read, &norm, &sink], w, h)` — stage list in, ONE generated NVRTC kernel out; intermediates stay in registers.
- **Scope, stated honestly**: the engine composes *linear per-output-pixel transform chains* (one source, `float3` between stages, one sink). The build/exec split and `__grid_constant__` blob come from FKL's design, but this is **not** a general FKL equivalent — FKL composes arbitrary inter-stage types, multi-operand ops and reductions. The README leads with this scope.
- Example chains: DNN preprocess (resize → ImageNet normalize → CHW), a novel resize → normalize → gray chain with no hand-written kernel, and FKL's own `TransformDPP` pipeline (resize → Mul(1/255) → planar split) for a one-pipeline kernel-quality benchmark against the FKL C++ binary on the same Orin (0.13/0.50 ms vs 0.13/0.49 ms single/batch-4).
- README documents composition, batching, the custom-`FusedStage` recipe (worked `Saturate` stage), kernel caching, and the f32-intermediate precision contract.

```bash
cargo run -p cuda-fusion --release
```

No library-code changes — example + docs + changelog only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)