### PR TITLE
chore(release): v0.1.15-rc.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ changes early: `cargo add kornia-imgproc@0.1.15-rc.1` or `pip install --pre korn
 
 ## [Unreleased]
 
+## [0.1.15-rc.5] — 2026-07-19 (pre-release)
+
 **Connected components 3-5x faster on CPU, ~2x on GPU.** The CPU path
 now indexes its union-find by run id instead of pixel index (tables stay
 cache-resident rather than costing two full-image allocations per call)
@@ -454,6 +456,7 @@ linear layer / kornia-nn, kornia-apriltag, zero-copy gstreamer images. See the
 [GitHub release](https://github.com/kornia/kornia-rs/releases/tag/v0.1.10) for
 the full per-PR list.
 
+[0.1.15-rc.5]: https://github.com/kornia/kornia-rs/compare/v0.1.15-rc.4...v0.1.15-rc.5
 [0.1.15-rc.4]: https://github.com/kornia/kornia-rs/compare/v0.1.15-rc.3...v0.1.15-rc.4
 [0.1.15-rc.3]: https://github.com/kornia/kornia-rs/compare/v0.1.15-rc.2...v0.1.15-rc.3
 [0.1.15-rc.2]: https://github.com/kornia/kornia-rs/compare/v0.1.15-rc.1...v0.1.15-rc.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "apriltag"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "argh",
  "ctrlc",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "apriltag-pose"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "argh",
  "kornia",
@@ -1488,7 +1488,7 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "binarize"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "argh",
  "kornia",
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "colmap_rerun"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "argh",
  "kornia",
@@ -2434,7 +2434,7 @@ dependencies = [
 
 [[package]]
 name = "color_detector"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "argh",
  "kornia",
@@ -2449,7 +2449,7 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "color_spaces"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "cudarc 0.19.8",
  "kornia-image",
@@ -2613,7 +2613,7 @@ dependencies = [
 
 [[package]]
 name = "contours"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "argh",
  "kornia",
@@ -2678,7 +2678,7 @@ dependencies = [
 
 [[package]]
 name = "copper"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "cu29",
  "kornia",
@@ -5012,7 +5012,7 @@ dependencies = [
 
 [[package]]
 name = "exif_auto_orient"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "kornia-io",
 ]
@@ -6513,7 +6513,7 @@ dependencies = [
 
 [[package]]
 name = "hello_world"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "argh",
  "kornia",
@@ -6699,7 +6699,7 @@ dependencies = [
 
 [[package]]
 name = "histogram"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "argh",
  "kornia",
@@ -6966,7 +6966,7 @@ dependencies = [
 
 [[package]]
 name = "icp_registration"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "argh",
  "env_logger",
@@ -7125,7 +7125,7 @@ dependencies = [
 
 [[package]]
 name = "image_api"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "kornia-image",
 ]
@@ -7175,7 +7175,7 @@ checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
 
 [[package]]
 name = "imgproc"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "argh",
  "kornia",
@@ -7704,7 +7704,7 @@ checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "kornia"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "kornia-3d",
  "kornia-algebra",
@@ -7718,7 +7718,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-3d"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "approx",
  "bincode 2.0.1",
@@ -7740,7 +7740,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-algebra"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "approx",
  "criterion 0.8.2",
@@ -7753,7 +7753,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-apriltag"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "aprilgrid",
  "apriltag 0.4.0",
@@ -7771,7 +7771,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-bow"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "bincode 2.0.1",
  "criterion 0.8.2",
@@ -7784,7 +7784,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-cpp"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -7795,7 +7795,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-image"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "arrow 59.0.0",
  "criterion 0.8.2",
@@ -7810,7 +7810,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-imgproc"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "criterion 0.8.2",
  "cudarc 0.19.8",
@@ -7832,7 +7832,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-io"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "circular-buffer",
  "criterion 0.8.2",
@@ -7857,7 +7857,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-py"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "cudarc 0.19.8",
  "dlpack-rs",
@@ -7877,7 +7877,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-tensor"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "bincode 2.0.1",
  "criterion 0.8.2",
@@ -7892,7 +7892,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-tensor-ops"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "approx",
  "criterion 0.8.2",
@@ -7904,7 +7904,7 @@ dependencies = [
 
 [[package]]
 name = "kornia-vlm"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "candle-core",
  "candle-flash-attn",
@@ -8540,7 +8540,7 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "argh",
  "kornia",
@@ -8672,7 +8672,7 @@ dependencies = [
 
 [[package]]
 name = "morphology"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "argh",
  "kornia",
@@ -9160,7 +9160,7 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "normalize"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "argh",
  "kornia",
@@ -9168,7 +9168,7 @@ dependencies = [
 
 [[package]]
 name = "normalize_ii"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "argh",
  "kornia",
@@ -9880,7 +9880,7 @@ dependencies = [
 
 [[package]]
 name = "onnx"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "argh",
  "kornia",
@@ -10211,7 +10211,7 @@ dependencies = [
 
 [[package]]
 name = "paligemma"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "argh",
  "kornia-io",
@@ -10654,7 +10654,7 @@ dependencies = [
 
 [[package]]
 name = "ply_rerun"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "argh",
  "kornia",
@@ -10721,7 +10721,7 @@ dependencies = [
 
 [[package]]
 name = "pnp_demo"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "argh",
  "env_logger",
@@ -13952,7 +13952,7 @@ dependencies = [
 
 [[package]]
 name = "rerun_viz"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "argh",
  "kornia",
@@ -14075,7 +14075,7 @@ dependencies = [
 
 [[package]]
 name = "rotate"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "argh",
  "kornia",
@@ -15078,7 +15078,7 @@ dependencies = [
 
 [[package]]
 name = "smol_vlm"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "argh",
  "kornia-image",
@@ -15129,7 +15129,7 @@ dependencies = [
 
 [[package]]
 name = "smol_vlm_convo"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "argh",
  "color-eyre",
@@ -15380,7 +15380,7 @@ dependencies = [
 
 [[package]]
 name = "std_mean"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "argh",
  "indicatif 0.18.5",
@@ -16698,7 +16698,7 @@ dependencies = [
 
 [[package]]
 name = "undistort"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "argh",
  "kornia",
@@ -16707,7 +16707,7 @@ dependencies = [
 
 [[package]]
 name = "undistort_points"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "argh",
  "kornia",
@@ -17112,7 +17112,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "video_player"
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 dependencies = [
  "eframe",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = ["examples/dora"]
 default-members = ["crates/*"]
 
 [workspace.package]
-version = "0.1.15-rc.4"
+version = "0.1.15-rc.5"
 authors = ["kornia.org <edgar@kornia.org>"]
 edition = "2021"
 rust-version = "1.89"


### PR DESCRIPTION
Release-candidate cut per the release checklist:

- `CHANGELOG.md`: `[Unreleased]` → `## [0.1.15-rc.5] — 2026-07-19 (pre-release)` (26 curated entries covering #1001–#1033), compare link added, `[Unreleased]` reset.
- Workspace version `0.1.15-rc.4` → `0.1.15-rc.5` (all crates inherit); `Cargo.lock` refreshed.

After merge: tag `v0.1.15-rc.5`, then (on explicit go-ahead) run `rust_release.yml` / `python_release.yml`. Reminder from the release skill: linux wheels need `--features cuda` in `python_release.yml` args so pip ships the GPU path — currently verified present or to be confirmed before publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)