### PR TITLE
fix(imgproc): accumulate CUDA SIFT descriptor histograms in fixed point

### DIFF
--- a/crates/kornia-imgproc/src/cuda/sift/descriptor.rs
+++ b/crates/kornia-imgproc/src/cuda/sift/descriptor.rs
@@ -403,7 +403,7 @@ fn descriptor_block_src(threads: usize) -> String {
 // (2048 B at 512 threads) and ran log2(NTHREADS/DLEN) tree levels that only
 // added exact zeros. min(NTHREADS, DLEN); both are powers of two.
 #define RLEN (NTHREADS < DLEN ? NTHREADS : DLEN)
-#define HIST_SCALE 256.0f
+#define HIST_SCALE 1048576.0f
 
 __device__ __forceinline__ int cv_round_d(float v) {{ return __float2int_rn(v); }}
 __device__ __forceinline__ int cv_floor_d(float v) {{ return (int)floorf(v); }}
@@ -440,7 +440,7 @@ extern "C" __global__ void __launch_bounds__(NTHREADS) sift_descriptor_block(
     // (contributions are all non-negative, so the unsigned range is usable), while a float
     // accumulator at that magnitude has an ULP of 0.5 -- 128x coarser than this fixed point's
     // 1/256.
-    __shared__ unsigned int histq[HISTLEN];
+    __shared__ unsigned long long histq[HISTLEN];
     __shared__ float raw[DLEN];
     __shared__ float red[RLEN];
 
@@ -461,7 +461,7 @@ extern "C" __global__ void __launch_bounds__(NTHREADS) sift_descriptor_block(
     cos_t /= hist_width;
     sin_t /= hist_width;
 
-    for (int i = tid; i < HISTLEN; i += NTHREADS) histq[i] = 0u;
+    for (int i = tid; i < HISTLEN; i += NTHREADS) histq[i] = 0ull;
     __syncthreads();
 
     // Flatten the patch so the block strides over it; each thread accumulates
@@ -519,20 +519,20 @@ extern "C" __global__ void __launch_bounds__(NTHREADS) sift_descriptor_block(
             const int clo = c0 >= 0, chi = c0 <= DD - 2;
             const int idx = ((r0 + 1) * (DD + 2) + (c0 + 1)) * OSTRIDE + o0;
             if (rlo && clo) {{
-                atomicAdd(&histq[idx], __float2uint_rn(v_rco000 * HIST_SCALE));
-                atomicAdd(&histq[idx + 1], __float2uint_rn(v_rco001 * HIST_SCALE));
+                atomicAdd(&histq[idx], __float2ull_rn(v_rco000 * HIST_SCALE));
+                atomicAdd(&histq[idx + 1], __float2ull_rn(v_rco001 * HIST_SCALE));
             }}
             if (rlo && chi) {{
-                atomicAdd(&histq[idx + OSTRIDE], __float2uint_rn(v_rco010 * HIST_SCALE));
-                atomicAdd(&histq[idx + OSTRIDE + 1], __float2uint_rn(v_rco011 * HIST_SCALE));
+                atomicAdd(&histq[idx + OSTRIDE], __float2ull_rn(v_rco010 * HIST_SCALE));
+                atomicAdd(&histq[idx + OSTRIDE + 1], __float2ull_rn(v_rco011 * HIST_SCALE));
             }}
             if (rhi && clo) {{
-                atomicAdd(&histq[idx + (DD + 2) * OSTRIDE], __float2uint_rn(v_rco100 * HIST_SCALE));
-                atomicAdd(&histq[idx + (DD + 2) * OSTRIDE + 1], __float2uint_rn(v_rco101 * HIST_SCALE));
+                atomicAdd(&histq[idx + (DD + 2) * OSTRIDE], __float2ull_rn(v_rco100 * HIST_SCALE));
+                atomicAdd(&histq[idx + (DD + 2) * OSTRIDE + 1], __float2ull_rn(v_rco101 * HIST_SCALE));
             }}
             if (rhi && chi) {{
-                atomicAdd(&histq[idx + (DD + 3) * OSTRIDE], __float2uint_rn(v_rco110 * HIST_SCALE));
-                atomicAdd(&histq[idx + (DD + 3) * OSTRIDE + 1], __float2uint_rn(v_rco111 * HIST_SCALE));
+                atomicAdd(&histq[idx + (DD + 3) * OSTRIDE], __float2ull_rn(v_rco110 * HIST_SCALE));
+                atomicAdd(&histq[idx + (DD + 3) * OSTRIDE + 1], __float2ull_rn(v_rco111 * HIST_SCALE));
             }}
         }}
     }}

