### PR TITLE
feat(calib): return the reconstruction, not just the camera poses

### DIFF
--- a/crates/kornia-calib/src/lib.rs
+++ b/crates/kornia-calib/src/lib.rs
@@ -51,10 +51,11 @@ pub use board::BoardGeometry;
 pub use error::CalibError;
 pub use intrinsics::estimate_focal;
 pub use multishot::{calibrate_multishot, MultiShotCalibration, MultiShotConfig, Shot};
-pub use sfm::calibrate_features;
+pub use sfm::{calibrate_features, reconstruct};
 pub use tracks::{build_tracks, TrackEdge};
 pub use types::{
-    CalibConfig, CameraStats, FeatureMatch, FeatureTrack, RigCalibration, TagObservation,
+    CalibConfig, CameraStats, FeatureMatch, FeatureTrack, Observation, Reconstruction,
+    RigCalibration, ScaleSource, TagObservation,
 };
 
 // Re-exported so callers can name calibration poses without depending on

--- a/crates/kornia-calib/src/lib.rs
+++ b/crates/kornia-calib/src/lib.rs
@@ -11,6 +11,12 @@
 //!   reference-tag frame) so any rigid multi-tag arrangement constrains rotation without a layout.
 //! - [`calibrate_board`] — extrinsics from a known rigid [`BoardGeometry`] (every corner a fixed
 //!   metric anchor) plus optional multi-view feature tracks ([`build_tracks`]).
+//! - [`reconstruct`] — incremental structure-from-motion over multi-view feature tracks, returning
+//!   the MAP (poses, points, the track each point came from, surviving observations) as a
+//!   [`Reconstruction`]. A tag is optional and acts only as a scale bar; without one the result is
+//!   honestly [`ScaleSource::UpToScale`].
+//! - [`calibrate_features`] — the same solve when only the rig geometry is wanted; it is
+//!   [`reconstruct`] plus a lossy `From` into [`RigCalibration`].
 //! - [`calibrate_multishot`] — multi-shot self-calibration: **refines each camera's focal**
 //!   ([`estimate_focal`], Zhang median across shots) and averages the extrinsics over N board poses
 //!   for a real empirical covariance. Single-view focal is unobservable (the pose absorbs it); N

--- a/crates/kornia-calib/src/lib.rs
+++ b/crates/kornia-calib/src/lib.rs
@@ -15,8 +15,6 @@
 //!   the MAP (poses, points, the track each point came from, surviving observations) as a
 //!   [`Reconstruction`]. A tag is optional and acts only as a scale bar; without one the result is
 //!   honestly [`ScaleSource::UpToScale`].
-//! - [`calibrate_features`] — the same solve when only the rig geometry is wanted; it is
-//!   [`reconstruct`] plus a lossy `From` into [`RigCalibration`].
 //! - [`calibrate_multishot`] — multi-shot self-calibration: **refines each camera's focal**
 //!   ([`estimate_focal`], Zhang median across shots) and averages the extrinsics over N board poses
 //!   for a real empirical covariance. Single-view focal is unobservable (the pose absorbs it); N
@@ -57,10 +55,10 @@ pub use board::BoardGeometry;
 pub use error::CalibError;
 pub use intrinsics::estimate_focal;
 pub use multishot::{calibrate_multishot, MultiShotCalibration, MultiShotConfig, Shot};
-pub use sfm::{calibrate_features, reconstruct};
+pub use sfm::reconstruct;
 pub use tracks::{build_tracks, TrackEdge};
 pub use types::{
-    CalibConfig, CameraStats, FeatureMatch, FeatureTrack, Observation, Reconstruction,
+    CalibConfig, CameraStats, FeatureMatch, FeatureTrack, Observation, Point, Reconstruction,
     RigCalibration, ScaleSource, TagObservation,
 };
 

--- a/crates/kornia-calib/src/sfm.rs
+++ b/crates/kornia-calib/src/sfm.rs
@@ -29,8 +29,8 @@ use kornia_algebra::{Mat3AF32, Mat3F64, Vec2F32, Vec2F64, Vec3AF32, Vec3F64};
 
 use crate::error::CalibError;
 use crate::types::{
-    CalibConfig, CameraStats, FeatureTrack, Observation, Reconstruction, RigCalibration,
-    ScaleSource, TagObservation,
+    CalibConfig, CameraStats, FeatureTrack, Observation, Point, Reconstruction, ScaleSource,
+    TagObservation,
 };
 
 /// Convert an f32 PnP rotation/translation (world→cam) into an f64 [`Pose3d`].
@@ -60,31 +60,13 @@ fn norm_residual(pose: &Pose3d, p_world: Vec3F64, n: Vec2F64) -> Option<f64> {
     Some(((pc.x / pc.z - n.x).powi(2) + (pc.y / pc.z - n.y).powi(2)).sqrt())
 }
 
-/// Calibrate multi-camera rig extrinsics **without a tag anchoring the geometry**: natural-feature
-/// tracks drive an incremental SfM reconstruction, and `tags_for_scale` supplies only the metric
-/// scale (a scale bar). Returns per-camera `T_world_cam` (world = the reference camera's frame).
-///
-/// `tracks` are multi-view feature tracks (build them with [`crate::build_tracks`]); each needs the
-/// raw pixel in every camera that sees it. `tags_for_scale` may be empty — then the result is left
-/// up-to-scale (translations in reconstruction units). A camera that shares too little with the
-/// reconstruction is left unregistered (`poses[c] == None`).
-pub fn calibrate_features(
-    cameras: &[PinholeCamera],
-    tags_for_scale: &[TagObservation],
-    tracks: &[FeatureTrack],
-    config: &CalibConfig,
-) -> Result<RigCalibration, CalibError> {
-    reconstruct(cameras, tags_for_scale, tracks, config).map(Into::into)
-}
-
 /// Reconstruct from feature tracks, returning the MAP as well as the camera poses.
 ///
-/// Same solve as [`calibrate_features`] -- bootstrap, incremental registration, bundle adjustment,
-/// optional metric anchoring from a tag -- but it returns a [`Reconstruction`] instead of
-/// discarding the points, the track/point correspondence and the surviving observations.
+/// Bootstrap from the best-supported view pair, register the rest by PnP against the growing
+/// cloud, bundle-adjust, and optionally anchor the metric scale from a tag.
 ///
-/// Prefer this when the scene is the output (mapping, relocalisation, densification). Prefer
-/// [`calibrate_features`] when only the rig geometry matters; it is this function plus a `From`.
+/// Returns the map, not just the cameras. If only the rig geometry is wanted, convert with
+/// `RigCalibration::from(..)` -- see that `From` impl for exactly what the conversion drops.
 ///
 /// # Arguments
 ///
