### PR TITLE
fix(imgproc): correct the PSNR formula

### DIFF
--- a/crates/kornia-imgproc/src/metrics/mse.rs
+++ b/crates/kornia-imgproc/src/metrics/mse.rs
@@ -116,7 +116,11 @@ pub fn mse<const C: usize>(
 ///
 /// // MSE here is 4/3, so sqrt(MSE) > MAX and the ratio falls below 1 —
 /// // a negative dB value is correct for a distortion this large.
-/// assert_eq!(psnr, -1.2493869);
+/// //
+/// // Compared with a tolerance rather than for equality: `log10` is not
+/// // required to be correctly rounded, so the last bit of the result varies
+/// // between platforms.
+/// assert!((psnr - -1.2493874).abs() < 1e-5);
 /// ```
 ///
 /// # Panics
@@ -217,8 +221,18 @@ mod tests {
             },
             vec![1f32, 3f32, 2f32, 4f32, 5f32, 6f32],
         )?;
+        // MSE is 4/3 here, so sqrt(MSE) > MAX and the ratio drops below 1 — a
+        // negative dB value is correct for a distortion this large.
+        //
+        // Tolerance rather than equality: `log10` is not required to be
+        // correctly rounded, so the last bit differs between platforms
+        // (aarch64 gives -1.2493869, x86_64 gives -1.249387).
         let psnr = crate::metrics::psnr(&image1, &image2, 1.0)?;
-        assert_eq!(psnr, -1.2493869);
+        let expected = 20.0 * (1.0f32 / (4.0f32 / 3.0).sqrt()).log10();
+        assert!(
+            (psnr - expected).abs() < 1e-5,
+            "expected ~{expected} dB, got {psnr}"
+        );
 
         Ok(())
     }

--- a/crates/kornia-imgproc/src/metrics/mse.rs
+++ b/crates/kornia-imgproc/src/metrics/mse.rs
@@ -114,7 +114,9 @@ pub fn mse<const C: usize>(
 ///
 /// let psnr = psnr(&image1, &image2, 1.0).unwrap();
 ///
-/// assert_eq!(psnr, 320.15698);
+/// // MSE here is 4/3, so sqrt(MSE) > MAX and the ratio falls below 1 —
+/// // a negative dB value is correct for a distortion this large.
+/// assert_eq!(psnr, -1.2493869);
 /// ```
 ///
 /// # Panics
@@ -148,7 +150,7 @@ pub fn psnr<const C: usize>(
         return Ok(f32::INFINITY);
     }
 
-    Ok(20f32 * (max_value / mse.sqrt().log10()))
+    Ok(20f32 * (max_value / mse.sqrt()).log10())
 }
 
 #[cfg(test)]
@@ -216,7 +218,43 @@ mod tests {
             vec![1f32, 3f32, 2f32, 4f32, 5f32, 6f32],
         )?;
         let psnr = crate::metrics::psnr(&image1, &image2, 1.0)?;
-        assert_eq!(psnr, 320.15698);
+        assert_eq!(psnr, -1.2493869);
+
+        Ok(())
+    }
+
+    /// A case whose expected value can be read off by hand: every element
+    /// differs by 0.25, so MSE = 0.0625, sqrt(MSE) = 0.25, and with MAX = 1.0
+    /// the result is 20*log10(4) = 12.0412 dB.
+    #[test]
+    fn test_psnr_known_ratio() -> Result<(), ImageError> {
+        let size = ImageSize {
+            width: 2,
+            height: 2,
+        };
+        let image1 = Image::<_, 1>::new(size, vec![0.5f32; 4])?;
+        let image2 = Image::<_, 1>::new(size, vec![0.75f32; 4])?;
+
+        let psnr = crate::metrics::psnr(&image1, &image2, 1.0)?;
+        let expected = 20.0 * 4f32.log10();
+        assert!(
+            (psnr - expected).abs() < 1e-5,
+            "expected ~{expected} dB, got {psnr}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_psnr_identical_is_infinite() -> Result<(), ImageError> {
+        let size = ImageSize {
+            width: 2,
+            height: 2,
+        };
+        let image = Image::<_, 1>::new(size, vec![0.25f32, 0.5, 0.75, 1.0])?;
+
+        let psnr = crate::metrics::psnr(&image, &image, 1.0)?;
+        assert!(psnr.is_infinite() && psnr.is_sign_positive());
 
         Ok(())
     }


### PR DESCRIPTION
## 📝 Description

`crates/kornia-imgproc/src/metrics/mse.rs:151` computes:

```rust
Ok(20f32 * (max_value / mse.sqrt().log10()))
```

That divides `max_value` by a logarithm. The definition — stated in this function's own doc comment 70 lines above — is:

> PSNR = 20 log₁₀ ( MAX / √MSE )

where the log is taken **of the ratio**. The parentheses are misplaced.

### Demonstration

Using the inputs already in `test_psnr` (`[0,1,2,3,4,5]` vs `[1,3,2,4,5,6]`, MSE = 4/3, MAX = 1.0):

| | value |
|---|---|
| what the code computed — `20 × (MAX ÷ log₁₀(√MSE))` | **320.157** |
| what `test_psnr` and the doctest asserted | **320.15698** |
| correct — `20 × log₁₀(MAX ÷ √MSE)` | **−1.2493869 dB** |

PSNR is conventionally in the 20–50 dB range. 320 is not a value any real image pair can produce, so this is wrong output rather than a debatable convention.

The existing assertions did not catch it because they were written *from* the broken output — the wrong number was recorded in both a unit test and a doctest, which is why it survived.

---

## 🛠️ Changes Made

- Moved the parenthesis: `20f32 * (max_value / mse.sqrt()).log10()`.
- Updated `test_psnr` and the doctest to the correct `-1.2493869`, with a comment explaining why a negative value is right for that input (MSE = 4/3 means √MSE > MAX, so the ratio is below 1).
- Added `test_psnr_known_ratio` — every element differs by 0.25, so MSE = 0.0625, √MSE = 0.25, and with MAX = 1.0 the answer is `20*log10(4)` ≈ 12.0412 dB. This one is checkable by hand, so it cannot be silently re-derived from whatever the implementation happens to return.
- Added `test_psnr_identical_is_infinite`, pinning the `mse == 0` early return.

---

## ⚠️ This changes a documented return value

`psnr` is public and re-exported from `metrics`. Anyone comparing against previously recorded numbers will see different (correct) output. It is **not** exposed in the Python bindings, so the blast radius is Rust only. The one in-tree consumer is `examples/metrics/src/main.rs:35`, which prints the value and asserts nothing.

Flagging it explicitly since you may want this called out in the changelog rather than landing quietly.

---

## 🧪 How Was This Tested?

Apple M5, aarch64-apple-darwin, `--release`.

- Full crate suite: **408 passed, 0 failed, 4 ignored** (406 before, +2 new tests).
- Doc-tests: 52 passed, including `metrics::mse::psnr (line 93)` with the corrected value.
- `cargo fmt --all` clean.

I verified the arithmetic outside Rust before touching the code — `20*(1.0/log10(sqrt(4/3)))` = 320.1569, reproducing the old assertion exactly, and `20*log10(1.0/sqrt(4/3))` = −1.2493874, matching the new one to f32 precision.

Same pre-existing clippy note as #1077: `src/canny.rs:88` fails under the pinned 1.96.0 toolchain on unmodified `main` too.

---

## 🕵️ AI Usage Disclosure

- 🟡 **AI-assisted:** found and fixed with AI assistance; the arithmetic above was verified independently and is mine to defend.

---

## 🚦 Checklist

- [x] My code follows the existing style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective.