### PR TITLE
fix(imgproc,py): address post-merge review on the remap kernel

### DIFF
--- a/crates/kornia-imgproc/src/cuda/remap.rs
+++ b/crates/kornia-imgproc/src/cuda/remap.rs
@@ -341,7 +341,7 @@ pub fn launch_remap_nearest_cuda(
     )
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "cuda"))]
 mod tests {
     use super::*;
     use crate::cuda::color::test_utils::{default_stream, pattern_f32};
@@ -431,7 +431,6 @@ mod tests {
 
     /// Identity map: GPU output must reproduce the source exactly and match CPU.
     #[test]
-    #[ignore = "requires CUDA"]
     fn remap_identity_bilinear() {
         let (w, h) = (65, 33);
         let mx: Vec<f32> = (0..h).flat_map(|_| (0..w).map(|x| x as f32)).collect();
@@ -440,7 +439,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "requires CUDA"]
     fn remap_identity_nearest() {
         let (w, h) = (65, 33);
         let mx: Vec<f32> = (0..h).flat_map(|_| (0..w).map(|x| x as f32)).collect();
@@ -451,7 +449,6 @@ mod tests {
     /// Sub-pixel bilinear: non-integer source coordinates in the image interior —
     /// exercises the weight expression against bilinear_interpolation's shape.
     #[test]
-    #[ignore = "requires CUDA"]
     fn remap_subpixel_bilinear() {
         let (w, h) = (97, 65);
         // Each output pixel maps to (x+0.3, y+0.4); clamped to keep both taps
@@ -468,7 +465,6 @@ mod tests {
 
     /// OOB coordinates must produce 0 on GPU; verifies the border guard.
     #[test]
-    #[ignore = "requires CUDA"]
     fn remap_oob_writes_zero() {
         let (w, h) = (32, 32);
         let mx = vec![-5.0f32; w * h];

--- a/crates/kornia-imgproc/src/interpolation/remap.rs
+++ b/crates/kornia-imgproc/src/interpolation/remap.rs
@@ -297,21 +297,18 @@ mod cuda_tests {
     }
 
     #[test]
-    #[ignore = "requires CUDA"]
     fn public_remap_device_equals_host() -> Result<(), ImageError> {
         check_remap_mode(InterpolationMode::Bilinear)
     }
 
     /// Nearest-neighbor device path is bit-identical to host.
     #[test]
-    #[ignore = "requires CUDA"]
     fn public_remap_nearest_device_equals_host() -> Result<(), ImageError> {
         check_remap_mode(InterpolationMode::Nearest)
     }
 
     /// Mixed residency — device src/dst but host maps — must be a typed error.
     #[test]
-    #[ignore = "requires CUDA"]
     fn device_images_with_host_maps_is_error() -> Result<(), ImageError> {
         let stream = default_stream();
         let (w, h) = (16, 16);

--- a/kornia-py/src/resize.rs
+++ b/kornia-py/src/resize.rs
@@ -1,8 +1,6 @@
 use pyo3::prelude::*;
 
 use crate::dispatch::cpu_op;
-#[cfg(feature = "cuda")]
-use crate::image::PyImageApi;
 use crate::image::{alloc_output_pyarray, numpy_as_image, parse_interpolation, to_pyerr};
 use kornia_image::ImageSize;
 use kornia_imgproc::resize::resize_fast_rgb_aa;
@@ -15,6 +13,10 @@ use kornia_imgproc::resize::resize_fast_rgb_aa;
 /// loops allocate nothing; a host `Image` or numpy u8 array runs the CPU
 /// fast path. `antialias` shapes the u8 bicubic/lanczos kernels (CPU and
 /// GPU alike); the f32 paths have never antialiased.
+///
+/// The `Image` API itself is not CUDA-specific: a host `Image` is accepted on
+/// a CPU-only build too, where `cpu_op` runs it on its numpy view and returns
+/// an `Image`. Only the device branch below is feature-gated.
 #[pyfunction]
 #[pyo3(signature = (image, new_size, interpolation, antialias=true, out=None))]
 pub fn resize(


### PR DESCRIPTION
## 📝 Description

**Fixes/Relates to:** no issue — these are direct follow-ups to the review comments left on #998 after it merged.

Two small, independent fixes, both from that review.

### 1. Gate the CUDA remap tests by feature, not `#[ignore]`

> We shouldn't ignore but be under a feature flag with cuda

The ignores never gated anything. `cuda::remap`'s test module sits inside `#[cfg(feature = "cuda")] pub mod cuda;`, and `interpolation::remap::cuda_tests` is already `#[cfg(all(test, feature = "cuda"))]` — the tests only compile when the feature is on, so `#[ignore]` on top of that just stopped them from ever running.

The geometry siblings already do it this way: `cuda/resize.rs`, `cuda/warp_affine.rs` and `cuda/warp_perspective.rs` all use `#[cfg(all(test, feature = "cuda"))]` with no ignores. Remap was the only outlier, so `cuda/remap.rs` is now gated the same way.

The 9 tests this re-enables include the bit-exact device-vs-host parity checks, which a plain `cargo test --features cuda` previously skipped.

### 2. Don't feature-gate the Image API in `kornia-py`

> I don't think this is correct as the image api should support both cpu and cuda

Agreed — and that specific line was dead code. `resize.rs` had

```rust
#[cfg(feature = "cuda")]
use crate::image::PyImageApi;
```

while the only use site spells the path in full (`image.cast::<crate::image::PyImageApi>()`). The import did nothing except imply the Image API is GPU-only. It isn't: a host `Image` goes through `cpu_op`, which handles numpy and host `Image` identically regardless of the feature. `warp.rs`, which has the same dispatch shape, never had this import.

Removed, with a short note on `resize` recording that only the device branch is feature-gated.

---

## 🛠️ Changes Made
- [x] Removed all 7 `#[ignore = "requires CUDA"]` attributes across `cuda/remap.rs` (4) and `interpolation/remap.rs` (3)
- [x] Changed `cuda/remap.rs`'s test module from `#[cfg(test)]` to `#[cfg(all(test, feature = "cuda"))]`, matching the resize/warp modules
- [x] Removed the unused `#[cfg(feature = "cuda")] use crate::image::PyImageApi;` from `kornia-py/src/resize.rs` and documented that only the device branch is gated

---

## 🧪 How Was This Tested?
- [x] **Unit Tests:** No new tests — this makes 9 existing ones actually run. `cargo test -p kornia-imgproc --features cuda --lib remap` → `9 passed; 0 failed; 0 ignored` on a GTX 1650 (sm_75), covering `public_remap_device_equals_host`, `public_remap_nearest_device_equals_host`, `device_images_with_host_maps_is_error`, `remap_identity_bilinear`, `remap_identity_nearest`, `remap_subpixel_bilinear`, `remap_oob_writes_zero`, plus the two CPU tests.
- [x] **Manual Verification:** `cargo check -p kornia-py --all-targets` and `cargo check -p kornia-py --features cuda --all-targets` both clean — the point of change 2 is that the CPU-only build must still accept a host `Image`, so both configurations were checked.
- [x] **Performance/Edge Cases:** No runtime behaviour changes; this is test gating plus a dead import. The re-enabled parity tests are themselves the edge-case coverage (odd sizes 65×33, out-of-bounds map coordinates, sub-pixel weights, mixed host/device residency).

Also run: `cargo clippy -p kornia-imgproc --features cuda --all-targets -- -D warnings` and `cargo fmt --all --check`, both clean.

---

## 🕵️ AI Usage Disclosure
*Check one of the following:*
- [ ] 🟢 **No AI used.**
- [x] 🟡 **AI-assisted:** I used AI for boilerplate/refactoring but have manually reviewed and tested every line.
- [ ] 🔴 **AI-generated:** (Note: These PRs may be subject to stricter scrutiny or immediate closure if the logic is not explained).

---

## 🚦 Checklist
- [ ] I am assigned to the linked issue (required before PR submission)
- [ ] The linked issue has been approved by a maintainer
- [x] This PR strictly implements what the linked issue describes (no scope creep)
- [x] I have performed a **self-review** of my code (no "ghost" variables or hallucinations).
- [x] My code follows the existing style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] (Optional) I have attached screenshots/recordings for UI changes.

The first two boxes are unchecked because there is no linked issue — these come straight from review comments on an already-merged PR. Happy to open one if you'd prefer the process followed strictly.

---

## 💭 Additional Context

The third ask from that review — a u8 remap with quantisation during interpolation — is deliberately **not** in this PR. It needs a CPU u8 remap to be byte-exact against first (`remap` is `Image<f32, C>`-only today), and there's a design question worth settling before any kernel gets written: `warp_affine_u8` achieves exactness with a Q16 coordinate accumulator anchored at the row span's left edge, and remap has no span — the maps are arbitrary, so there is no per-row linear coordinate to anchor on. Either u8 remap accepts different rounding from `warp_affine_u8`, or the CPU side is defined per-pixel from the start and both mirror that. I'd rather agree that contract with you than pick one silently. It'll come as its own PR.
