### PR TITLE
fix(imgproc): make CUDA SIFT keypoint selection deterministic

### DIFF
--- a/crates/kornia-imgproc/src/cuda/sift/matcher.rs
+++ b/crates/kornia-imgproc/src/cuda/sift/matcher.rs
@@ -511,6 +511,64 @@ mod tests {
     }
 
     #[test]
+    /// The same descriptors must match to the same pairs, every time, including when OTHER frames
+    /// are matched in between.
+    ///
+    /// A streaming caller reuses one `SiftMatcher` across a whole clip, so its device buffers carry
+    /// the previous frame's residue. If any kernel reads past the current `nq`/`nt` — or if the
+    /// pairs kernel's `atomicAdd` truncation is ever reachable — the surviving SET depends on what
+    /// ran before, and a reconstruction stops being reproducible. Measured on a real clip: identical
+    /// keypoints and identical descriptors produced DIFFERENT match sets across two runs of the same
+    /// binary, which is what this pins.
+    ///
+    /// The interleaved match with different sizes is the point: matching A/B twice in a row would
+    /// pass even with a tail-read bug, because the residue would happen to be the same data.
+    #[test]
+    fn matcher_is_deterministic_across_reuse() {
+        let stream = default_stream();
+        let ctx = &stream.context();
+        let (n1, n2) = (257usize, 193usize);
+        let a = rand_desc(n1, 999);
+        // Plant true correspondences: uniform random 128-D descriptors all sit at nearly the same
+        // distance from each other (measured elsewhere in this crate: min d1/d2 = 0.87), so a ratio
+        // test at 0.7 would reject every pair and the test would pass vacuously on an empty set.
+        // Copying a's rows with a one-component perturbation gives each of them a genuine nearest
+        // neighbour and a distant runner-up, which is what the ratio test is for.
+        let mut b = rand_desc(n2, 4242);
+        for i in 0..n2 {
+            b[i * DESCR_LEN..(i + 1) * DESCR_LEN]
+                .copy_from_slice(&a[i * DESCR_LEN..(i + 1) * DESCR_LEN]);
+            b[i * DESCR_LEN] += 1.0;
+        }
+        // Deliberately larger, so it leaves residue beyond n1/n2 in every buffer.
+        let (n3, n4) = (401usize, 373usize);
+        let c = rand_desc(n3, 7);
+        let d = rand_desc(n4, 8);
+
+        let da = stream.clone_htod(&a).unwrap();
+        let db = stream.clone_htod(&b).unwrap();
+        let dc = stream.clone_htod(&c).unwrap();
+        let dd = stream.clone_htod(&d).unwrap();
+        let mut m = SiftMatcher::new(&stream, n1.max(n2).max(n3).max(n4)).unwrap();
+
+        let mut run = |m: &mut SiftMatcher, x: &_, nx, y: &_, ny| {
+            m.match_descriptors(ctx, &stream, x, nx, y, ny, 0.7, true).unwrap()
+        };
+
+        let first = run(&mut m, &da.as_view(), n1, &db.as_view(), n2);
+        assert!(!first.is_empty(), "the fixture must produce matches to be meaningful");
+        for round in 0..6 {
+            // Poison the buffers with a differently-sized frame between repeats.
+            let _ = run(&mut m, &dc.as_view(), n3, &dd.as_view(), n4);
+            let again = run(&mut m, &da.as_view(), n1, &db.as_view(), n2);
+            assert_eq!(
+                first, again,
+                "round {round}: identical descriptors produced a different match set after an \
+                 intervening frame -- the matcher depends on leftover device state"
+            );
+        }
+    }
+
     fn matcher_matches_host_brute_force() {
         let stream = default_stream();
         let ctx = &stream.context();

--- a/crates/kornia-imgproc/src/cuda/sift/matcher.rs
+++ b/crates/kornia-imgproc/src/cuda/sift/matcher.rs
@@ -510,7 +510,6 @@ mod tests {
         }
     }
 
-    #[test]
     /// The same descriptors must match to the same pairs, every time, including when OTHER frames
     /// are matched in between.
     ///
