### PR TITLE
feat(image): Impl kornia-image constructor for borrowed host buffers 

### DIFF
--- a/crates/kornia-image/src/image.rs
+++ b/crates/kornia-image/src/image.rs
@@ -341,7 +341,13 @@ impl<T, const C: usize> Image<T, C> {
         domain: kornia_tensor::resource::MemoryDomain,
         keepalive: Arc<dyn Any + Send + Sync>,
     ) -> Result<Self, ImageError> {
-        let len = size.height * size.width * C;
+        let len = size
+            .height
+            .checked_mul(size.width)
+            .and_then(|n| n.checked_mul(C))
+            .ok_or(ImageError::InvalidImageShape(
+                kornia_tensor::TensorError::ShapeOverflow,
+            ))?;
 
         let tensor =
             Tensor3::from_borrowed([size.height, size.width, C], data, len, domain, keepalive)?;
@@ -369,7 +375,13 @@ impl<T, const C: usize> Image<T, C> {
         domain: kornia_tensor::resource::MemoryDomain,
         keepalive: Arc<dyn Any + Send + Sync>,
     ) -> Result<Self, ImageError> {
-        let len = size.height * size.width * C;
+        let len = size
+            .height
+            .checked_mul(size.width)
+            .and_then(|n| n.checked_mul(C))
+            .ok_or(ImageError::InvalidImageShape(
+                kornia_tensor::TensorError::ShapeOverflow,
+            ))?;
 
         let tensor = Tensor3::from_borrowed_readonly(
             [size.height, size.width, C],

--- a/crates/kornia-image/src/image.rs
+++ b/crates/kornia-image/src/image.rs
@@ -1,6 +1,8 @@
 use crate::error::ImageError;
 use kornia_tensor::{host_alloc, AllocHandle, Tensor, Tensor2, Tensor3};
 use rayon::prelude::*;
+use std::any::Any;
+use std::sync::Arc;
 
 /// Image size in pixels
 ///
@@ -317,6 +319,62 @@ impl<T, const C: usize> Image<T, C> {
         T: Clone,
     {
         Image::new_in(size, data.to_vec(), alloc)
+    }
+
+    /// Wrap a foreign host buffer without copying. `keepalive` must own whatever
+    /// keeps `data` valid (mmap, GstBuffer, refcounted driver frame, ...).
+    ///
+    /// # Arguments
+    ///
+    /// * `size` - The size of the Image.
+    /// * `data` - A pointer to the data of the Image.
+    /// * `keepalive` - A thread safe pointer to the host buffer.
+    ///
+    /// # Safety
+    ///
+    /// - `data` must be valid for `size.width * size.height * C` elements of `T`
+    /// - the memory must stay valid for as long as `keepalive` is alive
+    pub unsafe fn from_borrowed_host(
+        size: ImageSize,
+        data: *const T,
+        keepalive: Arc<dyn Any + Send + Sync>,
+    ) -> Result<Self, ImageError> {
+        let len = size.height * size.width * C;
+
+        let tensor =
+            Tensor3::from_borrowed_host([size.height, size.width, C], data, len, keepalive)?;
+
+        Ok(Self(tensor))
+    }
+
+    /// Wrap a foreign host buffer without copying and ensures Read-only access. `keepalive` must own whatever
+    /// keeps `data` valid (mmap, GstBuffer, refcounted driver frame, ...).
+    ///
+    /// # Arguments
+    ///
+    /// * `size` - The size of the Image.
+    /// * `data` - A pointer to the data of the Image.
+    /// * `keepalive` - A thread safe pointer to the host buffer.
+    ///
+    /// # Safety
+    ///
+    /// - `data` must be valid for `size.width * size.height * C` elements of `T`
+    /// - the memory must stay valid for as long as `keepalive` is alive
+    pub unsafe fn from_borrowed_host_readonly(
+        size: ImageSize,
+        data: *const T,
+        keepalive: Arc<dyn Any + Send + Sync>,
+    ) -> Result<Self, ImageError> {
+        let len = size.height * size.width * C;
+
+        let tensor = Tensor3::from_borrowed_host_readonly(
+            [size.height, size.width, C],
+            data,
+            len,
+            keepalive,
+        )?;
+
+        Ok(Self(tensor))
     }
 
     /// Map the pixel data of the image to a different type.
@@ -698,6 +756,127 @@ impl<T, const C: usize> TryInto<Tensor3<T>> for Image<T, C> {
 mod tests {
     use crate::image::{Image, ImageError, ImageSize};
     use kornia_tensor::{host_alloc, Tensor};
+
+    use std::any::Any;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    struct MockForeignBuffer {
+        ptr: *mut f32,
+        len: usize,
+        is_dropped: Arc<AtomicBool>,
+    }
+
+    unsafe impl Send for MockForeignBuffer {}
+    unsafe impl Sync for MockForeignBuffer {}
+
+    impl MockForeignBuffer {
+        fn new(data: Vec<f32>, flag: Arc<AtomicBool>) -> Self {
+            let mut leaked_data = std::mem::ManuallyDrop::new(data);
+
+            Self {
+                ptr: leaked_data.as_mut_ptr(),
+                len: leaked_data.len(),
+                is_dropped: flag,
+            }
+        }
+    }
+
+    impl Drop for MockForeignBuffer {
+        fn drop(&mut self) {
+            unsafe {
+                let _ = Vec::from_raw_parts(self.ptr, self.len, self.len);
+            }
+
+            self.is_dropped.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn test_image_borrowed_host_lifecycle() -> Result<(), ImageError> {
+        let dropped_flag = Arc::new(AtomicBool::new(false));
+
+        let data = vec![
+            1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+        ];
+        let buffer = MockForeignBuffer::new(data, dropped_flag.clone());
+        let ptr = buffer.ptr as *const f32;
+
+        let keepalive: Arc<dyn Any + Send + Sync> = Arc::new(buffer);
+
+        {
+            let image = unsafe {
+                Image::<f32, 3>::from_borrowed_host(
+                    ImageSize {
+                        width: 2,
+                        height: 2,
+                    },
+                    ptr,
+                    keepalive.clone(),
+                )?
+            };
+
+            // Dropping the keepalive to check if Image data persists.
+            drop(keepalive);
+
+            assert!(!dropped_flag.load(Ordering::SeqCst));
+
+            assert_eq!(image.width(), 2);
+            assert_eq!(image.height(), 2);
+            assert_eq!(image.num_channels(), 3);
+
+            assert_eq!(image.shape, [2, 2, 3]);
+            assert_eq!(image.as_slice()[0], 1.0);
+            assert_eq!(image.as_slice()[11], 12.0);
+        } // `image` goes out of scope.
+
+        assert!(dropped_flag.load(Ordering::SeqCst));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_image_borrowed_host_readonly_reads() -> Result<(), ImageError> {
+        let data = vec![150.0, 200.0];
+        let ptr = data.as_ptr();
+        let keepalive: Arc<dyn Any + Send + Sync> = Arc::new(data);
+
+        let image = unsafe {
+            Image::<f32, 1>::from_borrowed_host_readonly(
+                ImageSize {
+                    width: 2,
+                    height: 1,
+                },
+                ptr,
+                keepalive,
+            )?
+        };
+
+        assert_eq!(image.as_slice(), &[150.0, 200.0]);
+        Ok(())
+    }
+
+    #[test]
+    #[should_panic(expected = "read-only")]
+    fn test_image_borrowed_host_readonly_prevents_mutation() {
+        let data = vec![150.0, 200.0];
+        let ptr = data.as_ptr();
+        let keepalive: Arc<dyn Any + Send + Sync> = Arc::new(data);
+
+        let mut image = unsafe {
+            Image::<f32, 1>::from_borrowed_host_readonly(
+                ImageSize {
+                    width: 2,
+                    height: 1,
+                },
+                ptr,
+                keepalive,
+            )
+            .unwrap()
+        };
+
+        let _mut_slice = image.as_slice_mut();
+    }
 
     #[test]
     fn test_image_size() {

--- a/crates/kornia-image/src/image.rs
+++ b/crates/kornia-image/src/image.rs
@@ -321,6 +321,67 @@ impl<T, const C: usize> Image<T, C> {
         Image::new_in(size, data.to_vec(), alloc)
     }
 
+    /// Wrap a foreign buffer without copying, specifying its memory domain, specifying its memory domain.
+    /// `keepalive` must own whatever keeps `data` valid.
+    ///
+    /// # Arguments
+    ///
+    /// * `size` - The size of the Image.
+    /// * `data` - A pointer to the data of the Image.
+    /// * `domain` - The memory domain (Host or Device) where the data resides.
+    /// * `keepalive` - A thread safe pointer to the buffer.
+    ///
+    /// # Safety
+    ///
+    /// - `data` must be valid for `size.width * size.height * C` elements of `T`
+    /// - the memory must stay valid for as long as `keepalive` is alive
+    pub unsafe fn from_borrowed(
+        size: ImageSize,
+        data: *const T,
+        domain: kornia_tensor::resource::MemoryDomain,
+        keepalive: Arc<dyn Any + Send + Sync>,
+    ) -> Result<Self, ImageError> {
+        let len = size.height * size.width * C;
+
+        let tensor =
+            Tensor3::from_borrowed([size.height, size.width, C], data, len, domain, keepalive)?;
+
+        Ok(Self(tensor))
+    }
+
+    /// Wrap a foreign buffer without copying and ensures Read-only access, specifying its memory domain.
+    /// `keepalive` must own whatever keeps `data` valid.
+    ///
+    /// # Arguments
+    ///
+    /// * `size` - The size of the Image.
+    /// * `data` - A pointer to the data of the Image.
+    /// * `domain` - The memory domain (Host or Device) where the data resides.
+    /// * `keepalive` - A thread safe pointer to the buffer.
+    ///
+    /// # Safety
+    ///
+    /// - `data` must be valid for `size.width * size.height * C` elements of `T`
+    /// - the memory must stay valid for as long as `keepalive` is alive
+    pub unsafe fn from_borrowed_readonly(
+        size: ImageSize,
+        data: *const T,
+        domain: kornia_tensor::resource::MemoryDomain,
+        keepalive: Arc<dyn Any + Send + Sync>,
+    ) -> Result<Self, ImageError> {
+        let len = size.height * size.width * C;
+
+        let tensor = Tensor3::from_borrowed_readonly(
+            [size.height, size.width, C],
+            data,
+            len,
+            domain,
+            keepalive,
+        )?;
+
+        Ok(Self(tensor))
+    }
+
     /// Wrap a foreign host buffer without copying. `keepalive` must own whatever
     /// keeps `data` valid (mmap, GstBuffer, refcounted driver frame, ...).
     ///
@@ -339,12 +400,12 @@ impl<T, const C: usize> Image<T, C> {
         data: *const T,
         keepalive: Arc<dyn Any + Send + Sync>,
     ) -> Result<Self, ImageError> {
-        let len = size.height * size.width * C;
-
-        let tensor =
-            Tensor3::from_borrowed_host([size.height, size.width, C], data, len, keepalive)?;
-
-        Ok(Self(tensor))
+        Self::from_borrowed(
+            size,
+            data,
+            kornia_tensor::resource::MemoryDomain::Host,
+            keepalive,
+        )
     }
 
     /// Wrap a foreign host buffer without copying and ensures Read-only access. `keepalive` must own whatever
@@ -365,16 +426,12 @@ impl<T, const C: usize> Image<T, C> {
         data: *const T,
         keepalive: Arc<dyn Any + Send + Sync>,
     ) -> Result<Self, ImageError> {
-        let len = size.height * size.width * C;
-
-        let tensor = Tensor3::from_borrowed_host_readonly(
-            [size.height, size.width, C],
+        Self::from_borrowed_readonly(
+            size,
             data,
-            len,
+            kornia_tensor::resource::MemoryDomain::Host,
             keepalive,
-        )?;
-
-        Ok(Self(tensor))
+        )
     }
 
     /// Map the pixel data of the image to a different type.

--- a/crates/kornia-image/src/image.rs
+++ b/crates/kornia-image/src/image.rs
@@ -346,7 +346,7 @@ impl<T, const C: usize> Image<T, C> {
             .checked_mul(size.width)
             .and_then(|n| n.checked_mul(C))
             .ok_or(ImageError::InvalidImageShape(
-                kornia_tensor::TensorError::ShapeOverflow,
+                kornia_tensor::TensorError::InvalidShape(usize::MAX),
             ))?;
 
         let tensor =
@@ -380,7 +380,7 @@ impl<T, const C: usize> Image<T, C> {
             .checked_mul(size.width)
             .and_then(|n| n.checked_mul(C))
             .ok_or(ImageError::InvalidImageShape(
-                kornia_tensor::TensorError::ShapeOverflow,
+                kornia_tensor::TensorError::InvalidShape(usize::MAX),
             ))?;
 
         let tensor = Tensor3::from_borrowed_readonly(

--- a/crates/kornia-io/src/gstreamer/mod.rs
+++ b/crates/kornia-io/src/gstreamer/mod.rs
@@ -138,7 +138,7 @@ pub(crate) fn image_from_gst_buffer(
     // - We verified `data_len >= expected_len` above, preventing out-of-bounds reads.
     // - `keepalive` (GstResource) holds the map alive for the lifetime of the Image.
     let image = unsafe {
-        Image::<u8, 3>::from_borrowed_host(size, data_ptr, keepalive)
+        Image::<u8, 3>::from_borrowed_host_readonly(size, data_ptr, keepalive)
             .map_err(crate::stream::error::StreamCaptureError::ImageError)?
     };
 

--- a/crates/kornia-io/src/gstreamer/mod.rs
+++ b/crates/kornia-io/src/gstreamer/mod.rs
@@ -26,6 +26,7 @@ pub use crate::stream::video::VideoWriter;
 use std::any::Any;
 use std::sync::Arc;
 
+use kornia_image::Image;
 use kornia_tensor::resource::{MemoryDomain, MemoryResource};
 
 /// A proper [`MemoryResource`] for a GStreamer-mapped buffer (sysmem).
@@ -100,9 +101,6 @@ pub(crate) fn image_from_gst_buffer(
     size: kornia_image::ImageSize,
     mapped_buffer: gstreamer::buffer::MappedBuffer<gstreamer::buffer::Readable>,
 ) -> Result<kornia_image::Image<u8, 3>, crate::stream::error::StreamCaptureError> {
-    use kornia_tensor::storage::{MemoryDomain, TensorStorage};
-    use kornia_tensor::Tensor;
-
     // Capture pointer and length BEFORE moving mapped_buffer into GstResource.
     let data_ptr: *const u8 = mapped_buffer.as_ptr();
     let data_len: usize = mapped_buffer.len();
@@ -135,36 +133,12 @@ pub(crate) fn image_from_gst_buffer(
     };
     let keepalive: Arc<dyn Any + Send + Sync> = Arc::new(resource);
 
-    // Build a TensorStorage that borrows the gst memory and holds the keepalive.
-    // SAFETY:
-    //   - data_ptr is non-null (gst sysmem buffers are always non-null).
-    //   - data_len equals the mapped size (captured above from mapped_buffer.len()).
-    //   - The memory is host-accessible (MemoryDomain::Host).
-    //   - The keepalive (Arc<GstResource>) holds the map alive for the storage's lifetime.
-    //   - The storage is read-only: `as_mut_slice` will panic (GstMappedBuffer is Readable).
-    let storage: TensorStorage<u8> = unsafe {
-        TensorStorage::from_borrowed_readonly(
-            data_ptr,
-            data_len,
-            kornia_tensor::host_alloc(),
-            MemoryDomain::Host,
-            keepalive,
-        )
+    let image = unsafe {
+        Image::<u8, 3>::from_borrowed_host(size, data_ptr, keepalive)
+            .map_err(crate::stream::error::StreamCaptureError::ImageError)?
     };
 
-    // Row-major strides for shape [H, W, 3]: strides = [W*3, 3, 1].
-    // We compute this inline since `get_strides_from_shape` is pub(crate) in kornia-tensor.
-    let shape = [size.height, size.width, 3_usize];
-    let strides = [size.width * 3, 3, 1];
-    let tensor = Tensor {
-        storage,
-        shape,
-        strides,
-    };
-
-    // TryFrom<Tensor3<T, >> for Image<T, C> validates that shape[2] == C (== 3).
-    kornia_image::Image::try_from(tensor)
-        .map_err(crate::stream::error::StreamCaptureError::ImageError)
+    Ok(image)
 }
 
 #[cfg(test)]

--- a/crates/kornia-io/src/gstreamer/mod.rs
+++ b/crates/kornia-io/src/gstreamer/mod.rs
@@ -133,6 +133,10 @@ pub(crate) fn image_from_gst_buffer(
     };
     let keepalive: Arc<dyn Any + Send + Sync> = Arc::new(resource);
 
+    // SAFETY:
+    // - `data_ptr` is non-null as GStreamer sysmem buffers are always non-null.
+    // - We verified `data_len >= expected_len` above, preventing out-of-bounds reads.
+    // - `keepalive` (GstResource) holds the map alive for the lifetime of the Image.
     let image = unsafe {
         Image::<u8, 3>::from_borrowed_host(size, data_ptr, keepalive)
             .map_err(crate::stream::error::StreamCaptureError::ImageError)?

--- a/crates/kornia-io/src/v4l/mod.rs
+++ b/crates/kornia-io/src/v4l/mod.rs
@@ -111,7 +111,7 @@ pub(crate) fn image_from_v4l_buffer(
 
     if data_len < expected_len {
         return Err(kornia_image::ImageError::InvalidImageShape(
-            kornia_tensor::TensorError::InvalidShape(expected_len)
+            kornia_tensor::TensorError::InvalidShape(expected_len),
         ));
     }
 
@@ -119,9 +119,7 @@ pub(crate) fn image_from_v4l_buffer(
     let resource = V4lResource { buffer };
     let keepalive: Arc<dyn Any + Send + Sync> = Arc::new(resource);
 
-    let image = unsafe{
-        Image::<u8, 3>::from_borrowed_host_readonly(size, data_ptr, keepalive)?
-    };
+    let image = unsafe { Image::<u8, 3>::from_borrowed_host_readonly(size, data_ptr, keepalive)? };
 
     Ok(image)
 }

--- a/crates/kornia-io/src/v4l/mod.rs
+++ b/crates/kornia-io/src/v4l/mod.rs
@@ -107,7 +107,7 @@ pub(crate) fn image_from_v4l_buffer(
         .width
         .checked_mul(size.height)
         .and_then(|n| n.checked_mul(3))
-        .expect("Image dimensions overflow");
+        .ok_or(kornia_tensor::TensorError::ShapeOverflow)?;
 
     if data_len < expected_len {
         return Err(kornia_image::ImageError::InvalidImageShape(

--- a/crates/kornia-io/src/v4l/mod.rs
+++ b/crates/kornia-io/src/v4l/mod.rs
@@ -107,7 +107,7 @@ pub(crate) fn image_from_v4l_buffer(
         .width
         .checked_mul(size.height)
         .and_then(|n| n.checked_mul(3))
-        .ok_or(kornia_tensor::TensorError::ShapeOverflow)?;
+        .ok_or(kornia_tensor::TensorError::InvalidShape(usize::MAX))?;
 
     if data_len < expected_len {
         return Err(kornia_image::ImageError::InvalidImageShape(

--- a/crates/kornia-io/src/v4l/mod.rs
+++ b/crates/kornia-io/src/v4l/mod.rs
@@ -9,7 +9,7 @@ pub use pixel_format::PixelFormat;
 pub use stream::MmapBuffer;
 
 use crate::v4l::camera_control::{CameraControlTrait, ControlType};
-use kornia_image::ImageSize;
+use kornia_image::{Image, ImageSize};
 use v4l::{
     buffer::Type, control::Value, video::capture::Parameters, video::Capture, Device, Timestamp,
 };
@@ -98,45 +98,32 @@ pub(crate) fn image_from_v4l_buffer(
     size: kornia_image::ImageSize,
     buffer: MmapBuffer,
 ) -> Result<kornia_image::Image<u8, 3>, kornia_image::ImageError> {
-    use kornia_tensor::storage::TensorStorage;
-    use kornia_tensor::Tensor;
-
     // Capture pointer and length BEFORE moving buffer into V4lResource.
     let data_ptr: *const u8 = buffer.as_slice().as_ptr();
     let data_len: usize = buffer.len();
+
+    // Defense-in-depth: verify the mapped buffer is actually large enough
+    let expected_len = size
+        .width
+        .checked_mul(size.height)
+        .and_then(|n| n.checked_mul(3))
+        .expect("Image dimensions overflow");
+
+    if data_len < expected_len {
+        return Err(kornia_image::ImageError::InvalidImageShape(
+            kornia_tensor::TensorError::InvalidShape(expected_len)
+        ));
+    }
 
     // Move the MmapBuffer into a V4lResource; its implicit Drop releases the mmap.
     let resource = V4lResource { buffer };
     let keepalive: Arc<dyn Any + Send + Sync> = Arc::new(resource);
 
-    // Build a TensorStorage that borrows the mmap memory and holds the keepalive.
-    // SAFETY:
-    //   - data_ptr is non-null (kernel mmap always returns a valid page-aligned address).
-    //   - data_len equals the "used bytes" of the frame (captured above).
-    //   - The memory is host-accessible (MemoryDomain::Host).
-    //   - The keepalive (Arc<V4lResource>) holds the MmapBuffer (and Arc<MmapInfo>) alive.
-    //   - The storage is read-only: `as_mut_slice` will panic (v4l mmap is read-only mapped memory).
-    let storage: TensorStorage<u8> = unsafe {
-        TensorStorage::from_borrowed_readonly(
-            data_ptr,
-            data_len,
-            kornia_tensor::host_alloc(),
-            MemoryDomain::Host,
-            keepalive,
-        )
+    let image = unsafe{
+        Image::<u8, 3>::from_borrowed_host_readonly(size, data_ptr, keepalive)?
     };
 
-    // Row-major strides for shape [H, W, 3]: strides = [W*3, 3, 1].
-    let shape = [size.height, size.width, 3_usize];
-    let strides = [size.width * 3, 3, 1];
-    let tensor = Tensor {
-        storage,
-        shape,
-        strides,
-    };
-
-    // TryFrom<Tensor3<T, >> for Image<T, C> validates that shape[2] == C (== 3).
-    kornia_image::Image::try_from(tensor)
+    Ok(image)
 }
 
 /// Error types for the v4l2 module.

--- a/crates/kornia-tensor/src/dlpack.rs
+++ b/crates/kornia-tensor/src/dlpack.rs
@@ -250,6 +250,11 @@ where
     // the source alive, domain correctly reflects the DLDevice.
     let data_ptr = unsafe { (dl.data as *const u8).add(byte_offset) as *const T };
 
+    // SAFETY:
+    // - `byte_offset` arithmetic is within bounds of the allocated tensor data per DLPack spec.
+    // - `data_ptr` is valid for `n_elems` elements of type `T` (guaranteed by the caller contract of this function).
+    // - `domain` correctly reflects the physical location of the memory (CPU vs GPU).
+    // - `keepalive` retains ownership of the underlying `DLManagedTensor`, ensuring the memory outlives the returned Tensor.
     let tensor = unsafe {
         Tensor::<T, N>::from_borrowed(shape, data_ptr, n_elems, domain, keepalive)
             .map_err(|_| DlpackError::Overflow)? // If shape != len, though mathematically impossible here

--- a/crates/kornia-tensor/src/dlpack.rs
+++ b/crates/kornia-tensor/src/dlpack.rs
@@ -13,7 +13,6 @@ use dlpack_rs::{
 };
 
 use crate::{
-    allocator::host_alloc,
     storage::MemoryDomain,
     tensor::{Tensor, TensorError},
 };
@@ -239,9 +238,6 @@ where
         .iter()
         .try_fold(1usize, |a, &d| a.checked_mul(d))
         .ok_or(DlpackError::Overflow)?;
-    let len_bytes = n_elems
-        .checked_mul(std::mem::size_of::<T>())
-        .ok_or(DlpackError::Overflow)?;
 
     // Map device (the device id is encoded in the returned domain).
     let (domain, _) = map_dl_device(dl.device);
@@ -253,23 +249,13 @@ where
     // SAFETY: data pointer is valid for len_bytes (caller contract), keepalive keeps
     // the source alive, domain correctly reflects the DLDevice.
     let data_ptr = unsafe { (dl.data as *const u8).add(byte_offset) as *const T };
-    let storage = unsafe {
-        crate::storage::TensorStorage::from_borrowed(
-            data_ptr,
-            len_bytes,
-            host_alloc(),
-            domain,
-            keepalive,
-        )
+
+    let tensor = unsafe {
+        Tensor::<T, N>::from_borrowed(shape, data_ptr, n_elems, domain, keepalive)
+            .map_err(|_| DlpackError::Overflow)? // If shape != len, though mathematically impossible here
     };
 
-    // Build tensor.
-    let strides = crate::tensor::get_strides_from_shape(shape);
-    Ok(Tensor {
-        storage,
-        shape,
-        strides,
-    })
+    Ok(tensor)
 }
 
 /// Maps a `DLDevice` to `(MemoryDomain, device_id)`.

--- a/crates/kornia-tensor/src/tensor.rs
+++ b/crates/kornia-tensor/src/tensor.rs
@@ -36,6 +36,10 @@ pub enum TensorError {
     /// Unsupported operation for the given data type or tensor configuration.
     #[error("Unsupported operation: {0}")]
     UnsupportedOperation(String),
+
+    /// The computed tensor dimensions exceed the maximum capacity of usize.
+    #[error("The computed tensor dimensions exceed the maximum capacity of usize")]
+    ShapeOverflow,
 }
 
 /// Computes the strides for a row-major (C-contiguous) tensor layout.

--- a/crates/kornia-tensor/src/tensor.rs
+++ b/crates/kornia-tensor/src/tensor.rs
@@ -36,10 +36,6 @@ pub enum TensorError {
     /// Unsupported operation for the given data type or tensor configuration.
     #[error("Unsupported operation: {0}")]
     UnsupportedOperation(String),
-
-    /// The computed tensor dimensions exceed the maximum capacity of usize.
-    #[error("The computed tensor dimensions exceed the maximum capacity of usize")]
-    ShapeOverflow,
 }
 
 /// Computes the strides for a row-major (C-contiguous) tensor layout.

--- a/crates/kornia-tensor/src/tensor.rs
+++ b/crates/kornia-tensor/src/tensor.rs
@@ -1,5 +1,9 @@
 use thiserror::Error;
 
+use crate::resource::MemoryDomain;
+use std::any::Any;
+use std::sync::Arc;
+
 use super::{
     allocator::{host_alloc, AllocHandle, TensorAllocatorError},
     storage::TensorStorage,
@@ -405,6 +409,99 @@ impl<T, const N: usize> Tensor<T, N> {
             shape,
             strides,
         }
+    }
+
+    /// Creates a tensor from a foreign borrowed buffer with zero-copy.
+    ///
+    /// The `keepalive` argument ensures that the external owner of the memory
+    /// (e.g., a GStreamer buffer or C++ reference count) is not dropped until
+    /// this tensor and all its views are destroyed.
+    ///
+    /// # Arguments
+    ///
+    /// * `shape` - An array containing the shape of the tensor.
+    /// * `data` - A pointer to the data of the tensor.
+    /// * `len` - The length of the data.
+    /// * `keepalive` - A thread safe pointer to the host buffer.
+    ///
+    /// # Safety
+    ///
+    /// - `data` must point to valid memory containing at least `len` elements of `T`.
+    /// - The memory must remain valid for the lifetime of `keepalive`.
+    pub unsafe fn from_borrowed_host(
+        shape: [usize; N],
+        data: *const T,
+        len: usize,
+        keepalive: Arc<dyn Any + Send + Sync>,
+    ) -> Result<Self, TensorError> {
+        let expected_len = shape.iter().product::<usize>();
+        if expected_len != len {
+            return Err(TensorError::InvalidShape(expected_len));
+        }
+
+        let len_bytes = len * std::mem::size_of::<T>();
+
+        let storage = TensorStorage::from_borrowed(
+            data,
+            len_bytes,
+            host_alloc(),
+            MemoryDomain::Host,
+            keepalive,
+        );
+
+        let strides = get_strides_from_shape(shape);
+
+        Ok(Self {
+            storage,
+            shape,
+            strides,
+        })
+    }
+
+    /// Creates a read-only tensor from a foreign borrowed buffer with zero-copy.
+    ///
+    /// Similar to `from_borrowed_host`, but strictly forbids mutable access
+    /// to the underlying foreign memory slice.
+    ///
+    /// # Arguments
+    ///
+    /// * `shape` - An array containing the shape of the tensor.
+    /// * `data` - A pointer to the data of the tensor.
+    /// * `len` - The length of the data.
+    /// * `keepalive` - A thread safe pointer to the host buffer.
+    ///
+    /// # Safety
+    ///
+    /// - `data` must point to valid memory containing at least `len` elements of `T`.
+    /// - The memory must remain valid for the lifetime of `keepalive`.
+    pub unsafe fn from_borrowed_host_readonly(
+        shape: [usize; N],
+        data: *const T,
+        len: usize,
+        keepalive: Arc<dyn Any + Send + Sync>,
+    ) -> Result<Self, TensorError> {
+        let expected_len = shape.iter().product::<usize>();
+        if expected_len != len {
+            return Err(TensorError::InvalidShape(expected_len));
+        }
+
+        let len_bytes = len * std::mem::size_of::<T>();
+
+        let storage = TensorStorage::from_borrowed_readonly(
+            data,
+            len_bytes,
+            host_alloc(),
+            MemoryDomain::Host,
+            keepalive,
+        );
+
+        let strides = get_strides_from_shape(shape);
+
+        Ok(Self {
+            storage,
+            shape,
+            strides,
+        })
     }
 
     /// Returns the number of elements in the tensor.
@@ -990,8 +1087,115 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::any::Any;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
     use crate::allocator::host_alloc;
     use crate::tensor::{Tensor, TensorError};
+
+    struct MockForeignBuffer {
+        ptr: *mut f32,
+        len: usize,
+        is_dropped: Arc<AtomicBool>,
+    }
+
+    unsafe impl Send for MockForeignBuffer {}
+    unsafe impl Sync for MockForeignBuffer {}
+
+    impl MockForeignBuffer {
+        fn new(data: Vec<f32>, flag: Arc<AtomicBool>) -> Self {
+            let mut leaked_data = std::mem::ManuallyDrop::new(data);
+
+            Self {
+                ptr: leaked_data.as_mut_ptr(),
+                len: leaked_data.len(),
+                is_dropped: flag,
+            }
+        }
+    }
+
+    impl Drop for MockForeignBuffer {
+        fn drop(&mut self) {
+            unsafe {
+                let _ = Vec::from_raw_parts(self.ptr, self.len, self.len);
+            }
+
+            self.is_dropped.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn test_borrowed_host_lifecycle() -> Result<(), TensorError> {
+        let dropped_flag = Arc::new(AtomicBool::new(false));
+        let buffer = MockForeignBuffer::new(vec![1.0, 2.0, 3.00, 4.0], dropped_flag.clone());
+        let ptr = buffer.ptr as *const f32;
+        let len = buffer.len;
+
+        let keepalive: Arc<dyn Any + Send + Sync> = Arc::new(buffer);
+
+        {
+            let tensor = unsafe {
+                Tensor::<f32, 2>::from_borrowed_host([2, 2], ptr, len, keepalive.clone())?
+            };
+
+            drop(keepalive);
+
+            assert!(!dropped_flag.load(Ordering::SeqCst));
+            assert_eq!(tensor.shape, [2, 2]);
+            assert_eq!(tensor.as_slice(), &[1.0, 2.0, 3.0, 4.0]);
+            assert_eq!(tensor.strides, [2, 1]);
+        }
+
+        assert!(dropped_flag.load(Ordering::SeqCst));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_borrowed_host_readonly_reads() -> Result<(), TensorError> {
+        let data = vec![1.0, 2.0, 3.0, 4.0];
+        let ptr = data.as_ptr();
+        let keepalive: Arc<dyn Any + Send + Sync> = Arc::new(data);
+
+        let tensor =
+            unsafe { Tensor::<f32, 2>::from_borrowed_host_readonly([2, 2], ptr, 4, keepalive)? };
+
+        assert_eq!(tensor.as_slice(), &[1.0, 2.0, 3.0, 4.0]);
+        Ok(())
+    }
+
+    #[test]
+    #[should_panic(expected = "read-only")]
+    fn test_borrowed_host_readonly_prevents_mutation() {
+        let data = vec![1.0, 2.0, 3.0, 4.0];
+        let ptr = data.as_ptr();
+        let keepalive: Arc<dyn Any + Send + Sync> = Arc::new(data);
+
+        let mut tensor = unsafe {
+            Tensor::<f32, 2>::from_borrowed_host_readonly([2, 2], ptr, 4, keepalive).unwrap()
+        };
+
+        let _mut_slice = tensor.as_slice_mut();
+    }
+
+    #[test]
+    fn test_borrowed_host_shape_mismatch() -> Result<(), TensorError> {
+        let dropped_flag = Arc::new(AtomicBool::new(false));
+        let buffer = MockForeignBuffer::new(vec![5.0, 6.0], dropped_flag.clone());
+        let ptr = buffer.ptr as *const f32;
+        let keepalive: Arc<dyn Any + Send + Sync> = Arc::new(buffer);
+
+        let result =
+            unsafe { Tensor::<f32, 1>::from_borrowed_host([3], ptr, 2, keepalive.clone()) };
+
+        assert!(
+            matches!(result, Err(TensorError::InvalidShape(3))),
+            "Expected InvalidShape(4) error"
+        );
+
+        Ok(())
+    }
 
     #[test]
     fn constructor_1d() -> Result<(), TensorError> {

--- a/crates/kornia-tensor/src/tensor.rs
+++ b/crates/kornia-tensor/src/tensor.rs
@@ -411,6 +411,50 @@ impl<T, const N: usize> Tensor<T, N> {
         }
     }
 
+    /// Creates a tensor from a foreign borrowed buffer with zero-copy, specifying its memory domain.
+    ///
+    /// The `keepalive` argument ensures that the external owner of the memory
+    /// (e.g., a GStreamer buffer or C++ reference count) is not dropped until
+    /// this tensor and all its views are destroyed.
+    ///
+    /// # Arguments
+    ///
+    /// * `shape` - An array containing the shape of the tensor.
+    /// * `data` - A pointer to the data of the tensor.
+    /// * `len` - The length of the data.
+    /// * `domain` - The memory domain (Host or Device) where the data resides.
+    /// * `keepalive` - A thread safe pointer to the host buffer.
+    ///
+    /// # Safety
+    ///
+    /// - `data` must point to valid memory containing at least `len` elements of `T`.
+    /// - The memory must remain valid for the lifetime of `keepalive`.
+    pub unsafe fn from_borrowed(
+        shape: [usize; N],
+        data: *const T,
+        len: usize,
+        domain: MemoryDomain,
+        keepalive: Arc<dyn Any + Send + Sync>,
+    ) -> Result<Self, TensorError> {
+        let expected_len = shape.iter().product::<usize>();
+        if expected_len != len {
+            return Err(TensorError::InvalidShape(expected_len));
+        }
+
+        let len_bytes = len * std::mem::size_of::<T>();
+
+        let storage =
+            TensorStorage::from_borrowed(data, len_bytes, host_alloc(), domain, keepalive);
+
+        let strides = get_strides_from_shape(shape);
+
+        Ok(Self {
+            storage,
+            shape,
+            strides,
+        })
+    }
+
     /// Creates a tensor from a foreign borrowed buffer with zero-copy.
     ///
     /// The `keepalive` argument ensures that the external owner of the memory
@@ -434,6 +478,33 @@ impl<T, const N: usize> Tensor<T, N> {
         len: usize,
         keepalive: Arc<dyn Any + Send + Sync>,
     ) -> Result<Self, TensorError> {
+        Self::from_borrowed(shape, data, len, MemoryDomain::Host, keepalive)
+    }
+
+    /// Creates a read-only tensor from a foreign borrowed buffer with zero-copy, specifying its memory domain.
+    ///
+    /// Similar to `from_borrowed_host`, but strictly forbids mutable access
+    /// to the underlying foreign memory slice.
+    ///
+    /// # Arguments
+    ///
+    /// * `shape` - An array containing the shape of the tensor.
+    /// * `data` - A pointer to the data of the tensor.
+    /// * `len` - The length of the data.
+    /// * `domain` - The memory domain (Host or Device) where the data resides.
+    /// * `keepalive` - A thread safe pointer to the host buffer.
+    ///
+    /// # Safety
+    ///
+    /// - `data` must point to valid memory containing at least `len` elements of `T`.
+    /// - The memory must remain valid for the lifetime of `keepalive`.
+    pub unsafe fn from_borrowed_readonly(
+        shape: [usize; N],
+        data: *const T,
+        len: usize,
+        domain: MemoryDomain,
+        keepalive: Arc<dyn Any + Send + Sync>,
+    ) -> Result<Self, TensorError> {
         let expected_len = shape.iter().product::<usize>();
         if expected_len != len {
             return Err(TensorError::InvalidShape(expected_len));
@@ -441,13 +512,8 @@ impl<T, const N: usize> Tensor<T, N> {
 
         let len_bytes = len * std::mem::size_of::<T>();
 
-        let storage = TensorStorage::from_borrowed(
-            data,
-            len_bytes,
-            host_alloc(),
-            MemoryDomain::Host,
-            keepalive,
-        );
+        let storage =
+            TensorStorage::from_borrowed_readonly(data, len_bytes, host_alloc(), domain, keepalive);
 
         let strides = get_strides_from_shape(shape);
 
@@ -480,28 +546,7 @@ impl<T, const N: usize> Tensor<T, N> {
         len: usize,
         keepalive: Arc<dyn Any + Send + Sync>,
     ) -> Result<Self, TensorError> {
-        let expected_len = shape.iter().product::<usize>();
-        if expected_len != len {
-            return Err(TensorError::InvalidShape(expected_len));
-        }
-
-        let len_bytes = len * std::mem::size_of::<T>();
-
-        let storage = TensorStorage::from_borrowed_readonly(
-            data,
-            len_bytes,
-            host_alloc(),
-            MemoryDomain::Host,
-            keepalive,
-        );
-
-        let strides = get_strides_from_shape(shape);
-
-        Ok(Self {
-            storage,
-            shape,
-            strides,
-        })
+        Self::from_borrowed_readonly(shape, data, len, MemoryDomain::Host, keepalive)
     }
 
     /// Returns the number of elements in the tensor.


### PR DESCRIPTION
## 📝 Description
This PR implements functions that allow `kornia-tensor` to construct tensors using borrowed buffers which intern acts as helper functions for similar constructors for the `kornia-image` crate.
Several tests to ensure tensor storage safety after buffer buffer is dropped and also read-only insurance have also been added.
The functions introduced, accept a `keepalive: Arc<dyn Any + Send + Sync>` reference from the foreign buffer for ensuring that the Image/Tensor produced lives as long as the borrowed buffer does.
Additionally this PR also updates the previously recurring code in `crates/kornia-io/src/v4l/mod.rs` `crates/kornia-io/src/gstreamer/mod.rs` and `crates/kornia-image/src/dlpack.rs`.

**Fixes/Relates to:** #1045 

---

## 🛠️ Changes Made
- Implemented `from_borrowed_host` and `from_borrowed_host_readonly`.
- Added approporiate docs
- Implemented `MockForeignBuffer`, `test_borrowed_host_lifecycle`, `test_borrowed_host_readonly_reads`, `test_borrowed_host_readonly_prevents_mutation`, `test_borrowed_host_shape_mismatch`.
- Implemented `from_borrowed_host` and `from_borrowed_host_readonly`.
- Implemented `MockForeignBuffer`, `test_image_borrowed_host_lifecycle`, `test_image_borrowed_host_readonly_reads`, `test_image_borrowed_host_readonly_prevents_mutation`.
- Created updated forms of `from_borrowed` and `from_borrowed_readonly` functions to include a domain field.
- refactored `from_borrowed_host` and `from_borrowed_host_readonly` to wrappers.
- refactored `image_from_v4l_buffer` , `image_from_gst_buffer` , `tensor_from_dlpack_raw` to use then new `from_borrowed` impls.

---

## 🧪 How Was This Tested?
- [x] **Unit Tests:** (List new/updated tests)
- [x] **Manual Verification:** (Describe the steps you took)

---

## 🕵️ AI Usage Disclosure
*Check one of the following:*
- [ ] 🟢 **No AI used.**
- [x] 🟡 **AI-assisted:** I used AI for boilerplate/refactoring but have manually reviewed and tested every line.
- [ ] 🔴 **AI-generated:**

---

## 🚦 Checklist
- [ ] I am assigned to the linked issue (required before PR submission)
- [ ] The linked issue has been approved by a maintainer
- [x] This PR strictly implements what the linked issue describes (no scope creep)
- [x] I have performed a **self-review** of my code (no "ghost" variables or hallucinations).
- [x] My code follows the existing style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] (Optional) I have attached screenshots/recordings for UI changes.

---

## 💭 Additional Context
Add any other context or screenshots about the pull request here.
