### PR TITLE
fix: recurse into functions/methods so doctests are actually collected

### DIFF
--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -3,6 +3,7 @@ import pytest
 import kornia_rs
 import inspect
 
+
 def get_testable_objects(mod):
     """Recursively discover all objects with docstrings in the compiled module."""
     objects = []
@@ -14,10 +15,15 @@ def get_testable_objects(mod):
         seen.add(id(obj))
 
         # 1. Add object if it has a docstring
-        if hasattr(obj, "__doc__") and obj.__doc__:
+        if getattr(obj, "__doc__", None):
             objects.append((obj, name_prefix))
 
-        # 2. Inspect members
+        # 2. Routines (functions/methods/builtins) have no further members
+        #    worth recursing into.
+        if inspect.isroutine(obj):
+            return
+
+        # 3. Inspect members (modules, classes, etc.)
         for name in dir(obj):
             if name.startswith("_"):
                 continue
@@ -30,14 +36,20 @@ def get_testable_objects(mod):
             # Check if member belongs to kornia_rs
             mod_name = getattr(member, "__module__", None)
             if mod_name and "kornia_rs" in mod_name:
-                if inspect.ismodule(member) or inspect.isclass(member):
-                     recurse(member, f"{name_prefix}.{name}")
+                if (
+                    inspect.ismodule(member)
+                    or inspect.isclass(member)
+                    or inspect.isroutine(member)
+                ):
+                    recurse(member, f"{name_prefix}.{name}")
 
     recurse(mod, "kornia_rs")
     return objects
 
+
 # Collect objects once
 TEST_OBJECTS = get_testable_objects(kornia_rs)
+
 
 @pytest.mark.parametrize("obj, name", TEST_OBJECTS)
 def test_docstrings(obj, name):
@@ -51,6 +63,11 @@ def test_docstrings(obj, name):
 
     # Create the test
     test = parser.get_doctest(obj.__doc__, globs, name, name, 0)
+
+    # Skip docstrings with no doctest examples instead of letting them
+    # silently "pass" with 0 assertions run.
+    if not test.examples:
+        pytest.skip(f"No doctest examples found for {name}.")
 
     # Run it
     runner.run(test)


### PR DESCRIPTION
get_testable_objects() only recursed into module and class members when walking kornia_rs, so any docstring living on a standalone function or method was never collected — and therefore never run as a doctest. For a PyO3/rust-binding module like this, most of the actual >>> examples likely live on function/method docstrings, so this test suite was giving a false sense of coverage: it looked comprehensive but was largely only exercising module- and class-level docstrings.

This PR fixes discovery and tightens the pass/fail signal.

Changes
Recurse into routines. recurse() now also descends into members where inspect.isroutine(member) is true (functions, methods, builtins), not just ismodule/isclass. Routines have no further members worth walking, so recursion stops there.
Skip empty doctests instead of trivially passing. parser.get_doctest() doesn't raise on a docstring with zero >>> examples — it returns a DocTest with an empty example list, and the test would previously report as passed with 0 assertions actually run. test_docstrings now calls pytest.skip(...) in that case, so "no examples found" is visible and distinguishable from "examples ran and passed."
Minor cleanup: hasattr(obj, "__doc__") and obj.__doc__ → getattr(obj, "__doc__", None) (equivalent, just tidier).
Why

Before this fix, adding a broken >>> example to a function's docstring would not fail CI, because that docstring was never collected in the first place. After this fix, it will show up as a parametrized test case and fail as expected.

Testing
Verified the patched file is syntactically valid.
Ran the existing test file against kornia_rs locally; TEST_OBJECTS now includes function/method entries that were previously absent, and skipped entries are reported as skips rather than passes.