### PR TITLE
Fix NVRTC preload initialization

### DIFF
--- a/kornia-py/python/kornia_rs/__init__.py
+++ b/kornia-py/python/kornia_rs/__init__.py
@@ -22,7 +22,9 @@ def _preload_nvrtc() -> None:
 
 
 _preload_nvrtc()
+del _preload_nvrtc
 
+from . import kornia_rs
 from .kornia_rs import *
 
 __doc__ = kornia_rs.__doc__


### PR DESCRIPTION

This PR improves the package initialization by ensuring the NVRTC library is preloaded before importing the native `kornia_rs` extension.

## Changes

- Added an explicit import of the `kornia_rs` module before wildcard imports.
- Removed the temporary `_preload_nvrtc` helper from the module namespace after execution using `del _preload_nvrtc`.
- Preserved the existing public API and package behavior.

## Why

Preloading NVRTC before importing the native extension helps avoid library loading issues on systems where `libnvrtc` is not available on the default loader path. Cleaning up the helper function also keeps the package namespace tidy.

## Testing

- Verified that the package imports successfully after the changes.
- Confirmed that the public API remains unchanged.