### PR TITLE
fix(imgproc): select the ORB NEON kernel from the CPU probe, not an env var

### DIFF
--- a/crates/kornia-imgproc/src/features/orb/extractor.rs
+++ b/crates/kornia-imgproc/src/features/orb/extractor.rs
@@ -1357,7 +1357,7 @@ fn corner_orientations_u8(src: &Image<u8, 1>, corners: &[[usize; 2]]) -> Vec<f32
     let src_slice = src.as_slice();
 
     #[cfg(target_arch = "aarch64")]
-    let use_neon = std::env::var("KORNIA_ORB_ORI_NEON").map_or(true, |v| v != "0");
+    let use_neon = crate::simd::cpu_features().has_neon;
 
     #[cfg(target_arch = "x86_64")]
     let use_avx2 = crate::simd::cpu_features().has_avx2;
@@ -1777,10 +1777,9 @@ mod tests {
             })
             .collect();
 
-        // Call both kernels directly rather than toggling `KORNIA_ORB_ORI_NEON`
-        // around the dispatcher: the test harness runs tests on multiple
-        // threads, so mutating the process environment here would race any
-        // concurrent reader (and is UB under the 2024 edition).
+        // Call both kernels directly rather than going through the dispatcher:
+        // on aarch64 it always selects NEON, so routing through it could not
+        // reach the scalar reference at all.
         let cols = img.cols();
         let slice = img.as_slice();
         let neon: Vec<f32> = corners


### PR DESCRIPTION
## 📝 Description

> **Stacked on #1077** — please review that one first. Base is set to its branch, so this diff shows only the dispatch change.

`corner_orientations_u8` picked its aarch64 kernel like this:

```rust
#[cfg(target_arch = "aarch64")]
let use_neon = std::env::var("KORNIA_ORB_ORI_NEON").map_or(true, |v| v != "0");

#[cfg(target_arch = "x86_64")]
let use_avx2 = crate::simd::cpu_features().has_avx2;
```

Four lines apart, the two architectures answer "is this kernel available?" in completely different ways — x86_64 asks the CPU, aarch64 reads an undocumented environment variable. The ARM path was using a debug toggle where the rest of the crate uses runtime feature detection.

---

## 🛠️ Changes Made

- `use_neon` now comes from `crate::simd::cpu_features().has_neon`, matching the x86_64 arm and every other dispatching kernel in the crate.
- Updated the comment in the parity test that referenced the now-removed variable.

**Behavioural impact:** none in practice. NEON is architectural on aarch64 (`simd/mod.rs` hardcodes `has_neon: true` for the target, and there is a test asserting it), so the selected path is identical except when someone set `KORNIA_ORB_ORI_NEON=0`. That override was undocumented, appeared in no docs or README, and its only in-tree consumer was `test_orientation_neon_matches_scalar` — which #1077 changed to call both kernels directly.

It also removes a `std::env::var` from a function that runs once per ORB extraction. That call allocates a `String` and takes a lock on the environment each time.

**If you would rather keep an escape hatch**, say so and I will restore it in the form used at `cuda/sift/orientation.rs:531` — cached in a `OnceLock` with a comment explaining why it must not be re-read per call. I left it out here because the x86 arm has no equivalent and I did not want to entrench the asymmetry, but that is your call, not mine.

---

## 🧪 How Was This Tested?

Apple M5, aarch64-apple-darwin, `--release`.

- Full crate suite: **406 passed, 0 failed, 4 ignored**.
- `cargo test -p kornia-imgproc --release features::orb` — 5 passed, including `test_orientation_neon_matches_scalar`.
- `cargo fmt --all -- --check` clean.
- `grep -rn KORNIA_ORB_ORI_NEON crates/ docs/ README.md` returns nothing after this change.

Same pre-existing clippy note as #1077: `src/canny.rs:88` fails under the pinned 1.96.0 toolchain on unmodified `main` too.

---

## 🕵️ AI Usage Disclosure

- 🟡 **AI-assisted:** change made with AI assistance; reviewed line by line and the reasoning above is mine to defend.

---

## 🚦 Checklist

- [x] My code follows the existing style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Existing tests cover this change.