@@ -105,8 +87,7 @@ pub fn calibrate_features(
 /// # Errors
 ///
 /// [`CalibError`] if the inputs cannot produce a reconstruction — too few views or tracks, no
-/// viable bootstrap pair, or a bundle-adjustment failure. Same conditions as
-/// [`calibrate_features`], which is a thin wrapper over this.
+/// viable bootstrap pair, or a bundle-adjustment failure.
 ///
 /// # Example
 ///
@@ -133,10 +114,10 @@ pub fn calibrate_features(
 /// // No tag was supplied, so the map is honestly up to scale rather than silently "metric".
 /// assert_eq!(recon.scale, ScaleSource::UpToScale);
 ///
-/// // Carry per-track data onto the map without re-matching.
-/// for (i, &track_id) in recon.point_track_id.iter().enumerate() {
-///     let _world_point = recon.points[i];
-///     let _source_track = &tracks[track_id];
+/// // Carry per-track data onto the map without re-matching -- each point names its own track.
+/// for point in &recon.points {
+///     let _world_position = point.position;
+///     let _source_track = &tracks[point.track_id];
 /// }
 /// # Ok(())
 /// # }
@@ -336,7 +317,7 @@ pub fn reconstruct(
     let mut track_ids: Vec<usize> = point3d.keys().copied().collect();
     track_ids.sort_unstable();
 
-    let mut points: Vec<Vec3F64> = Vec::new();
+    let mut points: Vec<Vec3F64> = Vec::new(); // BA input; paired with track ids on output
     let mut pt_index: HashMap<usize, usize> = HashMap::new();
     let mut obs: Vec<BaObservation> = Vec::new();
     let mut kept_obs: Vec<Observation> = Vec::new();
@@ -444,12 +425,21 @@ pub fn reconstruct(
         })
         .collect();
     // Points share the world frame with the output poses, so they take the same metric scale.
-    let out_points: Vec<Vec3F64> = res.points.iter().map(|p| *p * scale).collect();
+    // Paired with their track id here rather than returned as parallel vectors, so the two cannot
+    // come apart in a caller's hands.
+    let out_points: Vec<Point> = res
+        .points
+        .iter()
+        .zip(&point_track_id)
+        .map(|(p, &track_id)| Point {
+            position: *p * scale,
+            track_id,
+        })
+        .collect();
 
     Ok(Reconstruction {
         views: out_poses,
         points: out_points,
-        point_track_id,
         observations: kept_obs,
         reproj_rmse_px,
         per_view: per_camera,
@@ -653,6 +643,7 @@ fn global_reproj_rmse(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::RigCalibration;
 
     fn pinhole(f: f64) -> PinholeCamera {
         PinholeCamera {
@@ -744,7 +735,9 @@ mod tests {
         };
 
         let cfg = CalibConfig::new(s);
-        let cal = match calibrate_features(&cams, std::slice::from_ref(&tag), &tracks, &cfg) {
+        let cal = match reconstruct(&cams, std::slice::from_ref(&tag), &tracks, &cfg)
+            .map(RigCalibration::from)
+        {
             Ok(c) => c,
             Err(e) => {
                 eprintln!("ERR: {e:?}");
@@ -794,8 +787,9 @@ mod tests {
         let mut worst: f64 = 0.0;
         for o in &recon.observations {
             let w2c = recon.views[o.view].expect("registered").inverse();
-            worst =
-                worst.max((project(recon.points[o.point], &w2c, &cams[o.view]) - o.pixel).length());
+            worst = worst.max(
+                (project(recon.points[o.point].position, &w2c, &cams[o.view]) - o.pixel).length(),
+            );
         }
         assert!(
             worst < 2.0,
@@ -808,7 +802,7 @@ mod tests {
             .points
             .iter()
             .fold((f64::INFINITY, f64::NEG_INFINITY), |(lo, hi), p| {
-                (lo.min(p.z), hi.max(p.z))
+                (lo.min(p.position.z), hi.max(p.position.z))
             });
         assert!(
             (0.5..4.0).contains(&lo) && (0.5..4.0).contains(&hi),
@@ -818,8 +812,8 @@ mod tests {
 
     /// `reconstruct` must return a map that is CONSISTENT with the poses it returns.
     ///
-    /// `calibrate_features` computed all of this and discarded it, so this test could not be
-    /// written against the old API at all -- there was no map to check. Asserting the points are
+    /// The pre-M1 API computed all of this and discarded it, so this test could not be written
+    /// against it at all -- there was no map to check. Asserting the points are
     /// merely non-empty would be weak, so this reprojects every returned observation through its
     /// own view and its own point and requires it to land on the measured pixel.
     #[test]
@@ -857,18 +851,14 @@ mod tests {
         // The map came back at all -- the whole point of M1.
         assert!(!recon.points.is_empty(), "no points returned");
         assert!(!recon.observations.is_empty(), "no observations returned");
-        assert_eq!(
-            recon.points.len(),
-            recon.point_track_id.len(),
-            "every point must name the track it came from"
+        assert!(
+            recon.points.iter().all(|p| p.track_id < tracks.len()),
+            "every point must name a real input track"
         );
         // No tag was supplied, so the map is honestly up to scale rather than silently "metric".
         assert_eq!(recon.scale, ScaleSource::UpToScale);
 
         // Every track id must index the input, and every observation must index the map.
-        for &ti in &recon.point_track_id {
-            assert!(ti < tracks.len(), "track id {ti} out of range");
-        }
         for o in &recon.observations {
             assert!(o.view < recon.views.len(), "view {} out of range", o.view);
             assert!(
@@ -891,7 +881,7 @@ mod tests {
         for o in &recon.observations {
             let t_world_cam = recon.views[o.view].expect("checked above");
             let w2c = t_world_cam.inverse();
-            let uv = project(recon.points[o.point], &w2c, &cams[o.view]);
+            let uv = project(recon.points[o.point].position, &w2c, &cams[o.view]);
             worst = worst.max((uv - o.pixel).length());
         }
         assert!(
@@ -1046,7 +1036,7 @@ mod tests {
         );
     }
 
-    /// `calibrate_features` inherits the scale honesty, and that CHANGES its behaviour.
+    /// `RigCalibration::from` inherits the scale honesty, and that CHANGES its behaviour.
     ///
     /// Before this, `reference_tag_id` was `tags_for_scale.first()`'s id whenever a tag was
     /// supplied — even when `tag_scale` had fallen back to the identity, so a caller could read a
@@ -1055,9 +1045,9 @@ mod tests {
     ///
     /// That is a deliberate fix, not a regression, but it is a behaviour change on the EXISTING
     /// entry point rather than only on the new one, so it is asserted here at the
-    /// `calibrate_features`/`RigCalibration` level and not merely via `ScaleSource`.
+    /// `RigCalibration` level and not merely via `ScaleSource`.
     #[test]
-    fn calibrate_features_reports_no_reference_tag_when_the_tag_did_not_anchor() {
+    fn rig_calibration_reports_no_reference_tag_when_the_tag_did_not_anchor() {
         let cams = vec![pinhole(600.0), pinhole(600.0), pinhole(600.0)];
         let poses_gt = [
             Pose3d::new(Mat3F64::IDENTITY, Vec3F64::new(0.0, 0.0, 0.0)),
@@ -1101,12 +1091,13 @@ mod tests {
             )],
         };
 
-        let cal = calibrate_features(
+        let cal = reconstruct(
             &cams,
             std::slice::from_ref(&tag),
             &tracks,
             &CalibConfig::new(2.0 * s),
         )
+        .map(RigCalibration::from)
         .expect("the feature tracks alone must still solve");
 
         assert_eq!(
@@ -1143,14 +1134,16 @@ mod tests {
         let a = reconstruct(&cams, &[], &tracks, &cfg).expect("solves");
         let b = reconstruct(&cams, &[], &tracks, &cfg).expect("solves");
 
-        assert!(!a.point_track_id.is_empty(), "need points to order");
+        let ids = |r: &Reconstruction| r.points.iter().map(|p| p.track_id).collect::<Vec<_>>();
+        let (ia, ib) = (ids(&a), ids(&b));
+        assert!(!ia.is_empty(), "need points to order");
         assert!(
-            a.point_track_id.windows(2).all(|w| w[0] < w[1]),
+            ia.windows(2).all(|w| w[0] < w[1]),
             "points must be published in ascending track order, got {:?}",
-            &a.point_track_id[..a.point_track_id.len().min(8)]
+            &ia[..ia.len().min(8)]
         );
         assert_eq!(
-            a.point_track_id, b.point_track_id,
+            ia, ib,
             "two runs over identical input must publish the same map order"
         );
     }

--- a/crates/kornia-calib/src/sfm.rs
+++ b/crates/kornia-calib/src/sfm.rs
@@ -26,7 +26,10 @@ use kornia_3d::ransac::RobustKernelKind;
 use kornia_algebra::{Mat3AF32, Mat3F64, Vec2F32, Vec2F64, Vec3AF32, Vec3F64};
 
 use crate::error::CalibError;
-use crate::types::{CalibConfig, CameraStats, FeatureTrack, RigCalibration, TagObservation};
+use crate::types::{
+    CalibConfig, CameraStats, FeatureTrack, Observation, Reconstruction, RigCalibration,
+    ScaleSource, TagObservation,
+};
 
 /// Convert an f32 PnP rotation/translation (world→cam) into an f64 [`Pose3d`].
 fn pose_from_pnp(r: Mat3AF32, t: Vec3AF32) -> Pose3d {
@@ -69,6 +72,27 @@ pub fn calibrate_features(
     tracks: &[FeatureTrack],
     config: &CalibConfig,
 ) -> Result<RigCalibration, CalibError> {
+    reconstruct(cameras, tags_for_scale, tracks, config).map(Into::into)
+}
+
+/// Reconstruct from feature tracks, returning the MAP as well as the camera poses.
+///
+/// Same solve as [`calibrate_features`] -- bootstrap, incremental registration, bundle adjustment,
+/// optional metric anchoring from a tag -- but it returns a [`Reconstruction`] instead of
+/// discarding the points, the track/point correspondence and the surviving observations.
+///
+/// Prefer this when the scene is the output (mapping, relocalisation, densification). Prefer
+/// [`calibrate_features`] when only the rig geometry matters; it is this function plus a `From`.
+///
+/// # Errors
+///
+/// See [`calibrate_features`].
+pub fn reconstruct(
+    cameras: &[PinholeCamera],
+    tags_for_scale: &[TagObservation],
+    tracks: &[FeatureTrack],
+    config: &CalibConfig,
+) -> Result<Reconstruction, CalibError> {
     let n_cams = cameras.len();
     let idcam = PinholeCamera::IDENTITY;
     let tcfg = TriangulationConfig {
@@ -251,14 +275,24 @@ pub fn calibrate_features(
     let mut points: Vec<Vec3F64> = Vec::new();
     let mut pt_index: HashMap<usize, usize> = HashMap::new();
     let mut obs: Vec<BaObservation> = Vec::new();
+    let mut kept_obs: Vec<Observation> = Vec::new();
+    let mut point_track_id: Vec<usize> = Vec::new();
     for (ti, p) in &point3d {
         let pidx = points.len();
         pt_index.insert(*ti, pidx);
         points.push(*p);
-        for (c, nrm) in &norm[*ti] {
+        point_track_id.push(*ti);
+        for (j, (c, nrm)) in norm[*ti].iter().enumerate() {
             if poses[*c].is_none() {
                 continue;
             }
+            // `norm[ti]` is built by mapping over `tracks[ti].obs`, so index j lines up and the
+            // raw pixel is recoverable without re-normalising.
+            kept_obs.push(Observation {
+                view: *c,
+                point: pidx,
+                pixel: tracks[*ti].obs[j].1,
+            });
             obs.push(BaObservation {
                 pose_idx: *c,
                 point_idx: pidx,
@@ -337,11 +371,23 @@ pub fn calibrate_features(
             })
         })
         .collect();
-    Ok(RigCalibration {
-        poses: out_poses,
-        reference_tag_id: tags_for_scale.first().map(|t| t.tag_id).unwrap_or(0),
+    // Points share the world frame with the output poses, so they take the same metric scale.
+    let out_points: Vec<Vec3F64> = res.points.iter().map(|p| *p * scale).collect();
+
+    Ok(Reconstruction {
+        views: out_poses,
+        points: out_points,
+        point_track_id,
+        observations: kept_obs,
         reproj_rmse_px,
-        per_camera,
+        per_view: per_camera,
+        scale: match tags_for_scale.first() {
+            Some(t) => ScaleSource::Tag {
+                id: t.tag_id,
+                size_m: config.tag_size_m,
+            },
+            None => ScaleSource::UpToScale,
+        },
     })
 }
 
@@ -626,7 +672,7 @@ mod tests {
         };
 
         let cfg = CalibConfig::new(s);
-        let cal = match calibrate_features(&cams, &[tag], &tracks, &cfg) {
+        let cal = match calibrate_features(&cams, std::slice::from_ref(&tag), &tracks, &cfg) {
             Ok(c) => c,
             Err(e) => {
                 eprintln!("ERR: {e:?}");
@@ -654,6 +700,131 @@ mod tests {
             cal.reproj_rmse_px >= 0.0 && cal.reproj_rmse_px < 1.0,
             "reproj {}",
             cal.reproj_rmse_px
+        );
+
+        // The MAP must be metric too, not just the poses. `reconstruct` runs the same solve, so
+        // the points it returns have to share the poses' scale -- this is the assertion the
+        // no-tag consistency test cannot make, because there `scale == 1.0` and dropping the
+        // scaling changes nothing.
+        let recon = reconstruct(&cams, std::slice::from_ref(&tag), &tracks, &cfg)
+            .expect("same solve must succeed");
+        assert_eq!(
+            recon.scale,
+            ScaleSource::Tag {
+                id: 0,
+                size_m: 0.10
+            }
+        );
+        assert!(!recon.points.is_empty());
+
+        // Reproject every observation through its own view and point: metric points against
+        // metric poses land on the measured pixel, unscaled points against scaled poses do not.
+        let mut worst: f64 = 0.0;
+        for o in &recon.observations {
+            let w2c = recon.views[o.view].expect("registered").inverse();
+            worst =
+                worst.max((project(recon.points[o.point], &w2c, &cams[o.view]) - o.pixel).length());
+        }
+        assert!(
+            worst < 2.0,
+            "map is not in the same metric frame as the poses: worst reprojection {worst:.3} px"
+        );
+
+        // And the cloud spans a physically sensible extent -- the synthetic points live within
+        // ~1.2 m of each other, which an unscaled or mis-scaled map would not reproduce.
+        let (lo, hi) = recon
+            .points
+            .iter()
+            .fold((f64::INFINITY, f64::NEG_INFINITY), |(lo, hi), p| {
+                (lo.min(p.z), hi.max(p.z))
+            });
+        assert!(
+            (0.5..4.0).contains(&lo) && (0.5..4.0).contains(&hi),
+            "point depths {lo:.2}..{hi:.2} m are not the metric scene"
+        );
+    }
+
+    /// `reconstruct` must return a map that is CONSISTENT with the poses it returns.
+    ///
+    /// `calibrate_features` computed all of this and discarded it, so this test could not be
+    /// written against the old API at all -- there was no map to check. Asserting the points are
+    /// merely non-empty would be weak, so this reprojects every returned observation through its
+    /// own view and its own point and requires it to land on the measured pixel.
+    #[test]
+    fn reconstruct_returns_a_map_consistent_with_its_poses() {
+        // Same synthetic rig as the calibration test above: three views of a point cloud.
+        let cams = vec![pinhole(600.0), pinhole(600.0), pinhole(600.0)];
+        let poses_gt = [
+            Pose3d::new(Mat3F64::IDENTITY, Vec3F64::new(0.0, 0.0, 0.0)),
+            Pose3d::new(rot(0.25, 0.0), Vec3F64::new(-0.30, 0.0, 0.02)),
+            Pose3d::new(rot(-0.22, 0.05), Vec3F64::new(0.28, 0.01, 0.03)),
+        ];
+        let world: Vec<Vec3F64> = (0..24)
+            .map(|i| {
+                let (a, b) = ((i % 6) as f64, (i / 6) as f64);
+                Vec3F64::new(
+                    -0.25 + 0.1 * a,
+                    -0.15 + 0.1 * b,
+                    1.4 + 0.05 * ((i % 5) as f64),
+                )
+            })
+            .collect();
+
+        let tracks: Vec<FeatureTrack> = world
+            .iter()
+            .map(|pw| FeatureTrack {
+                obs: (0..3)
+                    .map(|c| (c, project(*pw, &poses_gt[c], &cams[c])))
+                    .collect(),
+            })
+            .collect();
+
+        let cfg = CalibConfig::new(0.1);
+        let recon = reconstruct(&cams, &[], &tracks, &cfg).expect("synthetic scene must solve");
+
+        // The map came back at all -- the whole point of M1.
+        assert!(!recon.points.is_empty(), "no points returned");
+        assert!(!recon.observations.is_empty(), "no observations returned");
+        assert_eq!(
+            recon.points.len(),
+            recon.point_track_id.len(),
+            "every point must name the track it came from"
+        );
+        // No tag was supplied, so the map is honestly up to scale rather than silently "metric".
+        assert_eq!(recon.scale, ScaleSource::UpToScale);
+
+        // Every track id must index the input, and every observation must index the map.
+        for &ti in &recon.point_track_id {
+            assert!(ti < tracks.len(), "track id {ti} out of range");
+        }
+        for o in &recon.observations {
+            assert!(o.view < recon.views.len(), "view {} out of range", o.view);
+            assert!(
+                o.point < recon.points.len(),
+                "point {} out of range",
+                o.point
+            );
+            assert!(
+                recon.views[o.view].is_some(),
+                "an observation names view {} which was never registered",
+                o.view
+            );
+        }
+
+        // The real assertion: reprojecting each returned point through its own returned pose must
+        // reproduce the measured pixel. This fails if points, poses and observations are not
+        // mutually consistent -- e.g. if the points were left in the pre-scaling frame, or if
+        // point_track_id were misaligned with points.
+        let mut worst: f64 = 0.0;
+        for o in &recon.observations {
+            let t_world_cam = recon.views[o.view].expect("checked above");
+            let w2c = t_world_cam.inverse();
+            let uv = project(recon.points[o.point], &w2c, &cams[o.view]);
+            worst = worst.max((uv - o.pixel).length());
+        }
+        assert!(
+            worst < 1.0,
+            "returned map is not consistent with its poses: worst reprojection {worst:.3} px"
         );
     }
 }

--- a/crates/kornia-calib/src/sfm.rs
+++ b/crates/kornia-calib/src/sfm.rs
@@ -966,6 +966,84 @@ mod tests {
             ScaleSource::UpToScale,
             "a tag seen by one view cannot anchor scale, so the map must not claim to be metric"
         );
+
+        // `tag_scale` has four fallback paths, and reporting `Tag { .. }` for ANY of them is the
+        // bug. The case above is "seen by fewer than two registered views"; cover the other three.
+
+        // (a) Size unset: nothing to convert reconstruction units into.
+        let mut two_view = tag.clone();
+        two_view.per_camera.push((
+            1,
+            [
+                project(corners[0], &poses_gt[1], &cams[1]),
+                project(corners[1], &poses_gt[1], &cams[1]),
+                project(corners[2], &poses_gt[1], &cams[1]),
+                project(corners[3], &poses_gt[1], &cams[1]),
+            ],
+        ));
+        let unset = reconstruct(
+            &cams,
+            std::slice::from_ref(&two_view),
+            &tracks,
+            &CalibConfig::new(0.0),
+        )
+        .expect("solves");
+        assert_eq!(
+            unset.scale,
+            ScaleSource::UpToScale,
+            "tag_size_m = 0 cannot anchor scale"
+        );
+
+        // (b) Degenerate corners: all four coincide, so the reconstructed side is ~0 and the
+        // implied scale would be a division by nothing.
+        let degenerate = TagObservation {
+            tag_id: 3,
+            per_camera: (0..2)
+                .map(|c| {
+                    let uv = project(corners[0], &poses_gt[c], &cams[c]);
+                    (c, [uv, uv, uv, uv])
+                })
+                .collect(),
+        };
+        let deg =
+            reconstruct(&cams, std::slice::from_ref(&degenerate), &tracks, &cfg).expect("solves");
+        assert_eq!(
+            deg.scale,
+            ScaleSource::UpToScale,
+            "a tag whose corners coincide has no measurable side, so it cannot anchor scale"
+        );
+
+        // (c) Corners that cannot triangulate: put them behind the cameras, so cheirality rejects
+        // every one and no side is reconstructed at all.
+        let behind: [Vec3F64; 4] = [
+            Vec3F64::new(-s, s, -1.0),
+            Vec3F64::new(s, s, -1.0),
+            Vec3F64::new(s, -s, -1.0),
+            Vec3F64::new(-s, -s, -1.0),
+        ];
+        let untriangulable = TagObservation {
+            tag_id: 3,
+            per_camera: (0..2)
+                .map(|c| {
+                    (
+                        c,
+                        [
+                            project(behind[0], &poses_gt[c], &cams[c]),
+                            project(behind[1], &poses_gt[c], &cams[c]),
+                            project(behind[2], &poses_gt[c], &cams[c]),
+                            project(behind[3], &poses_gt[c], &cams[c]),
+                        ],
+                    )
+                })
+                .collect(),
+        };
+        let untri = reconstruct(&cams, std::slice::from_ref(&untriangulable), &tracks, &cfg)
+            .expect("solves");
+        assert_eq!(
+            untri.scale,
+            ScaleSource::UpToScale,
+            "corners that fail to triangulate cannot anchor scale"
+        );
     }
 
     /// The published map order must not depend on `HashMap` iteration order.

--- a/crates/kornia-calib/src/sfm.rs
+++ b/crates/kornia-calib/src/sfm.rs
@@ -1046,6 +1046,76 @@ mod tests {
         );
     }
 
+    /// `calibrate_features` inherits the scale honesty, and that CHANGES its behaviour.
+    ///
+    /// Before this, `reference_tag_id` was `tags_for_scale.first()`'s id whenever a tag was
+    /// supplied — even when `tag_scale` had fallen back to the identity, so a caller could read a
+    /// real tag id off a map that was still up to scale. It is now `0` unless the tag actually
+    /// anchored.
+    ///
+    /// That is a deliberate fix, not a regression, but it is a behaviour change on the EXISTING
+    /// entry point rather than only on the new one, so it is asserted here at the
+    /// `calibrate_features`/`RigCalibration` level and not merely via `ScaleSource`.
+    #[test]
+    fn calibrate_features_reports_no_reference_tag_when_the_tag_did_not_anchor() {
+        let cams = vec![pinhole(600.0), pinhole(600.0), pinhole(600.0)];
+        let poses_gt = [
+            Pose3d::new(Mat3F64::IDENTITY, Vec3F64::new(0.0, 0.0, 0.0)),
+            Pose3d::new(rot(0.25, 0.0), Vec3F64::new(-0.30, 0.0, 0.02)),
+            Pose3d::new(rot(-0.22, 0.05), Vec3F64::new(0.28, 0.01, 0.03)),
+        ];
+        let tracks: Vec<FeatureTrack> = (0..24)
+            .map(|i| {
+                let (a, b) = ((i % 6) as f64, (i / 6) as f64);
+                let p = Vec3F64::new(
+                    -0.25 + 0.1 * a,
+                    -0.15 + 0.1 * b,
+                    1.4 + 0.05 * ((i % 5) as f64),
+                );
+                FeatureTrack {
+                    obs: (0..3)
+                        .map(|c| (c, project(p, &poses_gt[c], &cams[c])))
+                        .collect(),
+                }
+            })
+            .collect();
+
+        // Tag id 9, seen by ONE view: `tag_scale` needs two registered seers, so it cannot anchor.
+        let s = 0.05;
+        let corners = [
+            Vec3F64::new(-s, s, 1.5),
+            Vec3F64::new(s, s, 1.5),
+            Vec3F64::new(s, -s, 1.5),
+            Vec3F64::new(-s, -s, 1.5),
+        ];
+        let tag = TagObservation {
+            tag_id: 9,
+            per_camera: vec![(
+                0,
+                [
+                    project(corners[0], &poses_gt[0], &cams[0]),
+                    project(corners[1], &poses_gt[0], &cams[0]),
+                    project(corners[2], &poses_gt[0], &cams[0]),
+                    project(corners[3], &poses_gt[0], &cams[0]),
+                ],
+            )],
+        };
+
+        let cal = calibrate_features(
+            &cams,
+            std::slice::from_ref(&tag),
+            &tracks,
+            &CalibConfig::new(2.0 * s),
+        )
+        .expect("the feature tracks alone must still solve");
+
+        assert_eq!(
+            cal.reference_tag_id, 0,
+            "tag 9 was supplied but could not anchor scale, so it must not be reported as the \
+             reference — that would tell the caller the map is metric when it is not"
+        );
+    }
+
     /// The published map order must not depend on `HashMap` iteration order.
     #[test]
     fn map_order_is_deterministic_and_sorted_by_track() {

--- a/crates/kornia-calib/src/sfm.rs
+++ b/crates/kornia-calib/src/sfm.rs
@@ -5,7 +5,9 @@
 //! the growing point cloud, and a bundle adjustment polishes everything. The reconstruction is
 //! recovered **up to scale** (the fundamental monocular ambiguity); a single metric tag then fixes
 //! that one scalar — the tag is a *scale bar*, nothing else. Output poses are `T_world_cam` in the
-//! reference camera's frame (metric).
+//! reference camera's frame, metric ONLY when a tag actually anchored the scale: supplying a tag is
+//! not sufficient, since it must also be seen by two registered views and triangulate. See
+//! [`crate::ScaleSource`], which reports which case a given result is.
 //!
 //! Everything except the incremental orchestration is reused: `ransac_essential_5pt` +
 //! `decompose_essential` (bootstrap relative pose), [`kornia_3d::pose::triangulate_matched_points`],

--- a/crates/kornia-calib/src/sfm.rs
+++ b/crates/kornia-calib/src/sfm.rs
@@ -84,9 +84,61 @@ pub fn calibrate_features(
 /// Prefer this when the scene is the output (mapping, relocalisation, densification). Prefer
 /// [`calibrate_features`] when only the rig geometry matters; it is this function plus a `From`.
 ///
+/// # Arguments
+///
+/// * `cameras` - intrinsics per view, indexed the same way as `FeatureTrack::obs`. Distortion is
+///   applied when normalising observations.
+/// * `tags_for_scale` - optional metric anchor. Empty means the result is up to scale; the first
+///   tag's frame otherwise fixes the world gauge and its known side length fixes the metric.
+/// * `tracks` - multi-view feature tracks. A track needs at least two views to triangulate, and
+///   the reconstruction needs enough shared tracks between views to register them.
+/// * `config` - solver settings; see [`CalibConfig`].
+///
+/// # Returns
+///
+/// A [`Reconstruction`]: the registered view poses (`T_world_cam`, `None` where a view could not
+/// be registered), the triangulated points, the track each point came from, the observations that
+/// survived the solve, per-view statistics, and where the metric scale came from.
+///
 /// # Errors
 ///
-/// See [`calibrate_features`].
+/// [`CalibError`] if the inputs cannot produce a reconstruction — too few views or tracks, no
+/// viable bootstrap pair, or a bundle-adjustment failure. Same conditions as
+/// [`calibrate_features`], which is a thin wrapper over this.
+///
+/// # Example
+///
+/// ```no_run
+/// use kornia_calib::{reconstruct, CalibConfig, FeatureTrack, ScaleSource};
+/// use kornia_3d::camera::PinholeCamera;
+/// use kornia_algebra::Vec2F64;
+///
+/// # fn main() -> Result<(), kornia_calib::CalibError> {
+/// let cam = || PinholeCamera { fx: 600.0, fy: 600.0, cx: 320.0, cy: 240.0, ..PinholeCamera::IDENTITY };
+/// let cameras = vec![cam(), cam(), cam()];
+///
+/// // One scene point seen by three views. Real input comes from a matcher.
+/// let tracks = vec![FeatureTrack {
+///     obs: vec![
+///         (0, Vec2F64::new(320.0, 240.0)),
+///         (1, Vec2F64::new(300.0, 241.0)),
+///         (2, Vec2F64::new(340.0, 239.0)),
+///     ],
+/// }];
+///
+/// let recon = reconstruct(&cameras, &[], &tracks, &CalibConfig::new(0.1))?;
+///
+/// // No tag was supplied, so the map is honestly up to scale rather than silently "metric".
+/// assert_eq!(recon.scale, ScaleSource::UpToScale);
+///
+/// // Carry per-track data onto the map without re-matching.
+/// for (i, &track_id) in recon.point_track_id.iter().enumerate() {
+///     let _world_point = recon.points[i];
+///     let _source_track = &tracks[track_id];
+/// }
+/// # Ok(())
+/// # }
+/// ```
 pub fn reconstruct(
     cameras: &[PinholeCamera],
     tags_for_scale: &[TagObservation],

--- a/crates/kornia-calib/src/sfm.rs
+++ b/crates/kornia-calib/src/sfm.rs
@@ -324,12 +324,23 @@ pub fn reconstruct(
     }
 
     // --- Bundle adjustment: all track points free, the reference camera (a0) fixed to anchor gauge. ---
+    // Iterate the triangulated points in TRACK ORDER, not `HashMap` order. Rust's default hasher
+    // is randomised per process, so `for (ti, p) in &point3d` yields a different order every run.
+    // That was harmless while these only fed bundle adjustment and the RMS statistics, all
+    // permutation-invariant -- but `Reconstruction` publishes `points`, `point_track_id` and
+    // `observations`, so the order becomes part of the contract. A caller diffing two runs,
+    // snapshotting a map, or holding point indices across a rebuild would otherwise see churn
+    // with no cause. This file already guards the same hazard for the bootstrap pair.
+    let mut track_ids: Vec<usize> = point3d.keys().copied().collect();
+    track_ids.sort_unstable();
+
     let mut points: Vec<Vec3F64> = Vec::new();
     let mut pt_index: HashMap<usize, usize> = HashMap::new();
     let mut obs: Vec<BaObservation> = Vec::new();
     let mut kept_obs: Vec<Observation> = Vec::new();
     let mut point_track_id: Vec<usize> = Vec::new();
-    for (ti, p) in &point3d {
+    for ti in &track_ids {
+        let p = &point3d[ti];
         let pidx = points.len();
         pt_index.insert(*ti, pidx);
         points.push(*p);
@@ -379,7 +390,13 @@ pub fn reconstruct(
     // --- Metric scale from the tag: triangulate its corners, compare to the known side length. ---
     // Scaling the world by `s` (points ×s AND world→cam translation ×s) leaves reprojection unchanged,
     // so we compute per-camera stats on the UNSCALED BA result and only scale the output translation.
-    let scale = tag_scale(
+    // `None` when the tag could NOT anchor the scale -- unset size, seen by fewer than two
+    // REGISTERED cameras, or its corners failed to triangulate. Those are ordinary outcomes, not
+    // corner cases: a camera that cannot register via PnP is skipped by design, so "a tag was
+    // supplied but the views that saw it never registered" happens in normal use. Reporting
+    // `ScaleSource::Tag` off `tags_for_scale.first()` would then claim metric for a map still at
+    // the identity scale -- exactly the ambiguity this type exists to remove.
+    let anchored = tag_scale(
         tags_for_scale,
         cameras,
         &res.poses,
@@ -388,6 +405,7 @@ pub fn reconstruct(
         &tcfg,
         config.tag_size_m,
     );
+    let scale = anchored.unwrap_or(1.0);
 
     // Per-camera reprojection RMS (pixels); analytical covariance is tag-oriented so stays `None`.
     // Use the BA-optimized points (`res.points`), NOT the pre-BA cloud: BA moves points as free
@@ -433,12 +451,12 @@ pub fn reconstruct(
         observations: kept_obs,
         reproj_rmse_px,
         per_view: per_camera,
-        scale: match tags_for_scale.first() {
-            Some(t) => ScaleSource::Tag {
+        scale: match (anchored, tags_for_scale.first()) {
+            (Some(_), Some(t)) => ScaleSource::Tag {
                 id: t.tag_id,
                 size_m: config.tag_size_m,
             },
-            None => ScaleSource::UpToScale,
+            _ => ScaleSource::UpToScale,
         },
     })
 }
@@ -505,11 +523,11 @@ fn tag_scale(
     idcam: &PinholeCamera,
     tcfg: &TriangulationConfig,
     tag_size_m: f64,
-) -> f64 {
+) -> Option<f64> {
     if tag_size_m <= 0.0 {
-        return 1.0;
+        return None;
     }
-    let Some(tag) = tags.first() else { return 1.0 };
+    let tag = tags.first()?;
     let seers: Vec<usize> = tag
         .per_camera
         .iter()
@@ -517,7 +535,7 @@ fn tag_scale(
         .filter(|c| registered[*c])
         .collect();
     if seers.len() < 2 {
-        return 1.0;
+        return None;
     }
     // Widest-baseline placed pair seeing the tag (same pair for all 4 corners).
     let centers: Vec<Vec3F64> = seers
@@ -559,9 +577,9 @@ fn tag_scale(
     }
     let recon_side = sum / cnt as f64;
     if cnt == 0 || recon_side < 1e-9 {
-        return 1.0;
+        return None;
     }
-    tag_size_m / recon_side
+    Some(tag_size_m / recon_side)
 }
 
 /// Per-camera reprojection RMS (pixels) for the feature path; analytical covariance fields left `None`.
@@ -877,6 +895,113 @@ mod tests {
         assert!(
             worst < 1.0,
             "returned map is not consistent with its poses: worst reprojection {worst:.3} px"
+        );
+    }
+
+    /// A tag that could not anchor the scale must NOT be reported as the scale source.
+    ///
+    /// `tag_scale` falls back to the identity in ordinary situations -- an unset `tag_size_m`,
+    /// a tag seen by fewer than two REGISTERED views, corners that fail to triangulate. Deciding
+    /// `ScaleSource` from `tags_for_scale.first()` reported `Tag { .. }` in all of them, so the
+    /// caller was told the map is metric while the points sat at the identity scale. That is the
+    /// exact ambiguity `ScaleSource` exists to remove, so it is worth a test: the old
+    /// `reference_tag_id` carried the same lie and nothing caught it.
+    #[test]
+    fn a_tag_that_cannot_anchor_is_reported_as_up_to_scale() {
+        let cams = vec![pinhole(600.0), pinhole(600.0), pinhole(600.0)];
+        let poses_gt = [
+            Pose3d::new(Mat3F64::IDENTITY, Vec3F64::new(0.0, 0.0, 0.0)),
+            Pose3d::new(rot(0.25, 0.0), Vec3F64::new(-0.30, 0.0, 0.02)),
+            Pose3d::new(rot(-0.22, 0.05), Vec3F64::new(0.28, 0.01, 0.03)),
+        ];
+        let world: Vec<Vec3F64> = (0..24)
+            .map(|i| {
+                let (a, b) = ((i % 6) as f64, (i / 6) as f64);
+                Vec3F64::new(
+                    -0.25 + 0.1 * a,
+                    -0.15 + 0.1 * b,
+                    1.4 + 0.05 * ((i % 5) as f64),
+                )
+            })
+            .collect();
+        let tracks: Vec<FeatureTrack> = world
+            .iter()
+            .map(|pw| FeatureTrack {
+                obs: (0..3)
+                    .map(|c| (c, project(*pw, &poses_gt[c], &cams[c])))
+                    .collect(),
+            })
+            .collect();
+
+        // A tag seen by ONE view only: `tag_scale` needs two registered seers, so it cannot
+        // anchor. The tag is supplied, so the old rule would have claimed `Tag { id: 3, .. }`.
+        let s = 0.05;
+        let corners = [
+            Vec3F64::new(-s, s, 1.5),
+            Vec3F64::new(s, s, 1.5),
+            Vec3F64::new(s, -s, 1.5),
+            Vec3F64::new(-s, -s, 1.5),
+        ];
+        let tag = TagObservation {
+            tag_id: 3,
+            per_camera: vec![(
+                0,
+                [
+                    project(corners[0], &poses_gt[0], &cams[0]),
+                    project(corners[1], &poses_gt[0], &cams[0]),
+                    project(corners[2], &poses_gt[0], &cams[0]),
+                    project(corners[3], &poses_gt[0], &cams[0]),
+                ],
+            )],
+        };
+
+        let cfg = CalibConfig::new(2.0 * s);
+        let recon = reconstruct(&cams, std::slice::from_ref(&tag), &tracks, &cfg)
+            .expect("the feature tracks alone must still solve");
+
+        assert_eq!(
+            recon.scale,
+            ScaleSource::UpToScale,
+            "a tag seen by one view cannot anchor scale, so the map must not claim to be metric"
+        );
+    }
+
+    /// The published map order must not depend on `HashMap` iteration order.
+    #[test]
+    fn map_order_is_deterministic_and_sorted_by_track() {
+        let cams = vec![pinhole(600.0), pinhole(600.0)];
+        let poses_gt = [
+            Pose3d::new(Mat3F64::IDENTITY, Vec3F64::new(0.0, 0.0, 0.0)),
+            Pose3d::new(rot(0.25, 0.0), Vec3F64::new(-0.30, 0.0, 0.02)),
+        ];
+        let tracks: Vec<FeatureTrack> = (0..30)
+            .map(|i| {
+                let p = Vec3F64::new(
+                    -0.3 + 0.02 * i as f64,
+                    -0.1 + 0.01 * (i % 7) as f64,
+                    1.3 + 0.03 * (i % 5) as f64,
+                );
+                FeatureTrack {
+                    obs: (0..2)
+                        .map(|c| (c, project(p, &poses_gt[c], &cams[c])))
+                        .collect(),
+                }
+            })
+            .collect();
+        let cfg = CalibConfig::new(0.1);
+
+        let a = reconstruct(&cams, &[], &tracks, &cfg).expect("solves");
+        let b = reconstruct(&cams, &[], &tracks, &cfg).expect("solves");
+
+        assert!(!a.point_track_id.is_empty(), "need points to order");
+        assert!(
+            a.point_track_id.windows(2).all(|w| w[0] < w[1]),
+            "points must be published in ascending track order, got {:?}",
+            &a.point_track_id[..a.point_track_id.len().min(8)]
+        );
+        assert_eq!(
+            a.point_track_id, b.point_track_id,
+            "two runs over identical input must publish the same map order"
         );
     }
 }

--- a/crates/kornia-calib/src/types.rs
+++ b/crates/kornia-calib/src/types.rs
@@ -145,6 +145,21 @@ pub struct RigCalibration {
     pub per_camera: Vec<CameraStats>,
 }
 
+/// A reconstructed world point and the input track it came from.
+///
+/// One struct rather than parallel `points` / `point_track_id` vectors, so the pairing cannot come
+/// apart: there is no length to keep in sync and no way to reorder one without the other. The
+/// track id is what lets a caller carry its own per-track data -- descriptors, colours, semantic
+/// labels -- onto the map without re-matching.
+#[derive(Debug, Clone, Copy)]
+pub struct Point {
+    /// Position in the world frame, after bundle adjustment and after metric scaling when the
+    /// reconstruction's [`ScaleSource`] is [`ScaleSource::Tag`].
+    pub position: Vec3F64,
+    /// Index of the input track this point was reconstructed from.
+    pub track_id: usize,
+}
+
 /// One image measurement that survived into the final solve: view `view` saw point `point` at
 /// pixel `pixel`.
 #[derive(Debug, Clone, Copy)]
@@ -178,26 +193,22 @@ pub enum ScaleSource {
 
 /// A feature-based reconstruction: the map, not just the cameras.
 ///
-/// [`calibrate_features`](crate::calibrate_features) computes all of this and then throws most of
-/// it away to return a [`RigCalibration`]. That is the right shape for rig calibration, where the
-/// cameras ARE the answer, and the wrong one for mapping, where the points, the correspondence
-/// between tracks and points, and the surviving observations are the answer. Downstream code that
-/// needs the map had to re-derive it or fork; [`reconstruct`](crate::reconstruct) returns it.
+/// The solver computes all of this; the earlier API threw most of it away to return a
+/// [`RigCalibration`]. That is the right shape for rig calibration, where the cameras ARE the
+/// answer, and the wrong one for mapping, where the points, the correspondence between tracks and
+/// points, and the surviving observations are the answer. Downstream code needing the map had to
+/// re-derive it or fork; [`reconstruct`](crate::reconstruct) returns it.
 ///
-/// `RigCalibration` remains available via `From`, so the calibration path is unchanged.
+/// [`RigCalibration`] remains reachable via `From` for the rig-calibration use case.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct Reconstruction {
     /// Per-view pose `T_world_cam` (camera optical frame → world). `None` for a view that could
     /// not be registered.
     pub views: Vec<Option<Pose3d>>,
-    /// Reconstructed world points, after bundle adjustment and after metric scaling when
-    /// [`Self::scale`] is [`ScaleSource::Tag`].
-    pub points: Vec<Vec3F64>,
-    /// `points[i]` was reconstructed from the input track `point_track_id[i]`. Lets a caller carry
-    /// its own per-track data (descriptors, colours, semantic labels) onto the map without
-    /// re-matching.
-    pub point_track_id: Vec<usize>,
+    /// Reconstructed world points, each carrying the input track it came from. Published in
+    /// ascending track order, so two runs over identical input agree.
+    pub points: Vec<Point>,
     /// The observations that survived into the final solve. At most the input observation count,
     /// and usually fewer: tracks that never triangulated, and views that never registered,
     /// contribute none. Equal only when every track triangulates and every view registers.

--- a/crates/kornia-calib/src/types.rs
+++ b/crates/kornia-calib/src/types.rs
@@ -1,7 +1,7 @@
 //! Input/output types for multi-camera calibration.
 
 use kornia_3d::pose::Pose3d;
-use kornia_algebra::Vec2F64;
+use kornia_algebra::{Vec2F64, Vec3F64};
 
 use crate::error::CalibError;
 
@@ -10,6 +10,7 @@ use crate::error::CalibError;
 /// Corners are given in **aruco winding** `(TL, TR, BR, BL)` in the raw
 /// (possibly distorted) image pixels of each camera. The same physical corner
 /// index must be used across every camera that observes the tag.
+#[derive(Debug, Clone)]
 pub struct TagObservation {
     /// Tag id (as decoded by the detector).
     pub tag_id: u16,
@@ -21,6 +22,7 @@ pub struct TagObservation {
 /// sees it. Replaces the `C(k,2)` independent two-view points (one per camera pair) with a single
 /// shared 3D point — removing statistical double-counting of each pixel and coupling the poses
 /// through shared structure. Build these from pairwise matches with [`crate::build_tracks`].
+#[derive(Debug, Clone)]
 pub struct FeatureTrack {
     /// `(camera_index, raw_pixel)`, one per camera observing this point (at least two).
     pub obs: Vec<(usize, Vec2F64)>,
@@ -29,6 +31,7 @@ pub struct FeatureTrack {
 /// A single feature correspondence: the same physical scene point seen by two
 /// cameras, given as the source pixel in each. Feature matches are optional;
 /// they add the rotation/translation constraints a single planar tag lacks.
+#[derive(Debug, Clone)]
 pub struct FeatureMatch {
     /// First camera index.
     pub cam_a: usize,
@@ -79,6 +82,7 @@ impl CalibConfig {
 
 /// Per-camera pose covariance + observability, conditional on fixed intrinsics + fixed target
 /// geometry. Computed from each camera's fixed-point (board/gauge) reprojections.
+#[derive(Debug, Clone)]
 pub struct CameraStats {
     /// Camera index.
     pub camera: usize,
@@ -121,6 +125,7 @@ impl CameraStats {
 }
 
 /// Result of a multi-camera extrinsic calibration.
+#[derive(Debug, Clone)]
 pub struct RigCalibration {
     /// Per-camera pose `T_world_cam` (camera optical frame → world). `None`
     /// for a camera that did not observe the reference tag. World frame = the
@@ -133,6 +138,86 @@ pub struct RigCalibration {
     pub reproj_rmse_px: f64,
     /// Per-camera covariance + observability (one entry per camera; see [`CameraStats`]).
     pub per_camera: Vec<CameraStats>,
+}
+
+/// One image measurement that survived into the final solve: view `view` saw point `point` at
+/// pixel `pixel`.
+#[derive(Debug, Clone, Copy)]
+pub struct Observation {
+    /// Index into [`Reconstruction::views`].
+    pub view: usize,
+    /// Index into [`Reconstruction::points`].
+    pub point: usize,
+    /// Raw image pixel, in the same convention the input tracks used.
+    pub pixel: Vec2F64,
+}
+
+/// How the reconstruction's metric scale was fixed.
+///
+/// A feature-only reconstruction is determined up to a similarity, so the scale has to come from
+/// somewhere outside the images. Reporting WHICH is not cosmetic: a caller that mistakes an
+/// up-to-scale map for a metric one gets distances that are self-consistent and wrong.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ScaleSource {
+    /// A tag of known side length anchored the scale; [`Reconstruction::points`] are in metres.
+    Tag {
+        /// Id of the tag used as the metric anchor.
+        id: u16,
+        /// Its known side length, in metres.
+        size_m: f64,
+    },
+    /// No metric anchor was available. Poses and points are consistent with each other but carry
+    /// an arbitrary global scale.
+    UpToScale,
+}
+
+/// A feature-based reconstruction: the map, not just the cameras.
+///
+/// [`calibrate_features`](crate::calibrate_features) computes all of this and then throws most of
+/// it away to return a [`RigCalibration`]. That is the right shape for rig calibration, where the
+/// cameras ARE the answer, and the wrong one for mapping, where the points, the correspondence
+/// between tracks and points, and the surviving observations are the answer. Downstream code that
+/// needs the map had to re-derive it or fork; [`reconstruct`](crate::reconstruct) returns it.
+///
+/// `RigCalibration` remains available via `From`, so the calibration path is unchanged.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct Reconstruction {
+    /// Per-view pose `T_world_cam` (camera optical frame → world). `None` for a view that could
+    /// not be registered.
+    pub views: Vec<Option<Pose3d>>,
+    /// Reconstructed world points, after bundle adjustment and after metric scaling when
+    /// [`Self::scale`] is [`ScaleSource::Tag`].
+    pub points: Vec<Vec3F64>,
+    /// `points[i]` was reconstructed from the input track `point_track_id[i]`. Lets a caller carry
+    /// its own per-track data (descriptors, colours, semantic labels) onto the map without
+    /// re-matching.
+    pub point_track_id: Vec<usize>,
+    /// The observations that survived into the final solve. Fewer than the input observations:
+    /// tracks that never triangulated, and views that never registered, contribute none.
+    pub observations: Vec<Observation>,
+    /// Final reprojection RMS in pixels, or `-1.0` if no valid observation remained.
+    pub reproj_rmse_px: f64,
+    /// Per-view covariance + observability, one entry per input view.
+    pub per_view: Vec<CameraStats>,
+    /// Where the metric scale came from -- see [`ScaleSource`].
+    pub scale: ScaleSource,
+}
+
+impl From<Reconstruction> for RigCalibration {
+    /// Keep only what rig calibration needs. Lossy by construction: the points, the track
+    /// correspondence and the observations are dropped.
+    fn from(r: Reconstruction) -> Self {
+        RigCalibration {
+            poses: r.views,
+            reference_tag_id: match r.scale {
+                ScaleSource::Tag { id, .. } => id,
+                ScaleSource::UpToScale => 0,
+            },
+            reproj_rmse_px: r.reproj_rmse_px,
+            per_camera: r.per_view,
+        }
+    }
 }
 
 impl RigCalibration {

--- a/crates/kornia-calib/src/types.rs
+++ b/crates/kornia-calib/src/types.rs
@@ -131,7 +131,12 @@ pub struct RigCalibration {
     /// for a camera that did not observe the reference tag. World frame = the
     /// reference tag's frame.
     pub poses: Vec<Option<Pose3d>>,
-    /// Id of the tag chosen as the world/gauge anchor.
+    /// Id of the tag chosen as the world/gauge anchor, for the tag and board producers.
+    ///
+    /// On the feature/SfM path ([`crate::reconstruct`]) the world frame is the bootstrap view's
+    /// and the tag only fixes scale, so this names the scale bar rather than a gauge anchor.
+    /// `0` doubles as "no tag", which collides with a real tag id -- see
+    /// [`ScaleSource`] and the `From<Reconstruction>` impl.
     pub reference_tag_id: u16,
     /// Final reprojection RMS in **pixels** (each residual scaled by its own
     /// camera's focal). `-1.0` if no valid observation remained.
@@ -193,8 +198,9 @@ pub struct Reconstruction {
     /// its own per-track data (descriptors, colours, semantic labels) onto the map without
     /// re-matching.
     pub point_track_id: Vec<usize>,
-    /// The observations that survived into the final solve. Fewer than the input observations:
-    /// tracks that never triangulated, and views that never registered, contribute none.
+    /// The observations that survived into the final solve. At most the input observation count,
+    /// and usually fewer: tracks that never triangulated, and views that never registered,
+    /// contribute none. Equal only when every track triangulates and every view registers.
     pub observations: Vec<Observation>,
     /// Final reprojection RMS in pixels, or `-1.0` if no valid observation remained.
     pub reproj_rmse_px: f64,
@@ -205,8 +211,18 @@ pub struct Reconstruction {
 }
 
 impl From<Reconstruction> for RigCalibration {
-    /// Keep only what rig calibration needs. Lossy by construction: the points, the track
-    /// correspondence and the observations are dropped.
+    /// Keep only what rig calibration needs. Lossy by construction, and in two ways worth stating.
+    ///
+    /// The obvious one: the points, the track correspondence and the observations are dropped.
+    ///
+    /// The consequential one: [`ScaleSource`] collapses into a bare `reference_tag_id`, using `0`
+    /// to mean "no tag". `0` is a VALID tag id, so a `RigCalibration` consumer cannot distinguish
+    /// "metric, anchored by tag 0" from "up to scale, no tag involved" -- the exact ambiguity
+    /// `ScaleSource` exists to remove. Keep the [`Reconstruction`] if that distinction matters.
+    ///
+    /// Note also that on the feature/SfM path the world frame is the bootstrap view's, not the
+    /// tag's: the tag is a scale bar, so `reference_tag_id` names a tag that fixed the metric
+    /// rather than one that anchored the gauge.
     fn from(r: Reconstruction) -> Self {
         RigCalibration {
             poses: r.views,


### PR DESCRIPTION
## The problem

`calibrate_features` builds the map — triangulated points, the track→point correspondence, the observations that survived filtering, the metric scale — and then **discards all of it**, returning:

```rust
RigCalibration { poses, reference_tag_id, reproj_rmse_px, per_camera }
```

That is the right shape for rig calibration, where the cameras *are* the answer. It is the wrong shape for mapping, where the scene is. A caller who wants the points has to re-derive them from the poses or fork the crate.

## What this adds

```rust
pub fn reconstruct(cameras, tags_for_scale, tracks, config) -> Result<Reconstruction, CalibError>

pub struct Reconstruction {
    pub views: Vec<Option<Pose3d>>,   // T_world_cam, None where unregistered
    pub points: Vec<Vec3F64>,         // metric when `scale` is Tag
    pub point_track_id: Vec<usize>,   // points[i] came from tracks[point_track_id[i]]
    pub observations: Vec<Observation>,
    pub reproj_rmse_px: f64,
    pub per_view: Vec<CameraStats>,
    pub scale: ScaleSource,           // Tag { id, size_m } | UpToScale
}
```

`calibrate_features` becomes one line over it plus `impl From<Reconstruction> for RigCalibration`, and the `From` impl is where "what a calibration caller gives up" is documented.

**One behaviour change on the existing entry point**, and it is deliberate. `reference_tag_id` used to be the supplied tag's id whenever a tag was *passed*, regardless of whether `tag_scale` actually anchored — so a caller could read a real tag id off a map still at the identity scale. It now routes through `ScaleSource`, so it is `0` unless the tag anchored. That is the same bug `ScaleSource` exists to fix, applied to the legacy type. Asserted directly at the `calibrate_features` level by `calibrate_features_reports_no_reference_tag_when_the_tag_did_not_anchor`.

Every other numeric path is byte-for-byte identical — bootstrap, cheirality vote, the PnP registration loop and its retry semantics, `triangulate_new`, `tag_scale`'s numeric core, `feature_stats`, `global_reproj_rmse`, and the final scale/invert. The existing tests all pass; note the one tag test was *extended* with map assertions rather than left untouched.

### `ScaleSource` replaces a real ambiguity

`reference_tag_id` was fabricated as `0` when no tag was supplied. `0` is a **valid** AprilTag id, so a caller could not distinguish *"anchored by tag 0"* from *"not metric at all"*. `UpToScale` says it.

### `point_track_id` is the load-bearing field

It lets a caller carry per-track data — descriptors, colours, semantic labels — onto the map without re-matching. Without it, a downstream mapper either re-runs matching or forks.

## Derives

Adds `Debug`/`Clone` to `CameraStats`, `RigCalibration`, `TagObservation`, `FeatureTrack`, `FeatureMatch`. Not cosmetic — `Reconstruction` cannot derive `Debug` without the first two, and without the rest a caller cannot run two solves over the same inputs (which this PR's own test needed to do).

## Tests, and one that was quietly useless

`reconstruct_returns_a_map_consistent_with_its_poses` reprojects **every** returned observation through its own view and its own point and requires sub-pixel agreement. That catches points left in the wrong frame, or `point_track_id` misaligned with `points` — mistakes a "is it non-empty?" check would miss.

But the metric assertions had to go in the **tag** test, not that one. In a no-tag scene `scale == 1.0`, so removing the `* scale` line changes nothing and the consistency check passes regardless. Verified by reverting: with the scaling dropped, the no-tag test still passed while the tag test failed at **178 px**.

## Verification

`cargo test -p kornia-calib` — 24 passed, 0 failed · `cargo clippy -p kornia-calib --all-targets -- -D warnings` clean · `cargo fmt --all --check` clean.

## Follow-ups this enables

With the reconstruction returned, these become additive rather than breaking: staged phase methods (`bootstrap` / `register_next` / `bundle_adjust`), caller-supplied initial poses and fixed views, an open prior set, and cancellable progress. None of them have a type to hang on until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
