### PR TITLE
test(imgproc): benchmark all three metrics, on inputs that actually differ

### DIFF
--- a/crates/kornia-imgproc/benches/bench_metrics.rs
+++ b/crates/kornia-imgproc/benches/bench_metrics.rs
@@ -3,27 +3,70 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use kornia_image::Image;
 use kornia_imgproc::metrics;
 
-fn bench_mse(c: &mut Criterion) {
-    let mut group = c.benchmark_group("mse");
+/// Deterministic pseudo-random f32 in [0, 1).
+///
+/// The metrics take *two* images. Benchmarking them with one all-zero buffer
+/// compared against itself makes every difference exactly zero, which pins
+/// `huber` to one side of its `|diff| <= delta` branch and never exercises the
+/// other. Two independently seeded buffers keep both arms live.
+fn pseudo_random(len: usize, seed: u32) -> Vec<f32> {
+    let mut state = seed;
+    (0..len)
+        .map(|_| {
+            state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            (state >> 8) as f32 / (1u32 << 24) as f32
+        })
+        .collect()
+}
+
+fn bench_metrics(c: &mut Criterion) {
+    let mut group = c.benchmark_group("metrics");
 
     for (width, height) in [(256, 224), (512, 448), (1024, 896)].iter() {
-        group.throughput(criterion::Throughput::Elements((*width * *height) as u64));
+        group.throughput(criterion::Throughput::Elements(
+            (*width * *height * 3) as u64,
+        ));
 
         let parameter_string = format!("{width}x{height}");
-
-        // input image
         let image_size = [*width, *height].into();
-        let image = Image::<u8, 3>::new(image_size, vec![0u8; width * height * 3]).unwrap();
-        let image_f32 = image.cast::<f32>().unwrap();
+        let len = width * height * 3;
+
+        let image1 = Image::<f32, 3>::new(image_size, pseudo_random(len, 0x1234_5678)).unwrap();
+        let image2 = Image::<f32, 3>::new(image_size, pseudo_random(len, 0x9E37_79B9)).unwrap();
+        let pair = (image1, image2);
 
         group.bench_with_input(
-            BenchmarkId::new("mse_map", &parameter_string),
-            &image_f32,
-            |b, i| b.iter(|| metrics::mse(std::hint::black_box(i), std::hint::black_box(i))),
+            BenchmarkId::new("mse", &parameter_string),
+            &pair,
+            |b, (x, y)| b.iter(|| metrics::mse(std::hint::black_box(x), std::hint::black_box(y))),
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("l1_loss", &parameter_string),
+            &pair,
+            |b, (x, y)| {
+                b.iter(|| metrics::l1_loss(std::hint::black_box(x), std::hint::black_box(y)))
+            },
+        );
+
+        // delta = 0.25 straddles the branch for uniformly distributed inputs:
+        // most |diff| land above it, a meaningful minority below.
+        group.bench_with_input(
+            BenchmarkId::new("huber", &parameter_string),
+            &pair,
+            |b, (x, y)| {
+                b.iter(|| {
+                    metrics::huber(
+                        std::hint::black_box(x),
+                        std::hint::black_box(y),
+                        std::hint::black_box(0.25),
+                    )
+                })
+            },
         );
     }
     group.finish();
 }
 
-criterion_group!(benches, bench_mse);
+criterion_group!(benches, bench_metrics);
 criterion_main!(benches);


### PR DESCRIPTION
## 📝 Description

`benches/bench_metrics.rs` had two problems:

**1. It measured one function of three.** `criterion_group!(benches, bench_mse)` — `l1_loss` and `huber` were never benchmarked.

**2. It compared an image against itself:**

```rust
let image = Image::<u8, 3>::new(image_size, vec![0u8; width * height * 3]).unwrap();
let image_f32 = image.cast::<f32>().unwrap();
// ...
b.iter(|| metrics::mse(std::hint::black_box(i), std::hint::black_box(i)))
```

An all-zero buffer passed as both arguments, so every per-element difference was exactly zero. That is the degenerate case for this family — `huber` branches on `|diff| <= delta`, so with all-zero differences it would only ever have taken one arm even once it was benchmarked.

---

## 🛠️ Changes Made

- Renamed the group `mse` → `metrics` and added `l1_loss` and `huber` alongside `mse`.
- Two independently seeded pseudo-random f32 buffers instead of one zero buffer used twice. Deterministic LCG, no `rand` dev-dependency added.
- `delta = 0.25` for `huber`, chosen so that with uniform [0,1) inputs most `|diff|` land above the threshold and a meaningful minority below — both arms stay live.
- Throughput counts `width * height * C` rather than `width * height`, since these reductions walk every channel.

---

## 🧪 How Was This Tested?

`cargo bench -p kornia-imgproc --bench bench_metrics -- --quick` on an Apple M5:

```
metrics/mse/256x224       84.7 µs      metrics/mse/1024x896      1.623 ms
metrics/l1_loss/256x224  100.1 µs      metrics/l1_loss/1024x896  1.603 ms
metrics/huber/256x224    107.1 µs      metrics/huber/1024x896    1.697 ms
```

`cargo fmt --all` clean. Benchmarks only — no library code touched.

---

## 💭 Additional Context

Worth flagging what these numbers show, though it is out of scope for this PR: throughput is roughly flat across sizes (~1.9 G elements/sec at every size), which is the signature of a loop-carried dependency rather than a memory limit. All three functions are plain serial `fold`s with no `rayon` — they are the only ops in `kornia-imgproc` that never use more than one core. Now that they are measured, that is at least visible.

---

## 🕵️ AI Usage Disclosure

- 🟡 **AI-assisted:** written with AI assistance; the numbers above are from my machine.

---

## 🚦 Checklist

- [x] My code follows the existing style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] This PR *is* the test/benchmark improvement.