### PR TITLE
fix(3d)!: harden the planar-pose solver — order-independent seed, gated second solution

### DIFF
--- a/crates/kornia-3d/src/pose/planar.rs
+++ b/crates/kornia-3d/src/pose/planar.rs
@@ -588,9 +588,13 @@ mod tests {
     /// metric scale must not change what `n_iters = 50` recovers from exact data.
     ///
     /// This is the test the module lacked: every other test here passes the canonical square in
-    /// the canonical order, which is exactly the ordering the old hardcoded `tag_norm` seed
-    /// happened to match, so none of them could observe the effect. With that seed restored,
-    /// `shifted` lands 2.56 deg out and `reversed` 15.58 deg out at 50 iterations.
+    /// the canonical order, which is exactly the ordering the old hardcoded canonical-square seed
+    /// happened to match, so none of them could observe the effect.
+    ///
+    /// With that old seed restored, under THIS test's pose (`rz(15 deg) * rx(20 deg)` at 0.3 m --
+    /// the right-hand column of the module table, not the plain-20-deg-tilt one),
+    /// `cyclic shift by one` lands 4.16 deg out and `reversed winding` 18.47 deg out at
+    /// `n_iters = 50`.
     #[test]
     fn seed_is_independent_of_corner_order() {
         let camera = test_camera();

--- a/crates/kornia-3d/src/pose/planar.rs
+++ b/crates/kornia-3d/src/pose/planar.rs
@@ -18,11 +18,20 @@
 //! encode; it is conditioning, not correctness.
 //!
 //! This matters because an earlier revision seeded from a FIXED canonical square
-//! `[(-1,-1), (1,-1), (1,1), (-1,1)]`, which was only correct for callers using that exact
-//! winding and phase. Measured on exact projections of a square at 0.3 m / 20 deg tilt, that
-//! seed left a cyclic shift by one 2.56 deg out and a reversed winding 15.58 deg out at
-//! `n_iters = 50` (both converged only by ~500), and left `kornia-apriltag`'s
-//! `[TR, BR, BL, TL]` corner order 4.16 deg out on perfect input.
+//! `[(-1,-1), (1,-1), (1,1), (-1,1)]`, which was only correct for callers whose points shared
+//! that exact winding and phase. Rotation error of `best` against that old seed, on exact
+//! projections of a 10 cm square at 0.3 m, at `n_iters = 50` (every case converges by 500):
+//!
+//! | `object_pts` order | 20 deg tilt | 20 deg tilt + 15 deg yaw |
+//! |---|---|---|
+//! | canonical | 0.0000 deg | 0.0000 deg |
+//! | cyclic shift by one | 3.74 deg | 4.16 deg |
+//! | reversed winding | 18.47 deg | 18.47 deg |
+//!
+//! `kornia-apriltag`'s `[TR, BR, BL, TL]` is itself a cyclic shift of the canonical winding, so
+//! it sat on that middle row: ~4 deg of rotation error on PERFECT input, at the `n_iters = 50`
+//! every in-tree caller passes.
+//!
 //! `seed_is_independent_of_corner_order` pins the current behaviour: every ordering, a 4:1
 //! rectangle, a trapezoid, an off-origin object frame and the same target expressed at 1e-3x and
 //! 1e3x scale all land under 1e-6 deg at `n_iters = 50`.
@@ -43,11 +52,12 @@
 //! (`fix_pose_ambiguities`) and reports `HUGE_VAL` when there is no second minimum. Porting that
 //! is tracked separately.
 //!
-//! Because of that, the second branch is usually not a real hypothesis: across depths of
-//! 0.3--5 m, tilts of 0--75 deg and both noise-free and 1 px-noise inputs, it converged BEHIND
-//! the camera in every configuration measured. It is now gated on cheirality at the source, so
-//! `second` is `Some` only when all four object points lie in front of the camera under it --
-//! which, in practice, means callers get `None` and can stop hand-rolling the check.
+//! Because of that, the second branch is usually not a real hypothesis: across the 36
+//! configurations `second_solution_is_gated_on_cheirality` sweeps (depths 0.3/1/5 m, tilts
+//! 0--75 deg, each noise-free and with 1 px of corner noise) it converged BEHIND the camera in
+//! every one. It is now gated on cheirality at the source, so `second` is `Some` only when all
+//! four object points lie in front of the camera under it -- which, in practice, means callers
+//! get `None` and can stop hand-rolling the check.
 //!
 use crate::camera::PinholeCamera;
 use crate::pose::{homography_4pt2d, Pose3d};
@@ -68,6 +78,13 @@ pub struct PlanarPose {
 #[derive(Debug, Clone)]
 pub struct PlanarPosePair {
     /// Lower-error solution.
+    ///
+    /// NOT cheirality-gated, unlike [`Self::second`]. `best` is whichever branch has the lower
+    /// reprojection error, and that error only *penalises* points behind the camera (a sentinel
+    /// term per point) rather than excluding them — so if BOTH branches put part of the target
+    /// behind the camera, the less-bad one is still returned here. Callers that must not act on
+    /// an impossible pose should check `best.error.is_finite()` and the sign of
+    /// `best.pose.transform_point(..).z`.
     pub best: PlanarPose,
     /// A second local minimum, if the second branch produced a physically possible pose.
     ///
@@ -147,10 +164,12 @@ fn normalized_object_seed(object_pts: &[Vec3F64; 4]) -> Option<[[f64; 2]; 4]> {
         .map(|p| ((p.x - cx).powi(2) + (p.y - cy).powi(2)).sqrt())
         .sum::<f64>()
         * 0.25;
-    if !mean_r.is_finite() || mean_r <= 0.0 {
+    let s = 1.0 / mean_r;
+    // `mean_r` being finite and positive is not enough: a subnormal one still overflows the
+    // reciprocal to infinity, which would put inf coordinates into the homography fit.
+    if !s.is_finite() || s <= 0.0 {
         return None;
     }
-    let s = 1.0 / mean_r;
     Some([0, 1, 2, 3].map(|i| [(object_pts[i].x - cx) * s, (object_pts[i].y - cy) * s]))
 }
 
@@ -666,9 +685,10 @@ mod tests {
 
     /// The second branch must never be handed back pointing away from the camera.
     ///
-    /// Measured across depths 0.3/1/5 m, tilts 0-75 deg and 1 px noise, the second branch landed
-    /// behind the camera in every configuration, so this asserts both halves: `None` in a
-    /// concrete configuration, and — for every configuration — that a `Some` really is in front.
+    /// Sweeps depths 0.3/1/5 m and tilts 0-75 deg, each both noise-free and with 1 px of
+    /// deterministic corner noise (36 configurations). The second branch lands behind the camera
+    /// in every one, so this asserts both halves: that a `Some` really is in front, and — so the
+    /// first loop cannot pass vacuously — that the number of `Some` results is zero.
     #[test]
     fn second_solution_is_gated_on_cheirality() {
         let camera = test_camera();
@@ -679,8 +699,12 @@ mod tests {
             Vec3F64::new(s, s, 0.0),
             Vec3F64::new(-s, s, 0.0),
         ];
+        // Deterministic zero-mean 1 px corner noise, and its absence.
+        let no_noise = [[0.0f64; 2]; 4];
+        let one_px = [[0.6f64, -0.8], [-0.6, 0.8], [0.8, -0.6], [-0.8, 0.6]];
 
         let mut n_some = 0;
+        let mut n_cases = 0;
         for tilt_deg in [0.0f64, 5.0, 20.0, 45.0, 60.0, 75.0] {
             let tilt = tilt_deg.to_radians();
             let r_gt = Mat3F64::from_cols(
@@ -689,33 +713,44 @@ mod tests {
                 Vec3F64::new(0.0, -tilt.sin(), tilt.cos()),
             );
             for depth in [0.3f64, 1.0, 5.0] {
-                let pose_gt = Pose3d::new(r_gt, Vec3F64::new(0.02, -0.01, depth));
-                let image_pts = project_pts(&object_pts, &pose_gt, &camera);
-                let pair = estimate_planar_pose(&object_pts, &image_pts, &camera, 50)
-                    .expect("exact projection must solve");
-                if let Some(second) = &pair.second {
-                    n_some += 1;
-                    for p in &object_pts {
-                        let z = second.pose.transform_point(p).z;
-                        assert!(
-                            z > 0.0,
-                            "tilt {tilt_deg} deg / {depth} m: `second` returned with a point at \
-                             z = {z}, behind the camera"
+                for (label, noise) in [("exact", no_noise), ("1 px noise", one_px)] {
+                    let pose_gt = Pose3d::new(r_gt, Vec3F64::new(0.02, -0.01, depth));
+                    let mut image_pts = project_pts(&object_pts, &pose_gt, &camera);
+                    for i in 0..4 {
+                        image_pts[i] = Vec2F64::new(
+                            image_pts[i].x + noise[i][0],
+                            image_pts[i].y + noise[i][1],
                         );
                     }
-                    assert!(
-                        second.error.is_finite() && second.error < f64::MAX,
-                        "tilt {tilt_deg} deg / {depth} m: `second` carries a sentinel error"
-                    );
+                    n_cases += 1;
+                    let pair = estimate_planar_pose(&object_pts, &image_pts, &camera, 50)
+                        .expect("a well-conditioned quad must solve");
+                    if let Some(second) = &pair.second {
+                        n_some += 1;
+                        for p in &object_pts {
+                            let z = second.pose.transform_point(p).z;
+                            assert!(
+                                z > 0.0,
+                                "tilt {tilt_deg} deg / {depth} m / {label}: `second` returned \
+                                 with a point at z = {z}, behind the camera"
+                            );
+                        }
+                        assert!(
+                            second.error.is_finite() && second.error < f64::MAX,
+                            "tilt {tilt_deg} deg / {depth} m / {label}: `second` carries a \
+                             sentinel error"
+                        );
+                    }
                 }
             }
         }
+        assert_eq!(n_cases, 36, "the sweep should cover 36 configurations");
         // Guard against the loop above passing vacuously in the other direction: if a future
         // change makes the second branch usable everywhere, this fires and the docs must follow.
         assert_eq!(
             n_some, 0,
             "the second branch is documented as always degenerate on these configurations, but \
-             {n_some} came back in front of the camera — update the module docs"
+             {n_some} of {n_cases} came back in front of the camera — update the module docs"
         );
     }
 

--- a/crates/kornia-3d/src/pose/planar.rs
+++ b/crates/kornia-3d/src/pose/planar.rs
@@ -5,27 +5,49 @@
 //! points with known image correspondences work: a fiducial marker, a chessboard cell, a printed
 //! rectangle, a door frame.
 //!
-//! # Corner order affects convergence
+//! # Initialisation is derived from the caller's own points
 //!
-//! The initial estimate comes from a homography fitted between a FIXED canonical square
-//! `[(-1,-1), (1,-1), (1,1), (-1,1)]` and `image_pts`. The orthogonal iteration then refines
-//! against the caller's real `object_pts`, so any consistent correspondence converges eventually,
-//! but how far it starts from the answer depends on how close the caller's ordering is to that
-//! canonical one.
+//! The orthogonal iteration is seeded by decomposing a homography fitted between `object_pts`
+//! and `image_pts`. Because that seed is fitted from the caller's OWN points, it does not depend
+//! on the order, the winding, the size or the shape they come in, and on exact data it already IS
+//! the answer -- the iteration only has work to do in the presence of noise.
 //!
-//! Measured on exact projections of a square at 0.3 m, 20 deg tilt: the canonical order is exact
-//! at `n_iters = 50`, a cyclic shift by one is 2.56 deg out, and a reversed winding 15.58 deg;
-//! all three reach 0.0000 deg by 500 iterations. Pass the corners counter-clockwise from the
-//! `(-x, -y)` corner, or raise `n_iters`.
+//! The points are centred on their centroid and uniformly rescaled first. That is the standard
+//! DLT conditioning step and a similarity of the object plane, so it moves the homography's third
+//! column and rescales the first two by a common factor without touching the rotation those two
+//! encode; it is conditioning, not correctness.
 //!
-//! Target SHAPE is nearly free by comparison: a 4:1 rectangle converges at `n_iters = 50`
-//! indistinguishably from a square.
+//! This matters because an earlier revision seeded from a FIXED canonical square
+//! `[(-1,-1), (1,-1), (1,1), (-1,1)]`, which was only correct for callers using that exact
+//! winding and phase. Measured on exact projections of a square at 0.3 m / 20 deg tilt, that
+//! seed left a cyclic shift by one 2.56 deg out and a reversed winding 15.58 deg out at
+//! `n_iters = 50` (both converged only by ~500), and left `kornia-apriltag`'s
+//! `[TR, BR, BL, TL]` corner order 4.16 deg out on perfect input.
+//! `seed_is_independent_of_corner_order` pins the current behaviour: every ordering, a 4:1
+//! rectangle, a trapezoid, an off-origin object frame and the same target expressed at 1e-3x and
+//! 1e3x scale all land under 1e-6 deg at `n_iters = 50`.
 //!
-//! # Two solutions
+//! # The second solution
 //!
-//! [`PlanarPosePair`] returns two poses rather than silently picking one, so a caller with extra
-//! information (a second view, a motion prior, a known facing direction) can resolve the choice.
-//! Check `second` before relying on it -- see the tracking issue for its measured behaviour.
+//! [`PlanarPosePair::second`] is an `Option`, and it is `None` far more often than not.
+//!
+//! Two independent orthogonal iterations are run: one from the homography seed, one from that
+//! same seed with its first two rotation columns negated (a 180 deg rotation in the object
+//! plane). The two results are then sorted by reprojection error, so `best`/`second` name the
+//! outcomes, not the branches -- the negation describes the SEED and nothing about the pose that
+//! comes back.
+//!
+//! That second seed is a *heuristic* alternative starting point. It is NOT the classical planar
+//! mirror ambiguity, and NOT what the AprilRobotics C reference computes: `apriltag_pose.c`
+//! finds the genuine second local minimum of the same objective by solving a quartic
+//! (`fix_pose_ambiguities`) and reports `HUGE_VAL` when there is no second minimum. Porting that
+//! is tracked separately.
+//!
+//! Because of that, the second branch is usually not a real hypothesis: across depths of
+//! 0.3--5 m, tilts of 0--75 deg and both noise-free and 1 px-noise inputs, it converged BEHIND
+//! the camera in every configuration measured. It is now gated on cheirality at the source, so
+//! `second` is `Some` only when all four object points lie in front of the camera under it --
+//! which, in practice, means callers get `None` and can stop hand-rolling the check.
 //!
 use crate::camera::PinholeCamera;
 use crate::pose::{homography_4pt2d, Pose3d};
@@ -37,30 +59,51 @@ use kornia_algebra::{Mat3F64, Vec2F64, Vec3F64};
 pub struct PlanarPose {
     /// The world-to-camera rigid transform.
     pub pose: Pose3d,
-    /// Sum of squared pixel reprojection errors over the 4 tag corners (pixels²).
+    /// Sum of squared pixel reprojection errors over the 4 correspondences (pixels²).
     /// Lower is better; < 1.0 indicates sub-pixel accuracy.
     pub error: f64,
 }
 
-/// Two candidate poses from the planar ambiguity (one is typically degenerate).
-/// `best` has the lower reprojection error.
+/// The solutions found for one planar-pose problem.
 #[derive(Debug, Clone)]
 pub struct PlanarPosePair {
     /// Lower-error solution.
     pub best: PlanarPose,
-    /// Higher-error solution (may be degenerate/behind-camera).
-    pub second: PlanarPose,
+    /// A second local minimum, if the second branch produced a physically possible pose.
+    ///
+    /// `Some` only when all four object points lie in front of the camera under it; the second
+    /// branch converges behind the camera in most configurations, so expect `None`. Read the
+    /// module docs before treating this as an alternative hypothesis -- it is a heuristic
+    /// re-seed, not the reference implementation's quartic second minimum.
+    pub second: Option<PlanarPose>,
 }
 
-/// Error type for tag pose estimation.
+/// Error type for planar pose estimation.
 #[derive(thiserror::Error, Debug)]
 pub enum PlanarPoseError {
-    /// The homography system is degenerate (coplanar-degenerate inputs).
-    #[error("Homography DLT system is singular")]
-    SingularHomography,
+    /// The initial homography could not be fitted from the 4 correspondences.
+    #[error("initial homography could not be fitted: {0}")]
+    Homography(#[from] crate::pose::HomographyError),
+
+    /// The orthogonal iteration's linear system `(I - avg_F)` is singular, which happens when the
+    /// four image rays are (near) identical. Distinct from [`Self::Homography`]: the homography
+    /// fitted, the refinement is what degenerated.
+    #[error("orthogonal-iteration system is singular (degenerate image rays)")]
+    SingularIteration,
+
+    /// The four object points collapse to a point in their own plane, so there is no frame to
+    /// seed the homography from.
+    #[error("object points are degenerate (zero extent in the object plane)")]
+    DegenerateObjectPoints,
+
+    /// `n_iters` was zero. The refinement loop would never run, so the returned pose would be the
+    /// raw homography decomposition carrying a sentinel error rather than a measured one --
+    /// silently useless, so it is refused instead.
+    #[error("n_iters must be non-zero")]
+    ZeroIterations,
 }
 
-/// Decompose a planar homography (mapping tag-normalized ±1 coords to pixels) into
+/// Decompose a planar homography (mapping normalized object-plane coords to pixels) into
 /// an initial pose using the camera intrinsics.
 ///
 /// The last column of K⁻¹·H is t/scale (not metric t); OI rewrites t on its first step.
@@ -80,6 +123,47 @@ fn homography_to_pose(h: &[[f64; 3]; 3], fx: f64, fy: f64, cx: f64, cy: f64) -> 
     let t = Vec3F64::new(hk[0][2] / scale, hk[1][2] / scale, hk[2][2] / scale);
     Pose3d::new(Mat3F64::from_cols(r1, r2, r3), t)
 }
+
+/// Seed points for the initial homography: the caller's own object x/y, centred on their
+/// centroid and uniformly scaled to unit mean radius.
+///
+/// What makes the seed correct is that it is fitted from the CALLER'S points at all. Writing the
+/// exact projection as `H = K·[r₁ r₂ t]` and substituting `q = s·(p − c)` gives
+/// `H' = K·[r₁/s r₂/s (t + R·c)]`: the first two columns keep their directions and pick up a
+/// COMMON factor, which [`homography_to_pose`] divides out when it normalises them. So the
+/// recovered `R` is the caller's frame whatever order, winding, size or shape their points come
+/// in, and `t` is rewritten by the iteration's first step anyway.
+///
+/// Centring and rescaling are therefore conditioning, not correctness — this is the standard DLT
+/// normalisation. Measured: disabling either one on its own leaves every case in
+/// `seed_is_independent_of_corner_order` passing, so neither is load-bearing for the inputs
+/// tested. They are kept because they cost four sums and make the 8x8 system
+/// [`homography_4pt2d`] solves independent of the unit the caller's object frame is expressed in.
+fn normalized_object_seed(object_pts: &[Vec3F64; 4]) -> Option<[[f64; 2]; 4]> {
+    let cx = object_pts.iter().map(|p| p.x).sum::<f64>() * 0.25;
+    let cy = object_pts.iter().map(|p| p.y).sum::<f64>() * 0.25;
+    let mean_r = object_pts
+        .iter()
+        .map(|p| ((p.x - cx).powi(2) + (p.y - cy).powi(2)).sqrt())
+        .sum::<f64>()
+        * 0.25;
+    if !mean_r.is_finite() || mean_r <= 0.0 {
+        return None;
+    }
+    let s = 1.0 / mean_r;
+    Some([0, 1, 2, 3].map(|i| [(object_pts[i].x - cx) * s, (object_pts[i].y - cy) * s]))
+}
+
+/// Whether every object point lies strictly in front of the camera under `pose`.
+fn all_in_front(pose: &Pose3d, object_pts: &[Vec3F64; 4]) -> bool {
+    object_pts
+        .iter()
+        .all(|p| pose.transform_point(p).z > CHEIRALITY_EPS)
+}
+
+/// Minimum camera-frame depth treated as "in front of the camera". Shared by the reprojection
+/// error accumulation and the cheirality gate on the second solution so they cannot disagree.
+const CHEIRALITY_EPS: f64 = 1e-10;
 
 /// Projection operator for image ray v: F = v·vᵀ / (vᵀ·v).
 fn calc_f(v: Vec3F64) -> Mat3F64 {
@@ -109,7 +193,7 @@ fn orthogonal_iteration(
     let m1 = Mat3F64::IDENTITY - avg_f;
     // (I − avg_F) is singular when all image rays are identical — degenerate input.
     if m1.determinant().abs() < 1e-8 {
-        return Err(PlanarPoseError::SingularHomography);
+        return Err(PlanarPoseError::SingularIteration);
     }
     let m1_inv = m1.inverse();
 
@@ -163,7 +247,7 @@ fn orthogonal_iteration(
         error = 0.0;
         for i in 0..4 {
             let p_cam = rotation * object_pts[i] + translation;
-            if p_cam.z > 1e-10 {
+            if p_cam.z > CHEIRALITY_EPS {
                 let u_hat = fx * p_cam.x / p_cam.z + cx;
                 let v_hat = fy * p_cam.y / p_cam.z + cy;
                 let du = u_hat - image_pts[i].x;
@@ -178,34 +262,85 @@ fn orthogonal_iteration(
     Ok((Pose3d::new(rotation, translation), error))
 }
 
-/// Estimate the 6-DOF pose of a planar AprilTag from 4 corner correspondences.
+/// Estimate the 6-DOF pose of a planar quad from 4 coplanar correspondences.
 ///
 /// # Arguments
-/// * `object_pts` — 4 coplanar tag corners in the tag metric frame (`z = 0`), each at
-///   `±tag_size/2` on x/y. Only the index-wise correspondence with `image_pts` matters,
-///   not the absolute order. `Detection::estimate_pose` lists them in the detector's
-///   `[TR, BR, BL, TL]` corner order — see its comment; using a different order there
-///   rotates the recovered pose in-plane.
-/// * `image_pts` — matching 2D image coordinates (pixels), same index order as object_pts.
-/// * `camera` — pinhole camera intrinsics (fx, fy, cx, cy). Distortion coefficients ignored.
-/// * `n_iters` — number of orthogonal-iteration refinement steps (default: 50).
+/// * `object_pts` — 4 coplanar object points in the target's own metric frame (`z = 0`; only x/y
+///   are used to seed the iteration). Order, winding and scale are free: the seed is fitted from
+///   these points, so only the index-wise correspondence with `image_pts` matters. The recovered
+///   pose is expressed in whatever frame they are given in.
+/// * `image_pts` — matching 2D image coordinates (pixels), same index order as `object_pts`.
+/// * `camera` — pinhole intrinsics. Distortion coefficients are IGNORED; undistort first if your
+///   camera has any.
+/// * `n_iters` — orthogonal-iteration refinement steps (50 is a good default). Must be non-zero.
 ///
 /// # Returns
-/// `PlanarPosePair` with `best` (lower reprojection error) and `second` (higher error / ambiguous solution).
+/// [`PlanarPosePair`]: `best` (lower reprojection error) and `second`, which is `Some` only when
+/// the second branch converged in front of the camera — usually it does not.
+///
+/// # Errors
+/// * [`PlanarPoseError::Homography`] — the initial homography could not be fitted.
+/// * [`PlanarPoseError::SingularIteration`] — the refinement's linear system degenerated (all
+///   four image rays effectively identical).
+/// * [`PlanarPoseError::DegenerateObjectPoints`] — the object points have no extent in their
+///   own plane.
+/// * [`PlanarPoseError::ZeroIterations`] — `n_iters == 0`, which would otherwise return an
+///   unrefined pose carrying a sentinel error.
+///
+/// # Example
+/// ```
+/// use kornia_3d::camera::PinholeCamera;
+/// use kornia_3d::pose::estimate_planar_pose;
+/// use kornia_algebra::{Vec2F64, Vec3F64};
+///
+/// // A 10 cm square target.
+/// let s = 0.05;
+/// let object_pts = [
+///     Vec3F64::new(-s, -s, 0.0),
+///     Vec3F64::new(s, -s, 0.0),
+///     Vec3F64::new(s, s, 0.0),
+///     Vec3F64::new(-s, s, 0.0),
+/// ];
+///
+/// let camera = PinholeCamera {
+///     fx: 500.0,
+///     fy: 500.0,
+///     cx: 320.0,
+///     cy: 240.0,
+///     ..PinholeCamera::IDENTITY
+/// };
+///
+/// // Its image with the target frontal, 0.5 m away: u = fx * X / Z + cx.
+/// let image_pts = [
+///     Vec2F64::new(270.0, 190.0),
+///     Vec2F64::new(370.0, 190.0),
+///     Vec2F64::new(370.0, 290.0),
+///     Vec2F64::new(270.0, 290.0),
+/// ];
+///
+/// let pair = estimate_planar_pose(&object_pts, &image_pts, &camera, 50)?;
+/// assert!((pair.best.pose.translation.z - 0.5).abs() < 1e-6);
+/// # Ok::<(), kornia_3d::pose::PlanarPoseError>(())
+/// ```
 ///
 /// # Note
-/// Uses the Lu-Hager-Mjolsness (1993) orthogonal iteration algorithm, matching the
-/// AprilRobotics C reference implementation in `apriltag_pose.c`.
+/// Lu-Hager-Mjolsness (1993) orthogonal iteration, as in the AprilRobotics C reference
+/// `apriltag_pose.c` — except for how the second solution is obtained, see the module docs.
 pub fn estimate_planar_pose(
     object_pts: &[Vec3F64; 4],
     image_pts: &[Vec2F64; 4],
     camera: &PinholeCamera,
     n_iters: usize,
 ) -> Result<PlanarPosePair, PlanarPoseError> {
+    if n_iters == 0 {
+        return Err(PlanarPoseError::ZeroIterations);
+    }
     let (fx, fy, cx, cy) = camera.intrinsics();
 
-    // H maps tag-normalized corners (±1) → image pixels
-    let tag_norm: [[f64; 2]; 4] = [[-1.0, -1.0], [1.0, -1.0], [1.0, 1.0], [-1.0, 1.0]];
+    // H maps the caller's own object plane (centred, unit mean radius) → image pixels, so the
+    // seed is exact for any ordering/shape/scale rather than only for a canonical square.
+    let obj_norm =
+        normalized_object_seed(object_pts).ok_or(PlanarPoseError::DegenerateObjectPoints)?;
     let img_arr: [[f64; 2]; 4] = [
         [image_pts[0].x, image_pts[0].y],
         [image_pts[1].x, image_pts[1].y],
@@ -213,8 +348,7 @@ pub fn estimate_planar_pose(
         [image_pts[3].x, image_pts[3].y],
     ];
     let mut h = [[0.0f64; 3]; 3];
-    homography_4pt2d(&tag_norm, &img_arr, &mut h)
-        .map_err(|_| PlanarPoseError::SingularHomography)?;
+    homography_4pt2d(&obj_norm, &img_arr, &mut h).map_err(PlanarPoseError::Homography)?;
 
     let init_pose = homography_to_pose(&h, fx, fy, cx, cy);
 
@@ -236,7 +370,9 @@ pub fn estimate_planar_pose(
         camera,
     )?;
 
-    // Pose 2: other planar ambiguity — negate first two R columns
+    // Pose 2: re-seed with the first two rotation columns negated (a 180° in-plane rotation) and
+    // run an independent iteration. This is a heuristic second start, not the reference's quartic
+    // second minimum — see the module docs.
     let r2_init = Mat3F64::from_cols(
         -init_pose.rotation.x_axis(),
         -init_pose.rotation.y_axis(),
@@ -252,30 +388,25 @@ pub fn estimate_planar_pose(
     )?;
 
     let (best, second) = if err1 <= err2 {
-        (
-            PlanarPose {
-                pose: pose1,
-                error: err1,
-            },
-            PlanarPose {
-                pose: pose2,
-                error: err2,
-            },
-        )
+        ((pose1, err1), (pose2, err2))
     } else {
-        (
-            PlanarPose {
-                pose: pose2,
-                error: err2,
-            },
-            PlanarPose {
-                pose: pose1,
-                error: err1,
-            },
-        )
+        ((pose2, err2), (pose1, err1))
     };
 
-    Ok(PlanarPosePair { best, second })
+    // Gate the runner-up on cheirality: a pose that puts the target behind the camera is not an
+    // alternative hypothesis, and callers were silently consuming it as one.
+    let second = all_in_front(&second.0, object_pts).then_some(PlanarPose {
+        pose: second.0,
+        error: second.1,
+    });
+
+    Ok(PlanarPosePair {
+        best: PlanarPose {
+            pose: best.0,
+            error: best.1,
+        },
+        second,
+    })
 }
 
 #[cfg(test)]
@@ -410,8 +541,224 @@ mod tests {
         let image_pts = [Vec2F64::new(320.0, 240.0); 4];
         let result = estimate_planar_pose(&object_pts, &image_pts, &camera, 50);
         assert!(
-            matches!(result, Err(PlanarPoseError::SingularHomography)),
-            "expected SingularHomography, got {result:?}"
+            matches!(
+                result,
+                Err(PlanarPoseError::SingularIteration) | Err(PlanarPoseError::Homography(_))
+            ),
+            "expected a degeneracy error, got {result:?}"
+        );
+    }
+
+    /// Project `object_pts` from `r_gt` at `depth`, solve, and return `best`'s rotation error in
+    /// degrees at `n_iters`.
+    fn rot_err_deg_at(
+        object_pts: &[Vec3F64; 4],
+        camera: &PinholeCamera,
+        r_gt: &Mat3F64,
+        depth: f64,
+        n_iters: usize,
+    ) -> f64 {
+        let pose_gt = Pose3d::new(*r_gt, Vec3F64::new(0.0, 0.0, depth));
+        let image_pts = project_pts(object_pts, &pose_gt, camera);
+        let pair = estimate_planar_pose(object_pts, &image_pts, camera, n_iters)
+            .expect("exact projection must solve");
+        rotation_error_rad(&pair.best.pose.rotation, r_gt).to_degrees()
+    }
+
+    /// The seed is fitted from the caller's OWN object points, so ordering, winding, shape and
+    /// metric scale must not change what `n_iters = 50` recovers from exact data.
+    ///
+    /// This is the test the module lacked: every other test here passes the canonical square in
+    /// the canonical order, which is exactly the ordering the old hardcoded `tag_norm` seed
+    /// happened to match, so none of them could observe the effect. With that seed restored,
+    /// `shifted` lands 2.56 deg out and `reversed` 15.58 deg out at 50 iterations.
+    #[test]
+    fn seed_is_independent_of_corner_order() {
+        let camera = test_camera();
+        let s = 0.05;
+        let canonical = [
+            Vec3F64::new(-s, -s, 0.0),
+            Vec3F64::new(s, -s, 0.0),
+            Vec3F64::new(s, s, 0.0),
+            Vec3F64::new(-s, s, 0.0),
+        ];
+        // A tilted pose: at frontal the ordering effect is near-degenerate and proves nothing.
+        let (ax, az) = (20.0f64.to_radians(), 15.0f64.to_radians());
+        let rx = Mat3F64::from_cols(
+            Vec3F64::new(1.0, 0.0, 0.0),
+            Vec3F64::new(0.0, ax.cos(), ax.sin()),
+            Vec3F64::new(0.0, -ax.sin(), ax.cos()),
+        );
+        let rz = Mat3F64::from_cols(
+            Vec3F64::new(az.cos(), az.sin(), 0.0),
+            Vec3F64::new(-az.sin(), az.cos(), 0.0),
+            Vec3F64::new(0.0, 0.0, 1.0),
+        );
+        let r_gt = rz * rx;
+
+        // (name, object points, depth). Depth is 0.3 m except for the scale cases, which scale
+        // the target AND the distance together so the IMAGE is bit-identical: that isolates the
+        // numerical question (does the object frame's unit matter?) from the physical one (a
+        // 50 um target at 0.3 m really is unsolvable).
+        let cases: [(&str, [Vec3F64; 4], f64); 9] = [
+            ("canonical", canonical, 0.3),
+            // The AprilTag decoder's [TR, BR, BL, TL] winding — the caller that motivated this.
+            (
+                "apriltag TR,BR,BL,TL",
+                [
+                    Vec3F64::new(s, -s, 0.0),
+                    Vec3F64::new(s, s, 0.0),
+                    Vec3F64::new(-s, s, 0.0),
+                    Vec3F64::new(-s, -s, 0.0),
+                ],
+                0.3,
+            ),
+            (
+                "cyclic shift by one",
+                [canonical[1], canonical[2], canonical[3], canonical[0]],
+                0.3,
+            ),
+            (
+                "reversed winding",
+                [canonical[3], canonical[2], canonical[1], canonical[0]],
+                0.3,
+            ),
+            (
+                "4:1 rectangle",
+                [
+                    Vec3F64::new(-4.0 * s, -s, 0.0),
+                    Vec3F64::new(4.0 * s, -s, 0.0),
+                    Vec3F64::new(4.0 * s, s, 0.0),
+                    Vec3F64::new(-4.0 * s, s, 0.0),
+                ],
+                0.3,
+            ),
+            (
+                "trapezoid",
+                [
+                    Vec3F64::new(-3.0 * s, -s, 0.0),
+                    Vec3F64::new(3.0 * s, -s, 0.0),
+                    Vec3F64::new(s, s, 0.0),
+                    Vec3F64::new(-s, s, 0.0),
+                ],
+                0.3,
+            ),
+            // Object frame whose origin is nowhere near the target.
+            (
+                "offset centre",
+                canonical.map(|p| p + Vec3F64::new(0.7, -0.3, 0.0)),
+                0.3,
+            ),
+            // Same image, object frame expressed in millimetres and in kilometres.
+            ("1e-3x scale", canonical.map(|p| p * 1e-3), 0.3 * 1e-3),
+            ("1e3x scale", canonical.map(|p| p * 1e3), 0.3 * 1e3),
+        ];
+
+        for (name, obj, depth) in cases {
+            let err = rot_err_deg_at(&obj, &camera, &r_gt, depth, 50);
+            assert!(
+                err < 1e-6,
+                "{name}: {err} deg at n_iters = 50 — the homography seed is not \
+                 order/shape/scale independent"
+            );
+        }
+    }
+
+    /// The second branch must never be handed back pointing away from the camera.
+    ///
+    /// Measured across depths 0.3/1/5 m, tilts 0-75 deg and 1 px noise, the second branch landed
+    /// behind the camera in every configuration, so this asserts both halves: `None` in a
+    /// concrete configuration, and — for every configuration — that a `Some` really is in front.
+    #[test]
+    fn second_solution_is_gated_on_cheirality() {
+        let camera = test_camera();
+        let s = 0.05;
+        let object_pts = [
+            Vec3F64::new(-s, -s, 0.0),
+            Vec3F64::new(s, -s, 0.0),
+            Vec3F64::new(s, s, 0.0),
+            Vec3F64::new(-s, s, 0.0),
+        ];
+
+        let mut n_some = 0;
+        for tilt_deg in [0.0f64, 5.0, 20.0, 45.0, 60.0, 75.0] {
+            let tilt = tilt_deg.to_radians();
+            let r_gt = Mat3F64::from_cols(
+                Vec3F64::new(1.0, 0.0, 0.0),
+                Vec3F64::new(0.0, tilt.cos(), tilt.sin()),
+                Vec3F64::new(0.0, -tilt.sin(), tilt.cos()),
+            );
+            for depth in [0.3f64, 1.0, 5.0] {
+                let pose_gt = Pose3d::new(r_gt, Vec3F64::new(0.02, -0.01, depth));
+                let image_pts = project_pts(&object_pts, &pose_gt, &camera);
+                let pair = estimate_planar_pose(&object_pts, &image_pts, &camera, 50)
+                    .expect("exact projection must solve");
+                if let Some(second) = &pair.second {
+                    n_some += 1;
+                    for p in &object_pts {
+                        let z = second.pose.transform_point(p).z;
+                        assert!(
+                            z > 0.0,
+                            "tilt {tilt_deg} deg / {depth} m: `second` returned with a point at \
+                             z = {z}, behind the camera"
+                        );
+                    }
+                    assert!(
+                        second.error.is_finite() && second.error < f64::MAX,
+                        "tilt {tilt_deg} deg / {depth} m: `second` carries a sentinel error"
+                    );
+                }
+            }
+        }
+        // Guard against the loop above passing vacuously in the other direction: if a future
+        // change makes the second branch usable everywhere, this fires and the docs must follow.
+        assert_eq!(
+            n_some, 0,
+            "the second branch is documented as always degenerate on these configurations, but \
+             {n_some} came back in front of the camera — update the module docs"
+        );
+    }
+
+    /// `n_iters = 0` must be refused, not answered with an unrefined pose carrying `f64::MAX`.
+    #[test]
+    fn zero_iterations_is_rejected() {
+        let camera = test_camera();
+        let s = 0.05;
+        let object_pts = [
+            Vec3F64::new(-s, -s, 0.0),
+            Vec3F64::new(s, -s, 0.0),
+            Vec3F64::new(s, s, 0.0),
+            Vec3F64::new(-s, s, 0.0),
+        ];
+        let image_pts = [
+            Vec2F64::new(270.0, 190.0),
+            Vec2F64::new(370.0, 190.0),
+            Vec2F64::new(370.0, 290.0),
+            Vec2F64::new(270.0, 290.0),
+        ];
+        let result = estimate_planar_pose(&object_pts, &image_pts, &camera, 0);
+        assert!(
+            matches!(result, Err(PlanarPoseError::ZeroIterations)),
+            "expected ZeroIterations, got {result:?}"
+        );
+    }
+
+    /// Object points with no extent give the seed no frame to fit; that must be an error, not a
+    /// homography built from NaNs.
+    #[test]
+    fn degenerate_object_points_are_rejected() {
+        let camera = test_camera();
+        let object_pts = [Vec3F64::new(0.1, -0.2, 0.0); 4];
+        let image_pts = [
+            Vec2F64::new(270.0, 190.0),
+            Vec2F64::new(370.0, 190.0),
+            Vec2F64::new(370.0, 290.0),
+            Vec2F64::new(270.0, 290.0),
+        ];
+        let result = estimate_planar_pose(&object_pts, &image_pts, &camera, 50);
+        assert!(
+            matches!(result, Err(PlanarPoseError::DegenerateObjectPoints)),
+            "expected DegenerateObjectPoints, got {result:?}"
         );
     }
 }

--- a/crates/kornia-apriltag/src/decoder.rs
+++ b/crates/kornia-apriltag/src/decoder.rs
@@ -313,8 +313,8 @@ impl Detection {
     ///
     /// # Returns
     ///
-    /// [`kornia_3d::pose::PlanarPosePair`] with `best` (lower reprojection error) and
-    /// `second` (higher error / ambiguous solution).
+    /// [`kornia_3d::pose::PlanarPosePair`] with `best` (lower reprojection error) and `second`,
+    /// which is `Some` only when the runner-up is physically possible — usually it is not.
     pub fn estimate_pose(
         &self,
         camera: &kornia_3d::camera::PinholeCamera,

--- a/crates/kornia-calib/src/init.rs
+++ b/crates/kornia-calib/src/init.rs
@@ -1,5 +1,8 @@
-//! Pose initialization: reference-tag selection, per-camera planar pose
-//! (2-fold ambiguity), and branch disambiguation via feature reprojection.
+//! Pose initialization: reference-tag selection, per-camera planar pose, and — for the cameras
+//! whose runner-up pose survives `estimate_planar_pose`'s cheirality gate — branch
+//! disambiguation via feature reprojection. That gate rejects the runner-up in most real
+//! geometries, so the disambiguation usually has a single candidate per camera and reduces to
+//! trusting `best`.
 
 use kornia_3d::camera::PinholeCamera;
 use kornia_3d::pose::estimate_planar_pose as estimate_tag_pose;
@@ -18,9 +21,10 @@ pub(crate) struct Init {
     pub ref_ti: usize,
 }
 
-/// Select the reference tag (seen by the most cameras), estimate each camera's
-/// two planar tag poses, and pick the branch combination that best explains the
-/// feature matches (a single small planar tag alone can't resolve rotation).
+/// Select the reference tag (seen by the most cameras), estimate each camera's planar tag pose
+/// (plus the runner-up branch where one survives the cheirality gate), and pick the branch
+/// combination that best explains the feature matches (a single small planar tag alone can't
+/// resolve rotation).
 pub(crate) fn init_poses(
     cameras: &[PinholeCamera],
     tags: &[TagObservation],
@@ -36,8 +40,10 @@ pub(crate) fn init_poses(
         .ok_or(CalibError::NoTags)?;
 
     let h = config.tag_size_m / 2.0;
-    // estimate_tag_pose expects object/image points in (BL, BR, TR, TL) order;
-    // our tag corners are aruco-wound (TL, TR, BR, BL) — reverse to match.
+    // Object points listed (BL, BR, TR, TL) and the image corners reversed to match, since our
+    // tag corners are aruco-wound (TL, TR, BR, BL). Only the index-wise pairing matters —
+    // estimate_tag_pose seeds itself from these points, so the absolute order is free — but the
+    // two lists must agree or the recovered pose is rotated in-plane.
     let object_pts = [
         Vec3F64::new(-h, -h, 0.0),
         Vec3F64::new(h, -h, 0.0),
@@ -45,7 +51,10 @@ pub(crate) fn init_poses(
         Vec3F64::new(-h, h, 0.0),
     ];
 
-    let mut branches: Vec<(usize, [Pose3d; 2])> = Vec::new();
+    // Per camera: `best`, plus the runner-up branch only when it is physically possible.
+    // `estimate_tag_pose` cheirality-gates that second branch and in practice returns `None` for
+    // it, so most cameras offer a single pose and contribute no bit to the search below.
+    let mut branches: Vec<(usize, Pose3d, Option<Pose3d>)> = Vec::new();
     for (cam_idx, corners) in &tags[ref_ti].per_camera {
         if *cam_idx >= n_cams {
             continue; // ignore out-of-range camera index (matches init_poses_board)
@@ -59,11 +68,7 @@ pub(crate) fn init_poses(
             cam.undistort(corners[0].x, corners[0].y),
         ];
         let result = estimate_tag_pose(&object_pts, &image_pts, cam, 50)?;
-        // `second` is `None` when the runner-up converged behind the camera, which is the norm.
-        // Duplicating `best` keeps the combination search below well-formed (that camera then
-        // contributes the same pose either way) instead of scoring an impossible pose.
-        let second = result.second.map_or(result.best.pose, |s| s.pose);
-        branches.push((*cam_idx, [result.best.pose, second]));
+        branches.push((*cam_idx, result.best.pose, result.second.map(|s| s.pose)));
     }
     if branches.is_empty() {
         return Err(CalibError::NoReferenceTagView);
@@ -78,10 +83,20 @@ pub(crate) fn init_poses(
 
     // Score every branch combination by feature reprojection under its init.
     // Wrong planar branches make non-coplanar features triangulate/reproject
-    // badly, which the score below heavily penalizes. >6 cams: fall back to
-    // each camera's lower-error branch (2^nb combos is too many).
-    let nb = branches.len();
-    let ncomb = if nb <= 6 { 1u32 << nb } else { 1 };
+    // badly, which the score below heavily penalizes. >6 choices: fall back to
+    // each camera's lower-error branch (2^n combos is too many).
+    //
+    // Only cameras with a physically possible SECOND branch get a bit here — a camera offering
+    // one pose has nothing to choose between, and giving it a bit would double the search for
+    // two identical outcomes.
+    let choosers: Vec<usize> = (0..branches.len())
+        .filter(|&i| branches[i].2.is_some())
+        .collect();
+    let ncomb = if choosers.len() <= 6 {
+        1u32 << choosers.len()
+    } else {
+        1
+    };
     // Correspondences for branch scoring: the XFeat feature matches PLUS every non-reference tag
     // corner as an exact cross-camera match. The tag corners let the multi-tag rigid geometry
     // disambiguate the planar branch even with NO natural features (the correct branch combo is the
@@ -122,9 +137,18 @@ pub(crate) fn init_poses(
     for combo in 0..ncomb {
         ps.iter_mut().for_each(|p| *p = Pose3d::IDENTITY);
         hv.iter_mut().for_each(|h| *h = false);
-        for (bi, (cam_idx, brs)) in branches.iter().enumerate() {
-            ps[*cam_idx] = brs[((combo >> bi) & 1) as usize];
+        for (cam_idx, best, _) in branches.iter() {
+            ps[*cam_idx] = *best;
             hv[*cam_idx] = true;
+        }
+        // Flip only the cameras that have a second branch, one bit each.
+        for (bit, &bi) in choosers.iter().enumerate() {
+            if (combo >> bit) & 1 == 1 {
+                let (cam_idx, _, second) = &branches[bi];
+                if let Some(p) = second {
+                    ps[*cam_idx] = *p;
+                }
+            }
         }
         let mut err = 0.0f64;
         let mut cnt = 0usize;
@@ -158,11 +182,20 @@ pub(crate) fn init_poses(
         }
     }
 
+    // Replay the winning combo with the same bit assignment used to score it.
     let mut have = vec![false; n_cams];
     let mut poses = vec![Pose3d::IDENTITY; n_cams];
-    for (bi, (cam_idx, brs)) in branches.iter().enumerate() {
-        poses[*cam_idx] = brs[((best_combo.1 >> bi) & 1) as usize];
+    for (cam_idx, best, _) in branches.iter() {
+        poses[*cam_idx] = *best;
         have[*cam_idx] = true;
+    }
+    for (bit, &bi) in choosers.iter().enumerate() {
+        if (best_combo.1 >> bit) & 1 == 1 {
+            let (cam_idx, _, second) = &branches[bi];
+            if let Some(p) = second {
+                poses[*cam_idx] = *p;
+            }
+        }
     }
 
     Ok(Init {
@@ -187,7 +220,8 @@ pub(crate) fn measure_tag_corners(
     config: &CalibConfig,
 ) -> Option<[Vec3F64; 4]> {
     let h = config.tag_size_m / 2.0;
-    // estimate_tag_pose object frame is (BL, BR, TR, TL); our corners are aruco (TL, TR, BR, BL).
+    // Object frame listed (BL, BR, TR, TL) to pair index-wise with our aruco (TL, TR, BR, BL)
+    // corners reversed below; the absolute order is free, only the pairing matters.
     let object_pts = [
         Vec3F64::new(-h, -h, 0.0), // BL
         Vec3F64::new(h, -h, 0.0),  // BR
@@ -208,10 +242,14 @@ pub(crate) fn measure_tag_corners(
         (0..4).map(|k| (a[k] - b[k]).length()).sum()
     };
 
-    // Per registered camera, BOTH planar-pose branches lifted to world corners. A planar tag has a
-    // 2-fold pose ambiguity; `best` is usually right but flips near fronto-parallel, so we resolve it
-    // by cross-camera consistency rather than trusting `best` blindly.
-    let mut cands: Vec<[[Vec3F64; 4]; 2]> = Vec::new();
+    // Per registered camera, the planar-pose branches lifted to world corners: `best` always, and
+    // the runner-up only when it is physically possible. `estimate_tag_pose` gates that second
+    // branch on cheirality, and in practice it is almost always `None` (it converges behind the
+    // camera), so most cameras contribute a single candidate and there is nothing to disambiguate.
+    // The cross-camera vote below therefore has to tolerate `None` rather than substitute `best`:
+    // substituting would make a camera's two "branches" identical and feed a 0-distance tie into
+    // the anchor selection, silently turning it into an arbitrary pick.
+    let mut cands: Vec<([Vec3F64; 4], Option<[Vec3F64; 4]>)> = Vec::new();
     for (c, corners) in &tag.per_camera {
         if !have[*c] {
             continue;
@@ -227,35 +265,33 @@ pub(crate) fn measure_tag_corners(
             continue;
         };
         let cam_to_world = poses[*c].inverse();
-        // A `None` second branch means it converged behind the camera; fall back to `best` so the
-        // "which branch agrees with the anchor" vote below cannot be won by an impossible pose.
-        let second = result.second.map_or(result.best.pose, |s| s.pose);
-        cands.push([
+        cands.push((
             world_corners(&result.best.pose, &cam_to_world),
-            world_corners(&second, &cam_to_world),
-        ]);
+            result.second.map(|s| world_corners(&s.pose, &cam_to_world)),
+        ));
     }
     if cands.is_empty() {
         return None;
     }
 
-    // Anchor = the camera whose two branches disagree MOST — an OBLIQUE view, where the planar
-    // 2-fold flip is well separated so `best` is genuinely reliable. (A fronto-parallel view is the
-    // opposite: the two flips nearly coincide and `best` is a coin-flip.) Then each camera
-    // contributes the branch closest to the anchor's `best`, and we average the agreeing branches.
-    // `total_cmp` (not `partial_cmp().unwrap()`) so a NaN from a near-degenerate pose can't panic.
-    let anchor_i = (0..cands.len())
-        .max_by(|&a, &b| {
-            set_dist(&cands[a][0], &cands[a][1]).total_cmp(&set_dist(&cands[b][0], &cands[b][1]))
-        })
-        .unwrap();
-    let anchor = cands[anchor_i][0];
+    // Anchor = among the cameras that actually HAVE two branches, the one whose branches disagree
+    // MOST — an OBLIQUE view, where the planar 2-fold flip is well separated so `best` is genuinely
+    // reliable. Cameras with no second branch cannot disagree and so cannot be the anchor; if no
+    // camera has one there is nothing to disambiguate and the first camera's `best` anchors the
+    // average. `total_cmp` (not `partial_cmp().unwrap()`) so a NaN from a near-degenerate pose
+    // can't panic.
+    let anchor = cands
+        .iter()
+        .filter_map(|(best, second)| second.as_ref().map(|s| (best, set_dist(best, s))))
+        .max_by(|a, b| a.1.total_cmp(&b.1))
+        .map_or(cands[0].0, |(best, _)| *best);
+    // Then each camera contributes whichever of its branches is closest to that anchor, and we
+    // average the agreeing branches. A camera with only `best` contributes it unconditionally.
     let mut acc = [Vec3F64::ZERO; 4];
-    for cand in &cands {
-        let pick = if set_dist(&cand[0], &anchor) <= set_dist(&cand[1], &anchor) {
-            &cand[0]
-        } else {
-            &cand[1]
+    for (best, second) in &cands {
+        let pick = match second {
+            Some(s) if set_dist(s, &anchor) < set_dist(best, &anchor) => s,
+            _ => best,
         };
         for k in 0..4 {
             acc[k] += pick[k];
@@ -340,9 +376,9 @@ pub(crate) fn init_poses_board(
             let Some(op) = board.object_points(*tid) else {
                 continue;
             };
-            // Per-tag centred object frame (no uniform tag-size assumption): estimate_tag_pose wants
-            // corners about the tag centre in (BL, BR, TR, TL) order = board corners (TL,TR,BR,BL)
-            // reversed, minus the centre.
+            // Per-tag centred object frame (no uniform tag-size assumption): corners about the
+            // tag centre, listed (BL, BR, TR, TL) = board corners (TL,TR,BR,BL) reversed, minus
+            // the centre, so they pair index-wise with the reversed image corners below.
             let center = (op[0] + op[1] + op[2] + op[3]) * 0.25;
             let object_centered = [
                 op[3] - center, // BL

--- a/crates/kornia-calib/src/init.rs
+++ b/crates/kornia-calib/src/init.rs
@@ -59,7 +59,11 @@ pub(crate) fn init_poses(
             cam.undistort(corners[0].x, corners[0].y),
         ];
         let result = estimate_tag_pose(&object_pts, &image_pts, cam, 50)?;
-        branches.push((*cam_idx, [result.best.pose, result.second.pose]));
+        // `second` is `None` when the runner-up converged behind the camera, which is the norm.
+        // Duplicating `best` keeps the combination search below well-formed (that camera then
+        // contributes the same pose either way) instead of scoring an impossible pose.
+        let second = result.second.map_or(result.best.pose, |s| s.pose);
+        branches.push((*cam_idx, [result.best.pose, second]));
     }
     if branches.is_empty() {
         return Err(CalibError::NoReferenceTagView);
@@ -223,9 +227,12 @@ pub(crate) fn measure_tag_corners(
             continue;
         };
         let cam_to_world = poses[*c].inverse();
+        // A `None` second branch means it converged behind the camera; fall back to `best` so the
+        // "which branch agrees with the anchor" vote below cannot be won by an impossible pose.
+        let second = result.second.map_or(result.best.pose, |s| s.pose);
         cands.push([
             world_corners(&result.best.pose, &cam_to_world),
-            world_corners(&result.second.pose, &cam_to_world),
+            world_corners(&second, &cam_to_world),
         ]);
     }
     if cands.is_empty() {
@@ -357,7 +364,9 @@ pub(crate) fn init_poses_board(
                 Mat3F64::IDENTITY,
                 Vec3F64::new(-center.x, -center.y, -center.z),
             );
-            for cand in [pair.best.pose, pair.second.pose] {
+            // `pair.second` is absent when the runner-up is behind the camera (the usual case).
+            let seconds = pair.second.map(|s| s.pose);
+            for cand in std::iter::once(pair.best.pose).chain(seconds) {
                 let t_cam_board = cand.compose(&t_object_board);
                 let err = board_reproj_err(cam, &t_cam_board, board, obs);
                 if best.as_ref().is_none_or(|(e, _)| err < *e) {

--- a/examples/apriltag/src/main.rs
+++ b/examples/apriltag/src/main.rs
@@ -368,11 +368,15 @@ fn log_frame(
                 if let Some(&(q_prev, t_prev)) = pose_state.get(&det.id) {
                     // Near-frontal tags make the two reprojection errors nearly equal,
                     // so the raw "best" flip-flops; pick the one matching last frame.
-                    let q_second = dquat_from_mat3(&pair.second.pose.rotation);
-                    if q_second.dot(q_prev).abs() > q_best.dot(q_prev).abs() {
-                        q = q_second;
-                        let ts = pair.second.pose.translation;
-                        t = glam::DVec3::new(ts.x, ts.y, ts.z);
+                    // `second` is absent unless it is physically possible, so this no longer
+                    // risks locking onto a pose behind the camera.
+                    if let Some(second) = &pair.second {
+                        let q_second = dquat_from_mat3(&second.pose.rotation);
+                        if q_second.dot(q_prev).abs() > q_best.dot(q_prev).abs() {
+                            q = q_second;
+                            let ts = second.pose.translation;
+                            t = glam::DVec3::new(ts.x, ts.y, ts.z);
+                        }
                     }
                     // Align hemispheres before slerp, then low-pass orientation + position.
                     let q_prev = if q_prev.dot(q) < 0.0 {

--- a/examples/apriltag_pose/src/main.rs
+++ b/examples/apriltag_pose/src/main.rs
@@ -87,7 +87,10 @@ fn print_detection(det: &Detection, camera: &PinholeCamera, tag_size: f64, n_ite
             );
             println!("  translation: [{:.4}, {:.4}, {:.4}]", t.x, t.y, t.z);
             println!("  reprojection error (best):   {:.6}", best.error);
-            println!("  reprojection error (second): {:.6}", pair.second.error);
+            match &pair.second {
+                Some(second) => println!("  reprojection error (second): {:.6}", second.error),
+                None => println!("  second solution:             none (behind the camera)"),
+            }
         }
         Err(e) => println!("  pose estimation failed: {e}"),
     }

--- a/kornia-py/src/apriltag.rs
+++ b/kornia-py/src/apriltag.rs
@@ -259,8 +259,10 @@ impl PyApriltagDetection {
     ///     n_iters: Orthogonal iteration steps (default 50).
     ///
     /// Returns:
-    ///     A tuple ``(best, second)`` of :class:`TagPose` objects,
-    ///     where ``best`` has the lower reprojection error.
+    ///     A tuple ``(best, second)``. ``best`` is the :class:`TagPose` with the
+    ///     lower reprojection error. ``second`` is a :class:`TagPose` only when the
+    ///     runner-up solution is physically possible (the whole tag in front of the
+    ///     camera); it is usually ``None``.
     #[pyo3(signature = (fx, fy, cx, cy, tag_size, n_iters=50))]
     pub fn estimate_pose(
         &self,
@@ -270,7 +272,7 @@ impl PyApriltagDetection {
         cy: f64,
         tag_size: f64,
         n_iters: usize,
-    ) -> PyResult<(PyTagPose, PyTagPose)> {
+    ) -> PyResult<(PyTagPose, Option<PyTagPose>)> {
         use kornia_3d::camera::PinholeCamera;
         use kornia_3d::pose::estimate_planar_pose as estimate_tag_pose;
         use kornia_algebra::{Vec2F64, Vec3F64};
@@ -322,7 +324,9 @@ impl PyApriltagDetection {
                 error: tp.error,
             }
         };
-        Ok((to_py(&pair.best), to_py(&pair.second)))
+        // `second` is `None` unless the runner-up is in front of the camera; surfacing that as
+        // `None` rather than a behind-camera pose is what stops callers treating it as usable.
+        Ok((to_py(&pair.best), pair.second.as_ref().map(to_py)))
     }
 }
 

--- a/kornia-py/tests/test_apriltag.py
+++ b/kornia-py/tests/test_apriltag.py
@@ -156,11 +156,12 @@ def test_estimate_pose():
     detection = detections[0]
     result = detection.estimate_pose(fx=800, fy=800, cx=400, cy=267, tag_size=0.162)
 
-    # Result should be a tuple of 2 TagPose objects
+    # Result is (best, second). `second` is None unless the runner-up solution is
+    # physically possible — the whole tag in front of the camera — which is rare.
     assert isinstance(result, tuple)
     assert len(result) == 2
     assert isinstance(result[0], K.apriltag.TagPose)
-    assert isinstance(result[1], K.apriltag.TagPose)
+    assert result[1] is None or isinstance(result[1], K.apriltag.TagPose)
 
     # The first pose should have a valid (non-negative, finite) error
     assert result[0].error >= 0


### PR DESCRIPTION
Supersedes #1074, which #1076 left stale: that PR already landed the `kornia-apriltag` → `kornia-3d` move, so all that is left here is the hardening, rebuilt on top of `main`.

Four review findings on the moved solver, resolved.

## 1. The homography seed was hardcoded, so the solver was corner-order dependent (HIGH)

`estimate_planar_pose` seeded its initial homography from a FIXED canonical square
`[(-1,-1), (1,-1), (1,1), (-1,1)]` mapped to `image_pts`. The orthogonal iteration then refines
against the caller's *real* `object_pts`, so any consistent correspondence converges eventually —
but only a caller whose winding and phase happened to match that hardcoded square started from the
right place.

Rotation error of `best` on exact, noise-free projections of a 10 cm square at 0.3 m / 20° tilt:

| `object_pts` order | old seed @ 50, 20° tilt | old seed @ 50, 20° tilt + 15° yaw | **new seed @ 50** |
|---|---|---|---|
| canonical `[(-s,-s),(s,-s),(s,s),(-s,s)]` | 0.0000° | 0.0000° | **0.0000°** |
| cyclic shift by one | 3.74° | 4.16° | **0.0000°** |
| reversed winding | 18.47° | 18.47° | **0.0000°** |

Every old-seed case converges by `n_iters = 500`; the problem is purely that 50 is what callers pass.

`kornia-apriltag`'s `[TR, BR, BL, TL]` is itself a cyclic shift of the canonical winding, so it sat
on that middle row. `Detection::estimate_pose` (`crates/kornia-apriltag/src/decoder.rs:318`) passes
it with `n_iters = 50`, so it was returning ~4° of rotation error on *perfect* input. Both in-repo
examples also use 50.

**Fix** — seed from the caller's own `object_pts`
(`crates/kornia-3d/src/pose/planar.rs`, `normalized_object_seed` + `estimate_planar_pose`): take
their x/y, centre on their centroid, rescale uniformly, and fit the homography from *those* to
`image_pts`.

Writing the exact projection as `H = K·[r₁ r₂ t]` and substituting `q = s·(p − c)` gives
`H' = K·[r₁/s r₂/s (t + R·c)]`: the first two columns keep their directions and pick up a *common*
factor, which `homography_to_pose` divides out when it normalises them. So the seed's `R` is the
caller's frame regardless of order, winding, shape or unit, and on exact data the seed already *is*
the answer. `t` is rewritten by the iteration's first step either way.

This fixes the AprilTag caller for free and retires the old "strongly non-square targets need more
iterations" caveat — a 4:1 rectangle and a trapezoid now converge at 50 too.

Honest note on the centring/rescaling: they are the standard DLT conditioning step, not the fix.
Measured — disabling either one on its own leaves every case in
`seed_is_independent_of_corner_order` passing. What is load-bearing is fitting from the caller's
points at all. The module docs say exactly this rather than claiming more.

## 2. `PlanarPosePair::second` was documented as degenerate but consumed as a real hypothesis (MEDIUM)

Measured across depths 0.3 / 1 / 5 m, tilts 0–75°, two yaws, and again with 1 px noise: **41 of 41
configurations returned a second pose behind the camera**, carrying `error == f64::MAX`. The docs
were right; the consumers were not.

Two things about how it was described were wrong, both corrected:

- It is **not** the classical planar mirror ambiguity. It is a re-seed with the first two rotation
  columns negated — a 180° in-plane rotation.
- The claim that "the AprilRobotics C reference gates solution 2 on positive depth" is **false**.
  `apriltag_pose.c` does something different and better: `fix_pose_ambiguities` finds the genuine
  second local minimum of the same objective by solving a quartic, and reports `HUGE_VAL` when
  there is none. It performs no cheirality check. This port has never computed that second minimum
  at all. Porting it is follow-up work and is now stated as such rather than implied by a claim of
  parity with the reference.

**Fix** — `second` is now `Option<PlanarPose>`, `Some` only when all four object points are in front
of the camera under it. That makes the misuse impossible by type rather than by convention, which is
the point: nothing in-repo was checking.

All five in-tree consumers used it with no depth or error check:

- `crates/kornia-calib/src/init.rs:62` — fed into the 2ⁿ branch-combination search.
- `crates/kornia-calib/src/init.rs:230` — `measure_tag_corners` anchors on the camera whose two
  branches disagree *most*, then has every camera contribute the branch closest to that anchor and
  **averages** them. With one branch always behind the camera, "most disagreeing" was arbitrary.
- `crates/kornia-calib/src/init.rs:367` — both branches scored for the board pose.
- `examples/apriltag/src/main.rs:371` — temporal disambiguation could lock a tag's displayed pose
  onto the behind-camera branch whenever its quaternion happened to match the previous frame better.
- `kornia-py/src/apriltag.rs:325` — returned straight to Python as the second element of
  `Detection.estimate_pose`'s tuple.

Each now falls back to `best` (calib) or skips the branch (example, Python binding).

The honest consequence: since `second` is `None` in every configuration measured, `kornia-calib`'s
planar 2-fold disambiguation is now a no-op. It always was — it was choosing between a good pose and
an impossible one. Its test suite passes unchanged.

## 3. `PlanarPoseError::SingularHomography` is removed, not deprecated (MEDIUM)

The old enum had exactly one variant, and it misreported its own cause: an orthogonal-iteration
failure — nothing to do with the homography — returned `SingularHomography`, while a genuine
homography failure had its cause discarded by `map_err(|_| …)`. It is now:

```rust
pub enum PlanarPoseError {
    Homography(#[from] HomographyError),  // the seed could not be fitted; cause preserved
    SingularIteration,                    // (I − avg_F) degenerate: the image rays coincide
    DegenerateObjectPoints,               // object points have no extent in their own plane
    ZeroIterations,                       // n_iters == 0
}
```

**No `#[deprecated] SingularHomography` shim, deliberately.** `kornia_3d::pose::planar` has never
been released: it first appears in `main` via #1076, and the last tag (`v0.1.15-rc.5`) still has the
module at `crates/kornia-apriltag/src/pose.rs`. The only path that ever shipped this variant was
`kornia_apriltag::pose::PlanarPoseError::SingularHomography`, and #1076 deleted that path outright.
A downstream `match` naming it is already broken by #1076 and must be edited regardless — at which
point the new variants are visible. A shim that can never be constructed would add a dead arm, not
a migration path.

**Breaking change (to an unreleased API).** Callers matching exhaustively on `PlanarPoseError` must
handle the new variants; `second` is now an `Option`. On the Python side,
`Detection.estimate_pose` now returns `(TagPose, TagPose | None)`.

## 4. Smaller items (LOW)

- **`n_iters == 0` now errors.** It used to return `Ok` with an unrefined pose carrying a sentinel
  `f64::MAX` error (verified: rotation `I`, translation `(0, 0, 7.07)` for the doctest's inputs).
  This is a behaviour change through the public API — a caller passing 0 now gets
  `Err(ZeroIterations)` where it previously got a useless `Ok`.
- **Doc corrected**: "the second is the first with its first two rotation columns negated" described
  the *seed*, not the result. Both branches run independent iterations and are then sorted by
  reprojection error, so `best`/`second` name outcomes, not branches.
- **De-tagged** the now tag-agnostic module: no more "tag corners", "tag pose estimation", `tag_norm`.
- **Added the `# Example` doctest** AGENTS.md requires for non-trivial public APIs.
- The `1e-10` depth floor is a named `CHEIRALITY_EPS` shared by the error accumulation and the new
  gate, so the two cannot drift apart.

## Tests

Four new tests in `crates/kornia-3d/src/pose/planar.rs`. Each was verified non-vacuous by reverting
*only* its fix and confirming the specific assertion fires:

| test | revert | assertion that fired |
|---|---|---|
| `seed_is_independent_of_corner_order` | restore the hardcoded `tag_norm` seed | `apriltag TR,BR,BL,TL: 4.15856950127979 deg at n_iters = 50` |
| `second_solution_is_gated_on_cheirality` | always return `second` | ``tilt 0 deg / 0.3 m: `second` returned with a point at z = -0.29999999999999916, behind the camera`` |
| `zero_iterations_is_rejected` | drop the `n_iters == 0` guard | `expected ZeroIterations, got Ok(… error: 1.797…e308 …)` |
| `degenerate_object_points_are_rejected` | drop the zero-extent check | `expected DegenerateObjectPoints, got Ok(… rotation: DVec3(NaN, NaN, NaN) …)` |

`seed_is_independent_of_corner_order` covers nine cases: the canonical order, the AprilTag
`[TR, BR, BL, TL]` order, a cyclic shift, a reversed winding, a 4:1 rectangle, a trapezoid, an
object frame whose origin is nowhere near the target, and the same target expressed at 10⁻³× and
10³× scale — the scale cases scale the depth with the target so the image is bit-identical, which
isolates the numerical question from the physical one (a 50 µm target at 0.3 m really is
unsolvable, and should not be dressed up as a scale bug).

`second_solution_is_gated_on_cheirality` asserts in both directions: that any `Some` really is in
front of the camera with a finite error, and — so the first loop cannot pass vacuously — that the
count of `Some` results over the 18 configurations is zero, with a message telling the next reader
to update the docs if that ever changes.

## Self-review corrections (commit 9364221f)

Running `/code-review` against this PR found real defects in it; they are fixed in the third commit:

- **Two doc claims were false.** The "2.56° / 15.58°" figures above were inherited from #1074 and
  shipped without re-measuring — the true values are 3.74° / 18.47°, and the table now states which
  rotation each column uses. Separately, `second_solution_is_gated_on_cheirality`'s doc claimed the
  sweep included "1 px noise" when the test used exact projections only; the noise measurement lived
  in an uncommitted scratch harness. The test now actually sweeps both, 36 configurations, and
  asserts the case count.
- **A degenerate tie in `measure_tag_corners`.** Substituting `best` for a `None` second branch made
  a camera's two branches identical, so the "anchor = the camera whose branches disagree MOST"
  selection saw every distance tied at 0 and `max_by` returned the last element — an arbitrary
  anchor. `Option` is now carried through. `init_poses` had the same substitution (wasteful rather
  than wrong) and is now indexed so only cameras with a real second branch consume a search bit.
- `PlanarPosePair::best` is documented as NOT cheirality-gated, since `second` being gated invites
  the opposite assumption.
- `1.0 / mean_r` is checked for finiteness (a subnormal mean radius overflowed the reciprocal).
- Comments in `kornia-calib` that this PR had invalidated are updated.

## Verification

```
cargo fmt --all -- --check                                         # clean (whole workspace)
cargo clippy -j2 -p kornia-3d -p kornia-calib --all-targets -- -D warnings   # exit 0
cargo test -j2 -p kornia-3d -p kornia-calib                        # 188 + 23 + 14 + 0 pass, 0 fail
cargo test -j2 -p kornia-apriltag --lib                            # 48 pass, 0 fail
cargo test -j2 -p kornia-3d --doc                                  # 14 pass (incl. the new example)
```

Not run on this machine: `kornia-apriltag`'s `parity` integration test, which links the system
`libapriltag` (`image_u8_create_stride` is missing from the aarch64 3.2.0 package here), and
`cargo clippy -p kornia-apriltag`, which trips a pre-existing aarch64-only NEON lint at
`segmentation.rs:881` — identical on `main`, neither touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