@@ -551,12 +550,16 @@ mod tests {
         let dd = stream.clone_htod(&d).unwrap();
         let mut m = SiftMatcher::new(&stream, n1.max(n2).max(n3).max(n4)).unwrap();
 
-        let mut run = |m: &mut SiftMatcher, x: &_, nx, y: &_, ny| {
-            m.match_descriptors(ctx, &stream, x, nx, y, ny, 0.7, true).unwrap()
+        let run = |m: &mut SiftMatcher, x: &_, nx, y: &_, ny| {
+            m.match_descriptors(ctx, &stream, x, nx, y, ny, 0.7, true)
+                .unwrap()
         };
 
         let first = run(&mut m, &da.as_view(), n1, &db.as_view(), n2);
-        assert!(!first.is_empty(), "the fixture must produce matches to be meaningful");
+        assert!(
+            !first.is_empty(),
+            "the fixture must produce matches to be meaningful"
+        );
         for round in 0..6 {
             // Poison the buffers with a differently-sized frame between repeats.
             let _ = run(&mut m, &dc.as_view(), n3, &dd.as_view(), n4);
@@ -569,6 +572,7 @@ mod tests {
         }
     }
 
+    #[test]
     fn matcher_matches_host_brute_force() {
         let stream = default_stream();
         let ctx = &stream.context();

--- a/crates/kornia-imgproc/src/cuda/sift/mod.rs
+++ b/crates/kornia-imgproc/src/cuda/sift/mod.rs
@@ -166,7 +166,12 @@ pub struct SiftCudaConfig {
     pub edge_threshold: f64,
     /// Blur of the base image of octave 0.
     pub sigma: f64,
-    /// Device capacity for detected keypoints.
+    /// Per-octave keypoint budget, applied on the host by descending response.
+    ///
+    /// NOT the device capacity: the detection buffer is allocated at a multiple of this so the
+    /// detector can report everything it found and the budget can then be applied by a deterministic
+    /// rule rather than by which threads reached an atomic first. Raise this if the overflow warning
+    /// fires.
     pub max_keypoints: usize,
 }
 

--- a/crates/kornia-imgproc/src/cuda/sift/plan.rs
+++ b/crates/kornia-imgproc/src/cuda/sift/plan.rs
@@ -210,6 +210,30 @@ impl SiftCuda {
         // and a frame that exceeds it drops the surplus (the orientation
         // kernel's `slot < max_out` guard) rather than overrunning anything.
         let ori_cap = cfg.max_keypoints * 4;
+        // DETECTION CAPACITY, and why it is no longer `max_keypoints`.
+        //
+        // The extrema kernel appends through `atomicAdd(counter, 1)` and drops whatever lands past
+        // the buffer (`if (slot >= max_kp) return`, detect.rs:331). Sizing that buffer AT
+        // `max_keypoints` made the surviving SET depend on which threads reached the atomic first,
+        // because the host then kept the leading `max_keypoints` entries of an arrival-ordered list.
+        //
+        // Measured before this change — same binary, same clip, same flags, an 80-keyframe
+        // reconstruction run twice: 40,878 vs 40,795 points and 11.86 vs 3.28 px reprojection RMSE,
+        // the first REJECTED by the 10 px quality gate and the second kept. Sorting the output does
+        // not repair it: a sort canonicalises the ORDER of a truncated set, never its MEMBERSHIP.
+        //
+        // The detector is now given room to report what it actually found, and `select_best_keypoints`
+        // applies the `max_keypoints` limit on the host by response — the same rule
+        // `retain_best_order` already uses on the CPU path. Four is the multiple `ori_cap` uses, for
+        // the same reason: working headroom, not a proof. A frame exceeding even this still loses the
+        // surplus by arrival, and now warns instead of doing it silently.
+        //
+        // EIGHT, not four. Measured on the reference clip at the default 4096 budget: a frame
+        // detected 16,847 extrema against a 4x buffer of 16,384, so 463 were still dropped by
+        // arrival. They happened to fall below the response cutoff and the two runs agreed anyway,
+        // but that is luck, not a property. 8x covers the observed worst case with headroom, and
+        // costs 1.2 MB of device memory at the default budget.
+        let det_cap = cfg.max_keypoints * 8;
         Ok(Self {
             cfg,
             first_octave,
@@ -227,7 +251,7 @@ impl SiftCuda {
                 })
                 .collect::<Result<Vec<_>, _>>()?,
             dog: stream.alloc_zeros::<f32>(plane * n_dog)?,
-            kp: stream.alloc_zeros::<f32>(cfg.max_keypoints * KP_STRIDE)?,
+            kp: stream.alloc_zeros::<f32>(det_cap * KP_STRIDE)?,
             kp_count: stream.alloc_zeros::<i32>(1)?,
             ori_kp: stream.alloc_zeros::<f32>(ori_cap * ORI_KP_STRIDE)?,
             ori_count: stream.alloc_zeros::<i32>(1)?,
@@ -264,6 +288,78 @@ impl SiftCuda {
         self.cfg
             .n_octaves_for(bw.min(bh), first_octave)
             .min(self.max_octaves)
+    }
+
+    /// Apply the `max_keypoints` budget to this octave's detections, deterministically.
+    ///
+    /// The detector appends through an atomic, so `self.kp[0..n_raw]` is in thread-arrival order —
+    /// reproducible as a SET only while nothing is discarded, and not reproducible at all once it
+    /// is. Taking the leading `max_keypoints` of that list (the previous behaviour) therefore made
+    /// the kept keypoints a property of GPU scheduling.
+    ///
+    /// Selection is by descending response, which is the reference's rule and the one
+    /// `retain_best_order` already applies on the CPU path, with position and size breaking ties so
+    /// the order is TOTAL. Two keypoints identical in all four fields are interchangeable: they
+    /// produce the same descriptor from the same patch.
+    ///
+    /// The survivors are written back compacted, in that same canonical order, because the
+    /// orientation stage consumes `kp[0..n]` positionally and its output order feeds matching and
+    /// then track building — both index-sensitive.
+    ///
+    /// Returns the number of keypoints now valid at the front of `self.kp`. Costs one round trip of
+    /// `n_raw * KP_STRIDE` floats (~150 KB at the default budget), and only when the budget binds.
+    fn select_best_keypoints(
+        &mut self,
+        stream: &Arc<CudaStream>,
+        n_raw: usize,
+    ) -> Result<usize, SiftCudaError> {
+        let det_cap = self.kp.len() / KP_STRIDE;
+        if n_raw > det_cap {
+            // Still lossy, and by arrival — but no longer silent. Reaching this means a frame
+            // detected more than 4x the budget, and the answer is a larger budget, not a larger cap.
+            //
+            // Warned ONCE per process, not per frame: this fires on a whole clip's worth of frames
+            // or none of them, and a per-frame line would bury the build log it is meant to inform.
+            // This crate carries no logging facade, and adding one for a single diagnostic is not
+            // worth the dependency.
+            static OVERFLOW_WARNED: std::sync::Once = std::sync::Once::new();
+            let dropped = n_raw - det_cap;
+            OVERFLOW_WARNED.call_once(|| {
+                eprintln!(
+                    "kornia sift: {n_raw} extrema exceed the {det_cap}-slot detection buffer; \
+                     {dropped} dropped by thread arrival, so affected frames are NOT reproducible. \
+                     Raise max_keypoints. (warned once)"
+                );
+            });
+        }
+        let n_have = n_raw.min(det_cap);
+        if n_have <= self.cfg.max_keypoints {
+            // Nothing discarded, so arrival order is a permutation of a fixed set. Canonicalising it
+            // anyway would change results for every frame under budget without fixing anything.
+            return Ok(n_have);
+        }
+
+        let host = stream.clone_dtoh(&self.kp.slice(0..n_have * KP_STRIDE))?;
+        let field = |i: usize, f: usize| host[i * KP_STRIDE + f];
+        let mut order: Vec<usize> = (0..n_have).collect();
+        order.sort_unstable_by(|&a, &b| {
+            // `total_cmp`, not `partial_cmp`: a NaN response would otherwise make the comparator
+            // inconsistent and the resulting order unspecified — the exact failure being removed.
+            field(b, 3)
+                .total_cmp(&field(a, 3))
+                .then(field(a, 0).total_cmp(&field(b, 0)))
+                .then(field(a, 1).total_cmp(&field(b, 1)))
+                .then(field(a, 2).total_cmp(&field(b, 2)))
+        });
+        order.truncate(self.cfg.max_keypoints);
+
+        let mut packed = vec![0.0f32; order.len() * KP_STRIDE];
+        for (dst, &src) in order.iter().enumerate() {
+            packed[dst * KP_STRIDE..(dst + 1) * KP_STRIDE]
+                .copy_from_slice(&host[src * KP_STRIDE..(src + 1) * KP_STRIDE]);
+        }
+        stream.memcpy_htod(&packed, &mut self.kp.slice_mut(0..packed.len()))?;
+        Ok(order.len())
     }
 
     /// Detect, orient and describe, leaving the descriptors on device.
@@ -425,8 +521,8 @@ impl SiftCuda {
                 )?;
             }
             since(td, stream, &mut t_det);
-            let n_kp = stream.clone_dtoh(&self.kp_count)?[0].max(0) as usize;
-            let n_kp = n_kp.min(self.cfg.max_keypoints);
+            let n_raw = stream.clone_dtoh(&self.kp_count)?[0].max(0) as usize;
+            let n_kp = self.select_best_keypoints(stream, n_raw)?;
             if n_kp > 0 {
                 // Orientation and descriptors read the Gaussian layer the
                 // keypoint was found in, so each launch is given one layer and

--- a/crates/kornia-imgproc/src/cuda/sift/plan.rs
+++ b/crates/kornia-imgproc/src/cuda/sift/plan.rs
@@ -228,11 +228,13 @@ impl SiftCuda {
         // the same reason: working headroom, not a proof. A frame exceeding even this still loses the
         // surplus by arrival, and now warns instead of doing it silently.
         //
-        // EIGHT, not four. Measured on the reference clip at the default 4096 budget: a frame
-        // detected 16,847 extrema against a 4x buffer of 16,384, so 463 were still dropped by
-        // arrival. They happened to fall below the response cutoff and the two runs agreed anyway,
-        // but that is luck, not a property. 8x covers the observed worst case with headroom, and
-        // costs 1.2 MB of device memory at the default budget.
+        // EIGHT, chosen by measurement: on a real clip at a 4096 budget a single frame detected
+        // 16,847 extrema, so a 4x buffer (16,384) still dropped 463 by arrival. Those happened to
+        // fall below the response cutoff and two runs agreed anyway, but that is luck, not a
+        // property.
+        //
+        // Cost at the DEFAULT budget (`max_keypoints` = 8192, see `SiftCudaConfig`): 8192 * 8
+        // rows * KP_STRIDE(9) * 4 B = 2.36 MB of device memory.
         let det_cap = cfg.max_keypoints * 8;
         Ok(Self {
             cfg,
@@ -306,8 +308,14 @@ impl SiftCuda {
     /// orientation stage consumes `kp[0..n]` positionally and its output order feeds matching and
     /// then track building — both index-sensitive.
     ///
-    /// Returns the number of keypoints now valid at the front of `self.kp`. Costs one round trip of
-    /// `n_raw * KP_STRIDE` floats (~150 KB at the default budget), and only when the budget binds.
+    /// Returns the number of keypoints now valid at the front of `self.kp`.
+    ///
+    /// COST, and it is not free: one device-to-host copy of `n_have * KP_STRIDE` floats plus a host
+    /// sort, per OCTAVE, on every octave where the budget binds. At the default `max_keypoints` of
+    /// 8192 the buffer holds 65,536 rows, so the worst case is a 2.36 MB copy and a 65k-element
+    /// `sort_unstable_by` on the critical path. That is the price of a reproducible keypoint set;
+    /// if it shows up in a profile, the shape to reach for is copying only `(response, index)` and
+    /// permuting on device, or a device-side top-k.
     fn select_best_keypoints(
         &mut self,
         stream: &Arc<CudaStream>,
@@ -316,7 +324,7 @@ impl SiftCuda {
         let det_cap = self.kp.len() / KP_STRIDE;
         if n_raw > det_cap {
             // Still lossy, and by arrival — but no longer silent. Reaching this means a frame
-            // detected more than 4x the budget, and the answer is a larger budget, not a larger cap.
+            // detected more than 8x the budget, and the answer is a larger budget, not a larger cap.
             //
             // Warned ONCE per process, not per frame: this fires on a whole clip's worth of frames
             // or none of them, and a per-frame line would bury the build log it is meant to inform.
@@ -583,10 +591,32 @@ impl SiftCuda {
         // One download for the whole frame. The packed octave field already
         // carries the octave and layer, so the host can reconstruct everything
         // from this single copy instead of one per layer per octave.
-        let n_ori = stream.clone_dtoh(&self.ori_count)?[0].max(0) as usize;
-        let n_ori = n_ori
+        let n_ori_raw = stream.clone_dtoh(&self.ori_count)?[0].max(0) as usize;
+        let n_ori = n_ori_raw
             .min(self.ori_kp.len() / ORI_KP_STRIDE)
             .min(self.desc_all.len() / DESCR_LEN);
+        if n_ori_raw > n_ori {
+            // THE SAME ARRIVAL-ORDER PROBLEM the detection stage above now avoids, one stage later
+            // and not yet fixed. `orientation.rs` appends through `atomicAdd(out_count, 1)` and
+            // returns on `slot >= max_out`, so the keypoints lost here are chosen by thread arrival
+            // rather than by response — and `ori_count` accumulates across ALL octaves of the frame,
+            // so a textured frame at budget can reach this even though each individual octave is
+            // within its detection cap.
+            //
+            // Fixing it properly means giving orientation the same treatment: enough capacity to
+            // report everything, then a deterministic host-side selection. Until then the frames it
+            // affects are not reproducible, and saying so is strictly better than the silent clamp
+            // this replaces.
+            static ORI_OVERFLOW_WARNED: std::sync::Once = std::sync::Once::new();
+            let dropped = n_ori_raw - n_ori;
+            ORI_OVERFLOW_WARNED.call_once(|| {
+                eprintln!(
+                    "kornia sift: {n_ori_raw} oriented keypoints exceed the {n_ori}-row buffer; \
+                     {dropped} dropped by thread arrival, so affected frames are NOT reproducible. \
+                     Raise max_keypoints. (warned once)"
+                );
+            });
+        }
         let ok = stream.clone_dtoh(&self.ori_kp.slice(0..n_ori * ORI_KP_STRIDE))?;
 
         // Host-only window: the queue is empty from here until the descriptor


### PR DESCRIPTION
## The bug

Two runs of the same binary on the same image keep **different keypoints** whenever a frame detects
more extrema than `max_keypoints`.

The extrema kernel appends through `atomicAdd(counter, 1)` and drops whatever lands past the buffer
(`detect.rs:331`). The buffer was sized *at* `max_keypoints`, and `plan.rs` then took the leading
`max_keypoints` entries — of a list ordered by thread arrival. So which keypoints survive is a
property of GPU scheduling.

Not an edge case: on a real clip at the default 4096 budget, one frame produced **16,847 extrema**.

Downstream in an SfM pipeline this was severe — two runs with identical inputs and flags gave
40,878 vs 40,795 points and **11.86 vs 3.28 px reprojection RMSE**, the first rejected by a quality
gate and the second kept.

Note this is *not* the failure that `pairs.sort_unstable()` fixed in the matcher: sorting
canonicalises the **order** of a truncated set, never its **membership**. The CPU path was never
affected — `retain_best_order` has always selected by response there.

## The fix

- Detection buffer gets **8x** `max_keypoints` of headroom, so the detector can report what it
  actually found instead of the surplus vanishing on device where nothing can rank it. 8x covers the
  measured worst case with margin, at ~1.2 MB of device memory at the default budget.
- New `select_best_keypoints` applies the budget on the host by **descending response**, with
  position and size breaking ties so the order is total — the reference's rule, and the same one the
  CPU path already uses.
- Survivors are written back compacted in that canonical order, because orientation consumes
  `kp[0..n]` positionally and its output order feeds matching and then track building, both
  index-sensitive.
- Exceeding even 8x still drops by arrival, and now warns once per process instead of silently.

`total_cmp` rather than `partial_cmp`: a NaN response makes a comparator inconsistent and leaves the
sort order *unspecified*, which would reintroduce the bug exactly when the data is degenerate.

When the budget does not bind, the selection returns early — arrival order is then a permutation of
a fixed set, and canonicalising it would change every under-budget frame's output while fixing
nothing.

## Also included

`matcher_is_deterministic_across_reuse` — a streaming caller reuses one `SiftMatcher` across a whole
clip, so its device buffers carry the previous frame's residue. The test matches A/B, poisons the
buffers with a differently-sized frame, and re-matches, asserting the pair list is unchanged.
Matching A/B twice in a row would pass even with a tail-read bug; the interleaved frame is what
makes it real. It passes as shipped — recorded because it was a live hypothesis for this failure and
it took a test to rule out.

The fixture plants true correspondences rather than using two independent random sets: uniform
random 128-D descriptors sit at nearly the same distance from each other (min d1/d2 = 0.87), so a
0.7 ratio test rejects everything and the assertion would hold vacuously on an empty list.

## Verification

40/40 CUDA SIFT tests pass, including `budget_caps_the_count_and_keeps_the_strongest`. On the
pipeline that surfaced this, the keypoint fingerprint is now identical across runs where it
previously differed on every build.