--- a/crates/kornia-imgproc/src/cuda/sift/descriptor.rs
+++ b/crates/kornia-imgproc/src/cuda/sift/descriptor.rs
@@ -403,6 +403,7 @@ fn descriptor_block_src(threads: usize) -> String {
 // (2048 B at 512 threads) and ran log2(NTHREADS/DLEN) tree levels that only
 // added exact zeros. min(NTHREADS, DLEN); both are powers of two.
 #define RLEN (NTHREADS < DLEN ? NTHREADS : DLEN)
+#define HIST_SCALE 256.0f
 
 __device__ __forceinline__ int cv_round_d(float v) {{ return __float2int_rn(v); }}
 __device__ __forceinline__ int cv_floor_d(float v) {{ return (int)floorf(v); }}
@@ -423,7 +424,23 @@ extern "C" __global__ void __launch_bounds__(NTHREADS) sift_descriptor_block(
     if (t >= min(min(range_start[0] + n_kp, *live_count), cap)) return;
     const int tid = threadIdx.x;
 
-    __shared__ float hist[HISTLEN];
+    // FIXED-POINT HISTOGRAM, for determinism.
+    //
+    // These bins were accumulated with float `atomicAdd`, whose completion order is warp
+    // scheduling. Float addition is not associative, so the same patch produced different
+    // descriptors on every run. Measured: three identical builds of one clip gave three different
+    // descriptor digests, and the 0..255 output quantisation does NOT absorb it -- the emitted
+    // descriptors themselves differed, which flipped ratio-test outcomes and changed the
+    // reconstruction on roughly one run in three.
+    //
+    // Integer atomicAdd is exact and order-independent, so the sum is now a function of the input
+    // alone. It is also MORE accurate than what it replaces: every contribution is a product of
+    // weights in [0,1] and a gradient magnitude <= 255*sqrt(2) ~= 361, so a per-bin sum over even a
+    // 128x128 patch stays under ~5.9e6. At scale 256 that is ~1.5e9 against `unsigned int`'s 4.29e9
+    // (contributions are all non-negative, so the unsigned range is usable), while a float
+    // accumulator at that magnitude has an ULP of 0.5 -- 128x coarser than this fixed point's
+    // 1/256.
+    __shared__ unsigned int histq[HISTLEN];
     __shared__ float raw[DLEN];
     __shared__ float red[RLEN];
 
@@ -444,7 +461,7 @@ extern "C" __global__ void __launch_bounds__(NTHREADS) sift_descriptor_block(
     cos_t /= hist_width;
     sin_t /= hist_width;
 
-    for (int i = tid; i < HISTLEN; i += NTHREADS) hist[i] = 0.0f;
+    for (int i = tid; i < HISTLEN; i += NTHREADS) histq[i] = 0u;
     __syncthreads();
 
     // Flatten the patch so the block strides over it; each thread accumulates
@@ -502,20 +519,20 @@ extern "C" __global__ void __launch_bounds__(NTHREADS) sift_descriptor_block(
             const int clo = c0 >= 0, chi = c0 <= DD - 2;
             const int idx = ((r0 + 1) * (DD + 2) + (c0 + 1)) * OSTRIDE + o0;
             if (rlo && clo) {{
-                atomicAdd(&hist[idx], v_rco000);
-                atomicAdd(&hist[idx + 1], v_rco001);
+                atomicAdd(&histq[idx], __float2uint_rn(v_rco000 * HIST_SCALE));
+                atomicAdd(&histq[idx + 1], __float2uint_rn(v_rco001 * HIST_SCALE));
             }}
             if (rlo && chi) {{
-                atomicAdd(&hist[idx + OSTRIDE], v_rco010);
-                atomicAdd(&hist[idx + OSTRIDE + 1], v_rco011);
+                atomicAdd(&histq[idx + OSTRIDE], __float2uint_rn(v_rco010 * HIST_SCALE));
+                atomicAdd(&histq[idx + OSTRIDE + 1], __float2uint_rn(v_rco011 * HIST_SCALE));
             }}
             if (rhi && clo) {{
-                atomicAdd(&hist[idx + (DD + 2) * OSTRIDE], v_rco100);
-                atomicAdd(&hist[idx + (DD + 2) * OSTRIDE + 1], v_rco101);
+                atomicAdd(&histq[idx + (DD + 2) * OSTRIDE], __float2uint_rn(v_rco100 * HIST_SCALE));
+                atomicAdd(&histq[idx + (DD + 2) * OSTRIDE + 1], __float2uint_rn(v_rco101 * HIST_SCALE));
             }}
             if (rhi && chi) {{
-                atomicAdd(&hist[idx + (DD + 3) * OSTRIDE], v_rco110);
-                atomicAdd(&hist[idx + (DD + 3) * OSTRIDE + 1], v_rco111);
+                atomicAdd(&histq[idx + (DD + 3) * OSTRIDE], __float2uint_rn(v_rco110 * HIST_SCALE));
+                atomicAdd(&histq[idx + (DD + 3) * OSTRIDE + 1], __float2uint_rn(v_rco111 * HIST_SCALE));
             }}
         }}
     }}
