### PR TITLE
feat(kornia-io): zero-copy slice encoders for jpeg + gray16 png

### DIFF
--- a/crates/kornia-io/src/jpegturbo.rs
+++ b/crates/kornia-io/src/jpegturbo.rs
@@ -26,6 +26,15 @@ pub enum JpegTurboError {
     #[error("Mutex is poisoned")]
     MutexPoisoned,
 
+    /// The pixel buffer length does not match `width * height * channels`.
+    #[error("pixel buffer length {got} != expected {expected}")]
+    InvalidBufferLength {
+        /// Actual slice length.
+        got: usize,
+        /// Length implied by the given `ImageSize` and channel count.
+        expected: usize,
+    },
+
     /// I/O error, e.g. when reading a JPEG file from disk.
     #[error(transparent)]
     IoError(#[from] std::io::Error),
@@ -67,19 +76,40 @@ impl JpegTurboEncoder {
     ///
     /// The encoded data as `Vec<u8>`.
     pub fn encode_rgb8(&self, image: &Image<u8, 3>) -> Result<Vec<u8>, JpegTurboError> {
-        // get the image data
-        let image_data = image.as_slice();
+        self.encode_rgb8_slice(image.as_slice(), image.size())
+    }
 
-        // create a turbojpeg image
+    /// Encodes a borrowed RGB8 pixel slice (`width * height * 3`, row-major, no padding) into a
+    /// JPEG image.
+    ///
+    /// Zero-copy input: turbojpeg reads the slice directly, so no owning [`Image`] has to be
+    /// built first. [`encode_rgb8`](Self::encode_rgb8) delegates here.
+    ///
+    /// # Arguments
+    ///
+    /// * `pixels` - The RGB8 pixels, row-major `R,G,B` with no row padding.
+    /// * `size` - The image dimensions; `pixels.len()` must equal `width * height * 3`.
+    pub fn encode_rgb8_slice(
+        &self,
+        pixels: &[u8],
+        size: ImageSize,
+    ) -> Result<Vec<u8>, JpegTurboError> {
+        let expected = size.width * size.height * 3;
+        if pixels.len() != expected {
+            return Err(JpegTurboError::InvalidBufferLength {
+                got: pixels.len(),
+                expected,
+            });
+        }
+
         let buf = turbojpeg::Image {
-            pixels: image_data,
-            width: image.width(),
-            pitch: 3 * image.width(),
-            height: image.height(),
+            pixels,
+            width: size.width,
+            pitch: 3 * size.width,
+            height: size.height,
             format: turbojpeg::PixelFormat::RGB,
         };
 
-        // encode the image
         Ok(self
             .0
             .lock()
@@ -313,6 +343,30 @@ pub fn write_image_jpegturbo_rgb8(
 mod tests {
     use super::*;
     use crate::error::IoError;
+
+    #[test]
+    fn encode_rgb8_slice_matches_owning_and_validates_len() -> Result<(), JpegTurboError> {
+        let size = ImageSize {
+            width: 64,
+            height: 48,
+        };
+        let pixels: Vec<u8> = (0..size.width * size.height * 3)
+            .map(|i| (i % 251) as u8)
+            .collect();
+        let enc = JpegTurboEncoder::new()?;
+        // The zero-copy slice path and the owning path must produce identical bytes.
+        let img = Image::<u8, 3>::from_size_slice(size, &pixels)?;
+        assert_eq!(
+            enc.encode_rgb8_slice(&pixels, size)?,
+            enc.encode_rgb8(&img)?
+        );
+        // A wrong-length slice is rejected, not read out of bounds.
+        assert!(matches!(
+            enc.encode_rgb8_slice(&pixels[..pixels.len() - 1], size),
+            Err(JpegTurboError::InvalidBufferLength { .. })
+        ));
+        Ok(())
+    }
 
     #[test]
     fn image_decoder() -> Result<(), JpegTurboError> {

--- a/crates/kornia-io/src/png.rs
+++ b/crates/kornia-io/src/png.rs
@@ -577,8 +577,32 @@ pub fn encode_image_png_gray16(
     buffer: &mut Vec<u8>,
     compress_level: Option<u8>,
 ) -> Result<(), IoError> {
-    let image_size = image.size();
-    let image_buf = convert_buf_u16_u8(image.as_slice());
+    encode_image_png_gray16_slice(image.as_slice(), image.size(), buffer, compress_level)
+}
+
+/// Encodes a borrowed 16-bit grayscale pixel slice (`width * height` u16, row-major) into a PNG.
+///
+/// Zero-copy of the caller's buffer: the u16 values are borrowed and packed straight to
+/// big-endian PNG bytes, so no owning [`Image`] has to be built first.
+/// [`encode_image_png_gray16`] delegates here.
+///
+/// # Arguments
+///
+/// * `pixels` - The 16-bit grayscale values, row-major; `pixels.len()` must equal `width * height`.
+/// * `image_size` - The image dimensions.
+/// * `buffer` - The output buffer the PNG bytes are appended to.
+/// * `compress_level` - Optional zlib compression level.
+pub fn encode_image_png_gray16_slice(
+    pixels: &[u16],
+    image_size: ImageSize,
+    buffer: &mut Vec<u8>,
+    compress_level: Option<u8>,
+) -> Result<(), IoError> {
+    let expected = image_size.width * image_size.height;
+    if pixels.len() != expected {
+        return Err(IoError::InvalidBufferSize(pixels.len(), expected));
+    }
+    let image_buf = convert_buf_u16_u8(pixels);
     buffer.reserve(image_buf.len() / 2);
     write_png_into(
         buffer,
@@ -593,6 +617,31 @@ pub fn encode_image_png_gray16(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn encode_gray16_slice_matches_owning_and_validates_len() -> Result<(), IoError> {
+        let size = ImageSize {
+            width: 40,
+            height: 30,
+        };
+        let pixels: Vec<u16> = (0..(size.width * size.height) as u32)
+            .map(|i| (i % 9000) as u16)
+            .collect();
+        // The zero-copy slice path and the owning path must produce identical PNG bytes.
+        let img = Image::<u16, 1>::from_size_slice(size, &pixels)?;
+        let mut via_slice = Vec::new();
+        let mut via_owning = Vec::new();
+        encode_image_png_gray16_slice(&pixels, size, &mut via_slice, None)?;
+        encode_image_png_gray16(&img, &mut via_owning, None)?;
+        assert_eq!(via_slice, via_owning);
+        // A wrong-length slice is rejected.
+        let mut sink = Vec::new();
+        assert!(matches!(
+            encode_image_png_gray16_slice(&pixels[..pixels.len() - 1], size, &mut sink, None),
+            Err(IoError::InvalidBufferSize(..))
+        ));
+        Ok(())
+    }
     use crate::error::IoError;
     use std::fs::{create_dir_all, read};
 


### PR DESCRIPTION
## What

Add borrowing encode entry points so callers holding a raw pixel slice don't have to build an owning `Image` (a full-frame copy) first:

- `JpegTurboEncoder::encode_rgb8_slice(&[u8], ImageSize)` — turbojpeg reads the slice directly (zero input copy).
- `encode_image_png_gray16_slice(&[u16], ImageSize, &mut Vec<u8>, Option<u8>)` — borrows the u16 values, packs straight to PNG bytes.

The existing `encode_rgb8` / `encode_image_png_gray16` now **delegate** to these, so there is no behavior or API change for current callers.

## Why

`encode_rgb8` already borrowed the pixels for turbojpeg internally — the owning `Image` existed only to hand over `.as_slice()` + dims. Callers with an externally-owned buffer (a camera frame, a scratch slice) currently pay a full-frame `to_vec()` per encode just to satisfy the `Image` type. These entry points remove that copy on the encode hot path. (`Image` is an owning type with no safe borrowing constructor, so this is the clean way to offer zero-copy encode without an `unsafe` borrowed-`Image` or a lifetime-parameterized view.)

## Details

- Both validate the buffer length (`JpegTurboError::InvalidBufferLength` / existing `IoError::InvalidBufferSize`) instead of trusting the caller — a short slice is rejected, not read out of bounds.
- Parity tests assert the slice path produces **byte-identical** output to the owning path, plus the length-rejection cases.
- `+113 / -10`, two files (`jpegturbo.rs`, `png.rs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)