### PR TITLE
fix(kornia-io): cap RVL decode dimensions to prevent an allocation DoS

### DIFF
--- a/crates/kornia-io/src/rvl.rs
+++ b/crates/kornia-io/src/rvl.rs
@@ -23,6 +23,13 @@ use std::{fs, path::Path};
 const MAGIC: &[u8; 4] = b"RVL1";
 const HEADER_LEN: usize = 12; // magic(4) + width(4) + height(4)
 
+/// Sanity ceiling on decoded image pixels. `decode_image_rvl` takes the image dimensions from an
+/// untrusted 12-byte header and allocates `width * height` up front, before reading any pixel
+/// data. A tiny payload can declare a huge image (e.g. 65535x65535), so without a bound a corrupt
+/// or hostile buffer drives a multi-gigabyte allocation — an OOM/abort instead of a clean error.
+/// 8192x8192 covers any real frame with wide margin; anything larger is rejected.
+const MAX_PIXELS: usize = 8192 * 8192;
+
 // ── NibbleWriter ──────────────────────────────────────────────────────────────
 
 struct NibbleWriter {
@@ -302,6 +309,11 @@ pub fn decode_image_rvl(src: &[u8]) -> Result<Image<u16, 1>, IoError> {
     let n_pixels = width
         .checked_mul(height)
         .ok_or_else(|| IoError::RvlDecodeError("image dimensions overflow".into()))?;
+    if n_pixels > MAX_PIXELS {
+        return Err(IoError::RvlDecodeError(format!(
+            "image {width}x{height} exceeds max {MAX_PIXELS} pixels"
+        )));
+    }
 
     let mut pixels = vec![0u16; n_pixels];
     let mut reader = NibbleReader::new(&src[HEADER_LEN..]);
@@ -349,6 +361,16 @@ mod tests {
             data,
         )
         .unwrap()
+    }
+
+    #[test]
+    fn decode_rejects_oversized_dimensions() {
+        // A tiny payload declaring a 65535x65535 image (~4.29e9 px) must be rejected, not drive a
+        // multi-gigabyte allocation. Magic + width + height, empty stream.
+        let mut data = MAGIC.to_vec();
+        data.extend_from_slice(&0xFFFF_u32.to_le_bytes());
+        data.extend_from_slice(&0xFFFF_u32.to_le_bytes());
+        assert!(decode_image_rvl(&data).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`decode_image_rvl` reads `width`/`height` from the untrusted 12-byte RVL header and allocates the full image up front, before reading any pixel data:

```rust
let n_pixels = width.checked_mul(height)      // guards integer overflow only
    .ok_or_else(|| ... "image dimensions overflow")?;
let mut pixels = vec![0u16; n_pixels];        // unbounded alloc from untrusted dims
```

`checked_mul` catches only the `> usize::MAX` overflow edge — not a *valid but huge* product. A 12-byte payload declaring `width = height = 65535` yields `n_pixels ≈ 4.29e9`, so `vec![0u16; n_pixels]` requests **~8.6 GB** → OOM/abort instead of a clean `Err`. RVL data typically arrives from a network/replay source, so a corrupt or hostile frame can crash the decoder.

## Fix

Reject `n_pixels` above a `MAX_PIXELS` ceiling (8192×8192 — covers any real sensor frame with wide margin) before allocating. Malformed dimensions now return `IoError::RvlDecodeError` instead of allocating.

Guard test added (`decode_rejects_oversized_dimensions`); existing round-trip tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)