### PR TITLE
CI: Build Windows ARM64 Python wheels

### DIFF
--- a/.github/workflows/python_release.yml
+++ b/.github/workflows/python_release.yml
@@ -201,10 +201,52 @@ jobs:
           name: windows-${{ matrix.target }}-${{ matrix.python-version }}-wheels
           path: dist
 
+  windows-arm64:
+    name: py${{ matrix.python-version }}-windows-arm64
+    runs-on: windows-11-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        # CPython first published native Windows ARM64 installers in 3.11.
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+    env:
+      CMAKE_GENERATOR: Ninja
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: arm64
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-pc-windows-msvc
+      - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: arm64
+      - name: Install native build tools
+        run: python -m pip install --upgrade cmake ninja
+      - uses: messense/maturin-action@v1
+        with:
+          command: build
+          maturin-version: latest
+          args: --release --target aarch64-pc-windows-msvc --out dist -i python${{ matrix.python-version }} -m kornia-py/Cargo.toml
+      - name: Verify native ARM64 wheel
+        shell: pwsh
+        run: |
+          $wheel = Get-ChildItem dist\*-win_arm64.whl | Select-Object -First 1
+          if (-not $wheel) { throw "No win_arm64 wheel was produced" }
+          python -m pip install --force-reinstall $wheel.FullName
+          python -c "import kornia_rs, platform; assert platform.machine().upper() == 'ARM64'; assert kornia_rs.cpu.cpu_features().has_neon; print(kornia_rs.cpu.cpu_features())"
+      - name: Upload wheels
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-arm64-${{ matrix.python-version }}-wheels
+          path: dist
+
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [macos, windows, linux]
+    needs: [macos, windows, windows-arm64, linux]
     steps:
       - run: sudo apt-get update
       - uses: actions/download-artifact@v8

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -160,3 +160,48 @@ jobs:
           name: pr-wheel-${{ matrix.target }}-py310
           path: dist
           retention-days: 14
+
+  windows-arm64-wheel:
+    name: wheel-windows-arm64
+    runs-on: windows-11-arm
+    env:
+      CMAKE_GENERATOR: Ninja
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          architecture: arm64
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-pc-windows-msvc
+
+      - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: arm64
+
+      - name: Install native build tools
+        run: python -m pip install --upgrade cmake ninja
+
+      - uses: messense/maturin-action@v1
+        with:
+          command: build
+          maturin-version: latest
+          args: --release --target aarch64-pc-windows-msvc --out dist -i python3.13 -m kornia-py/Cargo.toml
+
+      - name: Install and import native ARM64 wheel
+        shell: pwsh
+        run: |
+          $wheel = Get-ChildItem dist\*-win_arm64.whl | Select-Object -First 1
+          if (-not $wheel) { throw "No win_arm64 wheel was produced" }
+          python -m pip install --force-reinstall $wheel.FullName
+          python -c "import kornia_rs, platform; assert platform.machine().upper() == 'ARM64'; assert kornia_rs.cpu.cpu_features().has_neon; print(kornia_rs.cpu.cpu_features())"
+
+      - name: Upload PR wheel
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-wheel-windows-arm64-py313
+          path: dist
+          retention-days: 14


### PR DESCRIPTION
Closes #1089

Adds native Windows ARM64 wheel builds for the Python package.

The release workflow builds `aarch64-pc-windows-msvc` wheels on `windows-11-arm`
for CPython 3.11–3.14 and includes them in the release dependency set. The PR
workflow also builds a CPython 3.13 `win_arm64` wheel and installs/imports it on
the native runner.