### PR TITLE
test(imgproc): benchmark morphology on real content, and at 1080p

### DIFF
--- a/crates/kornia-imgproc/benches/bench_morphology.rs
+++ b/crates/kornia-imgproc/benches/bench_morphology.rs
@@ -1,89 +1,68 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
-use kornia_image::Image;
+use kornia_image::{Image, ImageError};
 use kornia_imgproc::morphology::{close, dilate, erode, open, Kernel, KernelShape};
 use kornia_imgproc::padding::PaddingMode;
+
+type MorphOp =
+    fn(&Image<u8, 1>, &mut Image<u8, 1>, &Kernel, PaddingMode, [u8; 1]) -> Result<(), ImageError>;
+
+const OPS: [(&str, MorphOp); 4] = [
+    ("dilate", dilate::<u8, 1>),
+    ("erode", erode::<u8, 1>),
+    ("open", open::<u8, 1>),
+    ("close", close::<u8, 1>),
+];
+
+/// Deterministic pseudo-random bytes.
+///
+/// A constant-valued image is close to the best case for any running-min/max
+/// (van Herk / Gil-Werman) implementation, so benchmarking morphology on one
+/// would report speedups that do not hold on real images. The current
+/// `Ord`-based engine is content-independent, but the benchmark should not be
+/// the thing that hides that when the engine changes.
+fn pseudo_random(len: usize, seed: u32) -> Vec<u8> {
+    let mut state = seed;
+    (0..len)
+        .map(|_| {
+            state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            (state >> 24) as u8
+        })
+        .collect()
+}
 
 fn bench_morphology(c: &mut Criterion) {
     let mut group = c.benchmark_group("Morphology");
 
-    for (width, height) in [(256, 224), (512, 448), (1024, 896)].iter() {
+    for (width, height) in [(256, 224), (512, 448), (1024, 896), (1920, 1080)].iter() {
+        group.throughput(criterion::Throughput::Elements((*width * *height) as u64));
+
+        let image_size = [*width, *height].into();
+        let image =
+            Image::<u8, 1>::new(image_size, pseudo_random(width * height, 0x1234_5678)).unwrap();
+
         for kernel_size in [3, 5, 7].iter() {
             let parameter_string = format!("{width}x{height}_k{kernel_size}");
-            let image_size = [*width, *height].into();
-
-            let image = Image::<u8, 1>::from_size_val(image_size, 128).unwrap();
-            let dst = Image::<u8, 1>::from_size_val(image_size, 0).unwrap();
-
             let kernel = Kernel::new(KernelShape::Box { size: *kernel_size });
 
-            group.bench_with_input(
-                BenchmarkId::new("dilate", &parameter_string),
-                &(&image, &dst),
-                |b, i| {
-                    let (src, mut out) = (i.0, i.1.clone());
-                    b.iter(|| {
-                        std::hint::black_box(dilate(
-                            src,
-                            &mut out,
-                            &kernel,
-                            PaddingMode::Reflect101,
-                            [0],
-                        ))
-                    })
-                },
-            );
-
-            group.bench_with_input(
-                BenchmarkId::new("erode", &parameter_string),
-                &(&image, &dst),
-                |b, i| {
-                    let (src, mut out) = (i.0, i.1.clone());
-                    b.iter(|| {
-                        std::hint::black_box(erode(
-                            src,
-                            &mut out,
-                            &kernel,
-                            PaddingMode::Reflect101,
-                            [0],
-                        ))
-                    })
-                },
-            );
-
-            group.bench_with_input(
-                BenchmarkId::new("open", &parameter_string),
-                &(&image, &dst),
-                |b, i| {
-                    let (src, mut out) = (i.0, i.1.clone());
-                    b.iter(|| {
-                        std::hint::black_box(open(
-                            src,
-                            &mut out,
-                            &kernel,
-                            PaddingMode::Reflect101,
-                            [0],
-                        ))
-                    })
-                },
-            );
-
-            group.bench_with_input(
-                BenchmarkId::new("close", &parameter_string),
-                &(&image, &dst),
-                |b, i| {
-                    let (src, mut out) = (i.0, i.1.clone());
-                    b.iter(|| {
-                        std::hint::black_box(close(
-                            src,
-                            &mut out,
-                            &kernel,
-                            PaddingMode::Reflect101,
-                            [0],
-                        ))
-                    })
-                },
-            );
+            for (name, op) in OPS.iter() {
+                group.bench_with_input(
+                    BenchmarkId::new(*name, &parameter_string),
+                    &image,
+                    |b, src| {
+                        let mut out = Image::<u8, 1>::from_size_val(image_size, 0).unwrap();
+                        b.iter(|| {
+                            std::hint::black_box(op(
+                                src,
+                                &mut out,
+                                &kernel,
+                                PaddingMode::Reflect101,
+                                [0],
+                            ))
+                        })
+                    },
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## 📝 Description

`benches/bench_morphology.rs` builds its input as:

```rust
let image = Image::<u8, 1>::from_size_val(image_size, 128).unwrap();
```

Every pixel is 128 — a flat grey rectangle. Sizes stop at 1024×896.

This matters specifically because of **#1041**. The direction suggested there is a van Herk / Gil-Werman running min/max, which — unlike the current `Ord`-based per-tap scan — is **content dependent**. A uniform image is close to its best case, so benchmarking that rewrite against this input would report a speedup that does not hold on real images.

I would rather fix the measuring instrument before anyone's numbers depend on it, so the eventual optimisation PR is judged on an input that can actually disagree with it.

The size gap is smaller but real: `docs/performance-audit.md` reports morphology at 1080p, so today the benchmark cannot be compared against the audit table without extrapolating.

---

## 🛠️ Changes Made

- Deterministic pseudo-random input (LCG, no `rand` dev-dependency) instead of a constant.
- Added `1920×1080` to the size list, so results line up with the audit table.
- Declared `group.throughput(...)` so criterion reports elements/sec.
- Folded the four copy-pasted `bench_with_input` blocks into a loop over a `(name, fn)` table — the four ops share one signature, so this is ~85 lines down to ~20 with no change in what is measured.

Benchmark-only; no library code touched.

---

## 🧪 How Was This Tested?

`cargo bench -p kornia-imgproc --bench bench_morphology -- --quick "1920x1080"` on an Apple M5:

| op | k=3 | k=5 | k=7 |
|---|---|---|---|
| dilate | 4.03 ms | 10.12 ms | 20.81 ms |
| erode | 5.60 ms | 16.06 ms | 29.22 ms |
| open | 9.85 ms | 25.85 ms | — |
| close | 9.94 ms | 25.97 ms | — |

`cargo fmt --all` clean.

Adding 1080p makes a full run of this benchmark meaningfully longer (12 more cases, the slowest around 75 ms/iteration). If that is too much for routine runs, I am happy to gate 1080p behind a feature or drop 1024×896 in its favour — let me know which you prefer.

---

## 💭 Additional Context

For calibration, measured against OpenCV 5.0.0 on the same machine in the same sitting: at 1080p 3×3, `dilate` is ~51× slower than `cv2.dilate` and `erode` ~64×, widening to ~125× for `open` at 7×7. I verified the two produce byte-identical output on the same input, and that OpenCV was on its CPU path (OpenCL toggled off changed nothing; the explicit `UMat` GPU path was actually slower). That is context for #1041, not a claim in this PR.

---

## 🕵️ AI Usage Disclosure

- 🟡 **AI-assisted:** written with AI assistance; the numbers above are from my machine.

---

## 🚦 Checklist

- [x] My code follows the existing style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] This PR *is* the benchmark improvement.