### PR TITLE
feat(calib): depth-aware reconstruct, orientation/motion priors, intrinsics refinement and progress

### DIFF
--- a/crates/kornia-calib/src/sfm.rs
+++ b/crates/kornia-calib/src/sfm.rs
@@ -508,6 +508,15 @@ pub fn reconstruct(
     );
     let scale = anchored.unwrap_or(1.0);
 
+    // Pixels-per-normalized-unit correction for the reported RMS.
+    //
+    // `refine_intrinsics` rewrites `norm` IN PLACE into the true camera's normalized frame, where
+    // fx_true = fx_assumed / gamma. Every RMS below converts residuals to pixels with the ASSUMED
+    // fx from `cameras`, so without this the reported number is gamma times too large — and this
+    // is the number the callers quote as their acceptance metric, so a silent few-percent bias in
+    // it is worse than a loud one.
+    let focal_scale = camera_correction.map_or(1.0, |(gamma, ..)| 1.0 / gamma.max(1e-9));
+
     // Per-camera reprojection RMS (pixels); analytical covariance is tag-oriented so stays `None`.
     // Use the BA-optimized points (`res.points`), NOT the pre-BA cloud: BA moves points as free
     // variables, so evaluating the pre-BA cloud under post-BA poses would report a stale residual.
@@ -515,6 +524,7 @@ pub fn reconstruct(
     let per_camera = (0..n_cams)
         .map(|c| {
             feature_stats(
+                focal_scale,
                 c,
                 &res.poses,
                 &registered,
@@ -526,6 +536,7 @@ pub fn reconstruct(
         })
         .collect();
     let reproj_rmse_px = global_reproj_rmse(
+        focal_scale,
         &res.poses,
         &registered,
         &res.points,
@@ -653,8 +664,18 @@ fn fit_depth_scales(
     for ti in track_ids {
         let Some(p) = point3d.get(ti) else { continue };
         for (j, (c, _)) in norm[*ti].iter().enumerate() {
-            let (Some(pose), Some(d)) = (&poses[*c], norm_depth[*ti].get(j).copied().flatten())
-            else {
+            // `.get(ti)`, not `[ti]`: the contract on `obs_depth` is that a wrong-shaped array
+            // simply yields `None` per lookup, and `depth_fields` already honours that. Indexing
+            // here made a caller who supplied depth for only the first N tracks panic instead —
+            // the one shape of malformed input the documentation explicitly invites.
+            let (Some(pose), Some(d)) = (
+                &poses[*c],
+                norm_depth
+                    .get(*ti)
+                    .and_then(|t| t.get(j))
+                    .copied()
+                    .flatten(),
+            ) else {
                 continue;
             };
             let z = pose.transform_point(p).z;
@@ -1115,6 +1136,7 @@ fn tag_scale(
 /// Reprojection is scale-invariant, so the UNSCALED world→cam BA poses are used directly.
 #[allow(clippy::too_many_arguments)]
 fn feature_stats(
+    focal_scale: f64,
     camera: usize,
     poses_w2c: &[Pose3d],
     registered: &[bool],
@@ -1136,7 +1158,11 @@ fn feature_stats(
             continue;
         };
         if let Some(r) = norm_residual(&pose, points[pidx], *n) {
-            se += (r * cam.fx).powi(2); // r is Euclidean in normalized units; fx≈fy assumed
+            // `focal_scale` carries the intrinsics refinement: it rewrote `norm` into the TRUE
+            // camera's normalized frame, where fx_true = fx_assumed / gamma, so converting with
+            // the ASSUMED fx would report every residual gamma times too large. 1.0 when
+            // `refine_intrinsics` is off.
+            se += (r * cam.fx * focal_scale).powi(2); // r Euclidean in normalized units; fx≈fy
             num += 1;
         }
     }
@@ -1148,6 +1174,7 @@ fn feature_stats(
 }
 
 fn global_reproj_rmse(
+    focal_scale: f64,
     poses_w2c: &[Pose3d],
     registered: &[bool],
     points: &[Vec3F64],
@@ -1165,7 +1192,7 @@ fn global_reproj_rmse(
                 continue;
             }
             if let Some(r) = norm_residual(&poses_w2c[*c], points[pidx], *n) {
-                se += (r * cameras[*c].fx).powi(2);
+                se += (r * cameras[*c].fx * focal_scale).powi(2);
                 num += 1;
             }
         }
@@ -2094,6 +2121,78 @@ mod tests {
             with_priors.reproj_rmse_px < 1.0,
             "priors drove the fit away from the pixels: rmse {:.3} px",
             with_priors.reproj_rmse_px
+        );
+    }
+
+    /// The reported pixel RMS must be in the corrected camera's pixels, not the assumed one's.
+    ///
+    /// `refine_intrinsics` rewrites the observations into the TRUE camera's normalized frame,
+    /// where `fx_true = fx_assumed / gamma`. Converting those residuals to pixels with the
+    /// ASSUMED `fx` — which is what `cameras` still holds — scales every reported number by
+    /// gamma. It is a small factor, which is exactly why it is worth pinning: `reproj_rmse_px` is
+    /// the number callers quote as their acceptance metric, and a silent few-percent bias in an
+    /// acceptance metric is worse than a loud one.
+    #[test]
+    fn reported_rmse_is_in_corrected_pixels() {
+        const K1_TRUE: f64 = 0.25;
+        let (cams, _, clean) = converging_rig(500.0, 1.0);
+        let tracks: Vec<FeatureTrack> = clean
+            .iter()
+            .map(|t| FeatureTrack {
+                obs: t
+                    .obs
+                    .iter()
+                    .map(|(c, uv)| {
+                        let (x, y) = ((uv.x - 320.0) / 500.0, (uv.y - 240.0) / 500.0);
+                        let s = 1.0 + K1_TRUE * (x * x + y * y);
+                        (
+                            *c,
+                            Vec2F64::new(320.0 + 500.0 * x * s, 240.0 + 500.0 * y * s),
+                        )
+                    })
+                    .collect(),
+            })
+            .collect();
+
+        let refined = reconstruct(
+            &cams,
+            &[],
+            &tracks,
+            &CalibConfig {
+                refine_intrinsics: true,
+                ..CalibConfig::new(0.0)
+            },
+            None,
+        )
+        .expect("solves");
+
+        let (gamma, ..) = refined
+            .camera_correction
+            .expect("injected distortion must produce a fit");
+        assert!(
+            (gamma - 1.0).abs() > 1e-9,
+            "test is vacuous unless the fit actually moved gamma (got {gamma})"
+        );
+
+        // Reproduce the conversion by hand from the same reported per-camera numbers, and check
+        // the global figure is consistent with them under the CORRECTED focal. If the global RMS
+        // had been left in assumed-fx pixels while the per-camera ones were corrected (or vice
+        // versa), this ratio would sit at gamma rather than 1.
+        let n: usize = refined.per_view.iter().map(|s| s.num_obs).sum();
+        assert!(n > 0, "no observations to check");
+        let pooled: f64 = refined
+            .per_view
+            .iter()
+            .filter(|s| s.num_obs > 0)
+            .map(|s| s.reproj_rmse_px.powi(2) * s.num_obs as f64)
+            .sum::<f64>()
+            / n as f64;
+        let pooled = pooled.sqrt();
+        assert!(
+            (pooled - refined.reproj_rmse_px).abs() <= 1e-6 * refined.reproj_rmse_px.max(1.0),
+            "global RMS {:.6} disagrees with the pooled per-camera RMS {pooled:.6} — the two \
+             conversions are not using the same focal",
+            refined.reproj_rmse_px
         );
     }
 }

--- a/crates/kornia-calib/src/sfm.rs
+++ b/crates/kornia-calib/src/sfm.rs
@@ -16,8 +16,8 @@
 
 use std::collections::{HashMap, HashSet};
 
-use kornia_3d::ba::{BaObservation, BaParams};
-use kornia_3d::ba_schur::bundle_adjust_schur;
+use kornia_3d::ba::{BaMotionPrior, BaObservation, BaParams, BaPosePrior, BaResult};
+use kornia_3d::ba_schur::bundle_adjust_schur_with_all_priors;
 use kornia_3d::camera::PinholeCamera;
 use kornia_3d::pnp::{solve_pnp_ransac, PnPMethod, RansacParams as PnpRansacParams};
 use kornia_3d::pose::{
@@ -77,6 +77,26 @@ fn norm_residual(pose: &Pose3d, p_world: Vec3F64, n: Vec2F64) -> Option<f64> {
 /// * `tracks` - multi-view feature tracks. A track needs at least two views to triangulate, and
 ///   the reconstruction needs enough shared tracks between views to register them.
 /// * `config` - solver settings; see [`CalibConfig`].
+/// * `obs_depth` - optional metric depth per observation, shaped exactly like `tracks`:
+///   `obs_depth[i][j]` is the depth of `tracks[i].obs[j]`, `None` where none is available. Pass
+///   `None` for the classic depth-free solve. Ignored unless
+///   [`CalibConfig::depth_prior_rel_sigma`] is positive.
+///
+/// # Depth
+///
+/// Monocular reprojection is exactly scale-invariant, so the gauge has one free DoF that the
+/// optimiser navigates by numerical accident. That is the root of two failures a fiducial-free
+/// walkthrough cannot otherwise escape:
+///
+/// 1. **No metric scale.** Depth residuals observe absolute scale directly, so the reconstruction
+///    lands in metres with no tag in the scene.
+/// 2. **Scale drift.** Along a no-revisit walk the reconstruction's scale wanders — the measured
+///    symptom is rooms late in a clip reconstructing several times larger than early ones. A
+///    per-observation depth prior pins EVERY segment of the chain, not just a global average.
+///
+/// Depths are a soft prior, not a constraint: they are robustified, sigma-weighted by
+/// [`CalibConfig::depth_prior_rel_sigma`], and (by default) re-gauged per view — see
+/// [`CalibConfig::depth_per_keyframe_scale`].
 ///
 /// # Returns
 ///
@@ -109,7 +129,8 @@ fn norm_residual(pose: &Pose3d, p_world: Vec3F64, n: Vec2F64) -> Option<f64> {
 ///     ],
 /// }];
 ///
-/// let recon = reconstruct(&cameras, &[], &tracks, &CalibConfig::new(0.1))?;
+/// // `None` for the depth argument: no metric depth measurements, so the map is up to scale.
+/// let recon = reconstruct(&cameras, &[], &tracks, &CalibConfig::new(0.1), None)?;
 ///
 /// // No tag was supplied, so the map is honestly up to scale rather than silently "metric".
 /// assert_eq!(recon.scale, ScaleSource::UpToScale);
@@ -127,6 +148,7 @@ pub fn reconstruct(
     tags_for_scale: &[TagObservation],
     tracks: &[FeatureTrack],
     config: &CalibConfig,
+    obs_depth: Option<&[Vec<Option<f64>>]>,
 ) -> Result<Reconstruction, CalibError> {
     let n_cams = cameras.len();
     let idcam = PinholeCamera::IDENTITY;
@@ -137,7 +159,8 @@ pub fn reconstruct(
     };
 
     // Per track: normalized observation per camera (undistort + K⁻¹). Raw pixels stay in `tracks`.
-    let norm: Vec<Vec<(usize, Vec2F64)>> = tracks
+    // MUTABLE because `refine_intrinsics` rewrites these in place once it has fitted a correction.
+    let mut norm: Vec<Vec<(usize, Vec2F64)>> = tracks
         .iter()
         .map(|t| {
             t.obs
@@ -146,6 +169,16 @@ pub fn reconstruct(
                 .collect()
         })
         .collect();
+    // Parallel to `norm`: metric depth per observation, or `None`. All-`None` when the feature is
+    // off, so every downstream site indexes it unconditionally instead of branching on whether
+    // depth exists. A caller whose depth array is the wrong shape simply gets `None` per lookup.
+    let norm_depth: Vec<Vec<Option<f32>>> = match obs_depth {
+        Some(d) if config.depth_prior_rel_sigma > 0.0 => d
+            .iter()
+            .map(|t| t.iter().map(|x| x.map(|v| v as f32)).collect())
+            .collect(),
+        _ => norm.iter().map(|t| vec![None; t.len()]).collect(),
+    };
 
     // Count shared tracks per camera pair to choose the bootstrap pair.
     let mut pair_count: HashMap<(usize, usize), usize> = HashMap::new();
@@ -291,17 +324,73 @@ pub fn reconstruct(
             None,
             PnPMethod::EPnPDefault,
             &PnpRansacParams {
-                reproj_threshold_px: 0.01, // normalized units
+                // Normalized units, tied to the same threshold the rest of the pipeline calls an
+                // outlier bound. Defaults to 0.01, the value this was hardcoded to.
+                reproj_threshold_px: config.max_reprojection_error as f32,
+                // Seed the sampler. `RansacParams::default()` leaves `random_seed: None`, which
+                // draws from the thread RNG, so registration was NONDETERMINISTIC: identical
+                // inputs produced different reconstructions run to run (measured on 40 keyframes
+                // of EuRoC MH01 — 12 / 30 / 39 cameras registered over three runs of the same
+                // command). Because a transient PnP failure marks a camera unregisterable, that
+                // randomness changes the final map, not merely its timing. The seed varies per
+                // camera so different views still draw different sample sequences.
+                random_seed: Some(0x00C0_FFEE ^ c as u64),
                 ..Default::default()
             },
         );
-        match pnp {
-            Ok(r) => {
-                poses[c] = Some(pose_from_pnp(r.pose.rotation, r.pose.translation));
+        // Accepting a registration is not the same as PnP returning `Ok`. `solve_pnp_ransac`
+        // succeeds whenever it finds *a* consensus, however small, so an unguarded `Ok` arm admits
+        // cameras whose pose is fitted to a handful of correspondences. That is not a
+        // self-correcting mistake: `triangulate_new` immediately creates 3D points FROM the bad
+        // pose, and those points feed the next camera's PnP, so one bad registration propagates.
+        // Measured on EuRoC MH01 the symptom was global RMSE rising WITH the registered count —
+        // 34 cameras at 10.4 px, 38 at 23.2 px — the opposite of a healthy incremental SfM.
+        let accepted = pnp.as_ref().ok().and_then(|r| {
+            let pose = pose_from_pnp(r.pose.rotation, r.pose.translation);
+            // Score BOTH the returned (refit) pose and the RANSAC consensus, and keep the larger.
+            // `inliers` is classified against the PRE-refit minimal-sample model, and the refit can
+            // move either way, so trusting one alone under-counts: a solid 107-inlier consensus has
+            // been observed reclassifying to under 30 against its own refit, silently losing a good
+            // view. Both counts use the same threshold, so they are directly comparable.
+            let n_refit = wp
+                .iter()
+                .zip(ip.iter())
+                .filter(|(w, i)| {
+                    norm_residual(&pose, **w, **i)
+                        .is_some_and(|e| e <= config.max_reprojection_error)
+                })
+                .count();
+            (n_refit.max(r.inliers.len()) >= config.min_registration_inliers).then_some(pose)
+        });
+        match accepted {
+            Some(pose) => {
+                poses[c] = Some(pose);
+                if let Some(cb) = config.progress.as_ref() {
+                    cb(poses.iter().filter(|p| p.is_some()).count(), n_cams);
+                }
+                let before = point3d.len();
                 triangulate_new(&mut point3d, &norm, &poses, &idcam, &tcfg);
+                // A camera that could not register earlier may register comfortably NOW: each
+                // success triangulates new points, so the 2D-3D evidence available to the remaining
+                // views grows. Without this, `min_registration_inliers` would turn every transient
+                // rejection into a permanent one and strictly REDUCE the registered count versus
+                // having no gate at all — the gate is only safe in the presence of the retry.
+                //
+                // Gated on the cloud ACTUALLY growing, so a registration that added no evidence
+                // does not buy a re-run of every rejected camera against an unchanged map.
+                //
+                // This terminates: the set is cleared only when the cloud grows, the cloud is
+                // bounded by the track count, and between clears each iteration either registers a
+                // camera (at most `n_cams` times) or removes one from consideration.
+                if point3d.len() > before {
+                    pnp_failed.clear();
+                }
             }
-            Err(_) => {
-                pnp_failed.insert(c); // this camera can't register now; try the others
+            // PnP failed outright, or its consensus was too thin to trust. Either way this camera
+            // cannot register against the CURRENT map; try the others and revisit it after the
+            // cloud has grown.
+            None => {
+                pnp_failed.insert(c);
             }
         }
     }
@@ -317,18 +406,14 @@ pub fn reconstruct(
     let mut track_ids: Vec<usize> = point3d.keys().copied().collect();
     track_ids.sort_unstable();
 
-    let mut points: Vec<Vec3F64> = Vec::new(); // BA input; paired with track ids on output
-    let mut pt_index: HashMap<usize, usize> = HashMap::new();
-    let mut obs: Vec<BaObservation> = Vec::new();
+    // `pt_index[ti]` is just `ti`'s position in `track_ids`, so it is stable across BA rounds and
+    // the published `points` order matches the BA input order in every one of them.
+    let pt_index: HashMap<usize, usize> =
+        track_ids.iter().enumerate().map(|(i, t)| (*t, i)).collect();
+    let point_track_id: Vec<usize> = track_ids.clone();
     let mut kept_obs: Vec<Observation> = Vec::new();
-    let mut point_track_id: Vec<usize> = Vec::new();
     for ti in &track_ids {
-        let p = &point3d[ti];
-        let pidx = points.len();
-        pt_index.insert(*ti, pidx);
-        points.push(*p);
-        point_track_id.push(*ti);
-        for (j, (c, nrm)) in norm[*ti].iter().enumerate() {
+        for (j, (c, _)) in norm[*ti].iter().enumerate() {
             if poses[*c].is_none() {
                 continue;
             }
@@ -336,37 +421,70 @@ pub fn reconstruct(
             // raw pixel is recoverable without re-normalising.
             kept_obs.push(Observation {
                 view: *c,
-                point: pidx,
+                point: pt_index[ti],
                 pixel: tracks[*ti].obs[j].1,
-            });
-            obs.push(BaObservation {
-                pose_idx: *c,
-                point_idx: pidx,
-                pixel: [nrm.x as f32, nrm.y as f32],
-                fixed_pose: *c == a0, // reference camera fixed → gauge anchor
-                fixed_point: false,
-                depth_meas: None,
-                depth_sigma: 1.0,
             });
         }
     }
-    let poses_ba: Vec<Pose3d> = poses
-        .iter()
-        .map(|p| p.unwrap_or(Pose3d::IDENTITY))
-        .collect();
-    let res = bundle_adjust_schur(
-        &poses_ba,
-        &points,
-        &obs,
+
+    let mut res = global_ba(
+        &poses,
+        &point3d,
+        &track_ids,
+        &norm,
+        &norm_depth,
         &idcam,
-        &BaParams {
-            max_iterations: config.max_iterations,
-            robust: RobustKernelKind::Huber,
-            robust_scale_sq: config.robust_scale_sq,
-            ..Default::default()
-        },
-    )
-    .map_err(|e| CalibError::BundleAdjust(format!("{e:?}")))?;
+        a0,
+        config,
+    )?;
+
+    // --- Alternating intrinsics refinement (COLMAP refines focal/distortion INSIDE its BA; this is
+    // the alternating equivalent, which needs no solver surgery). The solver sees NORMALIZED
+    // coordinates, so a focal error is a single global scale `gamma` on them and lens distortion a
+    // radial/tangential polynomial. Against the current map that model is LINEAR in the stacked
+    // unknowns, so one closed-form least squares per round corrects the camera; the second bundle
+    // adjustment below then re-settles the geometry against it.
+    let camera_correction = if config.refine_intrinsics {
+        let fit = fit_camera_correction(&res, &pt_index, &norm, &poses);
+        if let Some((gamma, k1, k2, p1, p2)) = fit {
+            for track in norm.iter_mut() {
+                for (_, n) in track.iter_mut() {
+                    let (x, y) = (n.x, n.y);
+                    let r2 = x * x + y * y;
+                    let radial = 1.0 + k1 * r2 + k2 * r2 * r2;
+                    n.x = gamma * (x * radial + 2.0 * p1 * x * y + p2 * (r2 + 2.0 * x * x));
+                    n.y = gamma * (y * radial + p1 * (r2 + 2.0 * y * y) + 2.0 * p2 * x * y);
+                }
+            }
+            // Feed the first solve's state back in, then RE-SOLVE against the corrected
+            // observations. Without this second pass the refinement would be computed, reported,
+            // and never reflected in the poses this function returns — the observations it rewrote
+            // would go unread, since nothing downstream of here solves anything.
+            for (c, p) in poses.iter_mut().enumerate() {
+                if p.is_some() {
+                    *p = Some(res.poses[c]);
+                }
+            }
+            for (ti, pidx) in &pt_index {
+                if let Some(v) = res.points.get(*pidx) {
+                    point3d.insert(*ti, *v);
+                }
+            }
+            res = global_ba(
+                &poses,
+                &point3d,
+                &track_ids,
+                &norm,
+                &norm_depth,
+                &idcam,
+                a0,
+                config,
+            )?;
+        }
+        fit
+    } else {
+        None
+    };
 
     let registered: Vec<bool> = poses.iter().map(|p| p.is_some()).collect();
 
@@ -450,7 +568,408 @@ pub fn reconstruct(
             },
             _ => ScaleSource::UpToScale,
         },
+        camera_correction,
     })
+}
+
+/// Depth measurement + already-deflated sigma for observation `j` of track `ti`, or `(None, 0.0)`
+/// when there is no usable depth there.
+///
+/// The returned sigma is DEFLATED into reprojection units, not the raw metric sigma. The solver's
+/// reprojection residuals are unwhitened normalized-camera values (implicit σ = 1 normalized unit —
+/// an entire focal length!), while its depth residuals divide by their sigma. Passing the honest
+/// metric sigma therefore makes each depth row carry orders of magnitude more cost than a
+/// reprojection row, and the solve goes depth-dominated no matter how loose the relative sigma
+/// looks — measured: `rel_sigma` 5.0 (≈ no confidence at all) still halved registration.
+/// Multiplying by `1/σ_r` — where `σ_r` is the reprojection noise scale in normalized units, the
+/// threshold read as 2σ — puts both families in the same implicit unit.
+fn depth_fields(
+    norm_depth: &[Vec<Option<f32>>],
+    ti: usize,
+    j: usize,
+    config: &CalibConfig,
+) -> (Option<f32>, f32) {
+    let rel_sigma = config.depth_prior_rel_sigma;
+    match norm_depth.get(ti).and_then(|t| t.get(j)).copied().flatten() {
+        Some(d) if rel_sigma > 0.0 && d > 0.0 => {
+            let sigma_r = (config.max_reprojection_error / 2.0).max(1e-6) as f32;
+            (Some(d), (rel_sigma as f32) * d / sigma_r)
+        }
+        _ => (None, 0.0),
+    }
+}
+
+/// Robust per-view depth gauge: the median of `z_map / d_pred` over that view's depth
+/// observations, re-gauged against the median view and clamped. `1.0` where a view lacks enough
+/// pairs to fit.
+///
+/// # Why per view rather than one global scale
+///
+/// Learned depth is not gauge-stable frame to frame. On forward motion a per-frame scale error is
+/// indistinguishable from along-axis translation, so a single global scale hands every wander of
+/// the network straight to the trajectory: the residual is real, the solver dutifully moves the
+/// camera, every frame. That is a drift generator.
+///
+/// # Scale only, not the affine `s·d + t`
+///
+/// A free intercept absorbs bas-relief compression instead of correcting it — measured: sparse
+/// depth spanned a ratio of 1.13 across a view where the network saw 2.13, and an affine fit
+/// reproduced that flattening faithfully. It also makes the map's ABSOLUTE scale unobservable from
+/// depth, which defeats the point of supplying depth at all.
+///
+/// # Gauge
+///
+/// The scales are normalised by their own median, so this re-gauges views RELATIVE to each other
+/// without moving the map as a whole. Without that, the reconstruction would be free to breathe
+/// every time bundle adjustment ran.
+fn fit_depth_scales(
+    poses: &[Option<Pose3d>],
+    point3d: &HashMap<usize, Vec3F64>,
+    track_ids: &[usize],
+    norm: &[Vec<(usize, Vec2F64)>],
+    norm_depth: &[Vec<Option<f32>>],
+    n_cams: usize,
+) -> Vec<f64> {
+    /// Below this many depth pairs a median is noise, and a wrong per-view gauge is worse than the
+    /// global one it replaces.
+    const MIN_PAIRS: usize = 12;
+
+    let mut per_cam: Vec<Vec<f64>> = vec![Vec::new(); n_cams];
+    for ti in track_ids {
+        let Some(p) = point3d.get(ti) else { continue };
+        for (j, (c, _)) in norm[*ti].iter().enumerate() {
+            let (Some(pose), Some(d)) = (&poses[*c], norm_depth[*ti].get(j).copied().flatten())
+            else {
+                continue;
+            };
+            let z = pose.transform_point(p).z;
+            if z > 1e-9 && d > 0.0 {
+                per_cam[*c].push(z / d as f64); // map units per network unit
+            }
+        }
+    }
+    // Median, not mean: a depth network hallucinates at occlusion boundaries and on mirrors, and
+    // those observations are a fat tail, not Gaussian noise.
+    let median = |v: &mut Vec<f64>| -> Option<f64> {
+        if v.len() < MIN_PAIRS {
+            return None;
+        }
+        v.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let m = v[v.len() / 2];
+        (m.is_finite() && m > 1e-9).then_some(m)
+    };
+    let mut scales: Vec<Option<f64>> = per_cam.iter_mut().map(median).collect();
+
+    let mut fitted: Vec<f64> = scales.iter().flatten().copied().collect();
+    if fitted.len() < 2 {
+        return vec![1.0; n_cams];
+    }
+    fitted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let anchor = fitted[fitted.len() / 2];
+    for s in scales.iter_mut().flatten() {
+        *s /= anchor;
+    }
+    // A view whose scale is wildly off has a broken pose or a broken depth map, not a gauge
+    // offset; trusting its fit would let it drag the solve. Fall back to neutral.
+    scales
+        .into_iter()
+        .map(|s| match s {
+            Some(v) if (0.5..2.0).contains(&v) => v,
+            _ => 1.0,
+        })
+        .collect()
+}
+
+/// Per-view up priors, or `None` when [`CalibConfig::up_prior_sigma`] is off.
+///
+/// The camera-frame direction asserted to be up is image-up `(0, −1, 0)` — "the camera was held
+/// roughly upright" — so `up_prior_sigma` must be chosen to match how much that is actually
+/// believed.
+///
+/// World up is a GAUGE choice and has to agree with the anchor camera `a0`, whose pose is held
+/// fixed: `up_world = R_a0ᵀ · up_cam`. Any other choice fights the one pose the solve cannot move.
+fn up_priors(
+    poses: &[Option<Pose3d>],
+    a0: usize,
+    config: &CalibConfig,
+) -> Option<Vec<Option<BaPosePrior>>> {
+    if config.up_prior_sigma <= 0.0 {
+        return None;
+    }
+    const UP_CAM: [f64; 3] = [0.0, -1.0, 0.0];
+    let up_world: [f32; 3] = match poses.get(a0).and_then(|p| *p) {
+        Some(pa) => {
+            let w = pa.rotation.transpose() * Vec3F64::new(UP_CAM[0], UP_CAM[1], UP_CAM[2]);
+            [w.x as f32, w.y as f32, w.z as f32]
+        }
+        None => [0.0, -1.0, 0.0],
+    };
+    // Deflated into reprojection units for the same reason as `depth_fields`: bundle adjustment
+    // runs against `PinholeCamera::IDENTITY`, so its reprojection residuals are in NORMALISED units
+    // while this sigma is quoted in unit-vector units. Passing it raw made the prior `1/σ_r` times
+    // stiffer than every other term in the same solve — 360× at fx 1440 with an 8 px threshold,
+    // where 1° of pitch deviation cost what a 489 px reprojection error would.
+    let sigma_r = (config.max_reprojection_error / 2.0).max(1e-6);
+    Some(
+        poses
+            .iter()
+            .map(|p| {
+                p.as_ref().map(|_| BaPosePrior {
+                    // No positional anchor: a huge sigma makes the centre residual contribute
+                    // nothing, leaving a purely rotational prior.
+                    center_world: [0.0; 3],
+                    sigma: 1e6,
+                    up_world: Some(up_world),
+                    up_cam: [UP_CAM[0] as f32, UP_CAM[1] as f32, UP_CAM[2] as f32],
+                    up_sigma: (config.up_prior_sigma / sigma_r) as f32,
+                })
+            })
+            .collect(),
+    )
+}
+
+/// Constant-velocity motion priors over consecutive REGISTERED triplets, or `None` when off.
+///
+/// Consecutive in VIEW-INDEX order (video keyframes are time-ordered), `alpha` from the index
+/// spacing, and triplets spanning more than [`MAX_TRIPLET_SPAN`] indices skipped — a bridge across
+/// a long unregistered stretch is not a constant-velocity hypothesis worth asserting. Sigmas are
+/// deflated into reprojection units exactly like the depth and up priors.
+fn motion_priors_for(poses: &[Option<Pose3d>], config: &CalibConfig) -> Option<Vec<BaMotionPrior>> {
+    /// Widest index gap a triplet may span before it stops being a plausible motion hypothesis.
+    const MAX_TRIPLET_SPAN: usize = 12;
+
+    if config.motion_prior_sigma <= 0.0 {
+        return None;
+    }
+    let sigma_r = (config.max_reprojection_error / 2.0).max(1e-6);
+    let sp = (config.motion_prior_sigma / sigma_r) as f32;
+    let so = (0.5 * config.motion_prior_sigma / sigma_r) as f32;
+    let reg: Vec<usize> = poses
+        .iter()
+        .enumerate()
+        .filter_map(|(i, p)| p.as_ref().map(|_| i))
+        .collect();
+    let out: Vec<BaMotionPrior> = reg
+        .windows(3)
+        .filter(|w| w[2] - w[0] <= MAX_TRIPLET_SPAN)
+        .map(|w| BaMotionPrior {
+            i0: w[0],
+            i1: w[1],
+            i2: w[2],
+            alpha: (w[1] - w[0]) as f32 / (w[2] - w[0]) as f32,
+            position_sigma: sp,
+            orientation_sigma: so,
+        })
+        .collect();
+    (!out.is_empty()).then_some(out)
+}
+
+/// One global bundle adjustment over every triangulated point and every registered view, with the
+/// anchor camera `a0` fixed to hold the gauge.
+///
+/// Callable more than once on the same problem, which is what `refine_intrinsics` needs: it
+/// rewrites `norm` in place and the geometry then has to re-settle against the corrected camera.
+#[allow(clippy::too_many_arguments)]
+fn global_ba(
+    poses: &[Option<Pose3d>],
+    point3d: &HashMap<usize, Vec3F64>,
+    track_ids: &[usize],
+    norm: &[Vec<(usize, Vec2F64)>],
+    norm_depth: &[Vec<Option<f32>>],
+    idcam: &PinholeCamera,
+    a0: usize,
+    config: &CalibConfig,
+) -> Result<BaResult, CalibError> {
+    // Re-fit the per-view depth gauge against the CURRENT geometry before every solve. Alternating
+    // rather than joint: the scales are closed-form medians, so each pass refines the other.
+    let depth_scale = if config.depth_per_keyframe_scale {
+        fit_depth_scales(poses, point3d, track_ids, norm, norm_depth, poses.len())
+    } else {
+        vec![1.0; poses.len()]
+    };
+    let mut points: Vec<Vec3F64> = Vec::with_capacity(track_ids.len());
+    let mut obs: Vec<BaObservation> = Vec::new();
+    for (pidx, ti) in track_ids.iter().enumerate() {
+        // `track_ids` is derived from `point3d`'s keys and points are only ever updated in place,
+        // so every id resolves. Failing loudly rather than skipping matters: a skip would shift
+        // every later `pidx` off its point and silently solve a scrambled problem.
+        let p = point3d.get(ti).ok_or_else(|| {
+            CalibError::BundleAdjust(format!("track {ti} has no triangulated point"))
+        })?;
+        points.push(*p);
+        for (j, (c, nrm)) in norm[*ti].iter().enumerate() {
+            if poses[*c].is_none() {
+                continue;
+            }
+            let (depth_meas, depth_sigma) = depth_fields(norm_depth, *ti, j, config);
+            obs.push(BaObservation {
+                pose_idx: *c,
+                point_idx: pidx,
+                pixel: [nrm.x as f32, nrm.y as f32],
+                fixed_pose: *c == a0, // reference camera fixed → gauge anchor
+                fixed_point: false,
+                // This view's own gauge baked into the measurement, so the residual measures the
+                // shape the network got right rather than the scale it got wrong.
+                depth_meas: depth_meas.map(|d| d * depth_scale[*c] as f32),
+                depth_sigma,
+            });
+        }
+    }
+    let poses_ba: Vec<Pose3d> = poses
+        .iter()
+        .map(|p| p.unwrap_or(Pose3d::IDENTITY))
+        .collect();
+    bundle_adjust_schur_with_all_priors(
+        &poses_ba,
+        &points,
+        &obs,
+        idcam,
+        &BaParams {
+            max_iterations: config.max_iterations,
+            robust: RobustKernelKind::Huber,
+            robust_scale_sq: config.robust_scale_sq,
+            // Depth residuals live in reprojection-like units (see `depth_fields`), so their Huber
+            // knee is 1.345 × the reprojection noise scale, squared. Left at the default `0.0` —
+            // meaning "reuse the reprojection knee" — when depth is off.
+            depth_robust_scale_sq: if config.depth_prior_rel_sigma > 0.0 {
+                let sr = (config.max_reprojection_error / 2.0).max(1e-6) as f32;
+                (1.345 * sr) * (1.345 * sr)
+            } else {
+                0.0
+            },
+            ..Default::default()
+        },
+        up_priors(poses, a0, config).as_deref(),
+        motion_priors_for(poses, config).as_deref(),
+    )
+    .map_err(|e| CalibError::BundleAdjust(format!("{e:?}")))
+}
+
+/// Closed-form OpenCV-model intrinsics correction `(gamma, k1, k2, p1, p2)` fitted against the
+/// current reconstruction, or `None` when the fit is singular or outside its sanity bounds.
+///
+/// Linear in the stacked unknowns `beta = (gamma, gamma·k1, gamma·k2, gamma·p1, gamma·p2)`:
+///
+/// ```text
+///   u_x = b0·x + b1·x·r² + b2·x·r⁴ + b3·(2xy)     + b4·(r²+2x²)
+///   u_y = b0·y + b1·y·r² + b2·y·r⁴ + b3·(r²+2y²)  + b4·(2xy)
+/// ```
+///
+/// so the whole set costs one least squares. The tangential terms are what a focal-only fit can
+/// never see: a decentred lens bends verticals asymmetrically, and forcing that into `k1` leaves a
+/// residue that looks like scene curvature.
+fn fit_camera_correction(
+    res: &BaResult,
+    pt_index: &HashMap<usize, usize>,
+    norm: &[Vec<(usize, Vec2F64)>],
+    poses: &[Option<Pose3d>],
+) -> Option<(f64, f64, f64, f64, f64)> {
+    let mut ata = [[0.0f64; 5]; 5];
+    let mut atb = [0.0f64; 5];
+    // DETERMINISM. These are floating-point normal equations, and float addition is not
+    // associative, so the ORDER of accumulation changes the solved correction. `pt_index` is a
+    // `HashMap` and Rust randomises hash iteration per process, so summing in iteration order
+    // yields a different `(gamma, k1, k2, p1, p2)` — hence different intrinsics, hence a different
+    // reconstruction — from bit-identical input.
+    let mut ordered: Vec<(&usize, &usize)> = pt_index.iter().collect();
+    ordered.sort_unstable_by_key(|(ti, _)| **ti);
+    for (ti, pidx) in ordered {
+        let Some(p) = res.points.get(*pidx) else {
+            continue;
+        };
+        for (c, n) in &norm[*ti] {
+            if poses[*c].is_none() {
+                continue;
+            }
+            let pc = res.poses[*c].transform_point(p);
+            if pc.z <= 1e-9 {
+                continue;
+            }
+            let (u, v) = (pc.x / pc.z, pc.y / pc.z);
+            let (x, y) = (n.x, n.y);
+            let r2 = x * x + y * y;
+            let r4 = r2 * r2;
+            let rows = [
+                ([x, x * r2, x * r4, 2.0 * x * y, r2 + 2.0 * x * x], u),
+                ([y, y * r2, y * r4, r2 + 2.0 * y * y, 2.0 * x * y], v),
+            ];
+            for (basis, target) in rows {
+                for i in 0..5 {
+                    for j in 0..5 {
+                        ata[i][j] += basis[i] * basis[j];
+                    }
+                    atb[i] += basis[i] * target;
+                }
+            }
+        }
+    }
+    // Try the full 5-parameter fit first; when it is singular or out of bounds fall back to the
+    // (gamma, k1) subproblem rather than applying a fit the geometry cannot support — thin tracks
+    // make the r⁴ and tangential columns nearly collinear on a narrow-FOV rig.
+    let full = solve_sym5(&ata, &atb).and_then(|b| {
+        let gamma = b[0];
+        if gamma.abs() < 1e-9 {
+            return None;
+        }
+        let (k1, k2, p1, p2) = (b[1] / gamma, b[2] / gamma, b[3] / gamma, b[4] / gamma);
+        ((0.7..1.3).contains(&gamma)
+            && (-0.3..0.3).contains(&k1)
+            && (-0.1..0.1).contains(&k2)
+            && (-0.05..0.05).contains(&p1)
+            && (-0.05..0.05).contains(&p2))
+        .then_some((gamma, k1, k2, p1, p2))
+    });
+    full.or_else(|| {
+        let det = ata[0][0] * ata[1][1] - ata[0][1] * ata[0][1];
+        if det.abs() <= 1e-12 {
+            return None;
+        }
+        let gamma = (atb[0] * ata[1][1] - atb[1] * ata[0][1]) / det;
+        let gk1 = (atb[1] * ata[0][0] - atb[0] * ata[0][1]) / det;
+        let k1 = if gamma.abs() > 1e-9 { gk1 / gamma } else { 0.0 };
+        // Sanity bounds: a fit outside them means the MAP is wrong, not the camera, and applying
+        // it would let geometry errors masquerade as optics.
+        ((0.7..1.3).contains(&gamma) && (-0.3..0.3).contains(&k1))
+            .then_some((gamma, k1, 0.0, 0.0, 0.0))
+    })
+}
+
+/// Solve the symmetric positive-semidefinite `5×5` system `A x = b` by Gaussian elimination with
+/// partial pivoting. `None` when a pivot collapses — for the intrinsics fit that means the
+/// distortion columns are collinear and the caller falls back to the two-parameter model.
+fn solve_sym5(a: &[[f64; 5]; 5], b: &[f64; 5]) -> Option<[f64; 5]> {
+    let mut m = [[0.0f64; 6]; 5];
+    for i in 0..5 {
+        m[i][..5].copy_from_slice(&a[i]);
+        m[i][5] = b[i];
+    }
+    for col in 0..5 {
+        let piv = (col..5).max_by(|&i, &j| {
+            m[i][col]
+                .abs()
+                .partial_cmp(&m[j][col].abs())
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })?;
+        if m[piv][col].abs() < 1e-12 {
+            return None;
+        }
+        m.swap(col, piv);
+        for row in (col + 1)..5 {
+            let f = m[row][col] / m[col][col];
+            for k in col..6 {
+                m[row][k] -= f * m[col][k];
+            }
+        }
+    }
+    let mut x = [0.0f64; 5];
+    for i in (0..5).rev() {
+        let mut s = m[i][5];
+        for j in (i + 1)..5 {
+            s -= m[i][j] * x[j];
+        }
+        x[i] = s / m[i][i];
+    }
+    Some(x)
 }
 
 /// Triangulate every not-yet-reconstructed track that has ≥2 placed cameras, adding it to `point3d`.
@@ -735,7 +1254,7 @@ mod tests {
         };
 
         let cfg = CalibConfig::new(s);
-        let cal = match reconstruct(&cams, std::slice::from_ref(&tag), &tracks, &cfg)
+        let cal = match reconstruct(&cams, std::slice::from_ref(&tag), &tracks, &cfg, None)
             .map(RigCalibration::from)
         {
             Ok(c) => c,
@@ -771,7 +1290,7 @@ mod tests {
         // the points it returns have to share the poses' scale -- this is the assertion the
         // no-tag consistency test cannot make, because there `scale == 1.0` and dropping the
         // scaling changes nothing.
-        let recon = reconstruct(&cams, std::slice::from_ref(&tag), &tracks, &cfg)
+        let recon = reconstruct(&cams, std::slice::from_ref(&tag), &tracks, &cfg, None)
             .expect("same solve must succeed");
         assert_eq!(
             recon.scale,
@@ -846,7 +1365,8 @@ mod tests {
             .collect();
 
         let cfg = CalibConfig::new(0.1);
-        let recon = reconstruct(&cams, &[], &tracks, &cfg).expect("synthetic scene must solve");
+        let recon =
+            reconstruct(&cams, &[], &tracks, &cfg, None).expect("synthetic scene must solve");
 
         // The map came back at all -- the whole point of M1.
         assert!(!recon.points.is_empty(), "no points returned");
@@ -948,7 +1468,7 @@ mod tests {
         };
 
         let cfg = CalibConfig::new(2.0 * s);
-        let recon = reconstruct(&cams, std::slice::from_ref(&tag), &tracks, &cfg)
+        let recon = reconstruct(&cams, std::slice::from_ref(&tag), &tracks, &cfg, None)
             .expect("the feature tracks alone must still solve");
 
         assert_eq!(
@@ -976,6 +1496,7 @@ mod tests {
             std::slice::from_ref(&two_view),
             &tracks,
             &CalibConfig::new(0.0),
+            None,
         )
         .expect("solves");
         assert_eq!(
@@ -995,8 +1516,14 @@ mod tests {
                 })
                 .collect(),
         };
-        let deg =
-            reconstruct(&cams, std::slice::from_ref(&degenerate), &tracks, &cfg).expect("solves");
+        let deg = reconstruct(
+            &cams,
+            std::slice::from_ref(&degenerate),
+            &tracks,
+            &cfg,
+            None,
+        )
+        .expect("solves");
         assert_eq!(
             deg.scale,
             ScaleSource::UpToScale,
@@ -1027,8 +1554,14 @@ mod tests {
                 })
                 .collect(),
         };
-        let untri = reconstruct(&cams, std::slice::from_ref(&untriangulable), &tracks, &cfg)
-            .expect("solves");
+        let untri = reconstruct(
+            &cams,
+            std::slice::from_ref(&untriangulable),
+            &tracks,
+            &cfg,
+            None,
+        )
+        .expect("solves");
         assert_eq!(
             untri.scale,
             ScaleSource::UpToScale,
@@ -1096,6 +1629,7 @@ mod tests {
             std::slice::from_ref(&tag),
             &tracks,
             &CalibConfig::new(2.0 * s),
+            None,
         )
         .map(RigCalibration::from)
         .expect("the feature tracks alone must still solve");
@@ -1131,8 +1665,8 @@ mod tests {
             .collect();
         let cfg = CalibConfig::new(0.1);
 
-        let a = reconstruct(&cams, &[], &tracks, &cfg).expect("solves");
-        let b = reconstruct(&cams, &[], &tracks, &cfg).expect("solves");
+        let a = reconstruct(&cams, &[], &tracks, &cfg, None).expect("solves");
+        let b = reconstruct(&cams, &[], &tracks, &cfg, None).expect("solves");
 
         let ids = |r: &Reconstruction| r.points.iter().map(|p| p.track_id).collect::<Vec<_>>();
         let (ia, ib) = (ids(&a), ids(&b));
@@ -1145,6 +1679,403 @@ mod tests {
         assert_eq!(
             ia, ib,
             "two runs over identical input must publish the same map order"
+        );
+    }
+
+    /// Three converging views of a textured cloud, at a SPECIFIED metric scale.
+    ///
+    /// The shape is scale-free, so `scale` changes nothing about how well the geometry
+    /// reconstructs — only where the true metric sits relative to the bootstrap's unit baseline.
+    /// Returns `(cameras, world→cam ground truth, tracks)`.
+    fn converging_rig(f: f64, scale: f64) -> (Vec<PinholeCamera>, Vec<Pose3d>, Vec<FeatureTrack>) {
+        let cams = vec![pinhole(f), pinhole(f), pinhole(f)];
+        let gt = vec![
+            Pose3d::new(rot(0.0, 0.05), Vec3F64::new(0.0, 0.0, 0.0)),
+            Pose3d::new(rot(0.40, 0.05), Vec3F64::new(-0.6, 0.0, 0.10) * scale),
+            Pose3d::new(rot(-0.40, 0.05), Vec3F64::new(0.6, 0.0, 0.15) * scale),
+        ];
+        let (w, h) = (640.0, 480.0);
+        let mut tracks: Vec<FeatureTrack> = Vec::new();
+        for i in 0..10 {
+            for j in 0..10 {
+                let x = -0.5 + 0.111 * i as f64;
+                let y = -0.5 + 0.111 * j as f64;
+                let z = 1.4 + 0.5 * ((i * 5 + j) as f64 * 0.7).sin() + 0.05 * (i as f64 - j as f64);
+                let p = Vec3F64::new(x, y, z) * scale;
+                let obs: Vec<(usize, Vec2F64)> = (0..3)
+                    .filter_map(|c| {
+                        let pc = gt[c].transform_point(&p);
+                        if pc.z <= 0.1 * scale {
+                            return None;
+                        }
+                        let uv = project(p, &gt[c], &cams[c]);
+                        (uv.x >= 0.0 && uv.x < w && uv.y >= 0.0 && uv.y < h).then_some((c, uv))
+                    })
+                    .collect();
+                if obs.len() >= 2 {
+                    tracks.push(FeatureTrack { obs });
+                }
+            }
+        }
+        (cams, gt, tracks)
+    }
+
+    /// Ground-truth metric depth for every observation, shaped exactly like `tracks`.
+    fn gt_depths(
+        gt: &[Pose3d],
+        tracks: &[FeatureTrack],
+        cams: &[PinholeCamera],
+    ) -> Vec<Vec<Option<f64>>> {
+        // Recover each track's world point by intersecting its first two rays under the GT poses,
+        // which for noise-free synthetic data is exact; then take its z in each observing view.
+        tracks
+            .iter()
+            .map(|t| {
+                let (c0, uv0) = t.obs[0];
+                let (c1, uv1) = t.obs[1];
+                let pts = triangulate_matched_points(
+                    &[cams[c0].normalize(uv0)],
+                    &[cams[c1].normalize(uv1)],
+                    &gt[c0],
+                    &gt[c1],
+                    &PinholeCamera::IDENTITY,
+                    &TriangulationConfig {
+                        min_parallax_deg: 0.0,
+                        max_reprojection_error: 1e9,
+                        min_cheirality_count: 0,
+                        ..Default::default()
+                    },
+                )
+                .expect("synthetic rays must intersect");
+                let p = pts[0].position;
+                t.obs
+                    .iter()
+                    .map(|(c, _)| Some(gt[*c].transform_point(&p).z))
+                    .collect()
+            })
+            .collect()
+    }
+
+    /// Median of `z_reconstructed / d_measured` over every surviving observation: `1.0` exactly
+    /// when the map is at the metric scale the depths assert.
+    fn median_depth_ratio(
+        recon: &Reconstruction,
+        tracks: &[FeatureTrack],
+        depths: &[Vec<Option<f64>>],
+    ) -> f64 {
+        let mut r: Vec<f64> = Vec::new();
+        for o in &recon.observations {
+            let ti = recon.points[o.point].track_id;
+            let Some(j) = tracks[ti].obs.iter().position(|(c, _)| *c == o.view) else {
+                continue;
+            };
+            let Some(d) = depths[ti][j] else { continue };
+            let w2c = recon.views[o.view].expect("registered").inverse();
+            let z = w2c.transform_point(&recon.points[o.point].position).z;
+            if d > 1e-9 {
+                r.push(z / d);
+            }
+        }
+        assert!(!r.is_empty(), "no observation carried a depth to compare");
+        r.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        r[r.len() / 2]
+    }
+
+    /// **Depth measurements fix the scale of an otherwise scale-free reconstruction.**
+    ///
+    /// This is the whole point of the `obs_depth` argument. A feature-only monocular solve is
+    /// determined only up to a similarity: the bootstrap fixes the gauge by giving its seed pair a
+    /// UNIT baseline, so the map's absolute size is an artifact of that convention and has nothing
+    /// to do with the scene. Here the true seed baseline is deliberately far from 1, so the
+    /// depth-free control lands several times too large — and the depth priors have to pull it back.
+    ///
+    /// The control is not decoration. Every assertion below would also pass on a build where the
+    /// depth arguments were accepted and silently ignored, if the scene happened to be near unit
+    /// scale; asserting that the SAME scene reconstructs at the wrong scale without depth is what
+    /// makes this a test of the depth term rather than of the geometry.
+    #[test]
+    fn depth_priors_fix_the_scale_of_an_otherwise_scale_free_reconstruction() {
+        // Scale 0.4: the widest camera-centre baseline is ~0.5 m, so the unit-baseline convention
+        // inflates the depth-free map by roughly 2x.
+        let (cams, gt, tracks) = converging_rig(500.0, 0.4);
+        let depths = gt_depths(&gt, &tracks, &cams);
+
+        // Control: no depth. Same tracks, same config -- only the argument differs.
+        let free = reconstruct(&cams, &[], &tracks, &CalibConfig::new(0.0), None).expect("solves");
+        let free_ratio = median_depth_ratio(&free, &tracks, &depths);
+        assert!(
+            free_ratio > 1.5,
+            "the depth-free control must be visibly off-scale for this test to mean anything, \
+             got ratio {free_ratio:.4}"
+        );
+
+        // With depth. `depth_prior_rel_sigma` is what ARMS the feature: at 0.0 the depths are
+        // ignored no matter what is passed.
+        let cfg = CalibConfig {
+            depth_prior_rel_sigma: 0.15,
+            ..CalibConfig::new(0.0)
+        };
+        let metric = reconstruct(&cams, &[], &tracks, &cfg, Some(&depths)).expect("solves");
+        let ratio = median_depth_ratio(&metric, &tracks, &depths);
+        assert!(
+            (ratio - 1.0).abs() < 0.05,
+            "depth priors must bring the map to the metric scale they assert: ratio {ratio:.4} \
+             (depth-free control {free_ratio:.4})"
+        );
+
+        // Metric SCALE, not merely metric depths: the camera centres must now sit at their true
+        // separations, which is the quantity a downstream consumer actually uses.
+        let centre = |p: &Option<Pose3d>| p.expect("registered").translation;
+        let gt_centre = |p: &Pose3d| p.inverse().translation;
+        for (i, j) in [(0, 1), (0, 2), (1, 2)] {
+            let got = (centre(&metric.views[i]) - centre(&metric.views[j])).length();
+            let want = (gt_centre(&gt[i]) - gt_centre(&gt[j])).length();
+            assert!(
+                (got - want).abs() < 0.05 * want,
+                "baseline {i}-{j} is {got:.4} m, ground truth {want:.4} m"
+            );
+        }
+
+        // And the map is still HONEST about where that scale came from: no tag anchored it, so the
+        // reported `ScaleSource` stays `UpToScale` even though the numbers are now metric. Depth is
+        // a soft prior, not a fiducial, and `ScaleSource` names fiducials.
+        assert_eq!(metric.scale, ScaleSource::UpToScale);
+    }
+
+    /// Passing depths while `depth_prior_rel_sigma` is 0 must change NOTHING.
+    ///
+    /// The knob, not the argument, arms the feature -- so a caller that wires depth through before
+    /// deciding to trust it gets exactly the solve it had. Bit-identical, not merely close.
+    #[test]
+    fn depths_are_inert_until_the_sigma_arms_them() {
+        let (cams, gt, tracks) = converging_rig(500.0, 0.4);
+        let depths = gt_depths(&gt, &tracks, &cams);
+        let cfg = CalibConfig::new(0.0);
+
+        let without = reconstruct(&cams, &[], &tracks, &cfg, None).expect("solves");
+        let with = reconstruct(&cams, &[], &tracks, &cfg, Some(&depths)).expect("solves");
+
+        assert_eq!(without.points.len(), with.points.len());
+        for (a, b) in without.points.iter().zip(&with.points) {
+            assert_eq!(a.position, b.position, "depth leaked into a disarmed solve");
+        }
+    }
+
+    /// `min_registration_inliers` decides whether a thinly-supported view is admitted.
+    ///
+    /// Views 0 and 1 share 80 tracks and bootstrap the map; view 2 sees only 20 of them, so its
+    /// PnP consensus cannot exceed 20 however good the pose is. The default gate of 30 must refuse
+    /// it; lowering the gate must admit it. Without the gate there is nothing between a 4-point
+    /// consensus and a registration, and a bad registration is not self-correcting -- points get
+    /// triangulated FROM it and then feed the next view's PnP.
+    #[test]
+    fn min_registration_inliers_gates_a_thinly_supported_view() {
+        let cams = vec![pinhole(600.0), pinhole(600.0), pinhole(600.0)];
+        let gt = [
+            Pose3d::new(Mat3F64::IDENTITY, Vec3F64::new(0.0, 0.0, 0.0)),
+            Pose3d::new(rot(0.30, 0.0), Vec3F64::new(-0.35, 0.0, 0.02)),
+            Pose3d::new(rot(-0.28, 0.04), Vec3F64::new(0.33, 0.01, 0.03)),
+        ];
+        let tracks: Vec<FeatureTrack> = (0..100)
+            .map(|i| {
+                let p = Vec3F64::new(
+                    -0.30 + 0.006 * i as f64,
+                    -0.20 + 0.004 * (i % 11) as f64,
+                    1.30 + 0.05 * (i % 7) as f64,
+                );
+                // Only the last 20 tracks are visible to view 2.
+                let seen: &[usize] = if i < 80 { &[0, 1] } else { &[0, 1, 2] };
+                FeatureTrack {
+                    obs: seen
+                        .iter()
+                        .map(|c| (*c, project(p, &gt[*c], &cams[*c])))
+                        .collect(),
+                }
+            })
+            .collect();
+
+        let gated = reconstruct(&cams, &[], &tracks, &CalibConfig::new(0.0), None).expect("solves");
+        assert_eq!(
+            CalibConfig::new(0.0).min_registration_inliers,
+            30,
+            "this test is calibrated against the documented default"
+        );
+        assert!(
+            gated.views[2].is_none(),
+            "20 correspondences cannot clear a 30-inlier gate, so view 2 must stay unregistered"
+        );
+        assert!(gated.views[0].is_some() && gated.views[1].is_some());
+
+        let open = reconstruct(
+            &cams,
+            &[],
+            &tracks,
+            &CalibConfig {
+                min_registration_inliers: 15,
+                ..CalibConfig::new(0.0)
+            },
+            None,
+        )
+        .expect("solves");
+        assert!(
+            open.views[2].is_some(),
+            "lowering the gate below the available support must admit the view"
+        );
+    }
+
+    /// `refine_intrinsics` must REPORT its fit and then ACT on it.
+    ///
+    /// Two independent claims, with different failure modes:
+    ///
+    /// 1. The fit reaches the caller on [`Reconstruction::camera_correction`]. Refinement applies
+    ///    itself by rewriting normalized observations in place, so a caller that never sees the fit
+    ///    keeps storing the camera it guessed — one that did not produce these poses.
+    /// 2. The fit CHANGES THE POSES. Refinement runs after a bundle adjustment; unless a second
+    ///    solve follows it, the corrected observations are never read by anything that moves
+    ///    geometry, and the feature is an expensive no-op that still reports a number.
+    ///
+    /// # What this test does NOT claim, and why
+    ///
+    /// It does not claim the refinement recovers a known FOCAL error, because on a synthetic of
+    /// this size it cannot and no honest assertion would pass. The fit regresses the map's
+    /// predicted projections onto the observations, so it can only see error that bundle
+    /// adjustment failed to absorb — and a focal error is very nearly absorbable, since scaling
+    /// normalized coordinates stretches space in `x` and `y` at fixed `z`. MEASURED here: handing
+    /// the solver 320 for a true focal of 400 (a 25% error) left `plain.reproj_rmse_px = 0.636`
+    /// and `gamma = 0.9994` on a three-view converging rig, and 0.9994 again on a five-view rig
+    /// orbiting through ±52° of yaw. Bundle adjustment had swallowed all of it. The production
+    /// evidence for focal recovery is a 3208-frame handheld clip with hundreds of cameras, which
+    /// is not a unit test.
+    ///
+    /// Radial DISTORTION is a different matter: it is a nonlinear image warp, not a projective
+    /// one, so a rigid reconstruction cannot absorb it and it leaves the radially-systematic
+    /// residual this fit is shaped to see. So the scene injects barrel distortion the solver is
+    /// not told about, and the assertion is that the fit opposes it.
+    #[test]
+    fn refine_intrinsics_reports_its_fit_and_re_solves_against_it() {
+        const K1_TRUE: f64 = 0.25;
+        let (cams, _, clean) = converging_rig(500.0, 1.0);
+        // Barrel-distort every pixel. The cameras handed to the solver keep `k1 = 0`, so
+        // `normalize` leaves the distortion in the observations for the refinement to find.
+        let tracks: Vec<FeatureTrack> = clean
+            .iter()
+            .map(|t| FeatureTrack {
+                obs: t
+                    .obs
+                    .iter()
+                    .map(|(c, uv)| {
+                        let (x, y) = ((uv.x - 320.0) / 500.0, (uv.y - 240.0) / 500.0);
+                        let s = 1.0 + K1_TRUE * (x * x + y * y);
+                        (
+                            *c,
+                            Vec2F64::new(320.0 + 500.0 * x * s, 240.0 + 500.0 * y * s),
+                        )
+                    })
+                    .collect(),
+            })
+            .collect();
+
+        let plain = reconstruct(&cams, &[], &tracks, &CalibConfig::new(0.0), None).expect("solves");
+        assert_eq!(
+            plain.camera_correction, None,
+            "refinement is off by default, so there is no fit to report"
+        );
+
+        let refined = reconstruct(
+            &cams,
+            &[],
+            &tracks,
+            &CalibConfig {
+                refine_intrinsics: true,
+                ..CalibConfig::new(0.0)
+            },
+            None,
+        )
+        .expect("solves");
+
+        let (gamma, k1, ..) = refined
+            .camera_correction
+            .expect("injected distortion must produce a reportable fit");
+        assert!(
+            k1 < -0.005,
+            "the fit must UNDO the injected barrel distortion (k1_true = +{K1_TRUE}), so its own \
+             k1 has to be negative; got {k1:.5}"
+        );
+        // The focal was correct here, so the refinement must not invent a focal error while it is
+        // busy fitting distortion. `gamma` inverts into focal: fx_true = fx_assumed / gamma.
+        assert!(
+            (0.95..1.05).contains(&gamma),
+            "a correctly-assumed focal must survive the fit intact; gamma={gamma:.4} implies \
+             fx_true = {:.1} against the true 500",
+            500.0 / gamma
+        );
+
+        // The second solve is the load-bearing half. Without it the poses would be BIT-IDENTICAL
+        // to the unrefined run, because nothing after the refinement re-optimises anything: the
+        // rewritten observations would be reported on and then dropped on the floor.
+        let moved = plain
+            .views
+            .iter()
+            .zip(&refined.views)
+            .filter_map(|(a, b)| Some((a.as_ref()?.translation - b.as_ref()?.translation).length()))
+            .fold(0.0f64, f64::max);
+        assert!(
+            moved > 1e-6,
+            "the refinement was reported but never re-solved against: poses are unchanged"
+        );
+        assert!(
+            refined.views.iter().all(|v| v.is_some()),
+            "the re-solve must not cost a registration"
+        );
+    }
+
+    /// The up and motion priors reach the solver at a strength that does not overrule the images.
+    ///
+    /// Both sigmas are quoted in their own physical units and then DEFLATED into the normalized
+    /// reprojection units bundle adjustment actually works in. Skipping that deflation is not a
+    /// subtle mis-tuning: it makes each prior row `1/sigma_r` times stiffer than every reprojection
+    /// row in the same solve (360x at a phone focal), and the solve then fits the assumption
+    /// instead of the scene. So the assertion is that turning both priors ON, at their documented
+    /// production values, leaves a good reconstruction good.
+    #[test]
+    fn up_and_motion_priors_do_not_overrule_the_image_evidence() {
+        // Views are index-ordered along the rig, which is what makes a motion prior meaningful.
+        let (cams, gt, tracks) = converging_rig(500.0, 1.0);
+        let baseline =
+            reconstruct(&cams, &[], &tracks, &CalibConfig::new(0.0), None).expect("solves");
+        let with_priors = reconstruct(
+            &cams,
+            &[],
+            &tracks,
+            &CalibConfig {
+                up_prior_sigma: 0.25,
+                motion_prior_sigma: 0.1,
+                ..CalibConfig::new(0.0)
+            },
+            None,
+        )
+        .expect("solves");
+
+        assert!(
+            with_priors.views.iter().all(|v| v.is_some()),
+            "the priors must not cost a registration"
+        );
+        // Baselines are gauge-invariant up to the one global scale the bootstrap fixed, so compare
+        // their RATIOS against ground truth.
+        let c = |r: &Reconstruction, i: usize| r.views[i].expect("registered").translation;
+        let g = |i: usize| gt[i].inverse().translation;
+        let want = (g(0) - g(2)).length() / (g(0) - g(1)).length();
+        for (name, r) in [("baseline", &baseline), ("with priors", &with_priors)] {
+            let got = (c(r, 0) - c(r, 2)).length() / (c(r, 0) - c(r, 1)).length();
+            assert!(
+                (got - want).abs() < 0.05 * want,
+                "{name}: baseline ratio {got:.4} vs ground truth {want:.4}"
+            );
+        }
+        assert!(
+            with_priors.reproj_rmse_px < 1.0,
+            "priors drove the fit away from the pixels: rmse {:.3} px",
+            with_priors.reproj_rmse_px
         );
     }
 }

--- a/crates/kornia-calib/src/sfm.rs
+++ b/crates/kornia-calib/src/sfm.rs
@@ -571,6 +571,21 @@ pub fn reconstruct(
         camera_correction,
     })
 }
+/// The reference reprojection sigma every prior family is deflated by, in NORMALISED units.
+///
+/// Bundle adjustment here runs against `PinholeCamera::IDENTITY`, so its reprojection residuals are
+/// in normalised-camera units while the prior sigmas the caller supplies are quoted in physical
+/// ones (metres, unit-vector components). Dividing each prior sigma by this value puts every family
+/// on one numeric scale, which is what lets a single Huber knee gate them coherently.
+///
+/// `max_reprojection_error / 2` because that threshold reads as 2σ. Derived in ONE place because
+/// four call sites must agree exactly: the depth measurement's sigma, the up prior's, the motion
+/// prior's, and the robust knee that gates all three. If they drift, the knee stops matching the
+/// residuals it is meant to gate and the priors are silently mis-weighted rather than wrong in any
+/// way a test would show.
+fn reproj_sigma(config: &CalibConfig) -> f64 {
+    (config.max_reprojection_error / 2.0).max(1e-6)
+}
 
 /// Depth measurement + already-deflated sigma for observation `j` of track `ti`, or `(None, 0.0)`
 /// when there is no usable depth there.
@@ -592,7 +607,7 @@ fn depth_fields(
     let rel_sigma = config.depth_prior_rel_sigma;
     match norm_depth.get(ti).and_then(|t| t.get(j)).copied().flatten() {
         Some(d) if rel_sigma > 0.0 && d > 0.0 => {
-            let sigma_r = (config.max_reprojection_error / 2.0).max(1e-6) as f32;
+            let sigma_r = reproj_sigma(config) as f32;
             (Some(d), (rel_sigma as f32) * d / sigma_r)
         }
         _ => (None, 0.0),
@@ -687,7 +702,7 @@ fn fit_depth_scales(
 /// believed.
 ///
 /// World up is a GAUGE choice and has to agree with the anchor camera `a0`, whose pose is held
-/// fixed: `up_world = R_a0ᵀ · up_cam`. Any other choice fights the one pose the solve cannot move.
+/// fixed: `up_world = R_a0ᵀ · (0,−1,0)`. Any other choice fights the one pose the solve cannot move.
 fn up_priors(
     poses: &[Option<Pose3d>],
     a0: usize,
@@ -709,19 +724,16 @@ fn up_priors(
     // while this sigma is quoted in unit-vector units. Passing it raw made the prior `1/σ_r` times
     // stiffer than every other term in the same solve — 360× at fx 1440 with an 8 px threshold,
     // where 1° of pitch deviation cost what a 489 px reprojection error would.
-    let sigma_r = (config.max_reprojection_error / 2.0).max(1e-6);
+    let sigma_r = reproj_sigma(config);
     Some(
         poses
             .iter()
             .map(|p| {
-                p.as_ref().map(|_| BaPosePrior {
-                    // No positional anchor: a huge sigma makes the centre residual contribute
-                    // nothing, leaving a purely rotational prior.
-                    center_world: [0.0; 3],
-                    sigma: 1e6,
-                    up_world: Some(up_world),
-                    up_cam: [UP_CAM[0] as f32, UP_CAM[1] as f32, UP_CAM[2] as f32],
-                    up_sigma: (config.up_prior_sigma / sigma_r) as f32,
+                p.as_ref().map(|_| {
+                    BaPosePrior::orientation_only(
+                        up_world,
+                        (config.up_prior_sigma / sigma_r) as f32,
+                    )
                 })
             })
             .collect(),
@@ -741,7 +753,7 @@ fn motion_priors_for(poses: &[Option<Pose3d>], config: &CalibConfig) -> Option<V
     if config.motion_prior_sigma <= 0.0 {
         return None;
     }
-    let sigma_r = (config.max_reprojection_error / 2.0).max(1e-6);
+    let sigma_r = reproj_sigma(config);
     let sp = (config.motion_prior_sigma / sigma_r) as f32;
     let so = (0.5 * config.motion_prior_sigma / sigma_r) as f32;
     let reg: Vec<usize> = poses
@@ -828,12 +840,18 @@ fn global_ba(
             max_iterations: config.max_iterations,
             robust: RobustKernelKind::Huber,
             robust_scale_sq: config.robust_scale_sq,
-            // Depth residuals live in reprojection-like units (see `depth_fields`), so their Huber
-            // knee is 1.345 × the reprojection noise scale, squared. Left at the default `0.0` —
-            // meaning "reuse the reprojection knee" — when depth is off.
-            depth_robust_scale_sq: if config.depth_prior_rel_sigma > 0.0 {
-                let sr = (config.max_reprojection_error / 2.0).max(1e-6) as f32;
-                (1.345 * sr) * (1.345 * sr)
+            // Depth AND motion residuals are both deflated by `reproj_sigma` (see `depth_fields`
+            // and `motion_priors_for`), so their Huber knee is 1.345 × that scale, squared.
+            //
+            // Gated on EITHER family being armed, not just depth: `ba_schur` uses this one knee for
+            // both, so a config with motion priors but no depth would fall back to the reprojection
+            // knee and gate motion residuals at ~2σ instead of 1.345σ — tighter than intended, and
+            // silent.
+            depth_robust_scale_sq: if config.depth_prior_rel_sigma > 0.0
+                || config.motion_prior_sigma > 0.0
+            {
+                let sr = (1.345 * reproj_sigma(config)) as f32;
+                sr * sr
             } else {
                 0.0
             },

--- a/crates/kornia-calib/src/sfm.rs
+++ b/crates/kornia-calib/src/sfm.rs
@@ -78,25 +78,16 @@ fn norm_residual(pose: &Pose3d, p_world: Vec3F64, n: Vec2F64) -> Option<f64> {
 ///   the reconstruction needs enough shared tracks between views to register them.
 /// * `config` - solver settings; see [`CalibConfig`].
 /// * `obs_depth` - optional metric depth per observation, shaped exactly like `tracks`:
-///   `obs_depth[i][j]` is the depth of `tracks[i].obs[j]`, `None` where none is available. Pass
-///   `None` for the classic depth-free solve. Ignored unless
-///   [`CalibConfig::depth_prior_rel_sigma`] is positive.
+///   `obs_depth[i][j]` is the depth of `tracks[i].obs[j]`. `None` for the classic depth-free solve;
+///   ignored unless [`CalibConfig::depth_prior_rel_sigma`] is positive.
 ///
 /// # Depth
 ///
-/// Monocular reprojection is exactly scale-invariant, so the gauge has one free DoF that the
-/// optimiser navigates by numerical accident. That is the root of two failures a fiducial-free
-/// walkthrough cannot otherwise escape:
-///
-/// 1. **No metric scale.** Depth residuals observe absolute scale directly, so the reconstruction
-///    lands in metres with no tag in the scene.
-/// 2. **Scale drift.** Along a no-revisit walk the reconstruction's scale wanders — the measured
-///    symptom is rooms late in a clip reconstructing several times larger than early ones. A
-///    per-observation depth prior pins EVERY segment of the chain, not just a global average.
-///
-/// Depths are a soft prior, not a constraint: they are robustified, sigma-weighted by
-/// [`CalibConfig::depth_prior_rel_sigma`], and (by default) re-gauged per view — see
-/// [`CalibConfig::depth_per_keyframe_scale`].
+/// Monocular reprojection is exactly scale-invariant, so a fiducial-free walkthrough has no metric
+/// scale and no defence against drift along the chain — measured, rooms late in a clip reconstruct
+/// several times larger than early ones. Depth residuals observe absolute scale directly and pin
+/// EVERY segment, not just a global average. They are a soft prior: robustified, sigma-weighted by
+/// [`CalibConfig::depth_prior_rel_sigma`], re-gauged per [`CalibConfig::depth_per_keyframe_scale`].
 ///
 /// # Returns
 ///
@@ -170,8 +161,7 @@ pub fn reconstruct(
         })
         .collect();
     // Parallel to `norm`: metric depth per observation, or `None`. All-`None` when the feature is
-    // off, so every downstream site indexes it unconditionally instead of branching on whether
-    // depth exists. A caller whose depth array is the wrong shape simply gets `None` per lookup.
+    // off, so downstream sites index it unconditionally; a wrong-shaped caller array yields `None`.
     let norm_depth: Vec<Vec<Option<f32>>> = match obs_depth {
         Some(d) if config.depth_prior_rel_sigma > 0.0 => d
             .iter()
@@ -324,34 +314,26 @@ pub fn reconstruct(
             None,
             PnPMethod::EPnPDefault,
             &PnpRansacParams {
-                // Normalized units, tied to the same threshold the rest of the pipeline calls an
-                // outlier bound. Defaults to 0.01, the value this was hardcoded to.
+                // Normalized units: the pipeline's own outlier bound, defaulting to the 0.01 this
+                // was hardcoded to.
                 reproj_threshold_px: config.max_reprojection_error as f32,
-                // Seed the sampler. `RansacParams::default()` leaves `random_seed: None`, which
-                // draws from the thread RNG, so registration was NONDETERMINISTIC: identical
-                // inputs produced different reconstructions run to run (measured on 40 keyframes
-                // of EuRoC MH01 — 12 / 30 / 39 cameras registered over three runs of the same
-                // command). Because a transient PnP failure marks a camera unregisterable, that
-                // randomness changes the final map, not merely its timing. The seed varies per
-                // camera so different views still draw different sample sequences.
+                // Seed the sampler; `RansacParams::default()` leaves `random_seed: None`, which
+                // made registration NONDETERMINISTIC — 12 / 30 / 39 cameras over three runs of the
+                // same command on EuRoC MH01. A transient PnP failure marks a camera
+                // unregisterable, so that randomness changes the map, not merely its timing.
                 random_seed: Some(0x00C0_FFEE ^ c as u64),
                 ..Default::default()
             },
         );
-        // Accepting a registration is not the same as PnP returning `Ok`. `solve_pnp_ransac`
-        // succeeds whenever it finds *a* consensus, however small, so an unguarded `Ok` arm admits
-        // cameras whose pose is fitted to a handful of correspondences. That is not a
-        // self-correcting mistake: `triangulate_new` immediately creates 3D points FROM the bad
-        // pose, and those points feed the next camera's PnP, so one bad registration propagates.
-        // Measured on EuRoC MH01 the symptom was global RMSE rising WITH the registered count —
-        // 34 cameras at 10.4 px, 38 at 23.2 px — the opposite of a healthy incremental SfM.
+        // PnP returning `Ok` is not acceptance: `solve_pnp_ransac` succeeds on *any* consensus, and
+        // `triangulate_new` builds points FROM the pose which feed the next camera's PnP. Measured
+        // on EuRoC MH01, global RMSE rose WITH the registered count: 34 cams 10.4 px, 38 at 23.2.
         let accepted = pnp.as_ref().ok().and_then(|r| {
             let pose = pose_from_pnp(r.pose.rotation, r.pose.translation);
-            // Score BOTH the returned (refit) pose and the RANSAC consensus, and keep the larger.
-            // `inliers` is classified against the PRE-refit minimal-sample model, and the refit can
-            // move either way, so trusting one alone under-counts: a solid 107-inlier consensus has
-            // been observed reclassifying to under 30 against its own refit, silently losing a good
-            // view. Both counts use the same threshold, so they are directly comparable.
+            // Score BOTH the refit pose and the RANSAC consensus, keep the larger: `inliers` is
+            // classified against the PRE-refit minimal-sample model, so it under-counts — a
+            // 107-inlier consensus has been seen reclassifying to under 30 against its own refit.
+            // Same threshold for both.
             let n_refit = wp
                 .iter()
                 .zip(ip.iter())
@@ -370,25 +352,16 @@ pub fn reconstruct(
                 }
                 let before = point3d.len();
                 triangulate_new(&mut point3d, &norm, &poses, &idcam, &tcfg);
-                // A camera that could not register earlier may register comfortably NOW: each
-                // success triangulates new points, so the 2D-3D evidence available to the remaining
-                // views grows. Without this, `min_registration_inliers` would turn every transient
-                // rejection into a permanent one and strictly REDUCE the registered count versus
-                // having no gate at all — the gate is only safe in the presence of the retry.
-                //
-                // Gated on the cloud ACTUALLY growing, so a registration that added no evidence
-                // does not buy a re-run of every rejected camera against an unchanged map.
-                //
-                // This terminates: the set is cleared only when the cloud grows, the cloud is
-                // bounded by the track count, and between clears each iteration either registers a
-                // camera (at most `n_cams` times) or removes one from consideration.
+                // A camera that failed earlier may register comfortably once the cloud has grown;
+                // without this retry `min_registration_inliers` would make every transient
+                // rejection permanent and strictly REDUCE the registered count versus no gate at
+                // all. Gating on the cloud ACTUALLY growing also makes it terminate: between clears
+                // each iteration either registers a camera or drops one from consideration.
                 if point3d.len() > before {
                     pnp_failed.clear();
                 }
             }
-            // PnP failed outright, or its consensus was too thin to trust. Either way this camera
-            // cannot register against the CURRENT map; try the others and revisit it after the
-            // cloud has grown.
+            // Failed outright, or its consensus was too thin: retry once the cloud has grown.
             None => {
                 pnp_failed.insert(c);
             }
@@ -406,8 +379,8 @@ pub fn reconstruct(
     let mut track_ids: Vec<usize> = point3d.keys().copied().collect();
     track_ids.sort_unstable();
 
-    // `pt_index[ti]` is just `ti`'s position in `track_ids`, so it is stable across BA rounds and
-    // the published `points` order matches the BA input order in every one of them.
+    // `pt_index[ti]` is `ti`'s position in `track_ids`: stable across BA rounds, so the published
+    // `points` order matches the BA input order in every one of them.
     let pt_index: HashMap<usize, usize> =
         track_ids.iter().enumerate().map(|(i, t)| (*t, i)).collect();
     let point_track_id: Vec<usize> = track_ids.clone();
@@ -438,12 +411,9 @@ pub fn reconstruct(
         config,
     )?;
 
-    // --- Alternating intrinsics refinement (COLMAP refines focal/distortion INSIDE its BA; this is
-    // the alternating equivalent, which needs no solver surgery). The solver sees NORMALIZED
-    // coordinates, so a focal error is a single global scale `gamma` on them and lens distortion a
-    // radial/tangential polynomial. Against the current map that model is LINEAR in the stacked
-    // unknowns, so one closed-form least squares per round corrects the camera; the second bundle
-    // adjustment below then re-settles the geometry against it.
+    // --- Alternating intrinsics refinement (COLMAP does it INSIDE its BA; this equivalent needs no
+    // solver surgery). The solver sees NORMALIZED coordinates, so a focal error is one global scale
+    // `gamma` and distortion a radial/tangential polynomial — linear in the stacked unknowns.
     let camera_correction = if config.refine_intrinsics {
         let fit = fit_camera_correction(&res, &pt_index, &norm, &poses);
         if let Some((gamma, k1, k2, p1, p2)) = fit {
@@ -456,10 +426,8 @@ pub fn reconstruct(
                     n.y = gamma * (y * radial + p1 * (r2 + 2.0 * y * y) + 2.0 * p2 * x * y);
                 }
             }
-            // Feed the first solve's state back in, then RE-SOLVE against the corrected
-            // observations. Without this second pass the refinement would be computed, reported,
-            // and never reflected in the poses this function returns — the observations it rewrote
-            // would go unread, since nothing downstream of here solves anything.
+            // Feed the first solve's state back in and RE-SOLVE against the corrected observations:
+            // without this the refinement would be reported but never reach the returned poses.
             for (c, p) in poses.iter_mut().enumerate() {
                 if p.is_some() {
                     *p = Some(res.poses[c]);
@@ -508,13 +476,8 @@ pub fn reconstruct(
     );
     let scale = anchored.unwrap_or(1.0);
 
-    // Pixels-per-normalized-unit correction for the reported RMS.
-    //
-    // `refine_intrinsics` rewrites `norm` IN PLACE into the true camera's normalized frame, where
-    // fx_true = fx_assumed / gamma. Every RMS below converts residuals to pixels with the ASSUMED
-    // fx from `cameras`, so without this the reported number is gamma times too large — and this
-    // is the number the callers quote as their acceptance metric, so a silent few-percent bias in
-    // it is worse than a loud one.
+    // Pixels-per-normalized-unit correction: `refine_intrinsics` rewrote `norm` into the true
+    // camera's frame (fx_true = fx_assumed / gamma) but the RMS below uses the ASSUMED fx.
     let focal_scale = camera_correction.map_or(1.0, |(gamma, ..)| 1.0 / gamma.max(1e-9));
 
     // Per-camera reprojection RMS (pixels); analytical covariance is tag-oriented so stays `None`.
@@ -584,31 +547,20 @@ pub fn reconstruct(
 }
 /// The reference reprojection sigma every prior family is deflated by, in NORMALISED units.
 ///
-/// Bundle adjustment here runs against `PinholeCamera::IDENTITY`, so its reprojection residuals are
-/// in normalised-camera units while the prior sigmas the caller supplies are quoted in physical
-/// ones (metres, unit-vector components). Dividing each prior sigma by this value puts every family
-/// on one numeric scale, which is what lets a single Huber knee gate them coherently.
-///
-/// `max_reprojection_error / 2` because that threshold reads as 2σ. Derived in ONE place because
-/// four call sites must agree exactly: the depth measurement's sigma, the up prior's, the motion
-/// prior's, and the robust knee that gates all three. If they drift, the knee stops matching the
-/// residuals it is meant to gate and the priors are silently mis-weighted rather than wrong in any
-/// way a test would show.
+/// Bundle adjustment here runs against `PinholeCamera::IDENTITY`, so its residuals are in
+/// normalised units while caller prior sigmas are physical; dividing by this puts every family on
+/// one scale, which is what lets a single Huber knee gate them. `max_reprojection_error / 2`
+/// because that threshold reads as 2σ. Derived ONCE because four call sites must agree exactly —
+/// depth, up, motion, and the knee gating all three — and drift mis-weights them silently.
 fn reproj_sigma(config: &CalibConfig) -> f64 {
     (config.max_reprojection_error / 2.0).max(1e-6)
 }
 
-/// Depth measurement + already-deflated sigma for observation `j` of track `ti`, or `(None, 0.0)`
-/// when there is no usable depth there.
+/// Depth measurement + already-deflated sigma for observation `j` of track `ti`, or `(None, 0.0)`.
 ///
-/// The returned sigma is DEFLATED into reprojection units, not the raw metric sigma. The solver's
-/// reprojection residuals are unwhitened normalized-camera values (implicit σ = 1 normalized unit —
-/// an entire focal length!), while its depth residuals divide by their sigma. Passing the honest
-/// metric sigma therefore makes each depth row carry orders of magnitude more cost than a
-/// reprojection row, and the solve goes depth-dominated no matter how loose the relative sigma
-/// looks — measured: `rel_sigma` 5.0 (≈ no confidence at all) still halved registration.
-/// Multiplying by `1/σ_r` — where `σ_r` is the reprojection noise scale in normalized units, the
-/// threshold read as 2σ — puts both families in the same implicit unit.
+/// DEFLATED by [`reproj_sigma`], not the raw metric sigma: reprojection residuals are unwhitened
+/// normalized values (implicit σ = a whole focal length!) while depth residuals divide by theirs,
+/// so the metric sigma goes depth-dominated — measured, `rel_sigma` 5.0 still halved registration.
 fn depth_fields(
     norm_depth: &[Vec<Option<f32>>],
     ti: usize,
@@ -629,25 +581,12 @@ fn depth_fields(
 /// observations, re-gauged against the median view and clamped. `1.0` where a view lacks enough
 /// pairs to fit.
 ///
-/// # Why per view rather than one global scale
-///
-/// Learned depth is not gauge-stable frame to frame. On forward motion a per-frame scale error is
-/// indistinguishable from along-axis translation, so a single global scale hands every wander of
-/// the network straight to the trajectory: the residual is real, the solver dutifully moves the
-/// camera, every frame. That is a drift generator.
-///
-/// # Scale only, not the affine `s·d + t`
-///
-/// A free intercept absorbs bas-relief compression instead of correcting it — measured: sparse
-/// depth spanned a ratio of 1.13 across a view where the network saw 2.13, and an affine fit
-/// reproduced that flattening faithfully. It also makes the map's ABSOLUTE scale unobservable from
-/// depth, which defeats the point of supplying depth at all.
-///
-/// # Gauge
-///
-/// The scales are normalised by their own median, so this re-gauges views RELATIVE to each other
-/// without moving the map as a whole. Without that, the reconstruction would be free to breathe
-/// every time bundle adjustment ran.
+/// Per view rather than one global scale because learned depth is not gauge-stable frame to frame:
+/// on forward motion a per-frame scale error is indistinguishable from along-axis translation, so a
+/// global scale hands every wander of the network to the trajectory. Scale only, NOT the affine
+/// `s·d + t`: a free intercept absorbs bas-relief compression instead of correcting it (measured —
+/// sparse depth spanned 1.13 across a view where the network saw 2.13) and makes ABSOLUTE scale
+/// unobservable from depth. Normalising by the median re-gauges views without moving the map.
 fn fit_depth_scales(
     poses: &[Option<Pose3d>],
     point3d: &HashMap<usize, Vec3F64>,
@@ -656,18 +595,15 @@ fn fit_depth_scales(
     norm_depth: &[Vec<Option<f32>>],
     n_cams: usize,
 ) -> Vec<f64> {
-    /// Below this many depth pairs a median is noise, and a wrong per-view gauge is worse than the
-    /// global one it replaces.
+    /// Below this many pairs a median is noise, and a wrong gauge is worse than the global one.
     const MIN_PAIRS: usize = 12;
 
     let mut per_cam: Vec<Vec<f64>> = vec![Vec::new(); n_cams];
     for ti in track_ids {
         let Some(p) = point3d.get(ti) else { continue };
         for (j, (c, _)) in norm[*ti].iter().enumerate() {
-            // `.get(ti)`, not `[ti]`: the contract on `obs_depth` is that a wrong-shaped array
-            // simply yields `None` per lookup, and `depth_fields` already honours that. Indexing
-            // here made a caller who supplied depth for only the first N tracks panic instead —
-            // the one shape of malformed input the documentation explicitly invites.
+            // `.get(ti)`, not `[ti]`: a wrong-shaped `obs_depth` must yield `None` per lookup, not
+            // panic — indexing here panicked on depth supplied for only the first N tracks.
             let (Some(pose), Some(d)) = (
                 &poses[*c],
                 norm_depth
@@ -684,8 +620,7 @@ fn fit_depth_scales(
             }
         }
     }
-    // Median, not mean: a depth network hallucinates at occlusion boundaries and on mirrors, and
-    // those observations are a fat tail, not Gaussian noise.
+    // Median, not mean: depth networks hallucinate at occlusions and on mirrors — a fat tail.
     let median = |v: &mut Vec<f64>| -> Option<f64> {
         if v.len() < MIN_PAIRS {
             return None;
@@ -705,8 +640,7 @@ fn fit_depth_scales(
     for s in scales.iter_mut().flatten() {
         *s /= anchor;
     }
-    // A view whose scale is wildly off has a broken pose or a broken depth map, not a gauge
-    // offset; trusting its fit would let it drag the solve. Fall back to neutral.
+    // A wildly-off scale means a broken pose or depth map, not a gauge offset: fall back to neutral.
     scales
         .into_iter()
         .map(|s| match s {
@@ -718,10 +652,7 @@ fn fit_depth_scales(
 
 /// Per-view up priors, or `None` when [`CalibConfig::up_prior_sigma`] is off.
 ///
-/// The camera-frame direction asserted to be up is image-up `(0, −1, 0)` — "the camera was held
-/// roughly upright" — so `up_prior_sigma` must be chosen to match how much that is actually
-/// believed.
-///
+/// The camera-frame direction asserted to be up is image-up `(0, −1, 0)` — "held roughly upright".
 /// World up is a GAUGE choice and has to agree with the anchor camera `a0`, whose pose is held
 /// fixed: `up_world = R_a0ᵀ · (0,−1,0)`. Any other choice fights the one pose the solve cannot move.
 fn up_priors(
@@ -740,11 +671,8 @@ fn up_priors(
         }
         None => [0.0, -1.0, 0.0],
     };
-    // Deflated into reprojection units for the same reason as `depth_fields`: bundle adjustment
-    // runs against `PinholeCamera::IDENTITY`, so its reprojection residuals are in NORMALISED units
-    // while this sigma is quoted in unit-vector units. Passing it raw made the prior `1/σ_r` times
-    // stiffer than every other term in the same solve — 360× at fx 1440 with an 8 px threshold,
-    // where 1° of pitch deviation cost what a 489 px reprojection error would.
+    // Deflated into reprojection units, as in `depth_fields`. Raw, the prior was `1/σ_r` times
+    // stiffer than every other term in the solve — 360× at fx 1440 with an 8 px threshold.
     let sigma_r = reproj_sigma(config);
     Some(
         poses
@@ -763,10 +691,9 @@ fn up_priors(
 
 /// Constant-velocity motion priors over consecutive REGISTERED triplets, or `None` when off.
 ///
-/// Consecutive in VIEW-INDEX order (video keyframes are time-ordered), `alpha` from the index
-/// spacing, and triplets spanning more than [`MAX_TRIPLET_SPAN`] indices skipped — a bridge across
-/// a long unregistered stretch is not a constant-velocity hypothesis worth asserting. Sigmas are
-/// deflated into reprojection units exactly like the depth and up priors.
+/// Consecutive in VIEW-INDEX order (video keyframes are time-ordered), with triplets spanning more
+/// than [`MAX_TRIPLET_SPAN`] indices skipped: a bridge across a long unregistered stretch is not a
+/// constant-velocity hypothesis worth asserting. Sigmas are deflated like the other priors.
 fn motion_priors_for(poses: &[Option<Pose3d>], config: &CalibConfig) -> Option<Vec<BaMotionPrior>> {
     /// Widest index gap a triplet may span before it stops being a plausible motion hypothesis.
     const MAX_TRIPLET_SPAN: usize = 12;
@@ -798,10 +725,8 @@ fn motion_priors_for(poses: &[Option<Pose3d>], config: &CalibConfig) -> Option<V
 }
 
 /// One global bundle adjustment over every triangulated point and every registered view, with the
-/// anchor camera `a0` fixed to hold the gauge.
-///
-/// Callable more than once on the same problem, which is what `refine_intrinsics` needs: it
-/// rewrites `norm` in place and the geometry then has to re-settle against the corrected camera.
+/// anchor camera `a0` fixed to hold the gauge. Callable more than once on the same problem, which
+/// is what `refine_intrinsics` needs after it rewrites `norm` in place.
 #[allow(clippy::too_many_arguments)]
 fn global_ba(
     poses: &[Option<Pose3d>],
@@ -823,9 +748,7 @@ fn global_ba(
     let mut points: Vec<Vec3F64> = Vec::with_capacity(track_ids.len());
     let mut obs: Vec<BaObservation> = Vec::new();
     for (pidx, ti) in track_ids.iter().enumerate() {
-        // `track_ids` is derived from `point3d`'s keys and points are only ever updated in place,
-        // so every id resolves. Failing loudly rather than skipping matters: a skip would shift
-        // every later `pidx` off its point and silently solve a scrambled problem.
+        // Fail loudly rather than skip: a skip shifts every later `pidx` off its point.
         let p = point3d.get(ti).ok_or_else(|| {
             CalibError::BundleAdjust(format!("track {ti} has no triangulated point"))
         })?;
@@ -841,8 +764,7 @@ fn global_ba(
                 pixel: [nrm.x as f32, nrm.y as f32],
                 fixed_pose: *c == a0, // reference camera fixed → gauge anchor
                 fixed_point: false,
-                // This view's own gauge baked into the measurement, so the residual measures the
-                // shape the network got right rather than the scale it got wrong.
+                // This view's own gauge baked in: the residual measures shape, not scale.
                 depth_meas: depth_meas.map(|d| d * depth_scale[*c] as f32),
                 depth_sigma,
             });
@@ -861,13 +783,9 @@ fn global_ba(
             max_iterations: config.max_iterations,
             robust: RobustKernelKind::Huber,
             robust_scale_sq: config.robust_scale_sq,
-            // Depth AND motion residuals are both deflated by `reproj_sigma` (see `depth_fields`
-            // and `motion_priors_for`), so their Huber knee is 1.345 × that scale, squared.
-            //
-            // Gated on EITHER family being armed, not just depth: `ba_schur` uses this one knee for
-            // both, so a config with motion priors but no depth would fall back to the reprojection
-            // knee and gate motion residuals at ~2σ instead of 1.345σ — tighter than intended, and
-            // silent.
+            // Depth AND motion residuals are deflated by `reproj_sigma`, so their Huber knee is
+            // 1.345 × that scale, squared. Gated on EITHER family: `ba_schur` uses one knee for
+            // both, so motion priors without depth would silently gate at ~2σ instead of 1.345σ.
             depth_robust_scale_sq: if config.depth_prior_rel_sigma > 0.0
                 || config.motion_prior_sigma > 0.0
             {
@@ -885,18 +803,16 @@ fn global_ba(
 }
 
 /// Closed-form OpenCV-model intrinsics correction `(gamma, k1, k2, p1, p2)` fitted against the
-/// current reconstruction, or `None` when the fit is singular or outside its sanity bounds.
-///
-/// Linear in the stacked unknowns `beta = (gamma, gamma·k1, gamma·k2, gamma·p1, gamma·p2)`:
+/// current reconstruction, or `None` when singular or outside its sanity bounds. Linear in the
+/// stacked unknowns `beta = (gamma, gamma·k1, gamma·k2, gamma·p1, gamma·p2)`:
 ///
 /// ```text
 ///   u_x = b0·x + b1·x·r² + b2·x·r⁴ + b3·(2xy)     + b4·(r²+2x²)
 ///   u_y = b0·y + b1·y·r² + b2·y·r⁴ + b3·(r²+2y²)  + b4·(2xy)
 /// ```
 ///
-/// so the whole set costs one least squares. The tangential terms are what a focal-only fit can
-/// never see: a decentred lens bends verticals asymmetrically, and forcing that into `k1` leaves a
-/// residue that looks like scene curvature.
+/// so it costs one least squares. The tangential terms are what a focal-only fit can never see;
+/// forcing a decentred lens into `k1` leaves a residue that looks like scene curvature.
 fn fit_camera_correction(
     res: &BaResult,
     pt_index: &HashMap<usize, usize>,
@@ -905,11 +821,8 @@ fn fit_camera_correction(
 ) -> Option<(f64, f64, f64, f64, f64)> {
     let mut ata = [[0.0f64; 5]; 5];
     let mut atb = [0.0f64; 5];
-    // DETERMINISM. These are floating-point normal equations, and float addition is not
-    // associative, so the ORDER of accumulation changes the solved correction. `pt_index` is a
-    // `HashMap` and Rust randomises hash iteration per process, so summing in iteration order
-    // yields a different `(gamma, k1, k2, p1, p2)` — hence different intrinsics, hence a different
-    // reconstruction — from bit-identical input.
+    // DETERMINISM: float addition is not associative, so accumulation ORDER changes the fitted
+    // correction, and Rust randomises `HashMap` iteration per process. Sort, or the map varies.
     let mut ordered: Vec<(&usize, &usize)> = pt_index.iter().collect();
     ordered.sort_unstable_by_key(|(ti, _)| **ti);
     for (ti, pidx) in ordered {
@@ -942,9 +855,8 @@ fn fit_camera_correction(
             }
         }
     }
-    // Try the full 5-parameter fit first; when it is singular or out of bounds fall back to the
-    // (gamma, k1) subproblem rather than applying a fit the geometry cannot support — thin tracks
-    // make the r⁴ and tangential columns nearly collinear on a narrow-FOV rig.
+    // Full 5-parameter fit first, falling back to the (gamma, k1) subproblem: thin tracks make the
+    // r⁴ and tangential columns nearly collinear on a narrow-FOV rig.
     let full = solve_sym5(&ata, &atb).and_then(|b| {
         let gamma = b[0];
         if gamma.abs() < 1e-9 {
@@ -973,9 +885,8 @@ fn fit_camera_correction(
     })
 }
 
-/// Solve the symmetric positive-semidefinite `5×5` system `A x = b` by Gaussian elimination with
-/// partial pivoting. `None` when a pivot collapses — for the intrinsics fit that means the
-/// distortion columns are collinear and the caller falls back to the two-parameter model.
+/// Solve the symmetric PSD `5×5` system `A x = b` by Gaussian elimination with partial pivoting.
+/// `None` when a pivot collapses — collinear distortion columns, so the caller falls back to two.
 fn solve_sym5(a: &[[f64; 5]; 5], b: &[f64; 5]) -> Option<[f64; 5]> {
     let mut m = [[0.0f64; 6]; 5];
     for i in 0..5 {
@@ -1158,10 +1069,7 @@ fn feature_stats(
             continue;
         };
         if let Some(r) = norm_residual(&pose, points[pidx], *n) {
-            // `focal_scale` carries the intrinsics refinement: it rewrote `norm` into the TRUE
-            // camera's normalized frame, where fx_true = fx_assumed / gamma, so converting with
-            // the ASSUMED fx would report every residual gamma times too large. 1.0 when
-            // `refine_intrinsics` is off.
+            // `focal_scale` converts into the CORRECTED camera's pixels; 1.0 when refinement is off.
             se += (r * cam.fx * focal_scale).powi(2); // r Euclidean in normalized units; fx≈fy
             num += 1;
         }
@@ -1727,10 +1635,8 @@ mod tests {
         );
     }
 
-    /// Three converging views of a textured cloud, at a SPECIFIED metric scale.
-    ///
-    /// The shape is scale-free, so `scale` changes nothing about how well the geometry
-    /// reconstructs — only where the true metric sits relative to the bootstrap's unit baseline.
+    /// Three converging views of a textured cloud at a SPECIFIED metric scale (the shape is
+    /// scale-free, so `scale` only moves the metric relative to the bootstrap's unit baseline).
     /// Returns `(cameras, world→cam ground truth, tracks)`.
     fn converging_rig(f: f64, scale: f64) -> (Vec<PinholeCamera>, Vec<Pose3d>, Vec<FeatureTrack>) {
         let cams = vec![pinhole(f), pinhole(f), pinhole(f)];
@@ -1771,8 +1677,7 @@ mod tests {
         tracks: &[FeatureTrack],
         cams: &[PinholeCamera],
     ) -> Vec<Vec<Option<f64>>> {
-        // Recover each track's world point by intersecting its first two rays under the GT poses,
-        // which for noise-free synthetic data is exact; then take its z in each observing view.
+        // Intersect each track's first two rays under the GT poses — exact for noise-free data.
         tracks
             .iter()
             .map(|t| {
@@ -1828,20 +1733,13 @@ mod tests {
 
     /// **Depth measurements fix the scale of an otherwise scale-free reconstruction.**
     ///
-    /// This is the whole point of the `obs_depth` argument. A feature-only monocular solve is
-    /// determined only up to a similarity: the bootstrap fixes the gauge by giving its seed pair a
-    /// UNIT baseline, so the map's absolute size is an artifact of that convention and has nothing
-    /// to do with the scene. Here the true seed baseline is deliberately far from 1, so the
-    /// depth-free control lands several times too large — and the depth priors have to pull it back.
-    ///
-    /// The control is not decoration. Every assertion below would also pass on a build where the
-    /// depth arguments were accepted and silently ignored, if the scene happened to be near unit
-    /// scale; asserting that the SAME scene reconstructs at the wrong scale without depth is what
-    /// makes this a test of the depth term rather than of the geometry.
+    /// The bootstrap fixes the gauge with a UNIT seed baseline; here the true seed baseline is
+    /// deliberately far from 1, so the depth-free control lands several times too large. That
+    /// control is load-bearing: without it the assertions would pass on a build that ignored depth.
     #[test]
     fn depth_priors_fix_the_scale_of_an_otherwise_scale_free_reconstruction() {
-        // Scale 0.4: the widest camera-centre baseline is ~0.5 m, so the unit-baseline convention
-        // inflates the depth-free map by roughly 2x.
+        // Scale 0.4: widest camera-centre baseline ~0.5 m, so the unit-baseline convention
+        // inflates the depth-free map ~2x.
         let (cams, gt, tracks) = converging_rig(500.0, 0.4);
         let depths = gt_depths(&gt, &tracks, &cams);
 
@@ -1854,8 +1752,7 @@ mod tests {
              got ratio {free_ratio:.4}"
         );
 
-        // With depth. `depth_prior_rel_sigma` is what ARMS the feature: at 0.0 the depths are
-        // ignored no matter what is passed.
+        // With depth. `depth_prior_rel_sigma` is what ARMS the feature.
         let cfg = CalibConfig {
             depth_prior_rel_sigma: 0.15,
             ..CalibConfig::new(0.0)
@@ -1868,8 +1765,7 @@ mod tests {
              (depth-free control {free_ratio:.4})"
         );
 
-        // Metric SCALE, not merely metric depths: the camera centres must now sit at their true
-        // separations, which is the quantity a downstream consumer actually uses.
+        // Metric SCALE, not merely metric depths: camera centres must sit at their true separations.
         let centre = |p: &Option<Pose3d>| p.expect("registered").translation;
         let gt_centre = |p: &Pose3d| p.inverse().translation;
         for (i, j) in [(0, 1), (0, 2), (1, 2)] {
@@ -1881,16 +1777,12 @@ mod tests {
             );
         }
 
-        // And the map is still HONEST about where that scale came from: no tag anchored it, so the
-        // reported `ScaleSource` stays `UpToScale` even though the numbers are now metric. Depth is
-        // a soft prior, not a fiducial, and `ScaleSource` names fiducials.
+        // Still HONEST about the source: depth is a soft prior, and `ScaleSource` names fiducials.
         assert_eq!(metric.scale, ScaleSource::UpToScale);
     }
 
-    /// Passing depths while `depth_prior_rel_sigma` is 0 must change NOTHING.
-    ///
-    /// The knob, not the argument, arms the feature -- so a caller that wires depth through before
-    /// deciding to trust it gets exactly the solve it had. Bit-identical, not merely close.
+    /// Passing depths while `depth_prior_rel_sigma` is 0 must change NOTHING: the knob, not the
+    /// argument, arms the feature. Bit-identical, not merely close.
     #[test]
     fn depths_are_inert_until_the_sigma_arms_them() {
         let (cams, gt, tracks) = converging_rig(500.0, 0.4);
@@ -1906,13 +1798,9 @@ mod tests {
         }
     }
 
-    /// `min_registration_inliers` decides whether a thinly-supported view is admitted.
-    ///
-    /// Views 0 and 1 share 80 tracks and bootstrap the map; view 2 sees only 20 of them, so its
-    /// PnP consensus cannot exceed 20 however good the pose is. The default gate of 30 must refuse
-    /// it; lowering the gate must admit it. Without the gate there is nothing between a 4-point
-    /// consensus and a registration, and a bad registration is not self-correcting -- points get
-    /// triangulated FROM it and then feed the next view's PnP.
+    /// `min_registration_inliers` decides whether a thinly-supported view is admitted. Views 0 and
+    /// 1 share 80 tracks and bootstrap the map; view 2 sees only 20 of them, so its PnP consensus
+    /// cannot exceed 20. The default gate of 30 must refuse it; lowering the gate must admit it.
     #[test]
     fn min_registration_inliers_gates_a_thinly_supported_view() {
         let cams = vec![pinhole(600.0), pinhole(600.0), pinhole(600.0)];
@@ -1970,38 +1858,21 @@ mod tests {
 
     /// `refine_intrinsics` must REPORT its fit and then ACT on it.
     ///
-    /// Two independent claims, with different failure modes:
-    ///
-    /// 1. The fit reaches the caller on [`Reconstruction::camera_correction`]. Refinement applies
+    /// 1. It reaches the caller on [`Reconstruction::camera_correction`] — refinement applies
     ///    itself by rewriting normalized observations in place, so a caller that never sees the fit
-    ///    keeps storing the camera it guessed — one that did not produce these poses.
-    /// 2. The fit CHANGES THE POSES. Refinement runs after a bundle adjustment; unless a second
-    ///    solve follows it, the corrected observations are never read by anything that moves
-    ///    geometry, and the feature is an expensive no-op that still reports a number.
+    ///    keeps storing a camera that did not produce these poses.
+    /// 2. It CHANGES THE POSES: without a second solve, the corrected observations are never read.
     ///
-    /// # What this test does NOT claim, and why
-    ///
-    /// It does not claim the refinement recovers a known FOCAL error, because on a synthetic of
-    /// this size it cannot and no honest assertion would pass. The fit regresses the map's
-    /// predicted projections onto the observations, so it can only see error that bundle
-    /// adjustment failed to absorb — and a focal error is very nearly absorbable, since scaling
-    /// normalized coordinates stretches space in `x` and `y` at fixed `z`. MEASURED here: handing
-    /// the solver 320 for a true focal of 400 (a 25% error) left `plain.reproj_rmse_px = 0.636`
-    /// and `gamma = 0.9994` on a three-view converging rig, and 0.9994 again on a five-view rig
-    /// orbiting through ±52° of yaw. Bundle adjustment had swallowed all of it. The production
-    /// evidence for focal recovery is a 3208-frame handheld clip with hundreds of cameras, which
-    /// is not a unit test.
-    ///
-    /// Radial DISTORTION is a different matter: it is a nonlinear image warp, not a projective
-    /// one, so a rigid reconstruction cannot absorb it and it leaves the radially-systematic
-    /// residual this fit is shaped to see. So the scene injects barrel distortion the solver is
-    /// not told about, and the assertion is that the fit opposes it.
+    /// It deliberately does NOT claim recovery of a known FOCAL error: the fit only sees what
+    /// bundle adjustment failed to absorb, and a focal error is very nearly absorbable — MEASURED,
+    /// handing the solver 320 for a true focal of 400 left `gamma = 0.9994`. Radial DISTORTION is a
+    /// nonlinear warp a rigid reconstruction cannot absorb, so that is what the scene injects.
     #[test]
     fn refine_intrinsics_reports_its_fit_and_re_solves_against_it() {
         const K1_TRUE: f64 = 0.25;
         let (cams, _, clean) = converging_rig(500.0, 1.0);
-        // Barrel-distort every pixel. The cameras handed to the solver keep `k1 = 0`, so
-        // `normalize` leaves the distortion in the observations for the refinement to find.
+        // Barrel-distort every pixel; the solver's cameras keep `k1 = 0`, so it survives
+        // `normalize`.
         let tracks: Vec<FeatureTrack> = clean
             .iter()
             .map(|t| FeatureTrack {
@@ -2046,8 +1917,7 @@ mod tests {
             "the fit must UNDO the injected barrel distortion (k1_true = +{K1_TRUE}), so its own \
              k1 has to be negative; got {k1:.5}"
         );
-        // The focal was correct here, so the refinement must not invent a focal error while it is
-        // busy fitting distortion. `gamma` inverts into focal: fx_true = fx_assumed / gamma.
+        // The focal was correct here, so the fit must not invent one while fitting distortion.
         assert!(
             (0.95..1.05).contains(&gamma),
             "a correctly-assumed focal must survive the fit intact; gamma={gamma:.4} implies \
@@ -2055,9 +1925,7 @@ mod tests {
             500.0 / gamma
         );
 
-        // The second solve is the load-bearing half. Without it the poses would be BIT-IDENTICAL
-        // to the unrefined run, because nothing after the refinement re-optimises anything: the
-        // rewritten observations would be reported on and then dropped on the floor.
+        // The second solve is the load-bearing half: without it, poses BIT-IDENTICAL to `plain`.
         let moved = plain
             .views
             .iter()
@@ -2076,12 +1944,10 @@ mod tests {
 
     /// The up and motion priors reach the solver at a strength that does not overrule the images.
     ///
-    /// Both sigmas are quoted in their own physical units and then DEFLATED into the normalized
-    /// reprojection units bundle adjustment actually works in. Skipping that deflation is not a
-    /// subtle mis-tuning: it makes each prior row `1/sigma_r` times stiffer than every reprojection
-    /// row in the same solve (360x at a phone focal), and the solve then fits the assumption
-    /// instead of the scene. So the assertion is that turning both priors ON, at their documented
-    /// production values, leaves a good reconstruction good.
+    /// Both sigmas are physical and then DEFLATED into normalized reprojection units. Skipping that
+    /// makes each prior row `1/sigma_r` times stiffer than every reprojection row (360x at a phone
+    /// focal) and the solve fits the assumption instead of the scene. So: both priors ON at
+    /// production values must leave a good reconstruction good.
     #[test]
     fn up_and_motion_priors_do_not_overrule_the_image_evidence() {
         // Views are index-ordered along the rig, which is what makes a motion prior meaningful.
@@ -2105,8 +1971,7 @@ mod tests {
             with_priors.views.iter().all(|v| v.is_some()),
             "the priors must not cost a registration"
         );
-        // Baselines are gauge-invariant up to the one global scale the bootstrap fixed, so compare
-        // their RATIOS against ground truth.
+        // Baselines are gauge-invariant only up to the bootstrap's global scale: compare RATIOS.
         let c = |r: &Reconstruction, i: usize| r.views[i].expect("registered").translation;
         let g = |i: usize| gt[i].inverse().translation;
         let want = (g(0) - g(2)).length() / (g(0) - g(1)).length();
@@ -2124,14 +1989,10 @@ mod tests {
         );
     }
 
-    /// The reported pixel RMS must be in the corrected camera's pixels, not the assumed one's.
-    ///
-    /// `refine_intrinsics` rewrites the observations into the TRUE camera's normalized frame,
-    /// where `fx_true = fx_assumed / gamma`. Converting those residuals to pixels with the
-    /// ASSUMED `fx` — which is what `cameras` still holds — scales every reported number by
-    /// gamma. It is a small factor, which is exactly why it is worth pinning: `reproj_rmse_px` is
-    /// the number callers quote as their acceptance metric, and a silent few-percent bias in an
-    /// acceptance metric is worse than a loud one.
+    /// The reported pixel RMS must be in the corrected camera's pixels, not the assumed one's:
+    /// `refine_intrinsics` rewrites observations into the TRUE camera's frame, where
+    /// `fx_true = fx_assumed / gamma`, so converting with the assumed `fx` scales every reported
+    /// number by gamma. Worth pinning because `reproj_rmse_px` is callers' acceptance metric.
     #[test]
     fn reported_rmse_is_in_corrected_pixels() {
         const K1_TRUE: f64 = 0.25;
@@ -2174,10 +2035,8 @@ mod tests {
             "test is vacuous unless the fit actually moved gamma (got {gamma})"
         );
 
-        // Reproduce the conversion by hand from the same reported per-camera numbers, and check
-        // the global figure is consistent with them under the CORRECTED focal. If the global RMS
-        // had been left in assumed-fx pixels while the per-camera ones were corrected (or vice
-        // versa), this ratio would sit at gamma rather than 1.
+        // Global vs per-camera under the CORRECTED focal: either left in assumed-fx pixels and this
+        // ratio would sit at gamma rather than 1.
         let n: usize = refined.per_view.iter().map(|s| s.num_obs).sum();
         assert!(n > 0, "no observations to check");
         let pooled: f64 = refined

--- a/crates/kornia-calib/src/types.rs
+++ b/crates/kornia-calib/src/types.rs
@@ -64,10 +64,90 @@ pub struct CalibConfig {
     /// residual exceeds `median + x84_k·1.4826·MAD` are dropped before the final Cauchy pass. `2.5`
     /// is the standard X84 value; fixed board/tag corners (the gauge) are never dropped.
     pub x84_k: f64,
+    /// Relative standard deviation of the per-observation metric depth priors passed to
+    /// [`crate::reconstruct`], as `σ = depth_prior_rel_sigma · d`. **`0.0` (the default) disables
+    /// depth entirely**, so a caller that supplies depths but leaves this at zero gets exactly the
+    /// depth-free solve.
+    ///
+    /// `0.15` trusts a monocular depth network to ~15%. Depth is what makes a monocular
+    /// reconstruction metric without a fiducial, and — because it pins the scale of every segment
+    /// of the chain rather than one global average — what stops scale from drifting along a
+    /// no-revisit walkthrough.
+    ///
+    /// The sigma is deflated into reprojection units before it reaches the solver (see the private
+    /// `depth_fields` in `sfm.rs`): bundle adjustment runs on an identity pinhole, so its
+    /// reprojection rows are unwhitened normalized values while depth rows divide by their sigma.
+    /// Handing the honest metric sigma straight through makes each depth row carry orders of
+    /// magnitude more cost than a reprojection row.
+    pub depth_prior_rel_sigma: f64,
+    /// Re-gauge each view's depth priors by its OWN fitted scale before bundle adjustment, instead
+    /// of trusting a single global scale for the whole map. `true` by default; inert unless
+    /// [`Self::depth_prior_rel_sigma`] is non-zero and depths are supplied.
+    ///
+    /// Learned depth is not gauge-stable frame to frame, and on forward motion a per-frame scale
+    /// error is indistinguishable from along-axis translation — so one global scale hands every
+    /// wander of the network straight to the trajectory. The fit is a robust median of
+    /// `z_map / d_pred` per view, re-gauged against the median view so the map's own scale is not
+    /// moved, and clamped to `[0.5, 2.0]`; see the private `fit_depth_scales`.
+    pub depth_per_keyframe_scale: bool,
+    /// Standard deviation (unit-vector units) of a per-view prior pulling each camera's image-up
+    /// toward world up. **`0.0` (the default) disables it** — rig cameras are not all upright, so
+    /// this must stay off for rig calibration.
+    ///
+    /// For handheld walkthrough video it is the only absolute-orientation observation the capture
+    /// carries: with no revisits, nothing in the image data observes global orientation, so
+    /// rotational drift accumulates along the chain and no amount of reprojection refinement can
+    /// see it. `0.25` tolerates ~14° of genuine hand tilt at 1σ.
+    pub up_prior_sigma: f64,
+    /// Constant-velocity motion-prior sigma over consecutive registered triplets. **`0.0` (the
+    /// default) disables it.**
+    ///
+    /// The value is the sigma of the translation norm-RATIO residual (unitless — see
+    /// [`kornia_3d::ba::BaMotionPrior`]); the angular sigma is derived as half of it, in radians.
+    /// `0.1` tolerates ~10% deviation from constant velocity at 1σ: loose enough for a human
+    /// walking pace, tight enough to suppress the frame-to-frame scale and rotation jitter that
+    /// accumulates into drift on video with no revisits.
+    ///
+    /// Only meaningful when view indices are TIME-ORDERED, which is why it is off for a rig.
+    pub motion_prior_sigma: f64,
+    /// Absolute PnP inlier count required to register a view (COLMAP's
+    /// `abs_pose_min_num_inliers`). Default `30`.
+    ///
+    /// PnP-RANSAC succeeds whenever it finds *a* consensus, however small, so an unguarded accept
+    /// admits views whose pose is fitted to a handful of correspondences — and that is not a
+    /// self-correcting mistake, because new points are triangulated FROM the bad pose and then feed
+    /// the next view's PnP. Set to `0` to accept any successful PnP, which is what this solver did
+    /// before the gate existed.
+    pub min_registration_inliers: usize,
+    /// Refine a global focal scale plus radial/tangential distortion against the reconstruction,
+    /// alternating with bundle adjustment. **`false` by default**; leave it off when the intrinsics
+    /// are calibrated.
+    ///
+    /// For guessed intrinsics (a FOV sweep, `k1` assumed zero on an ultra-wide) the error bends the
+    /// whole reconstruction in a way no reprojection residual reveals. When enabled, the fit is
+    /// reported on [`Reconstruction::camera_correction`] and a second bundle adjustment re-settles
+    /// the geometry against the corrected camera.
+    pub refine_intrinsics: bool,
+    /// Called after each view is registered, as `(registered_so_far, total_views)`. `None` by
+    /// default.
+    ///
+    /// Registration is the longest phase of a large solve and the only one whose duration is
+    /// data-dependent: a caller driving a progress UI has nothing to report without this, and
+    /// cannot tell a solve that is growing from one stalled at a barrier.
+    pub progress: Option<std::sync::Arc<dyn Fn(usize, usize) + Send + Sync>>,
 }
 
 impl CalibConfig {
     /// Config with flux-derived defaults for the given tag size (metres).
+    ///
+    /// Every PRIOR defaults to off — all three sigmas are `0.0`, `refine_intrinsics` is `false`,
+    /// `progress` is `None` — so none of them touches a solve unless a caller opts in.
+    /// `depth_per_keyframe_scale` is `true` but inert while `depth_prior_rel_sigma` is `0.0`.
+    ///
+    /// [`Self::min_registration_inliers`] is the one exception worth knowing about: it defaults to
+    /// COLMAP's `30` rather than to `0`, so views whose PnP found only a handful of inliers are now
+    /// refused where they were previously admitted. That is the point of the gate — see its docs —
+    /// but it is a behaviour change, not an opt-in. Set it to `0` for the old behaviour.
     pub fn new(tag_size_m: f64) -> Self {
         Self {
             tag_size_m,
@@ -76,6 +156,13 @@ impl CalibConfig {
             min_parallax_deg: 0.2,
             max_reprojection_error: 0.01,
             x84_k: 2.5,
+            depth_prior_rel_sigma: 0.0,
+            depth_per_keyframe_scale: true,
+            up_prior_sigma: 0.0,
+            motion_prior_sigma: 0.0,
+            min_registration_inliers: 30,
+            refine_intrinsics: false,
+            progress: None,
         }
     }
 }
@@ -219,6 +306,20 @@ pub struct Reconstruction {
     pub per_view: Vec<CameraStats>,
     /// Where the metric scale came from -- see [`ScaleSource`].
     pub scale: ScaleSource,
+    /// Intrinsics correction the solve FITTED, as `(gamma, k1, k2, p1, p2)`. `None` when
+    /// [`CalibConfig::refine_intrinsics`] was off, the fit was singular, or it landed outside its
+    /// sanity bounds.
+    ///
+    /// Load-bearing output, not telemetry. Refinement applies itself by rewriting the NORMALIZED
+    /// observations in place -- `n' = gamma · (n · radial + tangential)` -- so the solve gets the
+    /// corrected camera while the caller's own camera model stays at whatever guess it started
+    /// from. A caller that then stores its guess alongside these poses is recording a camera that
+    /// did not produce them, and nothing downstream can detect the mismatch.
+    ///
+    /// `gamma` scales normalized coordinates, so it INVERTS into focal length:
+    /// `fx_true = fx_assumed / gamma`. `gamma < 1` means the true focal is LONGER than assumed.
+    /// The distortion terms are OpenCV's, to be applied to the assumed camera's existing model.
+    pub camera_correction: Option<(f64, f64, f64, f64, f64)>,
 }
 
 impl From<Reconstruction> for RigCalibration {

--- a/crates/kornia-calib/src/types.rs
+++ b/crates/kornia-calib/src/types.rs
@@ -66,88 +66,62 @@ pub struct CalibConfig {
     pub x84_k: f64,
     /// Relative standard deviation of the per-observation metric depth priors passed to
     /// [`crate::reconstruct`], as `σ = depth_prior_rel_sigma · d`. **`0.0` (the default) disables
-    /// depth entirely**, so a caller that supplies depths but leaves this at zero gets exactly the
-    /// depth-free solve.
+    /// depth entirely**; `0.15` trusts a monocular depth network to ~15%.
     ///
-    /// `0.15` trusts a monocular depth network to ~15%. Depth is what makes a monocular
-    /// reconstruction metric without a fiducial, and — because it pins the scale of every segment
-    /// of the chain rather than one global average — what stops scale from drifting along a
-    /// no-revisit walkthrough.
-    ///
-    /// The sigma is deflated into reprojection units before it reaches the solver (see the private
-    /// `depth_fields` in `sfm.rs`): bundle adjustment runs on an identity pinhole, so its
-    /// reprojection rows are unwhitened normalized values while depth rows divide by their sigma.
-    /// Handing the honest metric sigma straight through makes each depth row carry orders of
-    /// magnitude more cost than a reprojection row.
+    /// Depth is what makes a monocular reconstruction metric without a fiducial and — pinning every
+    /// segment of the chain rather than one global average — what stops scale drifting along a
+    /// no-revisit walkthrough. Deflated into reprojection units; see `sfm.rs::depth_fields`.
     pub depth_prior_rel_sigma: f64,
     /// Re-gauge each view's depth priors by its OWN fitted scale before bundle adjustment, instead
-    /// of trusting a single global scale for the whole map. `true` by default; inert unless
+    /// of trusting a single global scale. `true` by default; inert unless
     /// [`Self::depth_prior_rel_sigma`] is non-zero and depths are supplied.
     ///
     /// Learned depth is not gauge-stable frame to frame, and on forward motion a per-frame scale
     /// error is indistinguishable from along-axis translation — so one global scale hands every
-    /// wander of the network straight to the trajectory. The fit is a robust median of
-    /// `z_map / d_pred` per view, re-gauged against the median view so the map's own scale is not
-    /// moved, and clamped to `[0.5, 2.0]`; see the private `fit_depth_scales`.
+    /// wander of the network to the trajectory. See `sfm.rs::fit_depth_scales`.
     pub depth_per_keyframe_scale: bool,
     /// Standard deviation (unit-vector units) of a per-view prior pulling each camera's image-up
     /// toward world up. **`0.0` (the default) disables it** — rig cameras are not all upright, so
     /// this must stay off for rig calibration.
     ///
-    /// For handheld walkthrough video it is the only absolute-orientation observation the capture
-    /// carries: with no revisits, nothing in the image data observes global orientation, so
-    /// rotational drift accumulates along the chain and no amount of reprojection refinement can
-    /// see it. `0.25` tolerates ~14° of genuine hand tilt at 1σ.
+    /// On handheld walkthrough video with no revisits it is the only observation of global
+    /// orientation the capture carries. `0.25` tolerates ~14° of genuine hand tilt at 1σ.
     pub up_prior_sigma: f64,
     /// Constant-velocity motion-prior sigma over consecutive registered triplets. **`0.0` (the
     /// default) disables it.**
     ///
     /// The value is the sigma of the translation norm-RATIO residual (unitless — see
-    /// [`kornia_3d::ba::BaMotionPrior`]); the angular sigma is derived as half of it, in radians.
-    /// `0.1` tolerates ~10% deviation from constant velocity at 1σ: loose enough for a human
-    /// walking pace, tight enough to suppress the frame-to-frame scale and rotation jitter that
-    /// accumulates into drift on video with no revisits.
-    ///
-    /// Only meaningful when view indices are TIME-ORDERED, which is why it is off for a rig.
+    /// [`kornia_3d::ba::BaMotionPrior`]); the angular sigma is half of it, in radians. `0.1`
+    /// tolerates ~10% deviation from constant velocity at 1σ. Only meaningful when view indices are
+    /// TIME-ORDERED, which is why it is off for a rig.
     pub motion_prior_sigma: f64,
     /// Absolute PnP inlier count required to register a view (COLMAP's
     /// `abs_pose_min_num_inliers`). Default `30`.
     ///
-    /// PnP-RANSAC succeeds whenever it finds *a* consensus, however small, so an unguarded accept
-    /// admits views whose pose is fitted to a handful of correspondences — and that is not a
-    /// self-correcting mistake, because new points are triangulated FROM the bad pose and then feed
-    /// the next view's PnP. Set to `0` to accept any successful PnP, which is what this solver did
-    /// before the gate existed.
+    /// PnP-RANSAC succeeds whenever it finds *a* consensus, and a thin registration is not a
+    /// self-correcting mistake: new points are triangulated FROM the bad pose and then feed the
+    /// next view's PnP. Set to `0` for the pre-gate behaviour of accepting any successful PnP.
     pub min_registration_inliers: usize,
     /// Refine a global focal scale plus radial/tangential distortion against the reconstruction,
     /// alternating with bundle adjustment. **`false` by default**; leave it off when the intrinsics
     /// are calibrated.
     ///
     /// For guessed intrinsics (a FOV sweep, `k1` assumed zero on an ultra-wide) the error bends the
-    /// whole reconstruction in a way no reprojection residual reveals. When enabled, the fit is
-    /// reported on [`Reconstruction::camera_correction`] and a second bundle adjustment re-settles
-    /// the geometry against the corrected camera.
+    /// whole reconstruction in a way no reprojection residual reveals. The fit is reported on
+    /// [`Reconstruction::camera_correction`] and a second BA re-settles the geometry against it.
     pub refine_intrinsics: bool,
     /// Called after each view is registered, as `(registered_so_far, total_views)`. `None` by
     /// default.
-    ///
-    /// Registration is the longest phase of a large solve and the only one whose duration is
-    /// data-dependent: a caller driving a progress UI has nothing to report without this, and
-    /// cannot tell a solve that is growing from one stalled at a barrier.
     pub progress: Option<std::sync::Arc<dyn Fn(usize, usize) + Send + Sync>>,
 }
 
 impl CalibConfig {
     /// Config with flux-derived defaults for the given tag size (metres).
     ///
-    /// Every PRIOR defaults to off — all three sigmas are `0.0`, `refine_intrinsics` is `false`,
-    /// `progress` is `None` — so none of them touches a solve unless a caller opts in.
-    /// `depth_per_keyframe_scale` is `true` but inert while `depth_prior_rel_sigma` is `0.0`.
-    ///
-    /// [`Self::min_registration_inliers`] is the one exception worth knowing about: it defaults to
-    /// COLMAP's `30` rather than to `0`, so views whose PnP found only a handful of inliers are now
-    /// refused where they were previously admitted. That is the point of the gate — see its docs —
-    /// but it is a behaviour change, not an opt-in. Set it to `0` for the old behaviour.
+    /// Every prior defaults to off, so none of them touches a solve unless a caller opts in. The
+    /// one exception is [`Self::min_registration_inliers`], which defaults to COLMAP's `30` rather
+    /// than `0`: views whose PnP found only a handful of inliers are now refused where they were
+    /// previously admitted. Set it to `0` for the old behaviour.
     pub fn new(tag_size_m: f64) -> Self {
         Self {
             tag_size_m,
@@ -310,15 +284,13 @@ pub struct Reconstruction {
     /// [`CalibConfig::refine_intrinsics`] was off, the fit was singular, or it landed outside its
     /// sanity bounds.
     ///
-    /// Load-bearing output, not telemetry. Refinement applies itself by rewriting the NORMALIZED
-    /// observations in place -- `n' = gamma · (n · radial + tangential)` -- so the solve gets the
-    /// corrected camera while the caller's own camera model stays at whatever guess it started
-    /// from. A caller that then stores its guess alongside these poses is recording a camera that
-    /// did not produce them, and nothing downstream can detect the mismatch.
+    /// Load-bearing output, not telemetry: refinement applies itself by rewriting the NORMALIZED
+    /// observations in place, leaving the caller's camera model at its original guess — a caller
+    /// that stores that guess alongside these poses records a camera that did not produce them.
     ///
     /// `gamma` scales normalized coordinates, so it INVERTS into focal length:
-    /// `fx_true = fx_assumed / gamma`. `gamma < 1` means the true focal is LONGER than assumed.
-    /// The distortion terms are OpenCV's, to be applied to the assumed camera's existing model.
+    /// `fx_true = fx_assumed / gamma`. The distortion terms are OpenCV's, to be applied to the
+    /// assumed camera's existing model.
     pub camera_correction: Option<(f64, f64, f64, f64, f64)>,
 }
 


### PR DESCRIPTION
**Stacked on #1100.** Its three commits are the first three here, so this diff shows both until #1100 lands; review #1100 first and this will shrink to the `kornia-calib` commits alone.

Extends `sfm::reconstruct` so a caller with per-observation metric depth (a monocular depth network, an RGB-D stream) can use it, and wires up the two priors #1100 adds.

## Depth

`reconstruct` gains an optional `obs_depth: Option<&[Vec<Option<f64>>]>` — one entry per track observation, `None` where no depth is available. A monocular reconstruction is scale-free; depth measurements are what pin it to metric without a calibration target in the scene.

`depth_per_keyframe_scale` (default on) fits a per-view median scale `z_map/d` and folds it into the measurement before the solve. Monocular depth networks are consistent WITHIN a frame and drift between frames, so this surrenders the per-view gauge deliberately and keeps what the network is actually good at.

`depth_prior_rel_sigma` is RELATIVE — the sigma scales with the measurement, because a network's error grows with range.

## Priors and ergonomics

- `up_prior_sigma`, `motion_prior_sigma` — wire #1100's priors, both default `0.0` (off).
- `min_registration_inliers` (default 30) — a PnP solve that succeeds on 12 correspondences is not evidence. **This ships with a `pnp_failed.clear()` on each successful registration**: without it the gate would turn transient rejections into permanent ones, since the existing loop never clears that set, and registration count would strictly DECREASE.
- `refine_intrinsics` (default off) — fits `(gamma, k1, k2, p1, p2)` against the map's own predicted projections and re-solves so the correction actually reaches the returned poses. Reported on `Reconstruction::camera_correction` (`#[non_exhaustive]`, so non-breaking) because the refinement rewrites observations in place; without reporting it the caller stores a camera that did not produce the poses.
- `progress` — a callback, for long video-scale solves.

Every default preserves current behaviour except `min_registration_inliers`, which is called out in `CalibConfig::new`'s doc with `0` given as the way back.

## Tests

Five new synthetic tests. The headline one, `depth_priors_fix_the_scale_of_an_otherwise_scale_free_reconstruction`, asserts a depth-free control lands 2x off metric on the same tracks — so it fails on a build that ignores depth — then that the fitted scale is within 5% of ground truth.

`reported_rmse_is_in_corrected_pixels` pins the two RMS paths against each other rather than a constant, and was verified to fail when only one side is corrected.

**One test I could not honestly write:** a synthetic where `refine_intrinsics` recovers FOCAL length. Measured directly — a 25% focal error on a three-view converging rig gives `gamma = 1.0011`, and ±52° of yaw across five views gives `0.9994`. Bundle adjustment absorbs a focal error almost entirely, so the fit cannot see it. Radial distortion is a nonlinear warp a rigid reconstruction cannot absorb, so the test injects `k1 = +0.25` and checks the fit moves in the right direction. The test doc states plainly what is and is not proven.

`cargo test -p kornia-calib --lib`: 34 passed, plus the doctest. Clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)