### PR TITLE
feat(3d): orientation and constant-velocity motion priors for the Schur BA

### DIFF
--- a/crates/kornia-3d/src/ba.rs
+++ b/crates/kornia-3d/src/ba.rs
@@ -104,6 +104,8 @@ impl BaObservation {
 /// pose's world-frame position simultaneously.
 ///
 /// Currently only honoured by [`crate::ba_schur::bundle_adjust_schur`].
+///
+/// An optional ORIENTATION term rides along on the same struct — see [`BaPosePrior::up_world`].
 #[derive(Debug, Clone, Copy)]
 pub struct BaPosePrior {
     /// Prior camera centre in world frame.
@@ -111,6 +113,118 @@ pub struct BaPosePrior {
     /// Standard deviation (metres). Clamped to ≥ 1e-6 internally. Smaller
     /// σ → tighter anchor.
     pub sigma: f32,
+    /// Optional orientation (up-vector) prior: the world-frame direction that this camera's
+    /// [`Self::up_cam`] axis is claimed to point along. When `Some`, the BA cost gains
+    ///
+    /// ```text
+    ///     r_up_i = (R_i^T · up_cam − up_world) / up_sigma
+    /// ```
+    ///
+    /// `None` — the default — disables the term entirely.
+    ///
+    /// # Why the solver needs it
+    ///
+    /// The centre prior above constrains position and nothing else. On a single forward pass
+    /// with no revisits, **nothing in the image data observes absolute orientation**: the
+    /// reprojection objective is invariant to a global rotation, and along a monocular chain the
+    /// small per-frame rotation errors integrate into unbounded tilt drift that no amount of
+    /// reprojection refinement can see, let alone remove. A soft per-view up prior is the only
+    /// term in this solver that bounds it.
+    ///
+    /// Purely rotational: the Jacobian is `[R^T·up_cam]×` in the ω block and zero in the ρ block,
+    /// so like the centre prior it augments only the on-diagonal camera block `A_ii` in the Schur
+    /// reduction.
+    pub up_world: Option<[f32; 3]>,
+    /// Which CAMERA-frame direction is claimed to point along [`Self::up_world`].
+    ///
+    /// Defaults to image-up `(0, −1, 0)`, i.e. "the camera was held roughly upright". That
+    /// assumption is only as good as the capture — a phone tilted 20° downwards makes image-up a
+    /// 20° lie on every frame — so pick `up_sigma` to match how much you actually believe it.
+    /// The field is per-camera so a caller holding a real MEASUREMENT of this direction (a
+    /// vertical vanishing point, an IMU gravity vector) can supply that instead and tighten
+    /// `up_sigma` accordingly. The Jacobian depends only on the rotated result, so a per-camera
+    /// direction costs nothing over a fixed one.
+    pub up_cam: [f32; 3],
+    /// Standard deviation of the up prior, in unit-vector units (e.g. 0.25 ≈ tolerating ~14° of
+    /// tilt at 1σ). Clamped to ≥ 1e-6 internally. Ignored when [`Self::up_world`] is `None`.
+    pub up_sigma: f32,
+}
+
+impl Default for BaPosePrior {
+    fn default() -> Self {
+        Self {
+            center_world: [0.0; 3],
+            sigma: 1.0,
+            up_world: None,
+            up_cam: [0.0, -1.0, 0.0],
+            up_sigma: 0.25,
+        }
+    }
+}
+
+impl BaPosePrior {
+    /// A centre-only prior: anchor the camera centre at `center_world` with standard deviation
+    /// `sigma`, no orientation term.
+    pub fn new(center_world: [f32; 3], sigma: f32) -> Self {
+        Self {
+            center_world,
+            sigma,
+            ..Default::default()
+        }
+    }
+
+    /// Attach an orientation prior claiming that image-up `(0, −1, 0)` points along `up_world`.
+    pub fn with_up(mut self, up_world: [f32; 3], up_sigma: f32) -> Self {
+        self.up_world = Some(up_world);
+        self.up_sigma = up_sigma;
+        self
+    }
+
+    /// Attach an orientation prior for an arbitrary camera-frame direction. Use this when
+    /// `up_cam` comes from a measurement rather than the upright-camera assumption.
+    pub fn with_up_cam(mut self, up_cam: [f32; 3], up_world: [f32; 3], up_sigma: f32) -> Self {
+        self.up_cam = up_cam;
+        self.up_world = Some(up_world);
+        self.up_sigma = up_sigma;
+        self
+    }
+}
+
+/// Constant-velocity motion prior over a triplet of consecutive shots (OpenSfM's
+/// `LinearMotionError`).
+///
+/// Encodes "shot `i1` lies a fraction `alpha` of the way from `i0` to `i2`, and rotation advances
+/// at constant angular velocity". The translation term deliberately uses the norm-RATIO form
+/// `alpha − ‖C1−C0‖/‖C2−C0‖` rather than a position difference: a raw difference is degenerate
+/// while scale is itself being estimated (shrinking the whole map satisfies it), whereas the
+/// ratio is scale-invariant and constrains only the SHAPE of the motion.
+///
+/// # Why the solver needs it
+///
+/// Reprojection alone leaves a keyframe's baseline nearly unconstrained when its neighbours sit
+/// close together — the near-zero-baseline mode, where a frame's translation wanders along the
+/// viewing direction at almost no cost and the whole trajectory picks up scale drift. The
+/// triplet prior couples three consecutive poses so a middle frame that jumps off the local
+/// trajectory pays for it, while asserting no absolute scale of its own.
+///
+/// Unlike every other residual family in this solver it touches THREE pose blocks, so it is the
+/// only one that contributes off-diagonal pose-pose blocks to the reduced camera system.
+///
+/// Currently only honoured by [`crate::ba_schur::bundle_adjust_schur_with_all_priors`].
+#[derive(Debug, Clone, Copy)]
+pub struct BaMotionPrior {
+    /// First pose index of the triplet, in temporal order.
+    pub i0: usize,
+    /// Middle pose index.
+    pub i1: usize,
+    /// Last pose index.
+    pub i2: usize,
+    /// Fractional position of `i1` between `i0` and `i2` (0..1), e.g. from frame timestamps.
+    pub alpha: f32,
+    /// Sigma of the translation-ratio residual (unitless). Clamped to ≥ 1e-6 internally.
+    pub position_sigma: f32,
+    /// Sigma of the angular-velocity residual (radians). Clamped to ≥ 1e-6 internally.
+    pub orientation_sigma: f32,
 }
 
 /// Parameters for bundle adjustment.
@@ -138,6 +252,22 @@ pub struct BaParams {
     /// `f32::INFINITY` collapses to the L2 fast path even for non-Identity
     /// kernel choices.
     pub robust_scale_sq: f32,
+    /// Robust-kernel scale (squared) for the σ-WHITENED residual families — the per-observation
+    /// depth residual ([`BaObservation::depth_meas`]) and the constant-velocity motion prior
+    /// ([`BaMotionPrior`]). `0.0` (the default) reuses [`Self::robust_scale_sq`], preserving the
+    /// historical single-knee behaviour.
+    ///
+    /// These families live in different units from reprojection. Reprojection residuals are in
+    /// normalized-camera units, where a sensible Huber knee is ~2 px / fx ≈ 0.004; depth and
+    /// motion residuals are divided by their own sigma, so `1.0` already means "one standard
+    /// deviation". Sharing one knee therefore gates a perfectly ordinary 1σ depth measurement
+    /// like a hundreds-of-σ reprojection outlier: it survives with a few percent of its intended
+    /// weight, which silently disables metric anchoring while still injecting a biased gradient.
+    /// The whitened convention puts the Huber knee at 1.345 (95% Gaussian efficiency), i.e.
+    /// `depth_robust_scale_sq = 1.345² ≈ 1.81`.
+    ///
+    /// Only read by [`crate::ba_schur`]; ignored by [`bundle_adjust`].
+    pub depth_robust_scale_sq: f32,
 }
 
 impl Default for BaParams {
@@ -149,6 +279,7 @@ impl Default for BaParams {
             initial_lambda: 1e-3,
             robust: RobustKernelKind::Identity,
             robust_scale_sq: f32::INFINITY,
+            depth_robust_scale_sq: 0.0,
         }
     }
 }

--- a/crates/kornia-3d/src/ba.rs
+++ b/crates/kornia-3d/src/ba.rs
@@ -114,10 +114,10 @@ pub struct BaPosePrior {
     /// σ → tighter anchor.
     pub sigma: f32,
     /// Optional orientation (up-vector) prior: the world-frame direction that this camera's
-    /// [`Self::up_cam`] axis is claimed to point along. When `Some`, the BA cost gains
+    /// camera's IMAGE-UP axis `(0, −1, 0)` is claimed to point along. When `Some`, the BA cost gains
     ///
     /// ```text
-    ///     r_up_i = (R_i^T · up_cam − up_world) / up_sigma
+    ///     r_up_i = (R_i^T · (0, −1, 0) − up_world) / up_sigma
     /// ```
     ///
     /// `None` — the default — disables the term entirely.
@@ -131,20 +131,10 @@ pub struct BaPosePrior {
     /// reprojection refinement can see, let alone remove. A soft per-view up prior is the only
     /// term in this solver that bounds it.
     ///
-    /// Purely rotational: the Jacobian is `[R^T·up_cam]×` in the ω block and zero in the ρ block,
+    /// Purely rotational: the Jacobian is `[R^T·(0,−1,0)]×` in the ω block and zero in the ρ block,
     /// so like the centre prior it augments only the on-diagonal camera block `A_ii` in the Schur
     /// reduction.
     pub up_world: Option<[f32; 3]>,
-    /// Which CAMERA-frame direction is claimed to point along [`Self::up_world`].
-    ///
-    /// Defaults to image-up `(0, −1, 0)`, i.e. "the camera was held roughly upright". That
-    /// assumption is only as good as the capture — a phone tilted 20° downwards makes image-up a
-    /// 20° lie on every frame — so pick `up_sigma` to match how much you actually believe it.
-    /// The field is per-camera so a caller holding a real MEASUREMENT of this direction (a
-    /// vertical vanishing point, an IMU gravity vector) can supply that instead and tighten
-    /// `up_sigma` accordingly. The Jacobian depends only on the rotated result, so a per-camera
-    /// direction costs nothing over a fixed one.
-    pub up_cam: [f32; 3],
     /// Standard deviation of the up prior, in unit-vector units (e.g. 0.25 ≈ tolerating ~14° of
     /// tilt at 1σ). Clamped to ≥ 1e-6 internally. Ignored when [`Self::up_world`] is `None`.
     pub up_sigma: f32,
@@ -156,7 +146,6 @@ impl Default for BaPosePrior {
             center_world: [0.0; 3],
             sigma: 1.0,
             up_world: None,
-            up_cam: [0.0, -1.0, 0.0],
             up_sigma: 0.25,
         }
     }
@@ -173,17 +162,24 @@ impl BaPosePrior {
         }
     }
 
-    /// Attach an orientation prior claiming that image-up `(0, −1, 0)` points along `up_world`.
-    pub fn with_up(mut self, up_world: [f32; 3], up_sigma: f32) -> Self {
-        self.up_world = Some(up_world);
-        self.up_sigma = up_sigma;
-        self
+    /// An ORIENTATION-ONLY prior: constrain which way the camera is facing, and nothing about
+    /// where it is.
+    ///
+    /// There is no "disable the centre term" flag; the centre residual is disabled by making its
+    /// sigma large enough that its contribution vanishes. That convention lives here rather than
+    /// at each call site so it is stated — and picked — once: `1e6` puts a metre of centre error
+    /// at `1e-6` of whitened residual, which is below the solver's own convergence tolerances.
+    pub fn orientation_only(up_world: [f32; 3], up_sigma: f32) -> Self {
+        Self {
+            center_world: [0.0; 3],
+            sigma: 1e6,
+            up_world: Some(up_world),
+            up_sigma,
+        }
     }
 
-    /// Attach an orientation prior for an arbitrary camera-frame direction. Use this when
-    /// `up_cam` comes from a measurement rather than the upright-camera assumption.
-    pub fn with_up_cam(mut self, up_cam: [f32; 3], up_world: [f32; 3], up_sigma: f32) -> Self {
-        self.up_cam = up_cam;
+    /// Attach an orientation prior claiming that image-up `(0, −1, 0)` points along `up_world`.
+    pub fn with_up(mut self, up_world: [f32; 3], up_sigma: f32) -> Self {
         self.up_world = Some(up_world);
         self.up_sigma = up_sigma;
         self
@@ -258,13 +254,27 @@ pub struct BaParams {
     /// historical single-knee behaviour.
     ///
     /// These families live in different units from reprojection. Reprojection residuals are in
-    /// normalized-camera units, where a sensible Huber knee is ~2 px / fx ≈ 0.004; depth and
-    /// motion residuals are divided by their own sigma, so `1.0` already means "one standard
-    /// deviation". Sharing one knee therefore gates a perfectly ordinary 1σ depth measurement
-    /// like a hundreds-of-σ reprojection outlier: it survives with a few percent of its intended
-    /// weight, which silently disables metric anchoring while still injecting a biased gradient.
-    /// The whitened convention puts the Huber knee at 1.345 (95% Gaussian efficiency), i.e.
-    /// `depth_robust_scale_sq = 1.345² ≈ 1.81`.
+    /// normalized-camera units, where a sensible Huber knee is ~2 px / fx ≈ 0.004. Sharing one
+    /// knee across both therefore gates a perfectly ordinary 1σ depth measurement like a
+    /// hundreds-of-σ reprojection outlier: it survives with a few percent of its intended weight,
+    /// which silently disables metric anchoring while still injecting a biased gradient.
+    ///
+    /// # Picking a value — it depends on how the CALLER scaled its sigmas
+    ///
+    /// The knee is in whatever units the caller's `depth_sigma` and prior sigmas leave the
+    /// residuals in, and there are two conventions in use:
+    ///
+    /// * **Fully whitened** — the caller divides each residual by its own sigma, so `1.0` already
+    ///   means one standard deviation. Use the textbook knee directly:
+    ///   `depth_robust_scale_sq = 1.345² ≈ 1.81` (95% Gaussian efficiency).
+    /// * **Deflated into reprojection units** — the caller folds a reference reprojection sigma
+    ///   `σ_r` into its sigmas so every family shares one numeric range. The knee must be deflated
+    ///   to match: `depth_robust_scale_sq = (1.345 · σ_r)²`. This is what
+    ///   `kornia_calib::sfm::reconstruct` does, and with `σ_r ≈ 0.005` it lands near `4.5e-5` —
+    ///   four orders of magnitude from the whitened value, which is correct, not a typo.
+    ///
+    /// Both are consistent; what is NOT consistent is mixing them. Whichever the caller chose, the
+    /// sigmas fed to the residuals and the knee fed here must come from the same convention.
     ///
     /// Only read by [`crate::ba_schur`]; ignored by [`bundle_adjust`].
     pub depth_robust_scale_sq: f32,

--- a/crates/kornia-3d/src/ba_schur.rs
+++ b/crates/kornia-3d/src/ba_schur.rs
@@ -1225,6 +1225,15 @@ fn bundle_adjust_schur_impl(
         let mut h_offdiag: std::collections::HashMap<(usize, usize), [f32; 36]> =
             std::collections::HashMap::new();
         if let Some(mps) = motion_priors {
+            // Finite-difference step, RELATIVE for the translation block.
+            //
+            // The residual's translation term is built from camera centres (`-Rᵀt`, an f32 dot
+            // product of world-scale quantities), so a fixed absolute step loses relative
+            // precision as the map grows: measured, the error on dC/dρ is ~0.06% on a map a few
+            // metres across but degrades linearly with extent, and a walkthrough map is tens of
+            // metres. Scaling the step with the local coordinate magnitude holds the ratio
+            // constant instead. Rotation parameters are dimensionless radians, so they keep the
+            // absolute step.
             const FD_EPS: f32 = 1e-4;
             for mp in mps {
                 if mp.i0 >= p_total || mp.i1 >= p_total || mp.i2 >= p_total {
@@ -1247,9 +1256,17 @@ fn bundle_adjust_schur_impl(
                     if locs[pi] < 0 {
                         continue;
                     }
+                    // Magnitude of this camera's centre, the scale the translation columns are
+                    // differentiated at. `1.0 +` keeps the step finite at the origin.
+                    let c_mag = se3s[g].inverse().t.length();
                     for k in 0..6 {
+                        let step = if k < 3 {
+                            FD_EPS * (1.0 + c_mag)
+                        } else {
+                            FD_EPS
+                        };
                         let mut delta = [0.0f32; 6];
-                        delta[k] = FD_EPS;
+                        delta[k] = step;
                         let pert = se3s[g].retract(&delta);
                         let refs = [
                             if pi == 0 { &pert } else { &se3s[mp.i0] },
@@ -1257,8 +1274,9 @@ fn bundle_adjust_schur_impl(
                             if pi == 2 { &pert } else { &se3s[mp.i2] },
                         ];
                         let rp = motion_prior_residual(refs[0], refs[1], refs[2], mp);
+                        // Divided by the step ACTUALLY taken, not the nominal constant.
                         for row in 0..6 {
-                            jac[row][pi * 6 + k] = (rp[row] - r0[row]) / FD_EPS;
+                            jac[row][pi * 6 + k] = (rp[row] - r0[row]) / step;
                         }
                     }
                 }
@@ -3193,6 +3211,162 @@ mod tests {
         assert!(
             tilt < 0.05,
             "motion prior left {tilt:.4} rad of angular-velocity error (control {control_tilt:.4})"
+        );
+    }
+
+    /// The motion-prior FD Jacobian must stay usable on a map far from the origin.
+    ///
+    /// Its translation columns are differenced over camera centres — an f32 `-Rᵀt` — so a fixed
+    /// ABSOLUTE step loses relative precision as coordinates grow: at magnitude `m` the perturbed
+    /// centre keeps only `~7 - log10(m)` significant digits of the step.
+    ///
+    /// The offset here is deliberately extreme, and the honest reason is that anything realistic
+    /// does not discriminate. Measured on this test with the absolute step restored: 500 m passes,
+    /// 5 km passes, and only at 50 km does the ratio fall to 0.3864 and the recovery fail. So this
+    /// is a guard against a class of error, not a reproduction of one that was hurting a real map
+    /// — the relative step is simply free, and unlike the absolute one it has no horizon past
+    /// which it quietly stops working.
+    #[test]
+    fn motion_prior_survives_a_map_far_from_the_origin() {
+        const OFFSET: f64 = 50_000.0;
+        let cam = PinholeCamera {
+            fx: 600.0,
+            fy: 600.0,
+            cx: 320.0,
+            cy: 240.0,
+            k1: 0.0,
+            k2: 0.0,
+            p1: 0.0,
+            p2: 0.0,
+        };
+        let shift = Vec3F64::new(OFFSET, OFFSET, OFFSET);
+        let true_centres = [
+            shift,
+            shift + Vec3F64::new(0.0, 0.0, -1.0),
+            shift + Vec3F64::new(0.0, 0.0, -2.0),
+        ];
+        let true_poses: Vec<Pose3d> = true_centres
+            .iter()
+            .map(|c| Pose3d::new(Mat3F64::IDENTITY, -(Mat3F64::IDENTITY * *c)))
+            .collect();
+
+        let mut points: Vec<Vec3F64> = Vec::with_capacity(80);
+        for k in 0..80 {
+            let kf = k as f64;
+            points.push(
+                shift
+                    + Vec3F64::new(
+                        (kf * 0.37).sin() * 1.5 + (kf * 0.13).cos() * 0.6,
+                        (kf * 0.29).cos() * 1.2 + (kf * 0.11).sin() * 0.5,
+                        4.0 + (kf * 0.41).sin() * 1.5,
+                    ),
+            );
+        }
+        // Camera 1 sees a PRIVATE landmark set, so jittering it together with those points keeps
+        // its reprojection residuals at zero and only the triplet residual can object.
+        let visibility = |pose_idx: usize, point_idx: usize| -> bool {
+            if pose_idx == 1 {
+                point_idx >= 40
+            } else {
+                point_idx < 40
+            }
+        };
+        let mut observations: Vec<BaObservation> = Vec::new();
+        for (pi, pose) in true_poses.iter().enumerate() {
+            for (xi, pt) in points.iter().enumerate() {
+                if !visibility(pi, xi) {
+                    continue;
+                }
+                let pc = pose.transform_point(pt);
+                if pc.z <= 0.2 {
+                    continue;
+                }
+                observations.push(BaObservation {
+                    pose_idx: pi,
+                    point_idx: xi,
+                    pixel: [
+                        (cam.fx * pc.x / pc.z + cam.cx) as f32,
+                        (cam.fy * pc.y / pc.z + cam.cy) as f32,
+                    ],
+                    ..Default::default()
+                });
+            }
+        }
+
+        let c1_jit = shift + Vec3F64::new(0.0, 0.0, -0.4);
+        let pose1_jit = Pose3d::new(Mat3F64::IDENTITY, -(Mat3F64::IDENTITY * c1_jit));
+        let init_poses = vec![true_poses[0], pose1_jit, true_poses[2]];
+        let init_points: Vec<Vec3F64> = points
+            .iter()
+            .enumerate()
+            .map(|(xi, pt)| {
+                if xi < 40 {
+                    *pt
+                } else {
+                    let pc = true_poses[1].transform_point(pt);
+                    pose1_jit.rotation.transpose() * (pc - pose1_jit.translation)
+                }
+            })
+            .collect();
+
+        let pose_priors: Vec<Option<BaPosePrior>> = vec![
+            Some(BaPosePrior::new(
+                [
+                    true_centres[0].x as f32,
+                    true_centres[0].y as f32,
+                    true_centres[0].z as f32,
+                ],
+                0.01,
+            )),
+            None,
+            Some(BaPosePrior::new(
+                [
+                    true_centres[2].x as f32,
+                    true_centres[2].y as f32,
+                    true_centres[2].z as f32,
+                ],
+                0.01,
+            )),
+        ];
+        let motion = [BaMotionPrior {
+            i0: 0,
+            i1: 1,
+            i2: 2,
+            alpha: 0.5,
+            position_sigma: 0.02,
+            orientation_sigma: 0.02,
+        }];
+        let params = BaParams {
+            max_iterations: 300,
+            cost_tolerance: 1e-10,
+            ..BaParams::default()
+        };
+        let ratio_of = |poses: &[Pose3d]| -> f64 {
+            let centre = |p: &Pose3d| -(p.rotation.transpose() * p.translation);
+            let (c0, c1, c2) = (centre(&poses[0]), centre(&poses[1]), centre(&poses[2]));
+            (c1 - c0).length() / (c2 - c0).length()
+        };
+        assert!(
+            (ratio_of(&init_poses) - 0.2).abs() < 1e-4,
+            "setup error: initial ratio {:.4} should be 0.2",
+            ratio_of(&init_poses)
+        );
+
+        let res = bundle_adjust_schur_with_all_priors(
+            &init_poses,
+            &init_points,
+            &observations,
+            &cam,
+            &params,
+            Some(&pose_priors),
+            Some(&motion),
+        )
+        .unwrap();
+        let ratio = ratio_of(&res.poses);
+        assert!(
+            (ratio - 0.5).abs() < 0.1,
+            "motion prior left the position ratio at {ratio:.4} on a map {OFFSET} m from the \
+             origin (want 0.5, started 0.2) — the FD step is not tracking coordinate magnitude"
         );
     }
 }

--- a/crates/kornia-3d/src/ba_schur.rs
+++ b/crates/kornia-3d/src/ba_schur.rs
@@ -208,6 +208,33 @@ pub enum SchurBaError {
     #[error(transparent)]
     Ba(#[from] BaError),
 }
+/// The orientation-prior residual for one pose: how far the camera's IMAGE-UP axis has drifted
+/// from the direction the caller claims it points, whitened by `up_sigma`.
+///
+/// Shared by the linearisation and the trial-cost evaluation deliberately. Those two must score
+/// the SAME objective — if they drift apart, LM rejects exactly the steps this prior exists to
+/// take — and the motion prior already gets that guarantee from `motion_prior_residual`. Two
+/// copies of ten lines is how the up prior would lose it.
+///
+/// Image-up is FIXED at `(0, −1, 0)` (OpenCV convention: +Y down). A caller with a measured
+/// direction rather than the upright-camera assumption expresses it by rotating `up_world`, which
+/// constrains the same one degree of freedom without a second per-camera field to keep in sync.
+/// `r_row1` is row 1 of the pose's rotation matrix — i.e. `[R[1][0], R[1][1], R[1][2]]`, which for
+/// column-major storage is `(col0.y, col1.y, col2.y)`. `u_pred` is returned alongside the residual
+/// because the Jacobian `[u_pred]×` needs it.
+#[inline]
+fn up_prior_residual(r_row1: [f32; 3], up_world: [f32; 3], up_sigma: f32) -> ([f32; 3], [f32; 3]) {
+    let inv_su = 1.0_f32 / up_sigma.max(1e-6);
+    // u_pred = Rᵀ · (0,−1,0) = minus row 1 of R, i.e. the world direction the image's up axis
+    // currently points. Taking the row directly is why this needs three scalars, not the matrix.
+    let u_pred = [-r_row1[0], -r_row1[1], -r_row1[2]];
+    let r_up = [
+        (u_pred[0] - up_world[0]) * inv_su,
+        (u_pred[1] - up_world[1]) * inv_su,
+        (u_pred[2] - up_world[2]) * inv_su,
+    ];
+    (r_up, u_pred)
+}
 
 /// 6-vector residual of one [`BaMotionPrior`] on the CURRENT pose estimates, already whitened by
 /// the prior's two sigmas.
@@ -227,63 +254,18 @@ pub enum SchurBaError {
 /// walkthrough produces when the operator pauses. There is no scale in play in that case, so the
 /// plain difference form is both well posed and the correct constraint.
 fn motion_prior_residual(p0: &SE3F32, p1: &SE3F32, p2: &SE3F32, mp: &BaMotionPrior) -> [f32; 6] {
-    let centre = |p: &SE3F32| -> [f32; 3] {
-        let rm = p.r.matrix();
-        let t = p.t;
-        let (c0, c1, c2) = (rm.col(0), rm.col(1), rm.col(2));
-        [
-            -(c0.x * t.x + c0.y * t.y + c0.z * t.z),
-            -(c1.x * t.x + c1.y * t.y + c1.z * t.z),
-            -(c2.x * t.x + c2.y * t.y + c2.z * t.z),
-        ]
-    };
-    // SO(3) log of Ra · Rbᵀ, via the axis-angle (Rodrigues) formula on the composed matrix.
-    let rel_log = |a: &SE3F32, b: &SE3F32| -> [f32; 3] {
-        let (ra, rb) = (a.r.matrix(), b.r.matrix());
-        // m = Ra · Rbᵀ — element (i, j) = Σ_k Ra[i, k]·Rb[j, k].
-        let get = |m: &Mat3AF32, i: usize, j: usize| -> f32 {
-            let c = m.col(j);
-            match i {
-                0 => c.x,
-                1 => c.y,
-                _ => c.z,
-            }
-        };
-        let mut m = [[0.0f32; 3]; 3];
-        for (i, row) in m.iter_mut().enumerate() {
-            for (j, e) in row.iter_mut().enumerate() {
-                let mut acc = 0.0;
-                for k in 0..3 {
-                    acc += get(&ra, i, k) * get(&rb, j, k);
-                }
-                *e = acc;
-            }
-        }
-        let tr = (m[0][0] + m[1][1] + m[2][2]).clamp(-1.0, 3.0);
-        let cos_t = ((tr - 1.0) * 0.5).clamp(-1.0, 1.0);
-        let theta = cos_t.acos();
-        if theta < 1e-6 {
-            // Small-angle: sin θ ≈ θ, so the 0.5·θ/sin θ factor collapses to 0.5 and the
-            // division by a vanishing sine — which would return inf/NaN — never happens.
-            return [
-                0.5 * (m[2][1] - m[1][2]),
-                0.5 * (m[0][2] - m[2][0]),
-                0.5 * (m[1][0] - m[0][1]),
-            ];
-        }
-        let k = 0.5 * theta / theta.sin().max(1e-9);
-        [
-            k * (m[2][1] - m[1][2]),
-            k * (m[0][2] - m[2][0]),
-            k * (m[1][0] - m[0][1]),
-        ]
-    };
+    // Camera centre C = -Rᵀt, and the SO(3) log of Ra·Rbᵀ. Both come from `kornia-algebra`
+    // rather than being spelled out here: `SE3F32::inverse().t` IS -Rᵀt, and `SO3F32::log()`
+    // already carries the small-angle branch that a hand-rolled Rodrigues has to get right to
+    // avoid dividing by a vanishing sine.
+    let centre = |p: &SE3F32| p.inverse().t;
+    let rel_log = |a: &SE3F32, b: &SE3F32| (a.r * b.r.inverse()).log();
 
     let (c0, c1, c2) = (centre(p0), centre(p1), centre(p2));
-    let d01 = [c1[0] - c0[0], c1[1] - c0[1], c1[2] - c0[2]];
-    let d02 = [c2[0] - c0[0], c2[1] - c0[1], c2[2] - c0[2]];
-    let n01 = (d01[0] * d01[0] + d01[1] * d01[1] + d01[2] * d01[2]).sqrt();
-    let n02 = (d02[0] * d02[0] + d02[1] * d02[1] + d02[2] * d02[2]).sqrt();
+    let d01 = c1 - c0;
+    let d02 = c2 - c0;
+    let n01 = d01.length();
+    let n02 = d02.length();
     let inv_sp = 1.0 / mp.position_sigma.max(1e-6);
     let inv_so = 1.0 / mp.orientation_sigma.max(1e-6);
 
@@ -292,15 +274,15 @@ fn motion_prior_residual(p0: &SE3F32, p1: &SE3F32, p2: &SE3F32, mp: &BaMotionPri
         r[0] = (mp.alpha - n01 / n02) * inv_sp;
     } else {
         // Stationary endpoints: fall back to the position difference (no scale in play).
-        r[0] = (mp.alpha * d02[0] - d01[0]) * inv_sp;
-        r[1] = (mp.alpha * d02[1] - d01[1]) * inv_sp;
-        r[2] = (mp.alpha * d02[2] - d01[2]) * inv_sp;
+        let d = d02 * mp.alpha - d01;
+        r[0] = d.x * inv_sp;
+        r[1] = d.y * inv_sp;
+        r[2] = d.z * inv_sp;
     }
-    let w01 = rel_log(p1, p0);
-    let w02 = rel_log(p2, p0);
-    r[3] = (w01[0] - mp.alpha * w02[0]) * inv_so;
-    r[4] = (w01[1] - mp.alpha * w02[1]) * inv_so;
-    r[5] = (w01[2] - mp.alpha * w02[2]) * inv_so;
+    let w = rel_log(p1, p0) - rel_log(p2, p0) * mp.alpha;
+    r[3] = w.x * inv_so;
+    r[4] = w.y * inv_so;
+    r[5] = w.z * inv_so;
     r
 }
 
@@ -1167,9 +1149,8 @@ fn bundle_adjust_schur_impl(
                 }
 
                 // ── Optional orientation (up-vector) prior ────────────────
-                // u_pred = Rᵀ · up_cam: the claimed camera-frame direction expressed in the
-                // world. With the default up_cam = (0,−1,0) this is minus row 1 of R, i.e. the
-                // plain "image-up is world-up" form.
+                // u_pred = Rᵀ · (0,−1,0), i.e. minus row 1 of R: where the image's up axis
+                // currently points in the world. See `up_prior_residual`.
                 //
                 // For a FIXED camera-frame vector v this solver's right-perturbation convention
                 // gives ∂(Rᵀv)/∂ω = +[Rᵀv]× and no ρ coupling — the same pattern the centre
@@ -1177,17 +1158,8 @@ fn bundle_adjust_schur_impl(
                 // centre prior it augments only A_ii; B and C are untouched.
                 if let Some(upw) = prior.up_world {
                     let inv_su = 1.0_f32 / prior.up_sigma.max(1e-6);
-                    let a = prior.up_cam;
-                    let u_pred = [
-                        r_col0.x * a[0] + r_col0.y * a[1] + r_col0.z * a[2],
-                        r_col1.x * a[0] + r_col1.y * a[1] + r_col1.z * a[2],
-                        r_col2.x * a[0] + r_col2.y * a[1] + r_col2.z * a[2],
-                    ];
-                    let r_up = [
-                        (u_pred[0] - upw[0]) * inv_su,
-                        (u_pred[1] - upw[1]) * inv_su,
-                        (u_pred[2] - upw[2]) * inv_su,
-                    ];
+                    let (r_up, u_pred) =
+                        up_prior_residual([r_col0.y, r_col1.y, r_col2.y], upw, prior.up_sigma);
                     let r_sq_u = r_up[0] * r_up[0] + r_up[1] * r_up[1] + r_up[2] * r_up[2];
                     // Reprojection knee, not the whitened one: the up residual is divided by
                     // `up_sigma` in unit-vector units, but it is gated for the same reason the
@@ -1622,17 +1594,9 @@ fn bundle_adjust_schur_impl(
                 // linearisation minimised, or LM rejects every step that trades a little
                 // reprojection for uprightness — which is every step this prior exists to take.
                 if let Some(upw) = prior.up_world {
-                    let inv_su = 1.0_f32 / prior.up_sigma.max(1e-6);
-                    let a = prior.up_cam;
-                    let u_pred = [
-                        r_col0.x * a[0] + r_col0.y * a[1] + r_col0.z * a[2],
-                        r_col1.x * a[0] + r_col1.y * a[1] + r_col1.z * a[2],
-                        r_col2.x * a[0] + r_col2.y * a[1] + r_col2.z * a[2],
-                    ];
-                    let ru0 = (u_pred[0] - upw[0]) * inv_su;
-                    let ru1 = (u_pred[1] - upw[1]) * inv_su;
-                    let ru2 = (u_pred[2] - upw[2]) * inv_su;
-                    let r_sq_u = ru0 * ru0 + ru1 * ru1 + ru2 * ru2;
+                    let (r_up, _) =
+                        up_prior_residual([r_col0.y, r_col1.y, r_col2.y], upw, prior.up_sigma);
+                    let r_sq_u = r_up[0] * r_up[0] + r_up[1] * r_up[1] + r_up[2] * r_up[2];
                     new_cost += robust_cost(r_sq_u);
                 }
             }
@@ -2967,7 +2931,7 @@ mod tests {
 
         // World-frame up direction the cameras' image-up (0, −1, 0) should point along.
         const UP_WORLD: [f32; 3] = [0.0, -1.0, 0.0];
-        // Predicted image-up of a pose in the world frame: Rᵀ · up_cam.
+        // Predicted image-up of a pose in the world frame: Rᵀ · (0,−1,0).
         let up_of = |p: &Pose3d| -> [f64; 3] {
             let rt = p.rotation.transpose();
             let u = rt * Vec3F64::new(0.0, -1.0, 0.0);

--- a/crates/kornia-3d/src/ba_schur.rs
+++ b/crates/kornia-3d/src/ba_schur.rs
@@ -34,7 +34,10 @@
 //!   * z is clamped to `MIN_Z` to handle mid-iteration cheirality flips.
 //!
 //! Supports fixed-pose anchors, fixed-point gauge (motion-only BA), optional
-//! per-observation depth residuals, optional per-pose translation priors, and
+//! per-observation depth residuals, optional per-pose translation and
+//! orientation priors, optional constant-velocity motion priors over pose
+//! triplets (the one residual family that makes the reduced camera system
+//! non-block-diagonal — see [`bundle_adjust_schur_with_all_priors`]), and
 //! the robust kernels in `BaParams::robust` via IRLS (see
 //! [`bundle_adjust_schur`]). LM damping is ellipsoidal — `λ·diag(JᵀJ)`, as
 //! Ceres does it — so `λ` is dimensionless here, unlike
@@ -56,7 +59,7 @@ use kornia_algebra::{Mat3AF32, Mat3F64, Vec3AF32, Vec3F64, SE3F32, SO3F32};
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use thiserror::Error;
 
-use crate::ba::{BaError, BaObservation, BaParams, BaPosePrior, BaResult};
+use crate::ba::{BaError, BaMotionPrior, BaObservation, BaParams, BaPosePrior, BaResult};
 use crate::camera::PinholeCamera;
 use crate::pose::Pose3d;
 use crate::ransac::RobustKernelKind;
@@ -204,6 +207,101 @@ pub enum SchurBaError {
     /// Other BA setup error.
     #[error(transparent)]
     Ba(#[from] BaError),
+}
+
+/// 6-vector residual of one [`BaMotionPrior`] on the CURRENT pose estimates, already whitened by
+/// the prior's two sigmas.
+///
+/// Layout: `[t_ratio, 0, 0 | w01 − α·w02]` in the general case, or
+/// `[α(C2−C0) − (C1−C0) | w01 − α·w02]` in the degenerate `C0 ≈ C2` case. `C` are camera CENTRES
+/// (`−Rᵀt`) — the physically meaningful quantity, not the camera-frame translations — and `w` are
+/// SO(3) logs of the relative rotations.
+///
+/// The translation term is a norm RATIO precisely because the map's scale is a free parameter of
+/// the problem: a residual on the position difference would be minimised by shrinking the entire
+/// reconstruction, so it would fight the depth anchor instead of complementing it. The ratio is
+/// invariant to global scale and constrains only the shape of the local motion.
+///
+/// The `C0 ≈ C2` fallback is not cosmetic: with the endpoints coincident the ratio's denominator
+/// vanishes and the residual is undefined, yet that is exactly the near-stationary configuration a
+/// walkthrough produces when the operator pauses. There is no scale in play in that case, so the
+/// plain difference form is both well posed and the correct constraint.
+fn motion_prior_residual(p0: &SE3F32, p1: &SE3F32, p2: &SE3F32, mp: &BaMotionPrior) -> [f32; 6] {
+    let centre = |p: &SE3F32| -> [f32; 3] {
+        let rm = p.r.matrix();
+        let t = p.t;
+        let (c0, c1, c2) = (rm.col(0), rm.col(1), rm.col(2));
+        [
+            -(c0.x * t.x + c0.y * t.y + c0.z * t.z),
+            -(c1.x * t.x + c1.y * t.y + c1.z * t.z),
+            -(c2.x * t.x + c2.y * t.y + c2.z * t.z),
+        ]
+    };
+    // SO(3) log of Ra · Rbᵀ, via the axis-angle (Rodrigues) formula on the composed matrix.
+    let rel_log = |a: &SE3F32, b: &SE3F32| -> [f32; 3] {
+        let (ra, rb) = (a.r.matrix(), b.r.matrix());
+        // m = Ra · Rbᵀ — element (i, j) = Σ_k Ra[i, k]·Rb[j, k].
+        let get = |m: &Mat3AF32, i: usize, j: usize| -> f32 {
+            let c = m.col(j);
+            match i {
+                0 => c.x,
+                1 => c.y,
+                _ => c.z,
+            }
+        };
+        let mut m = [[0.0f32; 3]; 3];
+        for (i, row) in m.iter_mut().enumerate() {
+            for (j, e) in row.iter_mut().enumerate() {
+                let mut acc = 0.0;
+                for k in 0..3 {
+                    acc += get(&ra, i, k) * get(&rb, j, k);
+                }
+                *e = acc;
+            }
+        }
+        let tr = (m[0][0] + m[1][1] + m[2][2]).clamp(-1.0, 3.0);
+        let cos_t = ((tr - 1.0) * 0.5).clamp(-1.0, 1.0);
+        let theta = cos_t.acos();
+        if theta < 1e-6 {
+            // Small-angle: sin θ ≈ θ, so the 0.5·θ/sin θ factor collapses to 0.5 and the
+            // division by a vanishing sine — which would return inf/NaN — never happens.
+            return [
+                0.5 * (m[2][1] - m[1][2]),
+                0.5 * (m[0][2] - m[2][0]),
+                0.5 * (m[1][0] - m[0][1]),
+            ];
+        }
+        let k = 0.5 * theta / theta.sin().max(1e-9);
+        [
+            k * (m[2][1] - m[1][2]),
+            k * (m[0][2] - m[2][0]),
+            k * (m[1][0] - m[0][1]),
+        ]
+    };
+
+    let (c0, c1, c2) = (centre(p0), centre(p1), centre(p2));
+    let d01 = [c1[0] - c0[0], c1[1] - c0[1], c1[2] - c0[2]];
+    let d02 = [c2[0] - c0[0], c2[1] - c0[1], c2[2] - c0[2]];
+    let n01 = (d01[0] * d01[0] + d01[1] * d01[1] + d01[2] * d01[2]).sqrt();
+    let n02 = (d02[0] * d02[0] + d02[1] * d02[1] + d02[2] * d02[2]).sqrt();
+    let inv_sp = 1.0 / mp.position_sigma.max(1e-6);
+    let inv_so = 1.0 / mp.orientation_sigma.max(1e-6);
+
+    let mut r = [0.0f32; 6];
+    if n02 > 1e-6 {
+        r[0] = (mp.alpha - n01 / n02) * inv_sp;
+    } else {
+        // Stationary endpoints: fall back to the position difference (no scale in play).
+        r[0] = (mp.alpha * d02[0] - d01[0]) * inv_sp;
+        r[1] = (mp.alpha * d02[1] - d01[1]) * inv_sp;
+        r[2] = (mp.alpha * d02[2] - d01[2]) * inv_sp;
+    }
+    let w01 = rel_log(p1, p0);
+    let w02 = rel_log(p2, p0);
+    r[3] = (w01[0] - mp.alpha * w02[0]) * inv_so;
+    r[4] = (w01[1] - mp.alpha * w02[1]) * inv_so;
+    r[5] = (w01[2] - mp.alpha * w02[2]) * inv_so;
+    r
 }
 
 // ── f32 ↔ f64 conversion helpers (shared shape with ba.rs) ───────────────
@@ -543,6 +641,49 @@ pub fn bundle_adjust_schur(
     bundle_adjust_schur_with_priors(poses, points, observations, camera, params, None)
 }
 
+/// [`bundle_adjust_schur_with_priors`] plus constant-velocity motion priors over shot triplets
+/// (see [`BaMotionPrior`]).
+///
+/// # What this adds that no other prior does
+///
+/// Every other residual family here — reprojection, depth, the centre and up priors — touches at
+/// most ONE pose block, so the pose part of the Hessian stays block-diagonal and the reduced
+/// camera system `M = A − B C⁻¹ Bᵀ` picks up off-diagonal entries only through shared points. A
+/// motion residual couples THREE poses, so it writes genuine off-diagonal pose-pose blocks into
+/// `M` — including between cameras that share no landmark at all. That is the whole point: it is
+/// the only term that constrains a keyframe whose neighbours give it no parallax.
+///
+/// Jacobians are obtained by finite differences over the solver's own `retract`. The residual (a
+/// norm ratio composed with an SO(3) log) has an unpleasant closed form, the cost is negligible
+/// (a handful of triplets × 19 residual evaluations, against tens of thousands of observations),
+/// and differentiating through `retract` itself means the perturbation convention can never drift
+/// out of sync with the analytic residuals elsewhere in this file.
+///
+/// Motion residuals are σ-whitened, so they are gated by
+/// [`BaParams::depth_robust_scale_sq`] rather than the reprojection knee — see that field.
+///
+/// Triplets that name an out-of-range pose, or whose three poses are ALL fixed, are skipped.
+#[allow(clippy::too_many_arguments)]
+pub fn bundle_adjust_schur_with_all_priors(
+    poses: &[Pose3d],
+    points: &[Vec3F64],
+    observations: &[BaObservation],
+    camera: &PinholeCamera,
+    params: &BaParams,
+    pose_priors: Option<&[Option<BaPosePrior>]>,
+    motion_priors: Option<&[BaMotionPrior]>,
+) -> Result<BaResult, SchurBaError> {
+    bundle_adjust_schur_impl(
+        poses,
+        points,
+        observations,
+        camera,
+        params,
+        pose_priors,
+        motion_priors,
+    )
+}
+
 /// Bundle adjustment via dense Schur-complement reduction with optional
 /// per-pose translation priors.
 ///
@@ -566,6 +707,9 @@ pub fn bundle_adjust_schur(
 ///
 /// Poses marked fixed via `BaObservation::fixed_pose` have no free
 /// parameters; any prior on them is silently ignored.
+///
+/// When a prior also carries an orientation term ([`BaPosePrior::up_world`]) that residual is
+/// applied here too; it is likewise pose-only and lands in the same `A_ii` block.
 pub fn bundle_adjust_schur_with_priors(
     poses: &[Pose3d],
     points: &[Vec3F64],
@@ -573,6 +717,27 @@ pub fn bundle_adjust_schur_with_priors(
     camera: &PinholeCamera,
     params: &BaParams,
     pose_priors: Option<&[Option<BaPosePrior>]>,
+) -> Result<BaResult, SchurBaError> {
+    bundle_adjust_schur_impl(
+        poses,
+        points,
+        observations,
+        camera,
+        params,
+        pose_priors,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn bundle_adjust_schur_impl(
+    poses: &[Pose3d],
+    points: &[Vec3F64],
+    observations: &[BaObservation],
+    camera: &PinholeCamera,
+    params: &BaParams,
+    pose_priors: Option<&[Option<BaPosePrior>]>,
+    motion_priors: Option<&[BaMotionPrior]>,
 ) -> Result<BaResult, SchurBaError> {
     // Validate prior slice length matches poses.
     if let Some(pp) = pose_priors {
@@ -655,6 +820,19 @@ pub fn bundle_adjust_schur_with_priors(
     // a floor could only make the two solvers disagree: at `robust_scale_sq = 1e-20` a floor gives
     // this solver a knee 1e4x wider than `ba::bundle_adjust` gets from the same `BaParams`.
     let robust_scale = params.robust_scale_sq.sqrt();
+    // Separate knee for the σ-WHITENED residual families (depth measurements, motion priors).
+    // `0.0` — the default — reuses the reprojection knee, so nothing changes for callers that do
+    // not set it. See `BaParams::depth_robust_scale_sq` for why sharing one knee across two
+    // different residual units silently throws the whitened family away.
+    //
+    // Bound BEFORE the closures below shadow the free functions of the same name.
+    let depth_scale = if params.depth_robust_scale_sq > 0.0 {
+        params.depth_robust_scale_sq.sqrt()
+    } else {
+        robust_scale
+    };
+    let depth_weight = |r_sq: f32| -> f32 { robust_weight(robust, depth_scale, r_sq) };
+    let depth_cost = |r_sq: f32| -> f32 { robust_cost(robust, depth_scale, r_sq) };
     let robust_weight = |r_sq: f32| -> f32 { robust_weight(robust, robust_scale, r_sq) };
     let robust_cost = |r_sq: f32| -> f32 { robust_cost(robust, robust_scale, r_sq) };
 
@@ -810,10 +988,11 @@ pub fn bundle_adjust_schur_with_priors(
                 // boundary mis-samples) do not dominate the normal equations.
                 // The gate uses ‖r_z‖² of the *whitened* residual, matching
                 // the χ² interpretation (ORB-SLAM3 §IV.B uses χ²=7.815 for
-                // 3-DoF RGB-D; we reuse `robust_scale_sq` for simplicity).
+                // 3-DoF RGB-D; `BaParams::depth_robust_scale_sq` selects the knee, defaulting to
+                // the reprojection one for backwards compatibility).
                 let r_sq_d = r_z * r_z;
-                let w_d = robust_weight(r_sq_d);
-                cost += robust_cost(r_sq_d);
+                let w_d = depth_weight(r_sq_d);
+                cost += depth_cost(r_sq_d);
                 n_depth_obs_iter += 1;
 
                 // Accumulate into A (6×6) — w · outer product jpd·jpdᵀ.
@@ -986,6 +1165,180 @@ pub fn bundle_adjust_schur_with_priors(
                         gp[ii] -= w_p * row[ii] * r_pos[r_idx];
                     }
                 }
+
+                // ── Optional orientation (up-vector) prior ────────────────
+                // u_pred = Rᵀ · up_cam: the claimed camera-frame direction expressed in the
+                // world. With the default up_cam = (0,−1,0) this is minus row 1 of R, i.e. the
+                // plain "image-up is world-up" form.
+                //
+                // For a FIXED camera-frame vector v this solver's right-perturbation convention
+                // gives ∂(Rᵀv)/∂ω = +[Rᵀv]× and no ρ coupling — the same pattern the centre
+                // prior's ω part follows (its [C]× IS [Rᵀ(−t)]×). Purely rotational, so like the
+                // centre prior it augments only A_ii; B and C are untouched.
+                if let Some(upw) = prior.up_world {
+                    let inv_su = 1.0_f32 / prior.up_sigma.max(1e-6);
+                    let a = prior.up_cam;
+                    let u_pred = [
+                        r_col0.x * a[0] + r_col0.y * a[1] + r_col0.z * a[2],
+                        r_col1.x * a[0] + r_col1.y * a[1] + r_col1.z * a[2],
+                        r_col2.x * a[0] + r_col2.y * a[1] + r_col2.z * a[2],
+                    ];
+                    let r_up = [
+                        (u_pred[0] - upw[0]) * inv_su,
+                        (u_pred[1] - upw[1]) * inv_su,
+                        (u_pred[2] - upw[2]) * inv_su,
+                    ];
+                    let r_sq_u = r_up[0] * r_up[0] + r_up[1] * r_up[1] + r_up[2] * r_up[2];
+                    // Reprojection knee, not the whitened one: the up residual is divided by
+                    // `up_sigma` in unit-vector units, but it is gated for the same reason the
+                    // centre prior is — to stop one badly-oriented view dominating — and it
+                    // shares the centre prior's knee so a single pose prior is scored coherently.
+                    let w_u = robust_weight(r_sq_u);
+                    cost += robust_cost(r_sq_u);
+
+                    let (ux, uy, uz) = (u_pred[0], u_pred[1], u_pred[2]);
+                    // Row-major 3×6: rows of [u]× scaled by 1/σ in the ω half, ρ half zero.
+                    let j_up: [f32; 18] = [
+                        // Row 0 (dUx)
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        -uz * inv_su,
+                        uy * inv_su,
+                        // Row 1 (dUy)
+                        0.0,
+                        0.0,
+                        0.0,
+                        uz * inv_su,
+                        0.0,
+                        -ux * inv_su,
+                        // Row 2 (dUz)
+                        0.0,
+                        0.0,
+                        0.0,
+                        -uy * inv_su,
+                        ux * inv_su,
+                        0.0,
+                    ];
+                    let ab = &mut a_blocks[pli_u];
+                    for r_idx in 0..3 {
+                        let row = &j_up[r_idx * 6..(r_idx + 1) * 6];
+                        for ii in 0..6 {
+                            for kk in 0..6 {
+                                ab[ii * 6 + kk] += w_u * row[ii] * row[kk];
+                            }
+                        }
+                    }
+                    let gp = &mut g_pose[pli_u];
+                    for r_idx in 0..3 {
+                        let row = &j_up[r_idx * 6..(r_idx + 1) * 6];
+                        for ii in 0..6 {
+                            gp[ii] -= w_u * row[ii] * r_up[r_idx];
+                        }
+                    }
+                }
+            }
+        }
+
+        // ── Motion priors (constant-velocity triplets) ──────────────────────
+        // The ONLY residual family here that couples more than one pose, so the only one that
+        // produces off-diagonal pose-pose blocks in the reduced camera system. They are collected
+        // here and written into M after the A blocks are placed.
+        //
+        // Jacobians are finite differences over the solver's own `retract` (see
+        // `bundle_adjust_schur_with_all_priors` for why). Residuals are σ-whitened, so they are
+        // gated with the depth-family knee — see `BaParams::depth_robust_scale_sq` for why they
+        // must not share the reprojection knee.
+        let mut h_offdiag: std::collections::HashMap<(usize, usize), [f32; 36]> =
+            std::collections::HashMap::new();
+        if let Some(mps) = motion_priors {
+            const FD_EPS: f32 = 1e-4;
+            for mp in mps {
+                if mp.i0 >= p_total || mp.i1 >= p_total || mp.i2 >= p_total {
+                    continue;
+                }
+                let tri = [mp.i0, mp.i1, mp.i2];
+                let locs = [pose_local[mp.i0], pose_local[mp.i1], pose_local[mp.i2]];
+                if locs.iter().all(|&l| l < 0) {
+                    // Fully fixed triplet constrains nothing.
+                    continue;
+                }
+                let r0 = motion_prior_residual(&se3s[mp.i0], &se3s[mp.i1], &se3s[mp.i2], mp);
+                let r_sq_m: f32 = r0.iter().map(|v| v * v).sum();
+                let w_m = depth_weight(r_sq_m);
+                cost += depth_cost(r_sq_m);
+
+                // J: 6 residual rows × (3 poses × 6 params), FD one parameter at a time.
+                let mut jac = [[0.0f32; 18]; 6];
+                for (pi, &g) in tri.iter().enumerate() {
+                    if locs[pi] < 0 {
+                        continue;
+                    }
+                    for k in 0..6 {
+                        let mut delta = [0.0f32; 6];
+                        delta[k] = FD_EPS;
+                        let pert = se3s[g].retract(&delta);
+                        let refs = [
+                            if pi == 0 { &pert } else { &se3s[mp.i0] },
+                            if pi == 1 { &pert } else { &se3s[mp.i1] },
+                            if pi == 2 { &pert } else { &se3s[mp.i2] },
+                        ];
+                        let rp = motion_prior_residual(refs[0], refs[1], refs[2], mp);
+                        for row in 0..6 {
+                            jac[row][pi * 6 + k] = (rp[row] - r0[row]) / FD_EPS;
+                        }
+                    }
+                }
+
+                // Accumulate JᵀJ (per pose-PAIR block) and Jᵀr (per pose).
+                for a in 0..3 {
+                    let la = locs[a];
+                    if la < 0 {
+                        continue;
+                    }
+                    let la = la as usize;
+                    let gp = &mut g_pose[la];
+                    for i in 0..6 {
+                        let mut acc = 0.0f32;
+                        for row in 0..6 {
+                            acc += jac[row][a * 6 + i] * r0[row];
+                        }
+                        gp[i] -= w_m * acc;
+                    }
+                    for b in 0..3 {
+                        let lb = locs[b];
+                        if lb < 0 {
+                            continue;
+                        }
+                        let lb = lb as usize;
+                        let mut blk = [0.0f32; 36];
+                        for i in 0..6 {
+                            for j in 0..6 {
+                                let mut acc = 0.0f32;
+                                for row in &jac {
+                                    acc += row[a * 6 + i] * row[b * 6 + j];
+                                }
+                                blk[i * 6 + j] = w_m * acc;
+                            }
+                        }
+                        if la == lb {
+                            let ab = &mut a_blocks[la];
+                            for x in 0..36 {
+                                ab[x] += blk[x];
+                            }
+                        } else {
+                            // Both orderings (a,b) and (b,a) are visited by this double loop, so
+                            // BOTH keys get their own block — do NOT additionally write a
+                            // transpose when draining this map or every off-diagonal entry is
+                            // counted twice.
+                            let e = h_offdiag.entry((la, lb)).or_insert([0.0f32; 36]);
+                            for x in 0..36 {
+                                e[x] += blk[x];
+                            }
+                        }
+                    }
+                }
             }
         }
 
@@ -1030,6 +1383,22 @@ pub fn bundle_adjust_schur_with_priors(
             }
             for i in 0..6 {
                 m_vec[k * 6 + i] = g_pose[k][i] as f64;
+            }
+        }
+
+        // Motion-prior off-diagonal pose-pose blocks (already IRLS-weighted).
+        //
+        // `HashMap` iteration order is randomised per process, which normally makes a
+        // float accumulation order-dependent and therefore non-reproducible. It is safe here and
+        // only here: the keys are unique, each writes a DISJOINT 6×6 destination block, and each
+        // block is written with a single `+=` onto a cell no other key touches. Order cannot
+        // change the result. Do not extend this loop to accumulate onto shared cells without
+        // switching to a deterministic ordering.
+        for ((la, lb), blk) in &h_offdiag {
+            for i in 0..6 {
+                for j in 0..6 {
+                    m_mat[(la * 6 + i, lb * 6 + j)] += blk[i * 6 + j] as f64;
+                }
             }
         }
 
@@ -1216,7 +1585,7 @@ pub fn bundle_adjust_schur_with_priors(
                 // the difference is one-sided), which biases `new_cost < cost` toward accept.
                 let r_z = (z_pred - d_meas) * inv_sigma;
                 let r_sq_d = r_z * r_z;
-                new_cost += robust_cost(r_sq_d);
+                new_cost += depth_cost(r_sq_d);
             }
         }
 
@@ -1248,6 +1617,44 @@ pub fn bundle_adjust_schur_with_priors(
                 // reflects one objective.
                 let r_sq_p = r0 * r0 + r1 * r1 + r2 * r2;
                 new_cost += robust_cost(r_sq_p);
+
+                // Up-prior contribution. The accept test must see the SAME objective the
+                // linearisation minimised, or LM rejects every step that trades a little
+                // reprojection for uprightness — which is every step this prior exists to take.
+                if let Some(upw) = prior.up_world {
+                    let inv_su = 1.0_f32 / prior.up_sigma.max(1e-6);
+                    let a = prior.up_cam;
+                    let u_pred = [
+                        r_col0.x * a[0] + r_col0.y * a[1] + r_col0.z * a[2],
+                        r_col1.x * a[0] + r_col1.y * a[1] + r_col1.z * a[2],
+                        r_col2.x * a[0] + r_col2.y * a[1] + r_col2.z * a[2],
+                    ];
+                    let ru0 = (u_pred[0] - upw[0]) * inv_su;
+                    let ru1 = (u_pred[1] - upw[1]) * inv_su;
+                    let ru2 = (u_pred[2] - upw[2]) * inv_su;
+                    let r_sq_u = ru0 * ru0 + ru1 * ru1 + ru2 * ru2;
+                    new_cost += robust_cost(r_sq_u);
+                }
+            }
+        }
+
+        // Motion-prior contribution to the trial cost — same accept-test-consistency argument.
+        if let Some(mps) = motion_priors {
+            for mp in mps {
+                if mp.i0 >= p_total || mp.i1 >= p_total || mp.i2 >= p_total {
+                    continue;
+                }
+                if [mp.i0, mp.i1, mp.i2].iter().all(|&g| pose_local[g] < 0) {
+                    continue;
+                }
+                let r = motion_prior_residual(
+                    &se3s_trial[mp.i0],
+                    &se3s_trial[mp.i1],
+                    &se3s_trial[mp.i2],
+                    mp,
+                );
+                let r_sq_m: f32 = r.iter().map(|v| v * v).sum();
+                new_cost += depth_cost(r_sq_m);
             }
         }
 
@@ -2149,10 +2556,7 @@ mod tests {
                 // GT camera centre.
                 let r_t = p.rotation.transpose();
                 let c = -(r_t * p.translation);
-                Some(BaPosePrior {
-                    center_world: [c.x as f32, c.y as f32, c.z as f32],
-                    sigma: 0.05,
-                })
+                Some(BaPosePrior::new([c.x as f32, c.y as f32, c.z as f32], 0.05))
             })
             .collect();
 
@@ -2469,6 +2873,362 @@ mod tests {
             max_err_huber < 0.10,
             "Huber-BA max point error {:.4} m too large (regression in inliers?)",
             max_err_huber,
+        );
+    }
+
+    // ── Orientation (up) prior ───────────────────────────────────────────
+
+    /// An orientation prior removes the global TILT that reprojection BA is blind to.
+    ///
+    /// The perturbation applied here is an exact null direction of everything upstream scores:
+    /// the whole reconstruction — every pose and every point — is rotated about the world Z
+    /// axis, which is also the cameras' optical axis and the line their centres sit on. So
+    ///
+    ///   * every reprojection residual is unchanged (rigid rotation of the scene about the
+    ///     cameras),
+    ///   * every camera CENTRE is unchanged (they lie on the rotation axis), so the centre
+    ///     priors — which upstream already has — are satisfied exactly before and after.
+    ///
+    /// That is not a contrived setup, it is the monocular reality in miniature: a forward pass
+    /// with no revisits carries no observation of absolute orientation whatsoever, and the tilt
+    /// it accumulates is invisible to the objective. Only the up prior gives that direction any
+    /// curvature. The control branch below runs the identical problem with `up_world: None` —
+    /// i.e. exactly the upstream code path — and confirms the tilt survives untouched.
+    #[test]
+    fn schur_ba_up_prior_corrects_global_tilt() {
+        let cam = PinholeCamera {
+            fx: 600.0,
+            fy: 600.0,
+            cx: 320.0,
+            cy: 240.0,
+            k1: 0.0,
+            k2: 0.0,
+            p1: 0.0,
+            p2: 0.0,
+        };
+
+        // Cameras ON the world Z axis, identity rotation (looking down +Z). Their centres are
+        // therefore fixed points of any rotation about Z.
+        let centres: Vec<Vec3F64> = (0..5)
+            .map(|i| Vec3F64::new(0.0, 0.0, -0.2 * i as f64))
+            .collect();
+        let true_poses: Vec<Pose3d> = centres
+            .iter()
+            .map(|c| Pose3d::new(Mat3F64::IDENTITY, Vec3F64::new(-c.x, -c.y, -c.z)))
+            .collect();
+
+        // 60 points spread in front of the rig.
+        let mut true_points: Vec<Vec3F64> = Vec::with_capacity(60);
+        for k in 0..60 {
+            let kf = k as f64;
+            let x = (kf * 0.37).sin() * 1.4 + (kf * 0.13).cos() * 0.5;
+            let y = (kf * 0.29).cos() * 1.1 + (kf * 0.11).sin() * 0.4;
+            let z = 4.0 + (kf * 0.41).sin() * 1.5;
+            true_points.push(Vec3F64::new(x, y, z));
+        }
+
+        // Noise-free projections: the point of the test is a null direction, so any residual
+        // floor would just muddy the reading.
+        let mut observations: Vec<BaObservation> = Vec::new();
+        for (pi, pose) in true_poses.iter().enumerate() {
+            for (xi, pt) in true_points.iter().enumerate() {
+                let pc = pose.transform_point(pt);
+                if pc.z <= 0.2 {
+                    continue;
+                }
+                observations.push(BaObservation {
+                    pose_idx: pi,
+                    point_idx: xi,
+                    pixel: [
+                        (cam.fx * pc.x / pc.z + cam.cx) as f32,
+                        (cam.fy * pc.y / pc.z + cam.cy) as f32,
+                    ],
+                    ..Default::default()
+                });
+            }
+        }
+
+        // ── Perturb: roll the ENTIRE reconstruction about world Z by θ. ──
+        // World map p' = G·p, cameras R' = R·Gᵀ, t' = t. Reprojections are preserved exactly
+        // (R'·p' + t' = R·p + t) and centres C' = G·C = C because C is on the axis.
+        let theta = 0.35_f64;
+        let (s, c) = (theta.sin(), theta.cos());
+        let g = Mat3F64::from_cols(
+            Vec3F64::new(c, s, 0.0),
+            Vec3F64::new(-s, c, 0.0),
+            Vec3F64::new(0.0, 0.0, 1.0),
+        );
+        let g_t = g.transpose();
+        let init_poses: Vec<Pose3d> = true_poses
+            .iter()
+            .map(|p| Pose3d::new(p.rotation * g_t, p.translation))
+            .collect();
+        let init_points: Vec<Vec3F64> = true_points.iter().map(|p| g * *p).collect();
+
+        // World-frame up direction the cameras' image-up (0, −1, 0) should point along.
+        const UP_WORLD: [f32; 3] = [0.0, -1.0, 0.0];
+        // Predicted image-up of a pose in the world frame: Rᵀ · up_cam.
+        let up_of = |p: &Pose3d| -> [f64; 3] {
+            let rt = p.rotation.transpose();
+            let u = rt * Vec3F64::new(0.0, -1.0, 0.0);
+            [u.x, u.y, u.z]
+        };
+        let up_err = |p: &Pose3d| -> f64 {
+            let u = up_of(p);
+            ((u[0] - 0.0).powi(2) + (u[1] + 1.0).powi(2) + u[2].powi(2)).sqrt()
+        };
+
+        let init_err = init_poses.iter().map(up_err).fold(0.0_f64, f64::max);
+        assert!(
+            init_err > 0.3,
+            "test is vacuous: initial tilt {init_err:.4} is already small"
+        );
+
+        // Centre priors (an UPSTREAM feature) pin translation and scale but say nothing about
+        // roll — they are satisfied identically before and after the perturbation.
+        let centre_only: Vec<Option<BaPosePrior>> = centres
+            .iter()
+            .map(|c| Some(BaPosePrior::new([c.x as f32, c.y as f32, c.z as f32], 0.05)))
+            .collect();
+        let with_up: Vec<Option<BaPosePrior>> = centre_only
+            .iter()
+            .map(|p| p.map(|p| p.with_up(UP_WORLD, 0.05)))
+            .collect();
+
+        let params = BaParams {
+            max_iterations: 200,
+            cost_tolerance: 1e-10,
+            ..BaParams::default()
+        };
+
+        // Control: centre priors only — this is byte-for-byte the upstream objective.
+        let control = bundle_adjust_schur_with_priors(
+            &init_poses,
+            &init_points,
+            &observations,
+            &cam,
+            &params,
+            Some(&centre_only),
+        )
+        .unwrap();
+        let control_err = control.poses.iter().map(up_err).fold(0.0_f64, f64::max);
+        assert!(
+            control_err > 0.3,
+            "centre-prior-only BA unexpectedly fixed the tilt ({control_err:.4}); the \
+             perturbation is not the intended null direction and the test proves nothing"
+        );
+
+        // With the orientation prior.
+        let result = bundle_adjust_schur_with_priors(
+            &init_poses,
+            &init_points,
+            &observations,
+            &cam,
+            &params,
+            Some(&with_up),
+        )
+        .unwrap();
+        let err = result.poses.iter().map(up_err).fold(0.0_f64, f64::max);
+        assert!(
+            err < 0.05,
+            "up prior left {err:.4} of tilt (control {control_err:.4}, initial {init_err:.4})"
+        );
+    }
+
+    // ── Constant-velocity motion prior ───────────────────────────────────
+
+    /// The constant-velocity prior pulls a middle keyframe back onto its neighbours' trajectory
+    /// when reprojection cannot see where it is.
+    ///
+    /// Middle camera 1 observes a PRIVATE set of landmarks — no co-visibility with 0 or 2. That
+    /// is the near-zero-parallax keyframe in its purest form: camera 1 plus its own points are a
+    /// free-floating piece, and translating or rotating the pair together changes no reprojection
+    /// residual at all. Cameras 0 and 2 are pinned by centre priors (an upstream feature), so
+    /// upstream's objective is completely indifferent to where camera 1 sits between them.
+    ///
+    /// The triplet residual is what supplies the missing constraint, and it does so WITHOUT
+    /// asserting a scale: it constrains the norm RATIO ‖C1−C0‖/‖C2−C0‖ toward `alpha`, plus
+    /// constant angular velocity on the rotations. The control branch (`motion_priors = None`)
+    /// is the upstream path and leaves the jitter exactly where it started.
+    #[test]
+    fn schur_ba_motion_prior_pulls_jittered_middle_pose() {
+        let cam = PinholeCamera {
+            fx: 600.0,
+            fy: 600.0,
+            cx: 320.0,
+            cy: 240.0,
+            k1: 0.0,
+            k2: 0.0,
+            p1: 0.0,
+            p2: 0.0,
+        };
+
+        // True trajectory: C0 = origin, C1 = midpoint, C2 = 2 m back along −Z; identity rotations.
+        let true_centres = [
+            Vec3F64::new(0.0, 0.0, 0.0),
+            Vec3F64::new(0.0, 0.0, -1.0),
+            Vec3F64::new(0.0, 0.0, -2.0),
+        ];
+        let true_poses: Vec<Pose3d> = true_centres
+            .iter()
+            .map(|c| Pose3d::new(Mat3F64::IDENTITY, Vec3F64::new(-c.x, -c.y, -c.z)))
+            .collect();
+
+        // Landmarks: 0..40 shared by cameras 0 and 2; 40..80 seen ONLY by camera 1.
+        let mut points: Vec<Vec3F64> = Vec::with_capacity(80);
+        for k in 0..80 {
+            let kf = k as f64;
+            let x = (kf * 0.37).sin() * 1.5 + (kf * 0.13).cos() * 0.6;
+            let y = (kf * 0.29).cos() * 1.2 + (kf * 0.11).sin() * 0.5;
+            let z = 4.0 + (kf * 0.41).sin() * 1.5;
+            points.push(Vec3F64::new(x, y, z));
+        }
+        let visibility = |pose_idx: usize, point_idx: usize| -> bool {
+            if pose_idx == 1 {
+                point_idx >= 40
+            } else {
+                point_idx < 40
+            }
+        };
+
+        let project = |pose: &Pose3d, pt: &Vec3F64| -> Option<[f32; 2]> {
+            let pc = pose.transform_point(pt);
+            (pc.z > 0.2).then(|| {
+                [
+                    (cam.fx * pc.x / pc.z + cam.cx) as f32,
+                    (cam.fy * pc.y / pc.z + cam.cy) as f32,
+                ]
+            })
+        };
+
+        let mut observations: Vec<BaObservation> = Vec::new();
+        for (pi, pose) in true_poses.iter().enumerate() {
+            for (xi, pt) in points.iter().enumerate() {
+                if !visibility(pi, xi) {
+                    continue;
+                }
+                let Some(pixel) = project(pose, pt) else {
+                    continue;
+                };
+                observations.push(BaObservation {
+                    pose_idx: pi,
+                    point_idx: xi,
+                    pixel,
+                    ..Default::default()
+                });
+            }
+        }
+
+        // ── Jitter camera 1 AND its private points by the same rigid motion, so its
+        // reprojection residuals stay exactly zero. Only the triplet residual can object.
+        let phi = 0.25_f64;
+        let (sp, cp) = (phi.sin(), phi.cos());
+        // Ry(φ) as the jittered world→cam rotation of camera 1.
+        let r1_jit = Mat3F64::from_cols(
+            Vec3F64::new(cp, 0.0, -sp),
+            Vec3F64::new(0.0, 1.0, 0.0),
+            Vec3F64::new(sp, 0.0, cp),
+        );
+        let c1_jit = Vec3F64::new(0.0, 0.0, -0.4);
+        let t1_jit = -(r1_jit * c1_jit);
+        let pose1_jit = Pose3d::new(r1_jit, t1_jit);
+
+        let init_poses = vec![true_poses[0], pose1_jit, true_poses[2]];
+        let init_points: Vec<Vec3F64> = points
+            .iter()
+            .enumerate()
+            .map(|(xi, pt)| {
+                if xi < 40 {
+                    *pt
+                } else {
+                    // p' = R1'ᵀ · (pc − t1'), where pc are the point's TRUE camera-1 coordinates.
+                    let pc = true_poses[1].transform_point(pt);
+                    r1_jit.transpose() * (pc - t1_jit)
+                }
+            })
+            .collect();
+
+        // Centre priors on the ENDPOINTS only (upstream feature). Camera 1 gets none — its
+        // position is exactly what the motion prior is being asked to supply.
+        let pose_priors: Vec<Option<BaPosePrior>> = vec![
+            Some(BaPosePrior::new([0.0, 0.0, 0.0], 0.01)),
+            None,
+            Some(BaPosePrior::new([0.0, 0.0, -2.0], 0.01)),
+        ];
+
+        let motion = [BaMotionPrior {
+            i0: 0,
+            i1: 1,
+            i2: 2,
+            alpha: 0.5,
+            position_sigma: 0.02,
+            orientation_sigma: 0.02,
+        }];
+
+        let params = BaParams {
+            max_iterations: 300,
+            cost_tolerance: 1e-10,
+            ..BaParams::default()
+        };
+
+        // Diagnostics on the returned camera 1.
+        let ratio_of = |poses: &[Pose3d]| -> f64 {
+            let centre = |p: &Pose3d| -(p.rotation.transpose() * p.translation);
+            let (c0, c1, c2) = (centre(&poses[0]), centre(&poses[1]), centre(&poses[2]));
+            (c1 - c0).length() / (c2 - c0).length()
+        };
+        let tilt_of = |poses: &[Pose3d]| -> f64 {
+            let tr = poses[1].rotation.col(0).x
+                + poses[1].rotation.col(1).y
+                + poses[1].rotation.col(2).z;
+            (((tr - 1.0) * 0.5).clamp(-1.0, 1.0)).acos()
+        };
+
+        assert!(
+            (ratio_of(&init_poses) - 0.2).abs() < 1e-6,
+            "setup error: initial ratio {:.4} should be 0.2",
+            ratio_of(&init_poses)
+        );
+
+        // Control: no motion priors — the upstream code path.
+        let control = bundle_adjust_schur_with_all_priors(
+            &init_poses,
+            &init_points,
+            &observations,
+            &cam,
+            &params,
+            Some(&pose_priors),
+            None,
+        )
+        .unwrap();
+        let control_ratio = ratio_of(&control.poses);
+        let control_tilt = tilt_of(&control.poses);
+        assert!(
+            (control_ratio - 0.5).abs() > 0.2 && control_tilt > 0.15,
+            "reprojection alone unexpectedly recovered camera 1 (ratio {control_ratio:.4}, \
+             tilt {control_tilt:.4} rad); the jitter is not the intended null direction"
+        );
+
+        // With the constant-velocity prior.
+        let result = bundle_adjust_schur_with_all_priors(
+            &init_poses,
+            &init_points,
+            &observations,
+            &cam,
+            &params,
+            Some(&pose_priors),
+            Some(&motion),
+        )
+        .unwrap();
+        let ratio = ratio_of(&result.poses);
+        let tilt = tilt_of(&result.poses);
+        assert!(
+            (ratio - 0.5).abs() < 0.05,
+            "motion prior left the position ratio at {ratio:.4} (want 0.5; control {control_ratio:.4})"
+        );
+        assert!(
+            tilt < 0.05,
+            "motion prior left {tilt:.4} rad of angular-velocity error (control {control_tilt:.4})"
         );
     }
 }

--- a/kornia-py/src/ba.rs
+++ b/kornia-py/src/ba.rs
@@ -234,6 +234,7 @@ pub fn bundle_adjust_py<'py>(
         initial_lambda: 1e-3,
         robust: robust_kind,
         robust_scale_sq: robust_scale * robust_scale,
+        ..Default::default()
     };
 
     // Optional per-pose translation priors. None / all-sigmas <= 0 → no
@@ -261,10 +262,10 @@ pub fn bundle_adjust_py<'py>(
                 for i in 0..n_poses {
                     let sig = s_data[i];
                     if sig.is_finite() && sig > 0.0 {
-                        out.push(Some(BaPosePrior {
-                            center_world: [c_data[i * 3], c_data[i * 3 + 1], c_data[i * 3 + 2]],
-                            sigma: sig,
-                        }));
+                        out.push(Some(BaPosePrior::new(
+                            [c_data[i * 3], c_data[i * 3 + 1], c_data[i * 3 + 2]],
+                            sig,
+                        )));
                         any = true;
                     } else {
                         out.push(None);


### PR DESCRIPTION
Two new prior families for `bundle_adjust_schur`, both aimed at the failure mode a monocular forward pass cannot see for itself.

## Orientation (up) prior

The existing centre prior constrains position and nothing else. On a single forward walk with no revisits, **nothing in the image data observes absolute orientation**: the reprojection objective is invariant to a global rotation, and the small per-frame rotation errors integrate into unbounded tilt drift that no amount of reprojection refinement can detect. A soft per-view up prior is the only term that bounds it.

`BaPosePrior` gains `up_world` + `up_sigma`. Image-up is fixed at `(0, -1, 0)` (OpenCV convention); a caller with a measured direction expresses it by rotating `up_world`. Purely rotational, so like the centre prior it augments only the on-diagonal camera block `A_ii`.

## Constant-velocity motion prior

`BaMotionPrior` encodes "shot `i1` lies a fraction `alpha` of the way from `i0` to `i2`, and rotation advances at constant angular velocity" (OpenSfM's `LinearMotionError`).

The translation term uses the norm-RATIO form `alpha - |C1-C0|/|C2-C0|` rather than a position difference. A raw difference is degenerate while scale is itself being estimated — shrinking the whole map satisfies it — whereas the ratio is scale-invariant and constrains only the SHAPE of the local motion. There is a documented fallback for coincident endpoints, which is the near-stationary configuration a walkthrough produces when the operator pauses.

This is the first prior here that couples more than one pose, so it is also the first to produce **off-diagonal pose-pose blocks** in the reduced camera system. They are assembled into the dense reduced matrix; the sparse path is deliberately out of scope for this PR.

Jacobians are finite differences over the solver's own retraction, with the translation step scaled by coordinate magnitude so its accuracy does not degrade as the map moves away from the origin.

## Also

`BaParams::depth_robust_scale_sq` — a separate robust knee for the σ-whitened residual families (the existing per-observation depth residual, and now the motion prior). Sharing the reprojection knee gates an ordinary 1σ depth measurement like a hundreds-of-σ reprojection outlier. Defaults to `0.0`, which reuses `robust_scale_sq`, so **no existing caller changes behaviour**.

## Tests

Two new synthetic tests, each verified to FAIL on `main` by neutering the residual it exercises:

- `schur_ba_up_prior_corrects_global_tilt` — rolls the reconstruction about an axis that is simultaneously the optical axis and the line the camera centres lie on, so reprojection and the centre priors are exactly invariant. A centre-prior-only control leaves the tilt at 0.3482; the up prior drives it below 0.05.
- `schur_ba_motion_prior_pulls_jittered_middle_pose` — the middle camera sees a private landmark set and is jittered together with those points, so its reprojection residuals stay exactly zero and only the triplet residual can object. Control leaves the position ratio at 0.2000; the prior recovers ~0.5.

Plus `motion_prior_survives_a_map_far_from_the_origin`, which documents honestly that the FD step change is a guard rather than a fix for an observed bug: with an absolute step, 500 m and 5 km both pass and only 50 km fails.

`cargo test -p kornia-3d --lib`: 199 passed. Clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)