### PR TITLE
docs(imgproc): point the L1 loss reference at the right page

### DIFF
--- a/crates/kornia-imgproc/src/metrics/l1.rs
+++ b/crates/kornia-imgproc/src/metrics/l1.rs
@@ -53,7 +53,7 @@ use kornia_image::{Image, ImageError};
 ///
 /// # References
 ///
-/// [Wikipedia - L1 loss](https://en.wikipedia.org/wiki/Huber_loss)
+/// [Wikipedia - Mean absolute error](https://en.wikipedia.org/wiki/Mean_absolute_error)
 pub fn l1_loss<const C: usize>(
     image1: &Image<f32, C>,
     image2: &Image<f32, C>,


### PR DESCRIPTION
## 📝 Description

`crates/kornia-imgproc/src/metrics/l1.rs:56` reads:

```rust
/// [Wikipedia - L1 loss](https://en.wikipedia.org/wiki/Huber_loss)
```

The link text says L1 loss, the URL goes to Huber loss. `huber.rs:56` has the identical URL, where it is correct — so this looks like a copy-paste from the file next door.

---

## 🛠️ Changes Made

- Retarget the link to [Mean absolute error](https://en.wikipedia.org/wiki/Mean_absolute_error), which is what `l1_loss` computes (mean of `|a - b|`), and update the link text to match.

One line, docs only.

---

## 🧪 How Was This Tested?

`cargo test -p kornia-imgproc --release --doc metrics` passes. No code changed.

---

## 🕵️ AI Usage Disclosure

- 🟡 **AI-assisted:** spotted and fixed with AI assistance; trivially verifiable from the two lines quoted above.

---

## 🚦 Checklist

- [x] My code follows the existing style guidelines of this project.
- [x] Docs-only change; no tests needed.