### PR TITLE
fix(imgproc): stop mutating the environment inside the ORB orientation test

### DIFF
--- a/crates/kornia-imgproc/src/features/orb/extractor.rs
+++ b/crates/kornia-imgproc/src/features/orb/extractor.rs
@@ -1353,8 +1353,6 @@ unsafe fn orientation_kp_avx2(src_slice: &[u8], r0: usize, c0: usize, cols: usiz
 
 fn corner_orientations_u8(src: &Image<u8, 1>, corners: &[[usize; 2]]) -> Vec<f32> {
     // Caller must have already filtered keypoints by border distance ≥ 15.
-    const HALF: i32 = 15;
-
     let cols = src.cols();
     let src_slice = src.as_slice();
 
@@ -1376,40 +1374,53 @@ fn corner_orientations_u8(src: &Image<u8, 1>, corners: &[[usize; 2]]) -> Vec<f32
                 return unsafe { orientation_kp_avx2(src_slice, r0, c0, cols) };
             }
 
-            // Standard ORB `ICAngle`: v=0 processed alone, then pairs (+v, -v)
-            // together with half-width UMAX[v]. The mask is not a clean Euclidean
-            // disk — see UMAX docstring for the symmetrization that enforces
-            // 45°-diagonal symmetry.
-            let mut m01: i32 = 0;
-            let mut m10: i32 = 0;
-            let center = r0 as isize * cols as isize + c0 as isize;
-
-            for u in -HALF..=HALF {
-                let idx = (center + u as isize) as usize;
-                let px = unsafe { *src_slice.get_unchecked(idx) } as i32;
-                m10 += u * px;
-            }
-
-            for v in 1..=HALF {
-                let d = UMAX[v as usize];
-                let mut v_sum: i32 = 0;
-                let plus_base = center + (v as isize) * cols as isize;
-                let minus_base = center - (v as isize) * cols as isize;
-                for u in -d..=d {
-                    let val_plus =
-                        unsafe { *src_slice.get_unchecked((plus_base + u as isize) as usize) }
-                            as i32;
-                    let val_minus =
-                        unsafe { *src_slice.get_unchecked((minus_base + u as isize) as usize) }
-                            as i32;
-                    v_sum += val_plus - val_minus;
-                    m10 += u * (val_plus + val_minus);
-                }
-                m01 += v * v_sum;
-            }
-            (m01 as f32).atan2(m10 as f32)
+            unsafe { orientation_kp_scalar(src_slice, r0, c0, cols) }
         })
         .collect()
+}
+
+/// Portable reference orientation for a single keypoint.
+///
+/// Standard ORB `ICAngle`: v=0 processed alone, then pairs (+v, -v) together
+/// with half-width UMAX[v]. The mask is not a clean Euclidean disk — see UMAX
+/// docstring for the symmetrization that enforces 45°-diagonal symmetry.
+///
+/// Split out of [`corner_orientations_u8`] so the SIMD kernels can be compared
+/// against it directly, without routing through the dispatcher.
+///
+/// # Safety
+/// - the 31×31 patch centred on `(r0, c0)` must lie within `src_slice`; callers
+///   filter keypoints by border distance ≥ 15 beforehand.
+unsafe fn orientation_kp_scalar(src_slice: &[u8], r0: usize, c0: usize, cols: usize) -> f32 {
+    const HALF: i32 = 15;
+
+    let mut m01: i32 = 0;
+    let mut m10: i32 = 0;
+    let center = r0 as isize * cols as isize + c0 as isize;
+
+    for u in -HALF..=HALF {
+        let idx = (center + u as isize) as usize;
+        let px = unsafe { *src_slice.get_unchecked(idx) } as i32;
+        m10 += u * px;
+    }
+
+    for v in 1..=HALF {
+        let d = UMAX[v as usize];
+        let mut v_sum: i32 = 0;
+        let plus_base = center + (v as isize) * cols as isize;
+        let minus_base = center - (v as isize) * cols as isize;
+        for u in -d..=d {
+            let val_plus =
+                unsafe { *src_slice.get_unchecked((plus_base + u as isize) as usize) } as i32;
+            let val_minus =
+                unsafe { *src_slice.get_unchecked((minus_base + u as isize) as usize) } as i32;
+            v_sum += val_plus - val_minus;
+            m10 += u * (val_plus + val_minus);
+        }
+        m01 += v * v_sum;
+    }
+
+    (m01 as f32).atan2(m10 as f32)
 }
 
 fn corner_orientations(src: &Image<f32, 1>, corners: &[[usize; 2]]) -> Vec<f32> {
@@ -1766,14 +1777,20 @@ mod tests {
             })
             .collect();
 