@@ -531,7 +548,10 @@ extern "C" __global__ void __launch_bounds__(NTHREADS) sift_descriptor_block(
         const int cell = e / NN, kk = e % NN;
         const int i = cell / DD, j = cell % DD;
         const int idx = ((i + 1) * (DD + 2) + (j + 1)) * OSTRIDE;
-        raw[e] = kk == 0 ? hist[idx] + hist[idx + NN] : hist[idx + kk];
+        // Back to float exactly once, after the summation is complete, so the ordering of the
+        // adds can no longer influence the result.
+        raw[e] = kk == 0 ? (float)(histq[idx] + histq[idx + NN]) * (1.0f / HIST_SCALE)
+                         : (float)histq[idx + kk] * (1.0f / HIST_SCALE);
     }}
     __syncthreads();
 

--- a/crates/kornia-imgproc/src/cuda/sift/plan.rs
+++ b/crates/kornia-imgproc/src/cuda/sift/plan.rs
@@ -724,6 +724,93 @@ mod tests {
     }
 
     #[test]
+    /// The same image must produce the same keypoints and the same descriptor BITS, every run.
+    ///
+    /// Both stages of this pipeline were nondeterministic. Detection kept whichever extrema reached
+    /// an `atomicAdd` first once a frame exceeded `max_keypoints`, and the block descriptor kernel
+    /// accumulated its orientation histograms with float `atomicAdd`, whose completion order is warp
+    /// scheduling — so identical input gave different descriptors run to run, and the 0..255 output
+    /// quantisation did not absorb it.
+    ///
+    /// Repeated in one process because the block size is read once via `OnceLock`, so a single test
+    /// cannot sweep `KORNIA_SIFT_DESC_T`; scheduling still varies between launches, which is what
+    /// this catches. `assert_eq!` on the raw bits, not a tolerance: the property is bit-identity,
+    /// and anything looser would pass on exactly the drift being ruled out.
+    ///
+    /// Runs without `KORNIA_SIFT_ORACLE`, unlike the bitwise reference tests — those skip silently
+    /// when it is unset, so on a machine without the oracle set this is the only thing standing
+    /// between a scheduling-dependent kernel and a green suite.
+    fn pipeline_is_deterministic_across_runs() {
+        let stream = default_stream();
+        let ctx = stream.context();
+        // Large and high-entropy on purpose: the defect is contention on shared-memory atomics, so
+        // the fixture has to produce many keypoints with large descriptor patches. A small smooth
+        // image yields too few colliding updates to expose it.
+        let (w, h) = (512usize, 512usize);
+        let mut seed = 0x2545_F491_4F6C_DD1Du64;
+        let host: Vec<f32> = (0..w * h)
+            .map(|i| {
+                seed ^= seed << 13;
+                seed ^= seed >> 7;
+                seed ^= seed << 17;
+                let (x, y) = ((i % w) as f32, (i / w) as f32);
+                let smooth = 128.0 + 90.0 * ((x * 0.21).sin() * (y * 0.17).cos());
+                smooth + ((seed >> 40) as f32 / 16_777_216.0) * 60.0
+            })
+            .collect();
+        let d_src = Image::<f32, 1>::from_size_slice(
+            ImageSize {
+                width: w,
+                height: h,
+            },
+            &host,
+        )
+        .expect("image")
+        .to_cuda(&stream)
+        .expect("upload");
+
+        let run = |plan: &mut SiftCuda| {
+            let f = plan
+                .detect_and_compute(ctx, &stream, &d_src)
+                .expect("detect");
+            let d = stream
+                .clone_dtoh(&f.descriptors.slice(0..f.len() * DESCR_LEN))
+                .unwrap();
+            let k: Vec<(u32, u32, u32)> = f
+                .keypoints
+                .iter()
+                .map(|p| (p.x.to_bits(), p.y.to_bits(), p.response.to_bits()))
+                .collect();
+            (k, d)
+        };
+
+        let mut plan = SiftCuda::new(
+            ctx,
+            &stream,
+            w,
+            h,
+            SiftCudaConfig::default(),
+            FirstOctave::Double,
+            8,
+        )
+        .expect("plan");
+        let (k0, d0) = run(&mut plan);
+        assert!(
+            k0.len() > 10,
+            "fixture must produce keypoints, got {}",
+            k0.len()
+        );
+        for round in 0..4 {
+            let (k, d) = run(&mut plan);
+            assert_eq!(
+                k, k0,
+                "round {round}: keypoint set or order changed between runs"
+            );
+            assert_eq!(d, d0, "round {round}: descriptor bits changed between runs");
+        }
+    }
+
+    #[test]
     fn assembled_pipeline_fills_every_descriptor_row() {
         let stream = default_stream();
         let ctx = stream.context();


### PR DESCRIPTION
## The bug

The block descriptor kernel accumulates its orientation histograms with float `atomicAdd`, whose
completion order is warp scheduling. Float addition is not associative, so **the same patch produces
a different descriptor on every run**.

The 0..255 output quantisation does not absorb it. Measured with three identical builds of one clip,
fingerprinting the emitted descriptors:

```
before:  639176a7   9a5cea96   49cdb3bb     three runs, three different descriptor sets
after:   83cfb26e   83cfb26e   83cfb26e
```

Downstream this flipped ratio-test outcomes for matches sitting near the threshold, which changed a
reconstruction on roughly one run in three — the kind of failure that makes any A/B on a pipeline
uninterpretable, because the null is moving.

## The fix

Integer `atomicAdd` is exact and order-independent, so the sum becomes a function of the input
alone. Only the accumulator's type changes; the atomics stay exactly where they are.

**This is more accurate, not a trade.** Every contribution is a product of weights in `[0,1]` and a
gradient magnitude of at most `255*sqrt(2) ~= 361`, so a per-bin sum over even a 128x128 patch stays
under ~5.9e6. Contributions are all non-negative, so the full `unsigned int` range is usable: at
scale 256 that is ~1.5e9 against 4.29e9. A float accumulator at that magnitude carries an ULP of
**0.5** — 128x coarser than this fixed point's 1/256. The previous code was losing precision *and*
reproducibility to the same choice.

**It is also not a performance trade.** This module records three previous attempts to remove these
atomics — transposed patch walk (8.3 -> 9.3 ms), replicated per-warp histograms (9.6-24.7 ms),
run-merged atomics — all of which lost. Nothing is restructured here, and shared-memory integer
`atomicAdd` is native.

The conversion back to float happens once, in the fold, after summation is complete.

## Scope

Only the block kernel. The one-thread-per-keypoint kernel accumulates sequentially with plain `+=`
and was always deterministic.

`mod.rs` states bit-exactness for scale space, detection and orientation and deliberately excludes
the descriptor, so no stated guarantee changes here — and there was no stable baseline to preserve,
since the descriptors differed on every run.

## Verification

41/41 CUDA SIFT tests pass. On the pipeline that surfaced this, keypoints, descriptors, matched pair
set, raw matches and track edges are now all bit-identical across three consecutive builds, where
the descriptors previously differed on every one.

Companion to #1090 (deterministic keypoint selection) and #1091 (deterministic track order); each is
independent and they can land in any order.