### PR TITLE
refactor(imgproc): make the sobel/scharr magnitude pass actually run in parallel

### DIFF
--- a/crates/kornia-imgproc/src/filter/ops.rs
+++ b/crates/kornia-imgproc/src/filter/ops.rs
@@ -191,13 +191,9 @@ pub fn sobel<const C: usize>(
     separable_filter(src, &mut gy, &kernel_y, &kernel_x)?;
 
     // compute the magnitude in parallel by rows
-    dst.as_slice_mut()
-        .iter_mut()
-        .zip(gx.as_slice().iter())
-        .zip(gy.as_slice().iter())
-        .for_each(|((dst, &gx), &gy)| {
-            *dst = (gx * gx + gy * gy).sqrt();
-        });
+    crate::parallel::par_iter_rows_val_two(&gx, &gy, dst, |&gx_val, &gy_val, dst_val| {
+        *dst_val = (gx_val * gx_val + gy_val * gy_val).sqrt();
+    });
 
     Ok(())
 }
@@ -228,13 +224,10 @@ pub fn scharr<const C: usize>(
     let mut gy = Image::<f32, C>::from_size_val(src.size(), 0.0)?;
     separable_filter(src, &mut gy, &kernel_y, &kernel_x)?;
 
-    dst.as_slice_mut()
-        .iter_mut()
-        .zip(gx.as_slice().iter())
-        .zip(gy.as_slice().iter())
-        .for_each(|((dst, &gx), &gy)| {
-            *dst = (gx * gx + gy * gy).sqrt();
-        });
+    // compute the magnitude in parallel by rows
+    crate::parallel::par_iter_rows_val_two(&gx, &gy, dst, |&gx_val, &gy_val, dst_val| {
+        *dst_val = (gx_val * gx_val + gy_val * gy_val).sqrt();
+    });
 
     Ok(())
 }


### PR DESCRIPTION
## 📝 Description

`sobel` carries this comment directly above a serial loop:

```rust
    // compute the magnitude in parallel by rows
    dst.as_slice_mut()
        .iter_mut()          // <- single-threaded
        .zip(gx.as_slice().iter())
        .zip(gy.as_slice().iter())
```

`scharr` has the identical serial chain with no comment at all. Every other place in the crate that claims parallelism genuinely uses `par_iter_rows*` — this is the only comment-versus-code mismatch of its kind I could find.

---

## 🛠️ Changes Made

- Route both `sobel` and `scharr` magnitude passes through the existing `parallel::par_iter_rows_val_two` helper, which is precisely the `(src1, src2, dst)` row-parallel shape they need.
- Add the same explanatory comment to `scharr`, which had none.

---

## ⚠️ This is not a speedup — please read before merging

I benchmarked it, and it does **not** make `sobel` faster:

| | 1080p f32 C1, median of 20 |
|---|---|
| before (`main`) | 10.68 ms |
| after (this PR) | 10.80 ms |

That is the same within run-to-run noise. The reason is that the two `separable_filter` calls dominate the function and the magnitude pass is a small tail, so parallelising the tail changes almost nothing end to end.

I am proposing it anyway because the comment is actively misleading: anyone profiling `sobel` reads "in parallel by rows" and rules that step out. If you would rather keep the serial loop and just delete the comment, that is a completely reasonable call and I will switch it — the point is that the two should agree.

The real cost in `sobel` is elsewhere and is a separate discussion: the generic f32 `separable_filter` engine has no SIMD path (that is the sobel half of #1041), and each call allocates two full scratch images.

---

## 🧪 How Was This Tested?

Apple M5, aarch64-apple-darwin, `--release`.

- Full crate suite: **406 passed, 0 failed, 4 ignored**.
- Specifically `test_spatial_gradient`, `test_scharr_spatial_gradient`, `test_sobel_kernel_1d`, `test_scharr_kernel_1d` — all pass.
- `cargo fmt --all` clean.

Output is unchanged: `par_iter_rows_val_two` visits the same elements with the same per-element expression, and the operation is elementwise, so there is no reordering to worry about.

Same pre-existing clippy note as #1077: `src/canny.rs:88` fails under the pinned 1.96.0 toolchain on unmodified `main` too.

---

## 🕵️ AI Usage Disclosure

- 🟡 **AI-assisted:** change and benchmarking done with AI assistance; reviewed line by line and the numbers above are from my own machine.

---

## 🚦 Checklist

- [x] My code follows the existing style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Existing tests cover this change.