-        // TODO: Audit that the environment access only happens in single-threaded code.
-        unsafe { std::env::set_var("KORNIA_ORB_ORI_NEON", "1") };
-        let neon = corner_orientations_u8(&img, &corners);
-        // TODO: Audit that the environment access only happens in single-threaded code.
-        unsafe { std::env::set_var("KORNIA_ORB_ORI_NEON", "0") };
-        let scalar = corner_orientations_u8(&img, &corners);
-        // TODO: Audit that the environment access only happens in single-threaded code.
-        unsafe { std::env::remove_var("KORNIA_ORB_ORI_NEON") };
+        // Call both kernels directly rather than toggling `KORNIA_ORB_ORI_NEON`
+        // around the dispatcher: the test harness runs tests on multiple
+        // threads, so mutating the process environment here would race any
+        // concurrent reader (and is UB under the 2024 edition).
+        let cols = img.cols();
+        let slice = img.as_slice();
+        let neon: Vec<f32> = corners
+            .iter()
+            .map(|&[r0, c0]| unsafe { super::orientation_kp_neon(slice, r0, c0, cols) })
+            .collect();
+        let scalar: Vec<f32> = corners
+            .iter()
+            .map(|&[r0, c0]| unsafe { super::orientation_kp_scalar(slice, r0, c0, cols) })
+            .collect();
 
         for (i, (n, s)) in neon.iter().zip(scalar.iter()).enumerate() {
             // atan2 of identical integer moments is bit-identical.


### PR DESCRIPTION
## 📝 Description

`test_orientation_neon_matches_scalar` picked the NEON vs scalar path by setting `KORNIA_ORB_ORI_NEON` around two calls to `corner_orientations_u8`:

```rust
// TODO: Audit that the environment access only happens in single-threaded code.
unsafe { std::env::set_var("KORNIA_ORB_ORI_NEON", "1") };
let neon = corner_orientations_u8(&img, &corners);
// TODO: Audit that the environment access only happens in single-threaded code.
unsafe { std::env::set_var("KORNIA_ORB_ORI_NEON", "0") };
let scalar = corner_orientations_u8(&img, &corners);
```

The test harness runs tests on multiple threads, so mutating the process environment there races any concurrent reader. That is exactly why the 2024 edition requires `unsafe` for `set_var`/`remove_var`, and why the three auto-generated `TODO: Audit …` markers were sitting above each call — nobody had confirmed the invariant they ask about, and it does not hold.

Beyond the soundness point, the test was indirect: it asserted things about the *dispatcher* rather than about the two kernels it names.

---

## 🛠️ Changes Made

- Split the inline scalar body of `corner_orientations_u8` into a private `orientation_kp_scalar(src_slice, r0, c0, cols) -> f32`, mirroring the shape of the existing `orientation_kp_neon` / `orientation_kp_avx2` kernels. The doc comment explaining the ORB `ICAngle` mask moves with it.
- The dispatcher now calls that function on the path the inline code previously occupied — no behavioural change.
- `test_orientation_neon_matches_scalar` calls `orientation_kp_neon` and `orientation_kp_scalar` directly. No environment access remains in the test, and all three `TODO: Audit …` markers are gone.
- Removed `const HALF` from `corner_orientations_u8`, which became unused once the scalar body moved out (it is re-declared inside the extracted function).

The `KORNIA_ORB_ORI_NEON` switch in the dispatcher itself is left untouched here — that is a separate discussion, since on aarch64 it stands in for the runtime CPU probe that the x86 arm four lines below uses.

---

## 🧪 How Was This Tested?

Apple M5, aarch64-apple-darwin, `--release`.

- `cargo test -p kornia-imgproc --release features::orb` — `test_orientation_neon_matches_scalar ... ok`, 5 passed.
- Full crate suite: **406 passed, 0 failed, 4 ignored**.
- `cargo fmt --all -- --check` clean.

Note on clippy: `cargo clippy -p kornia-imgproc` fails on `src/canny.rs:88` (`unnecessary '>= y + 1'`) with the toolchain in `pixi.toml` (1.96.0). I confirmed that failure reproduces on an unmodified `main`, so it is pre-existing and not from this change.

The parity assertion itself is unchanged — `assert_eq!(n.to_bits(), s.to_bits())` across 50 keypoints on a deterministic pseudo-random 200×200 image — so it still pins NEON to the scalar reference bit-for-bit, just without touching global state to get there.

---

## 🕵️ AI Usage Disclosure

- 🟡 **AI-assisted:** the extraction and test rewrite were done with AI assistance; the diff has been reviewed line by line and the reasoning above is mine to defend.

---

## 🚦 Checklist

- [x] My code follows the existing style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Existing tests cover this change (the parity test is the thing being fixed).