### PR TITLE
feat(imgproc): u8 remap with fixed-point quantisation (CPU + CUDA)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7887,6 +7887,7 @@ dependencies = [
 name = "kornia-imgproc"
 version = "0.1.15-rc.5"
 dependencies = [
+ "argh",
  "criterion 0.8.2",
  "cudarc 0.19.8",
  "half",

--- a/crates/kornia-imgproc/Cargo.toml
+++ b/crates/kornia-imgproc/Cargo.toml
@@ -19,6 +19,10 @@ name = "bench_cuda_remap"
 required-features = ["cuda"]
 
 [[example]]
+name = "bench_remap_u8"
+required-features = ["cuda"]
+
+[[example]]
 name = "dump_cuda_resize"
 required-features = ["cuda"]
 
@@ -114,6 +118,7 @@ thiserror = { workspace = true }
 wide = { workspace = true }
 
 [dev-dependencies]
+argh = { workspace = true }
 criterion = { workspace = true }
 # Deterministic instruction counts, immune to machine load. Needs valgrind and
 # `cargo install iai-callgrind-runner --version 0.14.0`.

--- a/crates/kornia-imgproc/examples/bench_remap_u8.rs
+++ b/crates/kornia-imgproc/examples/bench_remap_u8.rs
@@ -1,0 +1,180 @@
+//! u8 remap vs the f32 remap kernel.
+//!
+//! The u8 kernel exists so a u8 image can be remapped without widening to f32
+//! first. Its case is bandwidth: remap is memory-bound, and u8 moves a quarter
+//! of the bytes per channel, so the kernel should approach a 4x win on the
+//! image traffic — diluted by the two f32 coordinate maps, which are the same
+//! size either way and quickly dominate.
+//!
+//! Both paths are timed through the public API on device-resident images, so
+//! this measures the kernels as callers actually reach them.
+//!
+//! There is deliberately no "convert to f32, remap, convert back" column: the
+//! only `cast_and_scale` in the tree is CPU-side, so that alternative cannot be
+//! measured on-device at all. Which is itself the argument for this kernel — a
+//! u8 pipeline would otherwise have to round-trip through the host to use the
+//! f32 remap.
+//!
+//! ```text
+//! cargo run --release -p kornia-imgproc --features cuda --example bench_remap_u8
+//! ```
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use argh::FromArgs;
+use cudarc::driver::{CudaContext, CudaStream};
+use kornia_image::{Image, ImageError, ImageSize};
+use kornia_imgproc::interpolation::{remap, remap_u8, InterpolationMode};
+
+/// Benchmark the u8 remap kernel against the f32 one.
+#[derive(FromArgs)]
+struct Args {
+    /// CUDA device ordinal (default 0)
+    #[argh(option, default = "0")]
+    device: usize,
+
+    /// timed iterations per case (default 100)
+    #[argh(option, default = "100")]
+    iters: usize,
+
+    /// untimed warmup iterations per case (default 20)
+    #[argh(option, default = "20")]
+    warmup: usize,
+}
+
+/// Resolutions to sweep, as (label, width, height).
+const SIZES: &[(&str, usize, usize)] = &[
+    ("VGA    640x480", 640, 480),
+    ("HD    1280x720", 1280, 720),
+    ("FHD  1920x1080", 1920, 1080),
+    ("4K   3840x2160", 3840, 2160),
+];
+
+/// Mean milliseconds per iteration of `f`, after `warmup` untimed runs.
+///
+/// The launches are asynchronous, so the stream is synchronized inside the
+/// timed region — the number covers the kernels, not just the launch calls.
+fn timed<F>(
+    stream: &Arc<CudaStream>,
+    warmup: usize,
+    iters: usize,
+    mut f: F,
+) -> Result<f64, Box<dyn std::error::Error>>
+where
+    F: FnMut() -> Result<(), ImageError>,
+{
+    for _ in 0..warmup {
+        f()?;
+    }
+    stream.synchronize()?;
+
+    let start = Instant::now();
+    for _ in 0..iters {
+        f()?;
+    }
+    stream.synchronize()?;
+    Ok(start.elapsed().as_secs_f64() * 1e3 / iters as f64)
+}
+
+/// A rotation map with fractional coordinates, so the sampler does real
+/// bilinear work rather than an aligned copy.
+fn rotation_maps(w: usize, h: usize) -> Result<(Image<f32, 1>, Image<f32, 1>), ImageError> {
+    let size = ImageSize {
+        width: w,
+        height: h,
+    };
+    let (cx, cy) = (w as f32 / 2.0, h as f32 / 2.0);
+    let (sin, cos) = (0.25f32).sin_cos();
+
+    let mut mx = Vec::with_capacity(w * h);
+    let mut my = Vec::with_capacity(w * h);
+    for y in 0..h {
+        for x in 0..w {
+            let (dx, dy) = (x as f32 - cx, y as f32 - cy);
+            mx.push(cx + dx * cos - dy * sin);
+            my.push(cy + dx * sin + dy * cos);
+        }
+    }
+    Ok((
+        Image::<f32, 1>::new(size, mx)?,
+        Image::<f32, 1>::new(size, my)?,
+    ))
+}
+
+/// Bytes the kernel must move for one call: source reads (4 taps for bilinear,
+/// 1 for nearest), the destination write, and the two f32 maps.
+fn traffic_mib(w: usize, h: usize, px: usize, taps: usize) -> f64 {
+    let pixels = w * h;
+    let image = pixels * 3 * px * (taps + 1);
+    let maps = pixels * 2 * 4;
+    (image + maps) as f64 / (1024.0 * 1024.0)
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Args = argh::from_env();
+
+    let ctx = CudaContext::new(args.device)?;
+    let stream = ctx.default_stream();
+
+    let cc_major = ctx.attribute(
+        cudarc::driver::sys::CUdevice_attribute::CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR,
+    )?;
+    let cc_minor = ctx.attribute(
+        cudarc::driver::sys::CUdevice_attribute::CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR,
+    )?;
+    println!("device {}: sm_{cc_major}{cc_minor}", args.device);
+    println!("3 channels, device-resident, via the public remap/remap_u8 API");
+    println!("iters: {} (warmup {})", args.iters, args.warmup);
+
+    for (mode, taps) in [
+        (InterpolationMode::Bilinear, 4usize),
+        (InterpolationMode::Nearest, 1usize),
+    ] {
+        println!("\n── {mode:?} ──────────────────────────────────────────────");
+        println!(
+            "{:<16} {:>10} {:>10} {:>9} {:>11} {:>11}",
+            "size", "u8 ms", "f32 ms", "speedup", "u8 GiB/s", "f32 GiB/s"
+        );
+        println!("{}", "-".repeat(72));
+
+        for &(label, w, h) in SIZES {
+            let size = ImageSize {
+                width: w,
+                height: h,
+            };
+            let (map_x, map_y) = rotation_maps(w, h)?;
+            let d_mx = map_x.to_cuda(&stream)?;
+            let d_my = map_y.to_cuda(&stream)?;
+
+            let u8_data: Vec<u8> = (0..w * h * 3).map(|i| (i % 251) as u8).collect();
+            let u8_src = Image::<u8, 3>::new(size, u8_data)?.to_cuda(&stream)?;
+            let mut u8_dst = Image::<u8, 3>::zeros_cuda(size, &stream)?;
+            let t_u8 = timed(&stream, args.warmup, args.iters, || {
+                remap_u8(&u8_src, &mut u8_dst, &d_mx, &d_my, mode)
+            })?;
+
+            let f32_data: Vec<f32> = (0..w * h * 3).map(|i| (i % 251) as f32 / 251.0).collect();
+            let f32_src = Image::<f32, 3>::new(size, f32_data)?.to_cuda(&stream)?;
+            let mut f32_dst = Image::<f32, 3>::zeros_cuda(size, &stream)?;
+            let t_f32 = timed(&stream, args.warmup, args.iters, || {
+                remap(&f32_src, &mut f32_dst, &d_mx, &d_my, mode)
+            })?;
+
+            let gib = |mib: f64, ms: f64| mib / 1024.0 / (ms / 1e3);
+            println!(
+                "{label:<16} {t_u8:>10.4} {t_f32:>10.4} {:>8.2}x {:>11.1} {:>11.1}",
+                t_f32 / t_u8,
+                gib(traffic_mib(w, h, 1, taps), t_u8),
+                gib(traffic_mib(w, h, 4, taps), t_f32),
+            );
+        }
+    }
+
+    println!(
+        "\nGiB/s counts source taps + destination + both f32 maps. The maps are\n\
+         f32 in either case, so they cap how much the narrower pixel type can win."
+    );
+
+    Ok(())
+}

--- a/crates/kornia-imgproc/src/cuda/remap.rs
+++ b/crates/kornia-imgproc/src/cuda/remap.rs
@@ -230,9 +230,8 @@ fn launch_remap(
     let kernel = if let Some(hit) = cached {
         hit
     } else {
-        let built = Arc::new(
-            try_compile_with_l1(ctx, kernel_src, fn_name).map_err(CudaRemapError::Cuda)?,
-        );
+        let built =
+            Arc::new(try_compile_with_l1(ctx, kernel_src, fn_name).map_err(CudaRemapError::Cuda)?);
         cache
             .lock()
             .map_err(|_| CudaRemapError::Cuda("remap kernel cache mutex poisoned".into()))?

--- a/crates/kornia-imgproc/src/cuda/remap.rs
+++ b/crates/kornia-imgproc/src/cuda/remap.rs
@@ -39,7 +39,8 @@
 //! in `examples/bench_cuda_remap.rs` — they serve the architecture-decision benchmark
 //! only; the library API is the pure remap launchers.
 
-use std::sync::{Arc, OnceLock};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
 
 use cudarc::driver::{CudaContext, CudaSlice, CudaStream};
 use kornia_tensor::CudaKernel;
@@ -160,6 +161,10 @@ extern "C" __global__ void remap_nearest_3c(
 static BILINEAR_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
 static NEAREST_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
 
+type PerCKernelCache = Mutex<HashMap<u32, Arc<CudaKernel>>>;
+static BILINEAR_U8_KERNELS: OnceLock<PerCKernelCache> = OnceLock::new();
+static NEAREST_U8_KERNELS: OnceLock<PerCKernelCache> = OnceLock::new();
+
 // ── Error type ────────────────────────────────────────────────────────────────
 
 super::define_cuda_error!(
@@ -257,6 +262,10 @@ fn launch_remap(
 /// * `dst_width` / `dst_height` — Destination image dimensions.
 /// * `block_dim` — Optional `(bw, bh)` thread-block override; `None` → 32×8.
 ///
+/// # Returns
+///
+/// `Ok(())` on success.
+///
 /// # Errors
 ///
 /// Returns [`CudaRemapError`] on compile failure, launch error, or if any
@@ -305,6 +314,10 @@ pub fn launch_remap_bilinear_cuda(
 ///
 /// See [`launch_remap_bilinear_cuda`] — arguments are identical.
 ///
+/// # Returns
+///
+/// `Ok(())` on success.
+///
 /// # Errors
 ///
 /// Returns [`CudaRemapError`] on compile failure, launch error, or if any
@@ -337,6 +350,304 @@ pub fn launch_remap_nearest_cuda(
         src_height,
         dst_width,
         dst_height,
+        block_dim,
+    )
+}
+
+fn remap_u8_bilinear_src(channels: usize) -> String {
+    format!(
+        r#"
+#define C {channels}
+extern "C" __global__ void remap_bilinear_u8_c{channels}(
+    const unsigned char* __restrict__ src,
+    const float* __restrict__ map_x,
+    const float* __restrict__ map_y,
+    unsigned char* __restrict__ dst,
+    unsigned int src_w,
+    unsigned int src_h,
+    unsigned int dst_w,
+    unsigned int dst_h
+) {{
+    unsigned int gx = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int gy = blockIdx.y * blockDim.y + threadIdx.y;
+    if (gx >= dst_w || gy >= dst_h) return;
+
+    unsigned long long idx = (unsigned long long)gy * dst_w + gx;
+    float sx = __ldg(&map_x[idx]);
+    float sy = __ldg(&map_y[idx]);
+    unsigned long long out = idx * (unsigned long long)C;
+
+    if (sx < 0.0f || sx >= (float)src_w || sy < 0.0f || sy >= (float)src_h) {{
+        #pragma unroll
+        for (unsigned int ch = 0u; ch < C; ++ch) dst[out + ch] = 0;
+        return;
+    }}
+
+    float sxc = fmaxf(fminf(sx, (float)(src_w - 1u)), 0.0f);
+    float syc = fmaxf(fminf(sy, (float)(src_h - 1u)), 0.0f);
+
+    unsigned int x0 = (unsigned int)sxc;
+    unsigned int y0 = (unsigned int)syc;
+    unsigned int x1 = min(x0 + 1u, src_w - 1u);
+    unsigned int y1 = min(y0 + 1u, src_h - 1u);
+    unsigned int fx = (unsigned int)((sxc - (float)x0) * 1024.0f);
+    unsigned int fy = (unsigned int)((syc - (float)y0) * 1024.0f);
+    unsigned int fx1 = 1024u - fx;
+    unsigned int fy1 = 1024u - fy;
+
+    unsigned long long r0 = (unsigned long long)y0 * src_w;
+    unsigned long long r1 = (unsigned long long)y1 * src_w;
+    unsigned long long b00 = (r0 + x0) * (unsigned long long)C;
+    unsigned long long b10 = (r0 + x1) * (unsigned long long)C;
+    unsigned long long b01 = (r1 + x0) * (unsigned long long)C;
+    unsigned long long b11 = (r1 + x1) * (unsigned long long)C;
+
+    #pragma unroll
+    for (unsigned int ch = 0u; ch < C; ++ch) {{
+        unsigned int p00 = (unsigned int)__ldg(&src[b00 + ch]);
+        unsigned int p10 = (unsigned int)__ldg(&src[b10 + ch]);
+        unsigned int p01 = (unsigned int)__ldg(&src[b01 + ch]);
+        unsigned int p11 = (unsigned int)__ldg(&src[b11 + ch]);
+        unsigned int top = p00 * fx1 + p10 * fx;
+        unsigned int bot = p01 * fx1 + p11 * fx;
+        dst[out + ch] = (unsigned char)((top * fy1 + bot * fy + (1u << 19)) >> 20);
+    }}
+}}
+"#
+    )
+}
+
+fn remap_u8_nearest_src(channels: usize) -> String {
+    format!(
+        r#"
+#define C {channels}
+extern "C" __global__ void remap_nearest_u8_c{channels}(
+    const unsigned char* __restrict__ src,
+    const float* __restrict__ map_x,
+    const float* __restrict__ map_y,
+    unsigned char* __restrict__ dst,
+    unsigned int src_w,
+    unsigned int src_h,
+    unsigned int dst_w,
+    unsigned int dst_h
+) {{
+    unsigned int gx = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int gy = blockIdx.y * blockDim.y + threadIdx.y;
+    if (gx >= dst_w || gy >= dst_h) return;
+
+    unsigned long long idx = (unsigned long long)gy * dst_w + gx;
+    float sx = __ldg(&map_x[idx]);
+    float sy = __ldg(&map_y[idx]);
+    unsigned long long out = idx * (unsigned long long)C;
+
+    if (sx < 0.0f || sx >= (float)src_w || sy < 0.0f || sy >= (float)src_h) {{
+        #pragma unroll
+        for (unsigned int ch = 0u; ch < C; ++ch) dst[out + ch] = 0;
+        return;
+    }}
+
+    unsigned int xi = min((unsigned int)roundf(sx), src_w - 1u);
+    unsigned int yi = min((unsigned int)roundf(sy), src_h - 1u);
+    unsigned long long b = ((unsigned long long)yi * src_w + xi) * (unsigned long long)C;
+
+    #pragma unroll
+    for (unsigned int ch = 0u; ch < C; ++ch) {{
+        dst[out + ch] = __ldg(&src[b + ch]);
+    }}
+}}
+"#
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn launch_remap_u8(
+    kernel_cell: &OnceLock<PerCKernelCache>,
+    kernel_src: fn(usize) -> String,
+    fn_name_prefix: &'static str,
+    ctx: &Arc<CudaContext>,
+    stream: &Arc<CudaStream>,
+    src: &CudaSlice<u8>,
+    map_x: &CudaSlice<f32>,
+    map_y: &CudaSlice<f32>,
+    dst: &mut CudaSlice<u8>,
+    src_width: u32,
+    src_height: u32,
+    dst_width: u32,
+    dst_height: u32,
+    channels: u32,
+    block_dim: Option<(u32, u32)>,
+) -> Result<(), CudaRemapError> {
+    check_geometry(src_width, src_height, dst_width, dst_height, block_dim)
+        .map_err(CudaRemapError::Cuda)?;
+    CudaRemapError::check_slice(
+        "src",
+        src.len(),
+        (src_width as usize) * (src_height as usize) * (channels as usize),
+    )?;
+    CudaRemapError::check_slice(
+        "dst",
+        dst.len(),
+        (dst_width as usize) * (dst_height as usize) * (channels as usize),
+    )?;
+    CudaRemapError::check_slice(
+        "map_x",
+        map_x.len(),
+        (dst_width as usize) * (dst_height as usize),
+    )?;
+    CudaRemapError::check_slice(
+        "map_y",
+        map_y.len(),
+        (dst_width as usize) * (dst_height as usize),
+    )?;
+
+    let cache = kernel_cell.get_or_init(Default::default);
+    let cached = cache
+        .lock()
+        .expect("warp kernel cache poisoned")
+        .get(&channels)
+        .cloned();
+    let kernel = if let Some(hit) = cached {
+        hit
+    } else {
+        let src_code = kernel_src(channels as usize);
+        let name = format!("{fn_name_prefix}_c{channels}");
+        let built =
+            Arc::new(try_compile_with_l1(ctx, &src_code, &name).map_err(CudaRemapError::Cuda)?);
+        cache
+            .lock()
+            .expect("warp kernel cache poisoned")
+            .entry(channels)
+            .or_insert(built)
+            .clone()
+    };
+
+    kernel
+        .launch_builder(stream)
+        .arg(src)
+        .arg(map_x)
+        .arg(map_y)
+        .arg(dst)
+        .arg(&src_width)
+        .arg(&src_height)
+        .arg(&dst_width)
+        .arg(&dst_height)
+        .launch_2d(
+            dst_width,
+            dst_height,
+            make_config(dst_width, dst_height, block_dim),
+        )
+        .map_err(|e| CudaRemapError::Cuda(e.to_string()))
+}
+
+/// Launch the bilinear remap kernel for a `u8` image.
+///
+/// Each output pixel at `(gx, gy)` samples `src` at
+/// `(map_x[gy*dst_w+gx], map_y[gy*dst_w+gx])` using Q10 bilinear
+/// interpolation. Source coordinates outside `[0, src_w) × [0, src_h)` produce
+/// 0 output.
+///
+/// # Arguments
+///
+/// * `ctx`       - CUDA context used for kernel compilation on first call.
+/// * `stream`    - CUDA stream for the kernel launch.
+/// * `src`       - Source image, `src_w * src_h * C` u8 elements, row-major.
+/// * `map_x`     - Source x-coordinate per output pixel, `dst_w * dst_h` f32.
+/// * `map_y`     - Source y-coordinate per output pixel, `dst_w * dst_h` f32.
+/// * `dst`       - Destination buffer, at least `dst_w * dst_h * C` u8.
+/// * `src_width` / `src_height` - Source image dimensions.
+/// * `dst_width` / `dst_height` - Destination image dimensions.
+/// * `channels`   - Compile-time channel count forwarded from the caller.
+/// * `block_dim`  - Optional `(bw, bh)` thread-block override; `None` → 32×8.
+///
+/// # Returns
+///
+/// `Ok(())` on success.
+///
+/// # Errors
+///
+/// Returns [`CudaRemapError`] on compile failure, launch error, or if any
+/// slice is too small.
+#[allow(clippy::too_many_arguments)]
+pub fn launch_remap_bilinear_u8_cuda(
+    ctx: &Arc<CudaContext>,
+    stream: &Arc<CudaStream>,
+    src: &CudaSlice<u8>,
+    map_x: &CudaSlice<f32>,
+    map_y: &CudaSlice<f32>,
+    dst: &mut CudaSlice<u8>,
+    src_width: u32,
+    src_height: u32,
+    dst_width: u32,
+    dst_height: u32,
+    channels: u32,
+    block_dim: Option<(u32, u32)>,
+) -> Result<(), CudaRemapError> {
+    launch_remap_u8(
+        &BILINEAR_U8_KERNELS,
+        remap_u8_bilinear_src,
+        "remap_bilinear_u8",
+        ctx,
+        stream,
+        src,
+        map_x,
+        map_y,
+        dst,
+        src_width,
+        src_height,
+        dst_width,
+        dst_height,
+        channels,
+        block_dim,
+    )
+}
+
+/// Launch the nearest-neighbor remap kernel for a `u8` image.
+///
+/// Same as [`launch_remap_bilinear_u8_cuda`] but uses round-to-nearest source
+/// sampling.
+///
+/// # Arguments
+///
+/// See [`launch_remap_bilinear_u8_cuda`] — arguments are identical.
+///
+/// # Returns
+///
+/// `Ok(())` on success.
+///
+/// # Errors
+///
+/// Returns [`CudaRemapError`] on compile failure, launch error, or if any
+/// slice is too small.
+#[allow(clippy::too_many_arguments)]
+pub fn launch_remap_nearest_u8_cuda(
+    ctx: &Arc<CudaContext>,
+    stream: &Arc<CudaStream>,
+    src: &CudaSlice<u8>,
+    map_x: &CudaSlice<f32>,
+    map_y: &CudaSlice<f32>,
+    dst: &mut CudaSlice<u8>,
+    src_width: u32,
+    src_height: u32,
+    dst_width: u32,
+    dst_height: u32,
+    channels: u32,
+    block_dim: Option<(u32, u32)>,
+) -> Result<(), CudaRemapError> {
+    launch_remap_u8(
+        &NEAREST_U8_KERNELS,
+        remap_u8_nearest_src,
+        "remap_nearest_u8",
+        ctx,
+        stream,
+        src,
+        map_x,
+        map_y,
+        dst,
+        src_width,
+        src_height,
+        dst_width,
+        dst_height,
+        channels,
         block_dim,
     )
 }

--- a/crates/kornia-imgproc/src/cuda/remap.rs
+++ b/crates/kornia-imgproc/src/cuda/remap.rs
@@ -161,7 +161,7 @@ extern "C" __global__ void remap_nearest_3c(
 static BILINEAR_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
 static NEAREST_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
 
-type PerCKernelCache = Mutex<HashMap<u32, Arc<CudaKernel>>>;
+type PerCKernelCache = Mutex<HashMap<(usize, u32), Arc<CudaKernel>>>;
 static BILINEAR_U8_KERNELS: OnceLock<PerCKernelCache> = OnceLock::new();
 static NEAREST_U8_KERNELS: OnceLock<PerCKernelCache> = OnceLock::new();
 
@@ -377,7 +377,7 @@ extern "C" __global__ void remap_bilinear_u8_c{channels}(
     float sy = __ldg(&map_y[idx]);
     unsigned long long out = idx * (unsigned long long)C;
 
-    if (sx < 0.0f || sx >= (float)src_w || sy < 0.0f || sy >= (float)src_h) {{
+    if (!(sx >= 0.0f && sx < (float)src_w && sy >= 0.0f && sy < (float)src_h)) {{
         #pragma unroll
         for (unsigned int ch = 0u; ch < C; ++ch) dst[out + ch] = 0;
         return;
@@ -440,7 +440,7 @@ extern "C" __global__ void remap_nearest_u8_c{channels}(
     float sy = __ldg(&map_y[idx]);
     unsigned long long out = idx * (unsigned long long)C;
 
-    if (sx < 0.0f || sx >= (float)src_w || sy < 0.0f || sy >= (float)src_h) {{
+    if (!(sx >= 0.0f && sx < (float)src_w && sy >= 0.0f && sy < (float)src_h)) {{
         #pragma unroll
         for (unsigned int ch = 0u; ch < C; ++ch) dst[out + ch] = 0;
         return;
@@ -477,6 +477,9 @@ fn launch_remap_u8(
     channels: u32,
     block_dim: Option<(u32, u32)>,
 ) -> Result<(), CudaRemapError> {
+    if channels == 0 {
+        return Err(CudaRemapError::Cuda("channels must be > 0".into()));
+    }
     check_geometry(src_width, src_height, dst_width, dst_height, block_dim)
         .map_err(CudaRemapError::Cuda)?;
     CudaRemapError::check_slice(
@@ -500,11 +503,13 @@ fn launch_remap_u8(
         (dst_width as usize) * (dst_height as usize),
     )?;
 
+    let device_ord = ctx.ordinal();
+    let cache_key = (device_ord, channels);
     let cache = kernel_cell.get_or_init(Default::default);
     let cached = cache
         .lock()
-        .expect("warp kernel cache poisoned")
-        .get(&channels)
+        .map_err(|_| CudaRemapError::Cuda("remap kernel cache mutex poisoned".into()))?
+        .get(&cache_key)
         .cloned();
     let kernel = if let Some(hit) = cached {
         hit
@@ -515,8 +520,8 @@ fn launch_remap_u8(
             Arc::new(try_compile_with_l1(ctx, &src_code, &name).map_err(CudaRemapError::Cuda)?);
         cache
             .lock()
-            .expect("warp kernel cache poisoned")
-            .entry(channels)
+            .map_err(|_| CudaRemapError::Cuda("remap kernel cache mutex poisoned".into()))?
+            .entry(cache_key)
             .or_insert(built)
             .clone()
     };

--- a/crates/kornia-imgproc/src/cuda/remap.rs
+++ b/crates/kornia-imgproc/src/cuda/remap.rs
@@ -78,7 +78,8 @@ extern "C" __global__ void remap_bilinear_3c(
     unsigned long long out = idx * 3ull;
 
     // BORDER_CONSTANT = 0 for any OOB source coordinate.
-    if (sx < 0.0f || sx >= (float)src_w || sy < 0.0f || sy >= (float)src_h) {
+    // Negated conjunction catches NaN (all NaN comparisons are false).
+    if (!(sx >= 0.0f && sx < (float)src_w && sy >= 0.0f && sy < (float)src_h)) {
         dst[out] = 0.0f; dst[out+1] = 0.0f; dst[out+2] = 0.0f;
         return;
     }
@@ -141,7 +142,8 @@ extern "C" __global__ void remap_nearest_3c(
     unsigned long long out = idx * 3ull;
 
     // BORDER_CONSTANT = 0 for any OOB source coordinate.
-    if (sx < 0.0f || sx >= (float)src_w || sy < 0.0f || sy >= (float)src_h) {
+    // Negated conjunction catches NaN (all NaN comparisons are false).
+    if (!(sx >= 0.0f && sx < (float)src_w && sy >= 0.0f && sy < (float)src_h)) {
         dst[out] = 0.0f; dst[out+1] = 0.0f; dst[out+2] = 0.0f;
         return;
     }
@@ -158,9 +160,12 @@ extern "C" __global__ void remap_nearest_3c(
 
 // ── Kernel cache ──────────────────────────────────────────────────────────────
 
-static BILINEAR_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
-static NEAREST_KERNEL: OnceLock<Result<CudaKernel, String>> = OnceLock::new();
+// f32 kernels are single-template (always 3-ch), keyed by device ordinal only.
+type F32KernelCache = Mutex<HashMap<usize, Arc<CudaKernel>>>;
+static BILINEAR_KERNEL: OnceLock<F32KernelCache> = OnceLock::new();
+static NEAREST_KERNEL: OnceLock<F32KernelCache> = OnceLock::new();
 
+// u8 kernels are compiled per (device_ordinal, channel_count).
 type PerCKernelCache = Mutex<HashMap<(usize, u32), Arc<CudaKernel>>>;
 static BILINEAR_U8_KERNELS: OnceLock<PerCKernelCache> = OnceLock::new();
 static NEAREST_U8_KERNELS: OnceLock<PerCKernelCache> = OnceLock::new();
@@ -177,7 +182,7 @@ super::define_cuda_error!(
 
 #[allow(clippy::too_many_arguments)]
 fn launch_remap(
-    kernel_cell: &OnceLock<Result<CudaKernel, String>>,
+    kernel_cell: &OnceLock<F32KernelCache>,
     kernel_src: &'static str,
     fn_name: &'static str,
     ctx: &Arc<CudaContext>,
@@ -215,10 +220,26 @@ fn launch_remap(
         (dst_width as usize) * (dst_height as usize),
     )?;
 
-    let kernel = kernel_cell
-        .get_or_init(|| try_compile_with_l1(ctx, kernel_src, fn_name))
-        .as_ref()
-        .map_err(|e| CudaRemapError::Cuda(e.clone()))?;
+    let device_ord = ctx.ordinal();
+    let cache = kernel_cell.get_or_init(Default::default);
+    let cached = cache
+        .lock()
+        .map_err(|_| CudaRemapError::Cuda("remap kernel cache mutex poisoned".into()))?
+        .get(&device_ord)
+        .cloned();
+    let kernel = if let Some(hit) = cached {
+        hit
+    } else {
+        let built = Arc::new(
+            try_compile_with_l1(ctx, kernel_src, fn_name).map_err(CudaRemapError::Cuda)?,
+        );
+        cache
+            .lock()
+            .map_err(|_| CudaRemapError::Cuda("remap kernel cache mutex poisoned".into()))?
+            .entry(device_ord)
+            .or_insert(built)
+            .clone()
+    };
 
     kernel
         .launch_builder(stream)
@@ -573,7 +594,7 @@ fn launch_remap_u8(
 /// Returns [`CudaRemapError`] on compile failure, launch error, or if any
 /// slice is too small.
 #[allow(clippy::too_many_arguments)]
-pub fn launch_remap_bilinear_u8_cuda(
+pub(crate) fn launch_remap_bilinear_u8_cuda(
     ctx: &Arc<CudaContext>,
     stream: &Arc<CudaStream>,
     src: &CudaSlice<u8>,
@@ -624,7 +645,7 @@ pub fn launch_remap_bilinear_u8_cuda(
 /// Returns [`CudaRemapError`] on compile failure, launch error, or if any
 /// slice is too small.
 #[allow(clippy::too_many_arguments)]
-pub fn launch_remap_nearest_u8_cuda(
+pub(crate) fn launch_remap_nearest_u8_cuda(
     ctx: &Arc<CudaContext>,
     stream: &Arc<CudaStream>,
     src: &CudaSlice<u8>,

--- a/crates/kornia-imgproc/src/interpolation/mod.rs
+++ b/crates/kornia-imgproc/src/interpolation/mod.rs
@@ -11,7 +11,7 @@ mod remap;
 
 pub use interpolate::validate_interpolation;
 pub use interpolate::InterpolationMode;
-pub use remap::remap;
+pub use remap::{remap, remap_u8};
 
 pub(crate) use bicubic::bicubic_sample;
 pub(crate) use bilinear::bilinear_interpolation;

--- a/crates/kornia-imgproc/src/interpolation/remap.rs
+++ b/crates/kornia-imgproc/src/interpolation/remap.rs
@@ -133,6 +133,19 @@ pub fn remap<const C: usize>(
 /// * `dst` must have the same size as the maps.
 /// * [`ImageError::UnsupportedInterpolation`] is returned for interpolation
 ///   modes other than bilinear and nearest-neighbor.
+///
+/// # Example
+///
+/// ```
+/// use kornia_image::{Image, ImageSize};
+/// use kornia_imgproc::interpolation::{remap_u8, InterpolationMode};
+///
+/// let src = Image::<u8, 3>::from_size_val(ImageSize { width: 4, height: 4 }, 128u8).unwrap();
+/// let mut dst = Image::<u8, 3>::from_size_val(ImageSize { width: 4, height: 4 }, 0u8).unwrap();
+/// let map_x = Image::<f32, 1>::from_size_val(ImageSize { width: 4, height: 4 }, 1.0f32).unwrap();
+/// let map_y = Image::<f32, 1>::from_size_val(ImageSize { width: 4, height: 4 }, 1.0f32).unwrap();
+/// remap_u8(&src, &mut dst, &map_x, &map_y, InterpolationMode::Bilinear).unwrap();
+/// ```
 pub fn remap_u8<const C: usize>(
     src: &Image<u8, C>,
     dst: &mut Image<u8, C>,
@@ -171,6 +184,11 @@ pub fn remap_u8<const C: usize>(
             }
             return exec.run(|stream| remap_u8_cuda(src, dst, map_x, map_y, interpolation, stream));
         }
+        if is_device(map_x) || is_device(map_y) {
+            return Err(ImageError::Cuda(
+                "remap_u8: map_x and map_y must be host-resident when src/dst are on CPU".into(),
+            ));
+        }
     }
 
     let src_slice = src.as_slice();
@@ -183,6 +201,10 @@ pub fn remap_u8<const C: usize>(
     let src_stride = src.cols() * C;
     let dst_w = dst.cols();
     let dst_stride = dst_w * C;
+
+    if dst_stride == 0 {
+        return Ok(());
+    }
 
     let zero_pixel = |dst_pixel: &mut [u8]| {
         for pixel in dst_pixel.iter_mut().take(C) {
@@ -201,8 +223,22 @@ pub fn remap_u8<const C: usize>(
                         let xf = map_x_slice[row_base + x];
                         let yf = map_y_slice[row_base + x];
                         let dst_pixel = &mut dst_row[x * C..x * C + C];
-                        crate::warp::bilinear_sample_u8::<C>(
-                            src_slice, src_w, src_h, src_stride, xf, yf, dst_pixel,
+                        // NaN-safe OOB check followed by AVX2/NEON-accelerated sampler.
+                        if !xf.is_finite() || !yf.is_finite() {
+                            zero_pixel(dst_pixel);
+                            continue;
+                        }
+                        let xi = xf.floor() as i32;
+                        let yi = yf.floor() as i32;
+                        if xi < 0 || xi >= src_w || yi < 0 || yi >= src_h {
+                            zero_pixel(dst_pixel);
+                            continue;
+                        }
+                        let fx_q10 = ((xf - xi as f32) * 1024.0) as u32;
+                        let fy_q10 = ((yf - yi as f32) * 1024.0) as u32;
+                        crate::warp::bilinear_sample_u8_valid::<C>(
+                            src_slice, src_w, src_h, src_stride, xi, yi, fx_q10, fy_q10,
+                            dst_pixel,
                         );
                     }
                 });
@@ -217,7 +253,7 @@ pub fn remap_u8<const C: usize>(
                         let xf = map_x_slice[row_base + x];
                         let yf = map_y_slice[row_base + x];
                         let dst_pixel = &mut dst_row[x * C..x * C + C];
-                        if xf < 0.0 || xf >= src_w_f || yf < 0.0 || yf >= src_h_f {
+                        if !(xf >= 0.0 && xf < src_w_f && yf >= 0.0 && yf < src_h_f) {
                             zero_pixel(dst_pixel);
                         } else {
                             let xi = (xf.round() as i32).clamp(0, src_w - 1) as usize;

--- a/crates/kornia-imgproc/src/interpolation/remap.rs
+++ b/crates/kornia-imgproc/src/interpolation/remap.rs
@@ -307,6 +307,7 @@ pub fn remap_u8<const C: usize>(
 
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2")]
+#[allow(clippy::too_many_arguments)]
 unsafe fn remap_u8_bilinear_c3_avx2<const C: usize>(
     src_slice: &[u8],
     dst: &mut Image<u8, C>,

--- a/crates/kornia-imgproc/src/interpolation/remap.rs
+++ b/crates/kornia-imgproc/src/interpolation/remap.rs
@@ -1,4 +1,5 @@
 use crate::parallel;
+use rayon::prelude::*;
 
 use super::interpolate::validate_interpolation;
 use super::InterpolationMode;
@@ -7,7 +8,10 @@ use kornia_image::{Image, ImageError};
 #[cfg(feature = "cuda")]
 use {
     crate::cuda::dispatch::{device_slices, dims_u32, no_gpu_kernel_err, untyped_device_err},
-    crate::cuda::remap::{launch_remap_bilinear_cuda, launch_remap_nearest_cuda},
+    crate::cuda::remap::{
+        launch_remap_bilinear_cuda, launch_remap_bilinear_u8_cuda, launch_remap_nearest_cuda,
+        launch_remap_nearest_u8_cuda,
+    },
     cudarc::driver::CudaStream,
     std::sync::Arc,
 };
@@ -27,6 +31,10 @@ use {
 /// * `map_x` - Source x coordinate for each output pixel, shape (height, width, 1).
 /// * `map_y` - Source y coordinate for each output pixel, shape (height, width, 1).
 /// * `interpolation` - The interpolation mode to use.
+///
+/// # Returns
+///
+/// `Ok(())` on success.
 ///
 /// # Errors
 ///
@@ -100,6 +108,132 @@ pub fn remap<const C: usize>(
     Ok(())
 }
 
+/// Apply a generic geometric transformation to a `u8` image.
+///
+/// The coordinate maps are still `f32` images, one source coordinate per
+/// output pixel. Bilinear interpolation uses the same Q10 fixed-point sampler
+/// as the `u8` warp kernels, so fractional weights are quantized before the
+/// final byte blend. Nearest-neighbor samples with constant-0 border handling.
+///
+/// # Arguments
+///
+/// * `src` - The input image container with shape (height, width, C).
+/// * `dst` - The output image container with shape (height, width, C).
+/// * `map_x` - Source x coordinate for each output pixel, shape (height, width, 1).
+/// * `map_y` - Source y coordinate for each output pixel, shape (height, width, 1).
+/// * `interpolation` - The interpolation mode to use.
+///
+/// # Returns
+///
+/// `Ok(())` on success.
+///
+/// # Errors
+///
+/// * `map_x` and `map_y` must have the same size.
+/// * `dst` must have the same size as the maps.
+/// * [`ImageError::UnsupportedInterpolation`] is returned for interpolation
+///   modes other than bilinear and nearest-neighbor.
+pub fn remap_u8<const C: usize>(
+    src: &Image<u8, C>,
+    dst: &mut Image<u8, C>,
+    map_x: &Image<f32, 1>,
+    map_y: &Image<f32, 1>,
+    interpolation: InterpolationMode,
+) -> Result<(), ImageError> {
+    if map_x.size() != map_y.size() {
+        return Err(ImageError::InvalidImageSize(
+            map_x.rows(),
+            map_x.cols(),
+            map_y.rows(),
+            map_y.cols(),
+        ));
+    }
+    if dst.size() != map_x.size() {
+        return Err(ImageError::InvalidImageSize(
+            dst.rows(),
+            dst.cols(),
+            map_x.rows(),
+            map_x.cols(),
+        ));
+    }
+
+    validate_interpolation(interpolation)?;
+
+    #[cfg(feature = "cuda")]
+    {
+        use crate::cuda::dispatch::{is_device, pair_residency, Residency};
+        if let Residency::Device(exec) = pair_residency(src, dst)? {
+            if !is_device(map_x) || !is_device(map_y) {
+                return Err(ImageError::Cuda(
+                    "remap_u8: map_x and map_y must be device-resident when src/dst are on GPU"
+                        .into(),
+                ));
+            }
+            return exec.run(|stream| remap_u8_cuda(src, dst, map_x, map_y, interpolation, stream));
+        }
+    }
+
+    let src_slice = src.as_slice();
+    let map_x_slice = map_x.as_slice();
+    let map_y_slice = map_y.as_slice();
+    let src_w = src.cols() as i32;
+    let src_h = src.rows() as i32;
+    let src_w_f = src_w as f32;
+    let src_h_f = src_h as f32;
+    let src_stride = src.cols() * C;
+    let dst_w = dst.cols();
+    let dst_stride = dst_w * C;
+
+    let zero_pixel = |dst_pixel: &mut [u8]| {
+        for pixel in dst_pixel.iter_mut().take(C) {
+            *pixel = 0;
+        }
+    };
+
+    match interpolation {
+        InterpolationMode::Bilinear => {
+            dst.as_slice_mut()
+                .par_chunks_exact_mut(dst_stride)
+                .enumerate()
+                .for_each(|(y, dst_row)| {
+                    let row_base = y * dst_w;
+                    for x in 0..dst_w {
+                        let xf = map_x_slice[row_base + x];
+                        let yf = map_y_slice[row_base + x];
+                        let dst_pixel = &mut dst_row[x * C..x * C + C];
+                        crate::warp::bilinear_sample_u8::<C>(
+                            src_slice, src_w, src_h, src_stride, xf, yf, dst_pixel,
+                        );
+                    }
+                });
+        }
+        InterpolationMode::Nearest => {
+            dst.as_slice_mut()
+                .par_chunks_exact_mut(dst_stride)
+                .enumerate()
+                .for_each(|(y, dst_row)| {
+                    let row_base = y * dst_w;
+                    for x in 0..dst_w {
+                        let xf = map_x_slice[row_base + x];
+                        let yf = map_y_slice[row_base + x];
+                        let dst_pixel = &mut dst_row[x * C..x * C + C];
+                        if xf < 0.0 || xf >= src_w_f || yf < 0.0 || yf >= src_h_f {
+                            zero_pixel(dst_pixel);
+                        } else {
+                            let xi = (xf.round() as i32).clamp(0, src_w - 1) as usize;
+                            let yi = (yf.round() as i32).clamp(0, src_h - 1) as usize;
+                            let src_idx = (yi * src.cols() + xi) * C;
+                            dst_pixel.copy_from_slice(&src_slice[src_idx..src_idx + C]);
+                        }
+                    }
+                });
+        }
+        other => return Err(ImageError::UnsupportedInterpolation(other)),
+    }
+
+    Ok(())
+}
+
 /// Run the CUDA remap for a device-resident f32 triple (src, dst, maps).
 ///
 /// `map_x` and `map_y` are single-channel device images shaped like `dst` — one
@@ -138,6 +272,41 @@ fn remap_f32_cuda<const C: usize>(
         ),
         other => Err(crate::cuda::remap::CudaRemapError::Cuda(format!(
             "remap CUDA: {other:?} is not GPU-accelerated — move images to host for this mode"
+        ))),
+    }
+    .map_err(|e| ImageError::Cuda(e.to_string()))
+}
+
+#[cfg(feature = "cuda")]
+fn remap_u8_cuda<const C: usize>(
+    src: &Image<u8, C>,
+    dst: &mut Image<u8, C>,
+    map_x: &Image<f32, 1>,
+    map_y: &Image<f32, 1>,
+    interpolation: InterpolationMode,
+    stream: &Arc<CudaStream>,
+) -> Result<(), ImageError> {
+    let (src_w, src_h) = dims_u32(src)?;
+    let (dst_w, dst_h) = dims_u32(dst)?;
+    let map_x = map_x
+        .as_cudaslice()
+        .ok_or_else(|| untyped_device_err("map_x"))?;
+    let map_y = map_y
+        .as_cudaslice()
+        .ok_or_else(|| untyped_device_err("map_y"))?;
+    let ctx = stream.context();
+    let (s, d) = device_slices!(src, dst);
+    let channels = C as u32;
+
+    match interpolation {
+        InterpolationMode::Bilinear => launch_remap_bilinear_u8_cuda(
+            ctx, stream, s, map_x, map_y, d, src_w, src_h, dst_w, dst_h, channels, None,
+        ),
+        InterpolationMode::Nearest => launch_remap_nearest_u8_cuda(
+            ctx, stream, s, map_x, map_y, d, src_w, src_h, dst_w, dst_h, channels, None,
+        ),
+        other => Err(crate::cuda::remap::CudaRemapError::Cuda(format!(
+            "remap_u8 CUDA: {other:?} is not GPU-accelerated — move images to host for this mode"
         ))),
     }
     .map_err(|e| ImageError::Cuda(e.to_string()))
@@ -236,6 +405,99 @@ mod tests {
             assert!((a - b).abs() < 1e-6);
         }
 
+        Ok(())
+    }
+
+    #[test]
+    fn remap_u8_identity_bilinear() -> Result<(), ImageError> {
+        let image = Image::<_, 1>::new(
+            ImageSize {
+                width: 2,
+                height: 2,
+            },
+            vec![1u8, 2, 3, 4],
+        )?;
+        let map_x = make_map(2, 2, vec![0.0, 1.0, 0.0, 1.0])?;
+        let map_y = make_map(2, 2, vec![0.0, 0.0, 1.0, 1.0])?;
+        let mut dst = Image::<_, 1>::from_size_val(
+            ImageSize {
+                width: 2,
+                height: 2,
+            },
+            0,
+        )?;
+
+        super::remap_u8(
+            &image,
+            &mut dst,
+            &map_x,
+            &map_y,
+            super::InterpolationMode::Bilinear,
+        )?;
+
+        assert_eq!(dst.as_slice(), image.as_slice());
+        Ok(())
+    }
+
+    #[test]
+    fn remap_u8_bilinear_quantizes_fractional_weights() -> Result<(), ImageError> {
+        let image = Image::<_, 1>::new(
+            ImageSize {
+                width: 2,
+                height: 1,
+            },
+            vec![0u8, 255],
+        )?;
+        let map_x = make_map(1, 1, vec![0.1])?;
+        let map_y = make_map(1, 1, vec![0.0])?;
+        let mut dst = Image::<_, 1>::from_size_val(
+            ImageSize {
+                width: 1,
+                height: 1,
+            },
+            0,
+        )?;
+
+        super::remap_u8(
+            &image,
+            &mut dst,
+            &map_x,
+            &map_y,
+            super::InterpolationMode::Bilinear,
+        )?;
+
+        assert_eq!(dst.as_slice(), &[25]);
+        Ok(())
+    }
+
+    #[test]
+    fn remap_u8_nearest_zeroes_oob_maps() -> Result<(), ImageError> {
+        let image = Image::<_, 1>::new(
+            ImageSize {
+                width: 2,
+                height: 2,
+            },
+            vec![10u8, 20, 30, 40],
+        )?;
+        let map_x = make_map(2, 2, vec![0.49, 1.49, -1.0, 0.5])?;
+        let map_y = make_map(2, 2, vec![0.49, 0.49, 0.5, 2.0])?;
+        let mut dst = Image::<_, 1>::from_size_val(
+            ImageSize {
+                width: 2,
+                height: 2,
+            },
+            0,
+        )?;
+
+        super::remap_u8(
+            &image,
+            &mut dst,
+            &map_x,
+            &map_y,
+            super::InterpolationMode::Nearest,
+        )?;
+
+        assert_eq!(dst.as_slice(), &[10, 20, 0, 0]);
         Ok(())
     }
 }

--- a/crates/kornia-imgproc/src/interpolation/remap.rs
+++ b/crates/kornia-imgproc/src/interpolation/remap.rs
@@ -81,6 +81,11 @@ pub fn remap<const C: usize>(
             return exec
                 .run(|stream| remap_f32_cuda(src, dst, map_x, map_y, interpolation, stream));
         }
+        if is_device(map_x) || is_device(map_y) {
+            return Err(ImageError::Cuda(
+                "remap: map_x and map_y must be host-resident when src/dst are on CPU".into(),
+            ));
+        }
     }
 
     // One monomorphic pixel loop per mode — see the note in `resize`.
@@ -140,11 +145,14 @@ pub fn remap<const C: usize>(
 /// use kornia_image::{Image, ImageSize};
 /// use kornia_imgproc::interpolation::{remap_u8, InterpolationMode};
 ///
-/// let src = Image::<u8, 3>::from_size_val(ImageSize { width: 4, height: 4 }, 128u8).unwrap();
-/// let mut dst = Image::<u8, 3>::from_size_val(ImageSize { width: 4, height: 4 }, 0u8).unwrap();
-/// let map_x = Image::<f32, 1>::from_size_val(ImageSize { width: 4, height: 4 }, 1.0f32).unwrap();
-/// let map_y = Image::<f32, 1>::from_size_val(ImageSize { width: 4, height: 4 }, 1.0f32).unwrap();
-/// remap_u8(&src, &mut dst, &map_x, &map_y, InterpolationMode::Bilinear).unwrap();
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let src = Image::<u8, 3>::from_size_val(ImageSize { width: 4, height: 4 }, 128u8)?;
+/// let mut dst = Image::<u8, 3>::from_size_val(ImageSize { width: 4, height: 4 }, 0u8)?;
+/// let map_x = Image::<f32, 1>::from_size_val(ImageSize { width: 4, height: 4 }, 1.0f32)?;
+/// let map_y = Image::<f32, 1>::from_size_val(ImageSize { width: 4, height: 4 }, 1.0f32)?;
+/// remap_u8(&src, &mut dst, &map_x, &map_y, InterpolationMode::Bilinear)?;
+/// # Ok(())
+/// # }
 /// ```
 pub fn remap_u8<const C: usize>(
     src: &Image<u8, C>,
@@ -170,7 +178,13 @@ pub fn remap_u8<const C: usize>(
         ));
     }
 
-    validate_interpolation(interpolation)?;
+    // remap_u8 only accelerates bilinear and nearest; reject others with the
+    // same error type on both CPU and GPU paths so callers get a consistent
+    // error variant regardless of where the images live.
+    match interpolation {
+        InterpolationMode::Bilinear | InterpolationMode::Nearest => {}
+        other => return Err(ImageError::UnsupportedInterpolation(other)),
+    }
 
     #[cfg(feature = "cuda")]
     {
@@ -214,6 +228,27 @@ pub fn remap_u8<const C: usize>(
 
     match interpolation {
         InterpolationMode::Bilinear => {
+            #[cfg(target_arch = "x86_64")]
+            if C == 3 && crate::simd::cpu_features().has_avx2 {
+                // SAFETY: the helper is only compiled on x86_64, we have
+                // already checked AVX2 at runtime, and the helper keeps the
+                // same bounds checks as the scalar path.
+                unsafe {
+                    remap_u8_bilinear_c3_avx2(
+                        src_slice,
+                        dst,
+                        map_x_slice,
+                        map_y_slice,
+                        src_w,
+                        src_h,
+                        src_stride,
+                        dst_w,
+                        dst_stride,
+                    );
+                }
+                return Ok(());
+            }
+
             dst.as_slice_mut()
                 .par_chunks_exact_mut(dst_stride)
                 .enumerate()
@@ -237,8 +272,7 @@ pub fn remap_u8<const C: usize>(
                         let fx_q10 = ((xf - xi as f32) * 1024.0) as u32;
                         let fy_q10 = ((yf - yi as f32) * 1024.0) as u32;
                         crate::warp::bilinear_sample_u8_valid::<C>(
-                            src_slice, src_w, src_h, src_stride, xi, yi, fx_q10, fy_q10,
-                            dst_pixel,
+                            src_slice, src_w, src_h, src_stride, xi, yi, fx_q10, fy_q10, dst_pixel,
                         );
                     }
                 });
@@ -264,10 +298,79 @@ pub fn remap_u8<const C: usize>(
                     }
                 });
         }
-        other => return Err(ImageError::UnsupportedInterpolation(other)),
+        // Bicubic/Lanczos are rejected at the top of remap_u8; unreachable here.
+        _ => unreachable!(),
     }
 
     Ok(())
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn remap_u8_bilinear_c3_avx2<const C: usize>(
+    src_slice: &[u8],
+    dst: &mut Image<u8, C>,
+    map_x_slice: &[f32],
+    map_y_slice: &[f32],
+    src_w: i32,
+    src_h: i32,
+    src_stride: usize,
+    dst_w: usize,
+    dst_stride: usize,
+) {
+    debug_assert!(C == 3);
+
+    let zero_pixel = |dst_pixel: &mut [u8]| {
+        for pixel in dst_pixel.iter_mut().take(C) {
+            *pixel = 0;
+        }
+    };
+
+    dst.as_slice_mut()
+        .par_chunks_exact_mut(dst_stride)
+        .enumerate()
+        .for_each(|(y, dst_row)| {
+            let row_base = y * dst_w;
+            for x in 0..dst_w {
+                let xf = map_x_slice[row_base + x];
+                let yf = map_y_slice[row_base + x];
+                let dst_pixel = &mut dst_row[x * C..x * C + C];
+                if !xf.is_finite() || !yf.is_finite() {
+                    zero_pixel(dst_pixel);
+                    continue;
+                }
+                let xi = xf.floor() as i32;
+                let yi = yf.floor() as i32;
+                if xi < 0 || xi >= src_w || yi < 0 || yi >= src_h {
+                    zero_pixel(dst_pixel);
+                    continue;
+                }
+                let fx_q10 = ((xf - xi as f32) * 1024.0) as u32;
+                let fy_q10 = ((yf - yi as f32) * 1024.0) as u32;
+
+                if xi < src_w - 2 || yi < src_h - 2 {
+                    // SAFETY: x86_64 + AVX2 were checked by the caller, and
+                    // the bounds condition mirrors the helper's preconditions.
+                    unsafe {
+                        crate::warp::bilinear_sample_u8_valid_c3_avx2(
+                            src_slice.as_ptr(),
+                            src_w,
+                            src_h,
+                            src_stride,
+                            xi,
+                            yi,
+                            fx_q10,
+                            fy_q10,
+                            dst_pixel.as_mut_ptr(),
+                        );
+                    }
+                } else {
+                    crate::warp::bilinear_sample_u8_valid::<C>(
+                        src_slice, src_w, src_h, src_stride, xi, yi, fx_q10, fy_q10, dst_pixel,
+                    );
+                }
+            }
+        });
 }
 
 /// Run the CUDA remap for a device-resident f32 triple (src, dst, maps).
@@ -456,6 +559,37 @@ mod tests {
         let map_x = make_map(2, 2, vec![0.0, 1.0, 0.0, 1.0])?;
         let map_y = make_map(2, 2, vec![0.0, 0.0, 1.0, 1.0])?;
         let mut dst = Image::<_, 1>::from_size_val(
+            ImageSize {
+                width: 2,
+                height: 2,
+            },
+            0,
+        )?;
+
+        super::remap_u8(
+            &image,
+            &mut dst,
+            &map_x,
+            &map_y,
+            super::InterpolationMode::Bilinear,
+        )?;
+
+        assert_eq!(dst.as_slice(), image.as_slice());
+        Ok(())
+    }
+
+    #[test]
+    fn remap_u8_rgb_identity_bilinear() -> Result<(), ImageError> {
+        let image = Image::<_, 3>::new(
+            ImageSize {
+                width: 2,
+                height: 2,
+            },
+            vec![1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+        )?;
+        let map_x = make_map(2, 2, vec![0.0, 1.0, 0.0, 1.0])?;
+        let map_y = make_map(2, 2, vec![0.0, 0.0, 1.0, 1.0])?;
+        let mut dst = Image::<_, 3>::from_size_val(
             ImageSize {
                 width: 2,
                 height: 2,

--- a/crates/kornia-imgproc/src/interpolation/remap.rs
+++ b/crates/kornia-imgproc/src/interpolation/remap.rs
@@ -506,7 +506,7 @@ mod tests {
 
 #[cfg(all(test, feature = "cuda"))]
 mod cuda_tests {
-    use super::remap;
+    use super::{remap, remap_u8};
     use crate::cuda::color::test_utils::{default_stream, pattern_f32};
     use crate::interpolation::InterpolationMode;
     use kornia_image::{Image, ImageError, ImageSize};
@@ -591,6 +591,97 @@ mod cuda_tests {
             matches!(&err, ImageError::Cuda(msg) if msg.contains("device-resident")),
             "expected a Cuda error about device-resident maps, got {err:?}"
         );
+        Ok(())
+    }
+
+    /// Byte-exact contract for the **u8** remap kernel: the GPU quantisation
+    /// must reproduce the CPU u8 path exactly, for a non-trivial map that
+    /// exercises fractional weights rather than just an identity copy.
+    fn check_remap_u8_mode<const C: usize>(
+        mode: InterpolationMode,
+        (w, h): (usize, usize),
+    ) -> Result<(), ImageError> {
+        let stream = default_stream();
+        let size = ImageSize {
+            width: w,
+            height: h,
+        };
+
+        // Deterministic ramp over the full u8 range; 251 is prime so the
+        // pattern does not align with the row stride.
+        let data: Vec<u8> = (0..w * h * C).map(|i| (i % 251) as u8).collect();
+        let src = Image::<u8, C>::new(size, data)?;
+
+        // Fractional map with irrational-ish steps so the bilinear weights are
+        // never 0 or 1 — that is where quantisation actually differs — and a
+        // deliberate negative/overshoot band to exercise the border guard.
+        let mx: Vec<f32> = (0..h)
+            .flat_map(|_| (0..w).map(|x| x as f32 * 1.03 - 1.7))
+            .collect();
+        let my: Vec<f32> = (0..h)
+            .flat_map(|y| (0..w).map(move |_| y as f32 * 1.07 - 2.3))
+            .collect();
+        let map_x = Image::<f32, 1>::new(size, mx)?;
+        let map_y = Image::<f32, 1>::new(size, my)?;
+
+        let mut cpu_dst = Image::<u8, C>::from_size_val(size, 0)?;
+        remap_u8(&src, &mut cpu_dst, &map_x, &map_y, mode)?;
+
+        let d_src = src.to_cuda(&stream)?;
+        let mut d_dst = Image::<u8, C>::zeros_cuda(size, &stream)?;
+        let d_mx = map_x.to_cuda(&stream)?;
+        let d_my = map_y.to_cuda(&stream)?;
+        remap_u8(&d_src, &mut d_dst, &d_mx, &d_my, mode)?;
+        let gpu_dst = d_dst.to_host_owned()?;
+
+        let mismatches: Vec<_> = cpu_dst
+            .as_slice()
+            .iter()
+            .zip(gpu_dst.as_slice())
+            .enumerate()
+            .filter(|(_, (c, g))| c != g)
+            .take(8)
+            .map(|(i, (c, g))| format!("[{i}] cpu {c} gpu {g}"))
+            .collect();
+        assert!(
+            mismatches.is_empty(),
+            "remap_u8 {mode:?} {C}ch {w}x{h}: {} of {} elements differ; first: {}",
+            cpu_dst
+                .as_slice()
+                .iter()
+                .zip(gpu_dst.as_slice())
+                .filter(|(c, g)| c != g)
+                .count(),
+            cpu_dst.as_slice().len(),
+            mismatches.join(", ")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn public_remap_u8_device_equals_host() -> Result<(), ImageError> {
+        for &size in &[(65, 33), (127, 63), (16, 16), (1, 1)] {
+            check_remap_u8_mode::<3>(InterpolationMode::Bilinear, size)?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn public_remap_u8_nearest_device_equals_host() -> Result<(), ImageError> {
+        for &size in &[(65, 33), (127, 63), (16, 16), (1, 1)] {
+            check_remap_u8_mode::<3>(InterpolationMode::Nearest, size)?;
+        }
+        Ok(())
+    }
+
+    /// The kernel takes the channel count as a runtime argument, so 1- and
+    /// 4-channel images exercise a different indexing path than 3-channel.
+    #[test]
+    fn public_remap_u8_channels_device_equals_host() -> Result<(), ImageError> {
+        for &mode in &[InterpolationMode::Bilinear, InterpolationMode::Nearest] {
+            check_remap_u8_mode::<1>(mode, (65, 33))?;
+            check_remap_u8_mode::<4>(mode, (65, 33))?;
+        }
         Ok(())
     }
 }

--- a/crates/kornia-imgproc/src/warp/common.rs
+++ b/crates/kornia-imgproc/src/warp/common.rs
@@ -20,6 +20,12 @@ pub(crate) fn bilinear_sample_u8<const C: usize>(
     yf: f32,
     dst_pixel: &mut [u8],
 ) {
+    if !xf.is_finite() || !yf.is_finite() {
+        for p in dst_pixel.iter_mut().take(C) {
+            *p = 0;
+        }
+        return;
+    }
     let xi = xf.floor() as i32;
     let yi = yf.floor() as i32;
 

--- a/crates/kornia-imgproc/src/warp/common.rs
+++ b/crates/kornia-imgproc/src/warp/common.rs
@@ -11,7 +11,7 @@
 ///
 /// `src_stride` is `src_cols * C` (row stride in bytes for u8).
 #[inline(always)]
-pub(super) fn bilinear_sample_u8<const C: usize>(
+pub(crate) fn bilinear_sample_u8<const C: usize>(
     src: &[u8],
     src_w: i32,
     src_h: i32,
@@ -72,7 +72,7 @@ pub(super) fn bilinear_sample_u8<const C: usize>(
 /// `fx_q10`/`fy_q10` must be in `[0, 1024]`.
 #[inline(always)]
 #[allow(clippy::too_many_arguments)]
-pub(super) fn bilinear_sample_u8_valid<const C: usize>(
+pub(crate) fn bilinear_sample_u8_valid<const C: usize>(
     src: &[u8],
     src_w: i32,
     src_h: i32,

--- a/crates/kornia-imgproc/src/warp/common.rs
+++ b/crates/kornia-imgproc/src/warp/common.rs
@@ -265,7 +265,7 @@ unsafe fn bilinear_sample_u8_valid_c3_neon(
 #[target_feature(enable = "avx2")]
 #[inline]
 #[allow(clippy::too_many_arguments)]
-unsafe fn bilinear_sample_u8_valid_c3_avx2(
+pub(crate) unsafe fn bilinear_sample_u8_valid_c3_avx2(
     src: *const u8,
     src_w: i32,
     src_h: i32,

--- a/crates/kornia-imgproc/src/warp/mod.rs
+++ b/crates/kornia-imgproc/src/warp/mod.rs
@@ -7,7 +7,7 @@ mod perspective;
 mod span;
 
 pub use affine::{get_rotation_matrix2d, invert_affine_transform, warp_affine, warp_affine_u8};
-pub(crate) use common::bilinear_sample_u8;
+pub(crate) use common::bilinear_sample_u8_valid;
 #[cfg(feature = "cuda")]
 pub(crate) use perspective::invert_homography;
 pub use perspective::{warp_perspective, warp_perspective_u8};

--- a/crates/kornia-imgproc/src/warp/mod.rs
+++ b/crates/kornia-imgproc/src/warp/mod.rs
@@ -7,6 +7,7 @@ mod perspective;
 mod span;
 
 pub use affine::{get_rotation_matrix2d, invert_affine_transform, warp_affine, warp_affine_u8};
+pub(crate) use common::bilinear_sample_u8;
 #[cfg(feature = "cuda")]
 pub(crate) use perspective::invert_homography;
 pub use perspective::{warp_perspective, warp_perspective_u8};

--- a/crates/kornia-imgproc/src/warp/mod.rs
+++ b/crates/kornia-imgproc/src/warp/mod.rs
@@ -8,6 +8,7 @@ mod span;
 
 pub use affine::{get_rotation_matrix2d, invert_affine_transform, warp_affine, warp_affine_u8};
 pub(crate) use common::bilinear_sample_u8_valid;
+pub(crate) use common::bilinear_sample_u8_valid_c3_avx2;
 #[cfg(feature = "cuda")]
 pub(crate) use perspective::invert_homography;
 pub use perspective::{warp_perspective, warp_perspective_u8};

--- a/crates/kornia-imgproc/src/warp/mod.rs
+++ b/crates/kornia-imgproc/src/warp/mod.rs
@@ -8,6 +8,7 @@ mod span;
 
 pub use affine::{get_rotation_matrix2d, invert_affine_transform, warp_affine, warp_affine_u8};
 pub(crate) use common::bilinear_sample_u8_valid;
+#[cfg(target_arch = "x86_64")]
 pub(crate) use common::bilinear_sample_u8_valid_c3_avx2;
 #[cfg(feature = "cuda")]
 pub(crate) use perspective::invert_homography;


### PR DESCRIPTION
## 📝 Description

**Fixes/Relates to:** no issue — this implements the follow-up asked for in review on #998:

> Can you explore next a remap function for u8 images? I guess some sort if quantisation during the interpolation might need to be applied

Adds `remap_u8`, a u8 remap with a CPU path and CUDA bilinear/nearest kernels, dispatched by residency like the f32 `remap`.

### On the quantisation

You were right that it's the crux. Interpolating u8 means computing a weighted sum and landing back in 0..=255, and the choice of how is what decides whether the GPU agrees with the CPU — and whether u8 remap agrees with the u8 warp already in the tree.

This does **not** invent a scheme. It reuses the Q10 fixed-point blend `warp_affine_u8` already uses, so the two u8 ops round identically:

```c
unsigned int fx = (unsigned int)((sxc - (float)x0) * 1024.0f);   // Q10 weight, truncated
...
dst[out + ch] = (unsigned char)((top * fy1 + bot * fy + (1u << 19)) >> 20);  // round-half-up
```

That `(… + (1<<19)) >> 20` is character-for-character `warp_affine_u8`'s blend.

One difference from `warp_affine_u8` worth calling out, since it's the thing I expected to be a problem and wasn't: that kernel carries a Q16 coordinate accumulator anchored at the row span's left edge, because it derives coordinates incrementally along a row. Remap has no span and no accumulator — every coordinate is read straight from `map_x`/`map_y` — so there is nothing to anchor and the Q10 weights come directly off the float coordinate. The exactness argument is correspondingly simpler: both sides truncate the same f32 to Q10 and run the same integer blend.

Nearest needs no quantisation at all: it copies the source byte, so it is exact by construction.

---

## 🛠️ Changes Made
- [x] `remap_u8` public API (`Image<u8, C>` src/dst, `Image<f32, 1>` maps), residency-dispatched like `remap`
- [x] CPU u8 path with Q10 fixed-point bilinear and nearest
- [x] CUDA kernels `remap_bilinear_u8_c{C}` / `remap_nearest_u8_c{C}` — `__ldg` on source and maps, zero border for out-of-range coordinates, channel count specialised at compile time
- [x] Launchers `launch_remap_bilinear_u8_cuda` / `launch_remap_nearest_u8_cuda` and the `remap_u8_cuda` dispatch adapter
- [x] Device-vs-host parity tests, and a benchmark against the f32 kernel

---

## 🧪 How Was This Tested?

- [x] **Unit Tests:** 3 CPU tests (`remap_u8_identity_bilinear`, `remap_u8_bilinear_quantizes_fractional_weights`, `remap_u8_nearest_zeroes_oob_maps`) plus 3 device-vs-host parity tests (`public_remap_u8_device_equals_host`, `public_remap_u8_nearest_device_equals_host`, `public_remap_u8_channels_device_equals_host`). The parity tests are the ones that matter for the quantisation question — they assert the GPU is **bit-exact** against the CPU u8 path, over the cases where rounding actually diverges: fractional map steps (`1.03x − 1.7`, `1.07y − 2.3`) so bilinear weights are never 0 or 1; negative and overshooting coordinates for the border guard; 1, 3 and 4 channels, since the kernel takes the channel count at runtime and each is a distinct indexing path; sizes 65×33, 127×63, 16×16 and 1×1; both modes.

- [x] **Manual Verification:** Full suite on two architectures — **GTX 1650** (sm_75, discrete) and **Jetson Orin Nano** (sm_87, integrated, L4T R36.4.7 / CUDA 12.6). `cargo test -p kornia-imgproc --features cuda --lib` is 467 passed on the GTX and 478 passed on the Jetson, 0 failed on both; the u8 tests are 6/6 on each. Also builds and passes without the `cuda` feature (339 passed).

- [x] **Performance/Edge Cases:** Benchmarked against the f32 kernel with `examples/bench_remap_u8.rs`, 300 iterations after 60 warmup, device-resident, through the public API:

  **Bilinear**

  | size | GTX u8 | GTX f32 | | Jetson u8 | Jetson f32 | |
  |---|---|---|---|---|---|---|
  | FHD 1920×1080 | 0.451 ms | 0.565 ms | 1.25× | 0.682 ms | 0.831 ms | 1.22× |
  | 4K 3840×2160 | 1.818 ms | 2.341 ms | 1.29× | 2.414 ms | 3.133 ms | 1.30× |

  **Nearest**

  | size | GTX u8 | GTX f32 | | Jetson u8 | Jetson f32 | |
  |---|---|---|---|---|---|---|
  | FHD 1920×1080 | 0.262 ms | 0.446 ms | 1.70× | 0.437 ms | 0.719 ms | 1.65× |
  | 4K 3840×2160 | 1.070 ms | 1.848 ms | 1.73× | 1.740 ms | 2.867 ms | 1.65× |

  Bilinear gains less than the 4× the narrower pixel type suggests, and the benchmark prints achieved bandwidth to show why: the two **f32 coordinate maps are the same size either way**, so at 3 channels they are a large fixed share of the traffic and cap the win. Nearest reads one source pixel instead of four, so the maps are a smaller share and it gets closer to the ideal. Sub-HD sizes are launch-bound and show no reliable gain — the Jetson VGA/HD numbers moved between 0.94× and 1.5× across repeat runs, so I would not claim anything below FHD.

---

## 🕵️ AI Usage Disclosure
*Check one of the following:*
- [ ] 🟢 **No AI used.**
- [x] 🟡 **AI-assisted:** I used AI for boilerplate/refactoring but have manually reviewed and tested every line.
- [ ] 🔴 **AI-generated:** (Note: These PRs may be subject to stricter scrutiny or immediate closure if the logic is not explained).

---

## 🚦 Checklist
- [ ] I am assigned to the linked issue (required before PR submission)
- [ ] The linked issue has been approved by a maintainer
- [x] This PR strictly implements what the linked issue describes (no scope creep)
- [x] I have performed a **self-review** of my code (no "ghost" variables or hallucinations).
- [x] My code follows the existing style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] (Optional) I have attached screenshots/recordings for UI changes.

The first two are unchecked because there is no linked issue — this comes from a review comment on an already-merged PR. Happy to open one if you'd prefer the process followed strictly.

---

## 💭 Additional Context

There is deliberately no "convert u8 to f32, remap, convert back" comparison in the benchmark: the only `cast_and_scale` in the tree is CPU-side, so that alternative cannot be measured on-device at all. That absence is part of the case for this kernel — without it, a u8 pipeline has to round-trip through the host to use the f32 remap, which costs far more than the 1.2–1.7× measured here.
