### PR TITLE
feat(3d): point-to-plane ICP and an RGB-D odometry front end

### DIFF
--- a/crates/kornia-3d/examples/icp_bench.rs
+++ b/crates/kornia-3d/examples/icp_bench.rs
@@ -1,0 +1,201 @@
+//! Times one full 320x180, 3-level projective point-to-plane ICP solve.
+//!
+//! Renders a synthetic corner-and-sphere scene from two nearby camera poses
+//! (mirroring the in-crate test renderer), builds both pyramids, then times
+//! `icp_projective_plane` alone. Run in release:
+//!
+//! ```sh
+//! cargo build --release -p kornia-3d --example icp_bench -j1
+//! ./target/release/examples/icp_bench
+//! ```
+
+use std::time::Instant;
+
+use kornia_3d::registration::{
+    icp_projective_plane, DepthIntrinsics, IcpPlaneCriteria, RgbdIcpError, RgbdPyramid,
+};
+
+/// Infinite plane `normal . p = d` and sphere, in world coordinates.
+struct Plane {
+    normal: [f64; 3],
+    d: f64,
+}
+
+struct Sphere {
+    center: [f64; 3],
+    radius: f64,
+}
+
+fn dot(a: &[f64; 3], b: &[f64; 3]) -> f64 {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+}
+
+/// Concave three-plane corner plus a sphere, raycast to a u16 millimetre
+/// z-depth image from camera pose `T_world_cam`.
+fn render_depth_mm(
+    intr: &DepthIntrinsics,
+    rot_world_cam: &[[f64; 3]; 3],
+    t_world_cam: &[f64; 3],
+) -> Vec<u16> {
+    let planes = [
+        Plane {
+            normal: [0.0, 0.0, 1.0],
+            d: 2.0,
+        },
+        Plane {
+            normal: [1.0, 0.0, 0.0],
+            d: 0.8,
+        },
+        Plane {
+            normal: [0.0, 1.0, 0.0],
+            d: 0.6,
+        },
+    ];
+    let sphere = Sphere {
+        center: [-0.2, -0.15, 1.2],
+        radius: 0.3,
+    };
+    const NEAR_M: f64 = 0.05;
+
+    let mut depth = vec![0u16; intr.width * intr.height];
+    for v in 0..intr.height {
+        for u in 0..intr.width {
+            // ray with dir_cam.z = 1 so the ray parameter equals z-depth
+            let dir_cam = [
+                (u as f64 - intr.cx) / intr.fx,
+                (v as f64 - intr.cy) / intr.fy,
+                1.0,
+            ];
+            let dir = [
+                dot(&rot_world_cam[0], &dir_cam),
+                dot(&rot_world_cam[1], &dir_cam),
+                dot(&rot_world_cam[2], &dir_cam),
+            ];
+
+            let mut best = f64::INFINITY;
+            for plane in &planes {
+                let denom = dot(&plane.normal, &dir);
+                if denom.abs() < 1e-12 {
+                    continue;
+                }
+                let t = (plane.d - dot(&plane.normal, t_world_cam)) / denom;
+                if t > NEAR_M && t < best {
+                    best = t;
+                }
+            }
+            let oc = [
+                t_world_cam[0] - sphere.center[0],
+                t_world_cam[1] - sphere.center[1],
+                t_world_cam[2] - sphere.center[2],
+            ];
+            let a = dot(&dir, &dir);
+            let b = dot(&oc, &dir);
+            let disc = b * b - a * (dot(&oc, &oc) - sphere.radius * sphere.radius);
+            if disc >= 0.0 {
+                for t in [(-b - disc.sqrt()) / a, (-b + disc.sqrt()) / a] {
+                    if t > NEAR_M && t < best {
+                        best = t;
+                    }
+                }
+            }
+
+            let mm = (best * 1000.0).round();
+            if mm.is_finite() && mm >= 1.0 && mm <= u16::MAX as f64 {
+                depth[v * intr.width + u] = mm as u16;
+            }
+        }
+    }
+    depth
+}
+
+/// Rotation of `angle` radians about the y axis.
+fn rot_y(angle: f64) -> [[f64; 3]; 3] {
+    let (s, c) = angle.sin_cos();
+    [[c, 0.0, s], [0.0, 1.0, 0.0], [-s, 0.0, c]]
+}
+
+fn main() -> Result<(), RgbdIcpError> {
+    let intr = DepthIntrinsics {
+        fx: 200.0,
+        fy: 200.0,
+        cx: 159.5,
+        cy: 89.5,
+        width: 320,
+        height: 180,
+    };
+    let identity = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]];
+
+    // target camera moved ~1.5 deg + ~2 cm
+    let rot_wc = rot_y(1.5f64.to_radians());
+    let t_wc = [0.02, 0.0, 0.01];
+
+    let src_depth = render_depth_mm(&intr, &identity, &[0.0; 3]);
+    let tgt_depth = render_depth_mm(&intr, &rot_wc, &t_wc);
+
+    // warmup (first-touch allocations), then steady-state per-frame pyramid cost
+    for _ in 0..2 {
+        RgbdPyramid::from_depth_mm(&src_depth, &intr, 3)?;
+    }
+    const PYR_RUNS: usize = 10;
+    let t0 = Instant::now();
+    for _ in 0..PYR_RUNS {
+        RgbdPyramid::from_depth_mm(&src_depth, &intr, 3)?;
+    }
+    let pyramid_ms = t0.elapsed().as_secs_f64() * 1e3 / PYR_RUNS as f64;
+
+    let src_pyr = RgbdPyramid::from_depth_mm(&src_depth, &intr, 3)?;
+    let tgt_pyr = RgbdPyramid::from_depth_mm(&tgt_depth, &intr, 3)?;
+
+    // warmup
+    for _ in 0..3 {
+        icp_projective_plane(
+            &src_pyr,
+            &tgt_pyr,
+            identity,
+            [0.0; 3],
+            IcpPlaneCriteria::default(),
+        )?;
+    }
+
+    const RUNS: usize = 20;
+    let mut total_ms = 0.0;
+    let mut min_ms = f64::INFINITY;
+    let mut last = None;
+    for _ in 0..RUNS {
+        let t = Instant::now();
+        let result = icp_projective_plane(
+            &src_pyr,
+            &tgt_pyr,
+            identity,
+            [0.0; 3],
+            IcpPlaneCriteria::default(),
+        )?;
+        let ms = t.elapsed().as_secs_f64() * 1e3;
+        total_ms += ms;
+        min_ms = min_ms.min(ms);
+        last = Some(result);
+    }
+
+    let mean_ms = total_ms / RUNS as f64;
+    println!("pyramid build (per frame): {pyramid_ms:.2} ms");
+    println!(
+        "icp_projective_plane 320x180 x3 levels: mean {mean_ms:.2} ms, min {min_ms:.2} ms over {RUNS} runs"
+    );
+    if let Some(result) = last {
+        println!(
+            "solution: iterations {}, rmse {:.4} mm, inliers {:.1} %",
+            result.iterations,
+            result.rmse * 1e3,
+            result.inlier_fraction * 100.0
+        );
+    }
+
+    // perf gate: a regression (debug-build measurement, O(N^2) slip) must FAIL, not just print
+    const GATE_MS: f64 = 60.0;
+    if mean_ms > GATE_MS {
+        eprintln!("FAIL: mean {mean_ms:.2} ms/solve exceeds the {GATE_MS} ms gate");
+        std::process::exit(1);
+    }
+    println!("PASS: mean {mean_ms:.2} ms/solve within the {GATE_MS} ms gate");
+    Ok(())
+}

--- a/crates/kornia-3d/examples/icp_debug_pair.rs
+++ b/crates/kornia-3d/examples/icp_debug_pair.rs
@@ -1,0 +1,91 @@
+//! Debug harness: run projective point-to-plane ICP on two captured RAW1 depth frames
+//! (`RAW1` magic + u32 w,h + u16 mm) and print association statistics per configuration.
+//!
+//! Usage: icp_debug_pair <frame0.raw1> <frame1.raw1> <fx> <fy> <cx> <cy>
+//! Intrinsics are for the RGB grid the camera_info describes; they are scaled per-axis
+//! onto the depth grid exactly like flux-odom does.
+
+use kornia_3d::registration::{
+    icp_projective_plane, DepthIntrinsics, IcpPlaneCriteria, RgbdPyramid,
+};
+
+fn load_raw1(path: &str) -> (Vec<u16>, u32, u32) {
+    let b = std::fs::read(path).expect("read");
+    assert_eq!(&b[0..4], b"RAW1");
+    let w = u32::from_le_bytes(b[4..8].try_into().unwrap());
+    let h = u32::from_le_bytes(b[8..12].try_into().unwrap());
+    let px: Vec<u16> = b[12..12 + (w * h) as usize * 2]
+        .chunks_exact(2)
+        .map(|c| u16::from_le_bytes([c[0], c[1]]))
+        .collect();
+    (px, w, h)
+}
+
+fn main() {
+    let a: Vec<String> = std::env::args().collect();
+    let (d0, w, h) = load_raw1(&a[1]);
+    let (d1, w1, h1) = load_raw1(&a[2]);
+    assert_eq!((w, h), (w1, h1));
+    let (rfx, rfy, rcx, rcy): (f64, f64, f64, f64) = (
+        a[3].parse().unwrap(),
+        a[4].parse().unwrap(),
+        a[5].parse().unwrap(),
+        a[6].parse().unwrap(),
+    );
+    // camera_info is on the 2x RGB grid (640x360) — scale to the depth grid like flux-odom.
+    let (sx, sy) = (w as f64 / (w as f64 * 2.0), h as f64 / (h as f64 * 2.0));
+    let intr = DepthIntrinsics {
+        fx: rfx * sx,
+        fy: rfy * sy,
+        cx: rcx * sx,
+        cy: rcy * sy,
+        width: w as usize,
+        height: h as usize,
+    };
+    let valid0 = d0.iter().filter(|&&d| d != 0).count();
+    let valid1 = d1.iter().filter(|&&d| d != 0).count();
+    println!(
+        "dims {w}x{h} valid0 {:.1}% valid1 {:.1}% intr fx={:.1} cx={:.1}",
+        100.0 * valid0 as f64 / (w * h) as f64,
+        100.0 * valid1 as f64 / (w * h) as f64,
+        intr.fx,
+        intr.cx
+    );
+    let p0 = RgbdPyramid::from_depth_mm(&d0, &intr, 3).expect("pyr0");
+    let p1 = RgbdPyramid::from_depth_mm(&d1, &intr, 3).expect("pyr1");
+    let ident = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]];
+    for (label, crit) in [
+        ("default", IcpPlaneCriteria::default()),
+        (
+            "loose-gates",
+            IcpPlaneCriteria {
+                max_dist_m: 0.5,
+                max_normal_angle_rad: 1.2,
+                ..Default::default()
+            },
+        ),
+    ] {
+        match icp_projective_plane(&p1, &p0, ident, [0.0; 3], crit) {
+            Ok(r) => println!(
+                "{label}: iters {} rmse {:.2}mm inliers {:.2}% t=({:.1},{:.1},{:.1})mm",
+                r.iterations,
+                r.rmse * 1000.0,
+                r.inlier_fraction * 100.0,
+                r.translation[0] * 1000.0,
+                r.translation[1] * 1000.0,
+                r.translation[2] * 1000.0
+            ),
+            Err(e) => println!("{label}: ERR {e}"),
+        }
+    }
+    // Frame vs ITSELF — must be ~100% inliers at identity if association is sane.
+    match icp_projective_plane(&p0, &p0, ident, [0.0; 3], IcpPlaneCriteria::default()) {
+        Ok(r) => println!(
+            "self: iters {} rmse {:.4}mm inliers {:.2}%",
+            r.iterations,
+            r.rmse * 1000.0,
+            r.inlier_fraction * 100.0
+        ),
+        Err(e) => println!("self: ERR {e}"),
+    }
+}

--- a/crates/kornia-3d/src/registration/icp.rs
+++ b/crates/kornia-3d/src/registration/icp.rs
@@ -1,0 +1,1210 @@
+//! Projective point-to-plane ICP on RGBD pyramids.
+//!
+//! Estimates the rigid transform `T_target_source` (`p_tgt = R * p_src + t`)
+//! between two depth frames given as [`RgbdPyramid`]s, coarse-to-fine.
+//! Correspondences come from projective association (no kd-tree): each source
+//! vertex is transformed by the current estimate, projected into the target
+//! grid with the target level intrinsics, and matched to the nearest pixel's
+//! vertex/normal.
+//!
+//! Per correspondence the point-to-plane residual is `r = n_t . (T*p_s - v_t)`
+//! with Jacobian row `[(p' x n_t)^T, n_t^T]` where `p' = T*p_s` (left
+//! perturbation `T <- exp([w, t]) * T`). Maps stay `f32`; `J^T W J` / `J^T W r`
+//! are accumulated in `f64` and the 6x6 system is solved by Cholesky.
+
+use super::rgbd::{is_valid_normal, is_valid_vertex, RgbdIcpError, RgbdLevel, RgbdPyramid};
+
+/// Parameters of [`icp_projective_plane`].
+#[derive(Debug, Clone)]
+pub struct IcpPlaneCriteria {
+    /// Gauss-Newton iterations per pyramid level, coarsest first. Levels
+    /// beyond the list reuse the last entry; an empty list runs no iterations
+    /// (the result is the evaluated initial guess).
+    pub iters_per_level: Vec<usize>,
+    /// Convergence threshold on the twist update norm `sqrt(|w|^2 + |dt|^2)`
+    /// (rad / metres); a level stops early once the update falls below it.
+    pub update_tolerance: f64,
+    /// Reject correspondences further apart than this in metres.
+    pub max_dist_m: f64,
+    /// Reject correspondences whose (rotated) source and target normals
+    /// disagree by more than this angle in radians.
+    pub max_normal_angle_rad: f64,
+    /// Huber loss scale in metres: residuals beyond it get weight `delta/|r|`.
+    pub huber_delta_m: f64,
+    /// Optional independent estimate of the rotation, e.g. an integrated gyro.
+    ///
+    /// Depth geometry does not always determine rotation: on a swept view the rotation block of
+    /// the normal equations collapses and the solve returns rotations wrong by degrees per frame
+    /// (measured: 1.4-4.4 deg against a 3.0 deg truth, eventually freezing at zero) while the
+    /// residual and the inlier fraction stay perfect. A gyro measures exactly that quantity, and
+    /// over a single frame interval it is roughly an order of magnitude more accurate than the
+    /// degraded solve, so it can carry the rotation while the geometry carries the translation.
+    ///
+    /// Regularises, never overrides: it enters as three weighted rows, so ample geometry
+    /// outvotes it and weak geometry defers to it.
+    pub rotation_prior: Option<RotationPrior>,
+}
+
+/// An external rotation estimate for [`IcpPlaneCriteria::rotation_prior`].
+#[derive(Debug, Clone, Copy)]
+pub struct RotationPrior {
+    /// Prior on the source-to-target rotation, same convention as
+    /// [`IcpPlaneResult::rotation`].
+    pub rotation: [[f64; 3]; 3],
+    /// One-sigma expected error of `rotation`, in radians, OVER THE INTERVAL IT SPANS.
+    ///
+    /// Scale it with elapsed time rather than passing a per-frame constant: a prior accumulated
+    /// across held frames covers a longer interval and has drifted further, and a fixed sigma
+    /// would make the constraint overconfident precisely after a stall. For a consumer MEMS gyro,
+    /// bias dominates — roughly 0.5 deg/s uncalibrated, so ~0.025 deg over a 50 ms frame.
+    ///
+    /// The weight is `1/sigma^2`, which puts a 0.05-0.1 deg sigma one to two orders of magnitude
+    /// tighter than a collapsed rotation block, and negligible against a healthy one.
+    ///
+    /// Size it against the sensor's TOTAL error, systematic terms included — not its bias and
+    /// noise alone. Two sweeps, measured:
+    ///
+    /// - varying the true error at fixed sigma: the prior is comfortably ahead at sigma, still
+    ///   winning around 1.5x, and loses beyond roughly 2x
+    /// - varying sigma at a fixed realistic error: accuracy improved monotonically as sigma
+    ///   LOOSENED (0.66 mm at 0.2 deg/s, 0.52 at 2.0, 0.24 at 5.0) with the tracked-frame count
+    ///   flat across the whole range
+    ///
+    /// The second is counter-intuitive and decides the tuning. The dominant error there was a
+    /// fixed 3 deg gyro-to-camera misalignment — systematic, not random — so a tight sigma does
+    /// not pull the solve toward truth, it pulls it toward a consistently wrong attitude, while a
+    /// loose one supplies just enough weight to stop the rotation block collapsing and leaves the
+    /// depth free to correct the rest. Tight weighting on a biased measurement buys you the bias.
+    /// The flat frame count is the same fact from the other side: a collapsed block carries
+    /// almost no information, so even a very loose prior dominates it.
+    ///
+    /// That ordering inverts once the systematic term is calibrated away. An unbiased gyro should
+    /// favour a tighter sigma, so re-measure for that case rather than inheriting this guidance.
+    pub sigma_rad: f64,
+}
+
+impl Default for IcpPlaneCriteria {
+    fn default() -> Self {
+        Self {
+            iters_per_level: vec![10, 7, 5],
+            update_tolerance: 1e-6,
+            max_dist_m: 0.10,
+            max_normal_angle_rad: 30.0_f64.to_radians(),
+            huber_delta_m: 0.02,
+            rotation_prior: None,
+        }
+    }
+}
+
+/// Result of [`icp_projective_plane`].
+///
+/// The transformation maps source-frame points into the target frame:
+/// `p_tgt = rotation * p_src + translation`.
+#[derive(Debug, Clone)]
+pub struct IcpPlaneResult {
+    /// Estimated rotation matrix (row-major).
+    pub rotation: [[f64; 3]; 3],
+    /// Estimated translation vector in metres.
+    pub translation: [f64; 3],
+    /// Root-mean-square point-to-plane residual (metres) of the gated
+    /// correspondences at the finest level under the final transform.
+    pub rmse: f64,
+    /// Gated correspondences divided by *associated* ones at the finest level
+    /// under the final transform: match quality alone. Deliberately not divided
+    /// by all valid source pixels — that conflates quality with view overlap and
+    /// collapses under camera motion, rejecting solves that converged perfectly.
+    /// Pair it with [`Self::overlap_fraction`] and [`Self::num_associated`]: a
+    /// small patch can match perfectly and still be too little to constrain a
+    /// pose.
+    pub inlier_fraction: f64,
+    /// Source pixels that projected into the target frame onto valid geometry,
+    /// before the distance and normal-angle gates. The observability figure: how
+    /// much evidence the solve actually had.
+    pub num_associated: usize,
+    /// Associated pixels divided by valid source pixels: how much of the source
+    /// view still overlaps the target. Falls as the camera moves away from the
+    /// keyframe and is the signal to re-key, not to reject the solve.
+    pub overlap_fraction: f64,
+    /// Total Gauss-Newton iterations performed across all levels.
+    pub iterations: usize,
+    /// Conditioning of the rotation block: weakest pivot over strongest, in `0..=1`.
+    pub rotation_conditioning: f64,
+    /// Conditioning of the translation block: weakest pivot over strongest, in `0..=1`.
+    ///
+    /// This is the one that catches a camera sweeping along a wall. As the surface comes to
+    /// dominate the view, translation along it stops being constrained while rotation stays
+    /// perfectly determined — measured on a sweep: rotation exact to 0.01 deg, translation four
+    /// times the truth, with [`Self::rmse`] at 0.4 mm and [`Self::inlier_fraction`] at 1.00
+    /// throughout. Residual and inlier fraction cannot see it; they are computed over
+    /// correspondences that all agree, on a surface that cannot pin the pose.
+    ///
+    /// Deliberately a ratio, not an absolute pivot: pivots accumulate over correspondences, so
+    /// an absolute floor tracks the inlier count and the scene depth instead of the geometry.
+    ///
+    /// Calibrate a gate against the SLIDING regime, not against the degenerate extreme. The
+    /// frames that corrupt a map sit orders of magnitude above a bare wall, so a threshold placed
+    /// to catch outright degeneracy passes every pose that does damage — that mistake has already
+    /// been made once here.
+    ///
+    /// Measured on a 320x180 depth camera sweeping a room at ~43 deg/s, 20 mm of true motion per
+    /// frame. Calibrate against the ONSET of failure:
+    ///
+    /// | | conditioning | published motion |
+    /// |---|---|---|
+    /// | worst frame still exact | 1.7e-2 | error <= 0.1 mm |
+    /// | first frame that slid | 7.2e-4 | 82.8 mm for 20 mm |
+    ///
+    /// A 24x separation with nothing in it, so a gate anywhere near the 3.5e-3 midpoint behaves
+    /// the same. Take the threshold from that transition only: once a pose is wrong, every later
+    /// frame's conditioning is measured against a corrupted estimate and is not independent
+    /// evidence — averaging those in understates the separation.
+    ///
+    /// Gate on [`Self::observability`], the weaker block, not on this field alone. Measured on
+    /// the same sweep, translation collapses first (7.2e-4 while rotation holds at 2.96e-2) and
+    /// then the blocks SWAP: translation recovers to 1e-1 while rotation falls to 2e-3, with the
+    /// published motion decaying to half of truth throughout. A gate on either block alone passes
+    /// one half of that failure.
+    ///
+    pub translation_conditioning: f64,
+    /// The weaker of the two blocks: a single scalar for callers that just need a gate.
+    pub observability: f64,
+}
+
+/// Relative Cholesky pivot threshold of the degeneracy guard: while factoring
+/// `A = J^T W J`, a squared pivot below `PIVOT_RTOL` times its *block's* max
+/// diagonal (rotation rows 0-2 / translation rows 3-5 are thresholded
+/// separately — rotational entries scale as `|p x n|^2` ~ depth² while
+/// translational ones are O(1) from unit normals, so one global max would let
+/// a collapsed translation pivot pass at large depth) means some twist
+/// direction is (numerically) unobserved — e.g. a single plane leaves its two
+/// in-plane translations and the in-plane rotation unconstrained, so three
+/// pivots collapse to rounding noise — and the solve is rejected as
+/// [`RgbdIcpError::SingularNormalEquations`] instead of returning a pose made
+/// up along the null space.
+const PIVOT_RTOL: f64 = 1e-8;
+
+/// Projective point-to-plane ICP between two RGBD pyramids.
+///
+/// # Arguments
+///
+/// * `source` - Source frame pyramid.
+/// * `target` - Target frame pyramid.
+/// * `initial_rot` - Initial rotation from the source to the target frame.
+/// * `initial_trans` - Initial translation from the source to the target frame.
+/// * `criteria` - Gating, robustness and convergence parameters.
+///
+/// # Errors
+///
+/// [`RgbdIcpError::SingularNormalEquations`] when the geometry does not
+/// constrain all six DoF (see [`PIVOT_RTOL`]);
+/// [`RgbdIcpError::TooFewCorrespondences`] when fewer than 6 correspondences
+/// survive gating (low overlap / bad initial guess);
+/// [`RgbdIcpError::InvalidNumLevels`] if either pyramid is empty.
+pub fn icp_projective_plane(
+    source: &RgbdPyramid,
+    target: &RgbdPyramid,
+    initial_rot: [[f64; 3]; 3],
+    initial_trans: [f64; 3],
+    criteria: IcpPlaneCriteria,
+) -> Result<IcpPlaneResult, RgbdIcpError> {
+    let num_levels = source.levels.len().min(target.levels.len());
+    if num_levels == 0 {
+        return Err(RgbdIcpError::InvalidNumLevels(0));
+    }
+
+    let mut rotation = initial_rot;
+    let mut translation = initial_trans;
+    let mut iterations = 0;
+    let mut rotation_conditioning = 0.0;
+    let mut translation_conditioning = 0.0;
+
+    // coarse-to-fine: level num_levels-1 down to 0 (levels[0] is finest)
+    for (coarse_idx, level_idx) in (0..num_levels).rev().enumerate() {
+        let iters = criteria
+            .iters_per_level
+            .get(coarse_idx)
+            .or(criteria.iters_per_level.last())
+            .copied()
+            .unwrap_or(0);
+        let src = &source.levels[level_idx];
+        let tgt = &target.levels[level_idx];
+
+        for _ in 0..iters {
+            let mut eqs = accumulate_level(src, tgt, &rotation, &translation, &criteria);
+            if eqs.num_inliers < 6 {
+                return Err(RgbdIcpError::TooFewCorrespondences(eqs.num_inliers));
+            }
+            // Diagnostic first, on the DATA-only equations — see `block_conditioning`. A prior
+            // must not be able to make weak geometry look strong to the caller.
+            let (data_rot_cond, data_trans_cond) = block_conditioning(&eqs.a);
+            if let Some(prior) = criteria.rotation_prior {
+                // Three rows penalising the current rotation's deviation from the prior.
+                //
+                // The error must live in the frame the update acts in. The solver applies
+                // `R <- exp(w) R`, a LEFT multiply, so the error is `e = log(R R_prior^T)`, also
+                // on the left: then `R_new R_prior^T = exp(w) exp(e)` and the residual in `w` is
+                // `e + w` to first order, with an identity Jacobian. Writing the body-frame error
+                // `log(R_prior^T R)` here instead would agree only when the prior is near
+                // identity and would otherwise pull toward the wrong attitude.
+                //
+                // Contribution is `1/sigma^2` on the rotation block's diagonal and `w e` on its
+                // gradient. Only that block is touched — the prior says nothing about translation.
+                let e = so3_log(&mat3_mul(&rotation, &mat3_transpose(&prior.rotation)));
+                let w = 1.0 / (prior.sigma_rad * prior.sigma_rad).max(f64::MIN_POSITIVE);
+                for (i, ei) in e.iter().enumerate() {
+                    eqs.a[i][i] += w;
+                    eqs.b[i] += w * ei;
+                }
+            }
+            // solve A x = -b for the twist x = [w, dt]
+            let neg_b = eqs.b.map(|v| -v);
+            let (x, _, _) =
+                cholesky_solve_6x6(&eqs.a, &neg_b).ok_or(RgbdIcpError::SingularNormalEquations)?;
+            // Report the finest level's last solve: the geometry the pose actually rests on,
+            // which is the data-only conditioning even when a prior carried the solve.
+            rotation_conditioning = data_rot_cond;
+            translation_conditioning = data_trans_cond;
+
+            let omega = [x[0], x[1], x[2]];
+            let dt = [x[3], x[4], x[5]];
+            let r_delta = so3_exp(&omega);
+            rotation = mat3_mul(&r_delta, &rotation);
+            translation = [
+                mat3_row_dot(&r_delta, 0, &translation) + dt[0],
+                mat3_row_dot(&r_delta, 1, &translation) + dt[1],
+                mat3_row_dot(&r_delta, 2, &translation) + dt[2],
+            ];
+            iterations += 1;
+
+            let update_norm = x.iter().map(|v| v * v).sum::<f64>().sqrt();
+            if update_norm < criteria.update_tolerance {
+                break;
+            }
+        }
+    }
+
+    // final metrics: one association pass at the finest level, final pose
+    let finest_src = &source.levels[0];
+    let finest_tgt = &target.levels[0];
+    let eqs = accumulate_level(finest_src, finest_tgt, &rotation, &translation, &criteria);
+    let rmse = if eqs.num_inliers > 0 {
+        (eqs.sum_sq_residual / eqs.num_inliers as f64).sqrt()
+    } else {
+        f64::INFINITY
+    };
+    let inlier_fraction = if eqs.num_associated > 0 {
+        eqs.num_inliers as f64 / eqs.num_associated as f64
+    } else {
+        0.0
+    };
+    let overlap_fraction = if eqs.num_valid > 0 {
+        eqs.num_associated as f64 / eqs.num_valid as f64
+    } else {
+        0.0
+    };
+
+    Ok(IcpPlaneResult {
+        rotation,
+        translation,
+        rmse,
+        inlier_fraction,
+        num_associated: eqs.num_associated,
+        rotation_conditioning,
+        translation_conditioning,
+        observability: rotation_conditioning.min(translation_conditioning),
+        overlap_fraction,
+        iterations,
+    })
+}
+
+/// Accumulated normal equations of one association pass over a level.
+struct NormalEquations {
+    /// `J^T W J` (full symmetric 6x6).
+    a: [[f64; 6]; 6],
+    /// `J^T W r`.
+    b: [f64; 6],
+    /// Correspondences that survived gating.
+    num_inliers: usize,
+    /// Projected inside the target onto valid geometry (pre-gating).
+    num_associated: usize,
+    /// Source pixels with a valid vertex and normal.
+    num_valid: usize,
+    /// Unweighted sum of squared residuals over the inliers.
+    sum_sq_residual: f64,
+}
+
+/// One projective-association pass: gate, weight and accumulate `J^T W J`,
+/// `J^T W r` in f64.
+fn accumulate_level(
+    src: &RgbdLevel,
+    tgt: &RgbdLevel,
+    rotation: &[[f64; 3]; 3],
+    translation: &[f64; 3],
+    criteria: &IcpPlaneCriteria,
+) -> NormalEquations {
+    let mut eqs = NormalEquations {
+        a: [[0.0; 6]; 6],
+        b: [0.0; 6],
+        num_inliers: 0,
+        num_associated: 0,
+        num_valid: 0,
+        sum_sq_residual: 0.0,
+    };
+    let cos_max_angle = criteria.max_normal_angle_rad.cos();
+    let max_dist_sq = criteria.max_dist_m * criteria.max_dist_m;
+    let (tw, th) = (tgt.intrinsics.width, tgt.intrinsics.height);
+
+    for (v_s, n_s) in src.vertices.iter().zip(src.normals.iter()) {
+        if !is_valid_vertex(v_s) || !is_valid_normal(n_s) {
+            continue;
+        }
+        eqs.num_valid += 1;
+
+        let p_s = [v_s[0] as f64, v_s[1] as f64, v_s[2] as f64];
+        // p' = T * p_s in the target frame
+        let p = [
+            mat3_row_dot(rotation, 0, &p_s) + translation[0],
+            mat3_row_dot(rotation, 1, &p_s) + translation[1],
+            mat3_row_dot(rotation, 2, &p_s) + translation[2],
+        ];
+        let Some(uv) = tgt.intrinsics.project(&p) else {
+            continue;
+        };
+        let (u, v) = (uv[0].round(), uv[1].round());
+        if u < 0.0 || v < 0.0 || u > (tw - 1) as f64 || v > (th - 1) as f64 {
+            continue;
+        }
+        let idx = v as usize * tw + u as usize;
+        let v_t = &tgt.vertices[idx];
+        let n_t = &tgt.normals[idx];
+        if !is_valid_vertex(v_t) || !is_valid_normal(n_t) {
+            continue;
+        }
+        eqs.num_associated += 1;
+
+        let diff = [
+            p[0] - v_t[0] as f64,
+            p[1] - v_t[1] as f64,
+            p[2] - v_t[2] as f64,
+        ];
+        if diff[0] * diff[0] + diff[1] * diff[1] + diff[2] * diff[2] > max_dist_sq {
+            continue;
+        }
+
+        let n_t = [n_t[0] as f64, n_t[1] as f64, n_t[2] as f64];
+        let n_s = [n_s[0] as f64, n_s[1] as f64, n_s[2] as f64];
+        let n_s_rot = [
+            mat3_row_dot(rotation, 0, &n_s),
+            mat3_row_dot(rotation, 1, &n_s),
+            mat3_row_dot(rotation, 2, &n_s),
+        ];
+        if n_s_rot[0] * n_t[0] + n_s_rot[1] * n_t[1] + n_s_rot[2] * n_t[2] < cos_max_angle {
+            continue;
+        }
+
+        let r = n_t[0] * diff[0] + n_t[1] * diff[1] + n_t[2] * diff[2];
+        // Jacobian row [(p' x n_t)^T, n_t^T]
+        let j = [
+            p[1] * n_t[2] - p[2] * n_t[1],
+            p[2] * n_t[0] - p[0] * n_t[2],
+            p[0] * n_t[1] - p[1] * n_t[0],
+            n_t[0],
+            n_t[1],
+            n_t[2],
+        ];
+        let w = if r.abs() <= criteria.huber_delta_m {
+            1.0
+        } else {
+            criteria.huber_delta_m / r.abs()
+        };
+
+        for i in 0..6 {
+            eqs.b[i] += w * j[i] * r;
+            for k in i..6 {
+                eqs.a[i][k] += w * j[i] * j[k];
+            }
+        }
+        eqs.num_inliers += 1;
+        eqs.sum_sq_residual += r * r;
+    }
+
+    // mirror the accumulated upper triangle
+    for i in 1..6 {
+        for k in 0..i {
+            eqs.a[i][k] = eqs.a[k][i];
+        }
+    }
+
+    eqs
+}
+
+/// Solve the SPD system `A x = b` by Cholesky. Returns `None` when a squared
+/// pivot falls below `PIVOT_RTOL` times its block's max diagonal (rotation /
+/// translation thresholded separately — see [`PIVOT_RTOL`]) — the degeneracy
+/// guard.
+/// Solves `A x = b` and reports the weakest pivot relative to its block's max diagonal — the
+/// observability of the least-constrained direction. A view that pins every DOF keeps this well
+/// above [`PIVOT_RTOL`]; a wall filling the frame drives it toward zero along the sliding
+/// direction, where the residual stays perfect while the pose drifts. Callers that must not act
+/// on such a pose gate on it; the residual and the inlier fraction cannot see it.
+/// Conditioning of each block WITHOUT solving: weakest pivot over strongest, `(rotation,
+/// translation)`, or `(0, 0)` when the matrix does not factor at all.
+///
+/// Prior-free in its INPUTS, not in the pose. A prior changes the solve, so the final transform
+/// differs, so the last association pass covers a slightly different correspondence set and the
+/// conditioning is computed over that — measured drift of about 5% on the same frame. That is
+/// benign for gating; evaluating at a fixed transform would be required to make it bit-stable.
+///
+/// Measured on the DATA-only normal equations, never on the prior-augmented ones. A rotation
+/// prior lifts the rotation block, and because the blocks are coupled through elimination it
+/// lifts the translation block's effective pivots too — measured, a 14x rise at a frame whose
+/// translation error was unchanged at 3.5x the truth. Reporting that would let the regulariser
+/// flatter the diagnostic and silently disarm the gate that catches unobservable translation.
+/// The prior belongs in the solve; the diagnostic must keep describing the geometry.
+fn block_conditioning(a: &[[f64; 6]; 6]) -> (f64, f64) {
+    match cholesky_factor(a) {
+        Some((_, rot, trans)) => (rot, trans),
+        None => (0.0, 0.0),
+    }
+}
+
+fn cholesky_solve_6x6(a: &[[f64; 6]; 6], b: &[f64; 6]) -> Option<([f64; 6], f64, f64)> {
+    let (l, rot_cond, trans_cond) = cholesky_factor(a)?;
+
+    // L y = b
+    let mut y = [0.0; 6];
+    for i in 0..6 {
+        let mut sum = b[i];
+        for k in 0..i {
+            sum -= l[i][k] * y[k];
+        }
+        y[i] = sum / l[i][i];
+    }
+    // L^T x = y
+    let mut x = [0.0; 6];
+    for i in (0..6).rev() {
+        let mut sum = y[i];
+        for k in i + 1..6 {
+            sum -= l[k][i] * x[k];
+        }
+        x[i] = sum / l[i][i];
+    }
+    Some((x, rot_cond, trans_cond))
+}
+
+fn cholesky_factor(a: &[[f64; 6]; 6]) -> Option<([[f64; 6]; 6], f64, f64)> {
+    let max_diag_rot = (0..3).map(|i| a[i][i]).fold(0.0, f64::max);
+    let max_diag_trans = (3..6).map(|i| a[i][i]).fold(0.0, f64::max);
+    if max_diag_rot <= 0.0 || max_diag_trans <= 0.0 {
+        return None;
+    }
+
+    // A = L L^T. Track each block's weakest and strongest pivot: their RATIO is the
+    // conditioning. An absolute pivot is not comparable across scenes — pivots accumulate over
+    // correspondences, so they grow with the inlier count and the depth, and a direction can be
+    // orders of magnitude worse constrained than its neighbours while still being numerically
+    // large. The ratio is scale-free and is what "one direction is unconstrained" means.
+    let (mut min_rot, mut max_rot) = (f64::INFINITY, 0.0f64);
+    let (mut min_trans, mut max_trans) = (f64::INFINITY, 0.0f64);
+    let mut l = [[0.0; 6]; 6];
+    for i in 0..6 {
+        for j in 0..=i {
+            let mut sum = a[i][j];
+            for (lik, ljk) in l[i].iter().zip(l[j].iter()).take(j) {
+                sum -= lik * ljk;
+            }
+            if i == j {
+                let block_scale = if i < 3 { max_diag_rot } else { max_diag_trans };
+                if i < 3 {
+                    min_rot = min_rot.min(sum);
+                    max_rot = max_rot.max(sum);
+                } else {
+                    min_trans = min_trans.min(sum);
+                    max_trans = max_trans.max(sum);
+                }
+                if sum < PIVOT_RTOL * block_scale {
+                    return None;
+                }
+                l[i][j] = sum.sqrt();
+            } else {
+                l[i][j] = sum / l[j][j];
+            }
+        }
+    }
+
+    let ratio = |lo: f64, hi: f64| {
+        if hi > 0.0 {
+            (lo / hi).clamp(0.0, 1.0)
+        } else {
+            0.0
+        }
+    };
+    Some((l, ratio(min_rot, max_rot), ratio(min_trans, max_trans)))
+}
+
+/// Axis-angle of a rotation matrix: the inverse of [`so3_exp`].
+fn so3_log(r: &[[f64; 3]; 3]) -> [f64; 3] {
+    let trace = r[0][0] + r[1][1] + r[2][2];
+    let cos = ((trace - 1.0) * 0.5).clamp(-1.0, 1.0);
+    let angle = cos.acos();
+    // Near zero the axis is ill-defined but the vector is not: sin(angle)/angle -> 1, so the
+    // off-diagonal difference IS the axis-angle to first order.
+    let scale = if angle < 1e-8 {
+        0.5
+    } else if angle > std::f64::consts::PI - 1e-6 {
+        // Near pi the same expression loses all precision; recover the axis from the symmetric
+        // part, where the diagonal stays well conditioned, and restore the sign from the skew.
+        let mut axis = [
+            ((r[0][0] - cos) / (1.0 - cos)).max(0.0).sqrt(),
+            ((r[1][1] - cos) / (1.0 - cos)).max(0.0).sqrt(),
+            ((r[2][2] - cos) / (1.0 - cos)).max(0.0).sqrt(),
+        ];
+        let skew = [r[2][1] - r[1][2], r[0][2] - r[2][0], r[1][0] - r[0][1]];
+        for k in 0..3 {
+            if skew[k] < 0.0 {
+                axis[k] = -axis[k];
+            }
+        }
+        let n = (axis[0] * axis[0] + axis[1] * axis[1] + axis[2] * axis[2]).sqrt();
+        return if n > 0.0 {
+            [
+                axis[0] / n * angle,
+                axis[1] / n * angle,
+                axis[2] / n * angle,
+            ]
+        } else {
+            [0.0; 3]
+        };
+    } else {
+        angle / (2.0 * angle.sin())
+    };
+    [
+        scale * (r[2][1] - r[1][2]),
+        scale * (r[0][2] - r[2][0]),
+        scale * (r[1][0] - r[0][1]),
+    ]
+}
+
+fn mat3_transpose(m: &[[f64; 3]; 3]) -> [[f64; 3]; 3] {
+    let mut t = [[0.0; 3]; 3];
+    for (i, row) in m.iter().enumerate() {
+        for (j, &v) in row.iter().enumerate() {
+            t[j][i] = v;
+        }
+    }
+    t
+}
+
+#[inline]
+fn mat3_row_dot(m: &[[f64; 3]; 3], row: usize, v: &[f64; 3]) -> f64 {
+    m[row][0] * v[0] + m[row][1] * v[1] + m[row][2] * v[2]
+}
+
+fn mat3_mul(a: &[[f64; 3]; 3], b: &[[f64; 3]; 3]) -> [[f64; 3]; 3] {
+    let mut out = [[0.0; 3]; 3];
+    for (out_row, a_row) in out.iter_mut().zip(a.iter()) {
+        for j in 0..3 {
+            out_row[j] = a_row[0] * b[0][j] + a_row[1] * b[1][j] + a_row[2] * b[2][j];
+        }
+    }
+    out
+}
+
+/// SO(3) exponential map (Rodrigues): `R = I + a [w]x + b [w]x^2` with
+/// `a = sin(t)/t`, `b = (1 - cos(t))/t^2`, Taylor fallback near zero.
+fn so3_exp(w: &[f64; 3]) -> [[f64; 3]; 3] {
+    let theta2 = w[0] * w[0] + w[1] * w[1] + w[2] * w[2];
+    let theta = theta2.sqrt();
+    let (a, b) = if theta < 1e-9 {
+        (1.0 - theta2 / 6.0, 0.5 - theta2 / 24.0)
+    } else {
+        (theta.sin() / theta, (1.0 - theta.cos()) / theta2)
+    };
+    // [w]x^2 = w w^T - theta^2 I
+    [
+        [
+            1.0 + b * (w[0] * w[0] - theta2),
+            -a * w[2] + b * w[0] * w[1],
+            a * w[1] + b * w[0] * w[2],
+        ],
+        [
+            a * w[2] + b * w[1] * w[0],
+            1.0 + b * (w[1] * w[1] - theta2),
+            -a * w[0] + b * w[1] * w[2],
+        ],
+        [
+            -a * w[1] + b * w[2] * w[0],
+            a * w[0] + b * w[2] * w[1],
+            1.0 + b * (w[2] * w[2] - theta2),
+        ],
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::rgbd::DepthIntrinsics;
+    use super::super::synth::{render_depth_mm, Plane, Scene, Sphere};
+    use super::*;
+    use crate::transforms::axis_angle_to_rotation_matrix;
+
+    const IDENTITY_ROT: [[f64; 3]; 3] = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]];
+
+    fn test_intrinsics() -> DepthIntrinsics {
+        DepthIntrinsics {
+            fx: 200.0,
+            fy: 200.0,
+            cx: 159.5,
+            cy: 89.5,
+            width: 320,
+            height: 180,
+        }
+    }
+
+    /// Angle in degrees between two rotation matrices.
+    fn rotation_error_deg(r_a: &[[f64; 3]; 3], r_b: &[[f64; 3]; 3]) -> f64 {
+        // trace(R_a^T R_b)
+        let mut trace = 0.0;
+        for i in 0..3 {
+            for k in 0..3 {
+                trace += r_a[k][i] * r_b[k][i];
+            }
+        }
+        ((trace - 1.0) / 2.0).clamp(-1.0, 1.0).acos().to_degrees()
+    }
+
+    fn translation_error(t_a: &[f64; 3], t_b: &[f64; 3]) -> f64 {
+        ((t_a[0] - t_b[0]).powi(2) + (t_a[1] - t_b[1]).powi(2) + (t_a[2] - t_b[2]).powi(2)).sqrt()
+    }
+
+    /// Ground-truth `T_target_source` from the target camera pose `T_world_cam`
+    /// (the source camera sits at the world origin):
+    /// `R = R_wc^T`, `t = -R_wc^T t_wc`.
+    fn gt_target_source(
+        rot_world_cam: &[[f64; 3]; 3],
+        t_world_cam: &[f64; 3],
+    ) -> ([[f64; 3]; 3], [f64; 3]) {
+        let mut rot = [[0.0; 3]; 3];
+        for (i, rot_row) in rot.iter_mut().enumerate() {
+            for (j, cell) in rot_row.iter_mut().enumerate() {
+                *cell = rot_world_cam[j][i];
+            }
+        }
+        let t = [
+            -(rot[0][0] * t_world_cam[0] + rot[0][1] * t_world_cam[1] + rot[0][2] * t_world_cam[2]),
+            -(rot[1][0] * t_world_cam[0] + rot[1][1] * t_world_cam[1] + rot[1][2] * t_world_cam[2]),
+            -(rot[2][0] * t_world_cam[0] + rot[2][1] * t_world_cam[1] + rot[2][2] * t_world_cam[2]),
+        ];
+        (rot, t)
+    }
+
+    #[test]
+    fn test_identity_self_icp() -> Result<(), Box<dyn std::error::Error>> {
+        let intr = test_intrinsics();
+        let depth = render_depth_mm(&Scene::corner_and_sphere(), &intr, &IDENTITY_ROT, &[0.0; 3]);
+        let pyr = RgbdPyramid::from_depth_mm(&depth, &intr, 3)?;
+
+        let result = icp_projective_plane(
+            &pyr,
+            &pyr,
+            IDENTITY_ROT,
+            [0.0; 3],
+            IcpPlaneCriteria::default(),
+        )?;
+
+        assert!(
+            rotation_error_deg(&result.rotation, &IDENTITY_ROT) < 0.01,
+            "self-ICP rotation drifted: {:?}",
+            result.rotation
+        );
+        let t_norm = translation_error(&result.translation, &[0.0; 3]);
+        assert!(t_norm < 1e-4, "self-ICP translation drifted: {t_norm}");
+        assert!(result.rmse < 1e-6, "self-ICP rmse: {}", result.rmse);
+        assert!(
+            result.inlier_fraction > 0.9,
+            "self-ICP inlier fraction: {}",
+            result.inlier_fraction
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_ground_truth_motion_grid() -> Result<(), Box<dyn std::error::Error>> {
+        let intr = test_intrinsics();
+        let scene = Scene::corner_and_sphere();
+        let src_pyr = {
+            let depth = render_depth_mm(&scene, &intr, &IDENTITY_ROT, &[0.0; 3]);
+            RgbdPyramid::from_depth_mm(&depth, &intr, 3)?
+        };
+
+        // (axis, angle deg, translation) of the target camera pose T_world_cam
+        let cases: &[([f64; 3], f64, [f64; 3])] = &[
+            ([1.0, 0.0, 0.0], 2.0, [0.0, 0.0, 0.0]),
+            ([0.0, 1.0, 0.0], -2.0, [0.0, 0.0, 0.0]),
+            ([0.0, 0.0, 1.0], 2.0, [0.0, 0.0, 0.0]),
+            ([1.0, 0.0, 0.0], 0.0, [0.03, 0.0, 0.0]),
+            ([1.0, 0.0, 0.0], 0.0, [0.0, -0.03, 0.0]),
+            ([1.0, 0.0, 0.0], 0.0, [0.0, 0.0, 0.03]),
+            ([1.0, 1.0, 1.0], 2.0, [0.02, -0.02, 0.015]),
+        ];
+
+        for (axis, angle_deg, t_wc) in cases {
+            let rot_wc = axis_angle_to_rotation_matrix(axis, angle_deg.to_radians())?;
+            let tgt_depth = render_depth_mm(&scene, &intr, &rot_wc, t_wc);
+            let tgt_pyr = RgbdPyramid::from_depth_mm(&tgt_depth, &intr, 3)?;
+            let (rot_gt, t_gt) = gt_target_source(&rot_wc, t_wc);
+
+            let result = icp_projective_plane(
+                &src_pyr,
+                &tgt_pyr,
+                IDENTITY_ROT,
+                [0.0; 3],
+                IcpPlaneCriteria::default(),
+            )?;
+
+            let rot_err = rotation_error_deg(&result.rotation, &rot_gt);
+            let t_err = translation_error(&result.translation, &t_gt);
+            assert!(
+                rot_err < 0.2,
+                "case {axis:?}/{angle_deg} deg/{t_wc:?}: rotation error {rot_err} deg"
+            );
+            assert!(
+                t_err < 5e-3,
+                "case {axis:?}/{angle_deg} deg/{t_wc:?}: translation error {} mm",
+                t_err * 1e3
+            );
+            assert!(
+                result.inlier_fraction > 0.5,
+                "case {axis:?}/{angle_deg} deg/{t_wc:?}: inlier fraction {}",
+                result.inlier_fraction
+            );
+        }
+        Ok(())
+    }
+
+    /// A partly-overlapping view must keep HIGH match quality while overlap falls.
+    ///
+    /// Regression guard for a live failure: `inlier_fraction` once divided by ALL valid source
+    /// pixels, so it fell with view overlap rather than with match error. A moving camera then
+    /// scored ~11% on solves that had converged to millimetres, every frame was rejected as
+    /// "tracking lost", the pose froze and the map stopped growing. Quality and overlap are
+    /// separate signals: low overlap means re-key, not reject.
+    #[test]
+    fn inlier_fraction_measures_quality_not_overlap() -> Result<(), Box<dyn std::error::Error>> {
+        let intr = test_intrinsics();
+        let scene = Scene::corner_and_sphere();
+        let src_depth = render_depth_mm(&scene, &intr, &IDENTITY_ROT, &[0.0; 3]);
+        let src_pyr = RgbdPyramid::from_depth_mm(&src_depth, &intr, 3)?;
+
+        // Yaw far enough that a large part of the source view leaves the target frustum.
+        let rot_wc = axis_angle_to_rotation_matrix(&[0.0, 1.0, 0.0], 18.0_f64.to_radians())?;
+        let t_wc = [0.35, 0.0, 0.0];
+        let tgt_depth = render_depth_mm(&scene, &intr, &rot_wc, &t_wc);
+        let tgt_pyr = RgbdPyramid::from_depth_mm(&tgt_depth, &intr, 3)?;
+        let (rot_gt, t_gt) = gt_target_source(&rot_wc, &t_wc);
+
+        // Rotation comes from the gyro prior in the live node; translation does not.
+        let result = icp_projective_plane(
+            &src_pyr,
+            &tgt_pyr,
+            rot_gt,
+            [0.0; 3],
+            IcpPlaneCriteria::default(),
+        )?;
+
+        // The solve is genuinely good ...
+        assert!(
+            rotation_error_deg(&result.rotation, &rot_gt) < 0.5,
+            "rotation error {} deg",
+            rotation_error_deg(&result.rotation, &rot_gt)
+        );
+        assert!(
+            translation_error(&result.translation, &t_gt) < 0.01,
+            "translation error {} m",
+            translation_error(&result.translation, &t_gt)
+        );
+        // ... so quality stays high, even though a chunk of the view is gone ...
+        // ... so quality stays high even though half the view has left the frustum ...
+        assert!(
+            result.inlier_fraction > 0.9,
+            "quality collapsed under partial overlap: {} (associated {})",
+            result.inlier_fraction,
+            result.num_associated
+        );
+        // ... the lost view registers as overlap instead, which is what should drive re-keying ...
+        assert!(
+            result.overlap_fraction < 0.7,
+            "overlap should register the rotated-away view: {}",
+            result.overlap_fraction
+        );
+        // ... and the two must not be the same number: the old inliers/valid metric (their
+        // product) is what sank to ~11% on hardware and rejected converged solves.
+        let inliers_over_valid = result.inlier_fraction * result.overlap_fraction;
+        assert!(
+            result.inlier_fraction > inliers_over_valid * 1.5,
+            "quality {} tracks the old inliers/valid metric {} — the split is gone",
+            result.inlier_fraction,
+            inliers_over_valid
+        );
+        assert!(
+            result.num_associated > 1000,
+            "too little evidence to trust the pose: {}",
+            result.num_associated
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_outlier_band_still_converges() -> Result<(), Box<dyn std::error::Error>> {
+        let intr = test_intrinsics();
+        let scene = Scene::corner_and_sphere();
+        let src_pyr = {
+            let depth = render_depth_mm(&scene, &intr, &IDENTITY_ROT, &[0.0; 3]);
+            RgbdPyramid::from_depth_mm(&depth, &intr, 3)?
+        };
+
+        let rot_wc = axis_angle_to_rotation_matrix(&[0.0, 1.0, 0.0], 1.5f64.to_radians())?;
+        let t_wc = [0.02, 0.0, 0.01];
+        let mut tgt_depth = render_depth_mm(&scene, &intr, &rot_wc, &t_wc);
+        // corrupt a 10% horizontal band with a +60 mm bias: inside the 100 mm
+        // distance gate, so it exercises the Huber weighting rather than the gate
+        let band_rows = intr.height / 10;
+        for v in 80..80 + band_rows {
+            for u in 0..intr.width {
+                let d = &mut tgt_depth[v * intr.width + u];
+                if *d != 0 {
+                    *d += 60;
+                }
+            }
+        }
+        let tgt_pyr = RgbdPyramid::from_depth_mm(&tgt_depth, &intr, 3)?;
+        let (rot_gt, t_gt) = gt_target_source(&rot_wc, &t_wc);
+
+        let result = icp_projective_plane(
+            &src_pyr,
+            &tgt_pyr,
+            IDENTITY_ROT,
+            [0.0; 3],
+            IcpPlaneCriteria::default(),
+        )?;
+
+        let rot_err = rotation_error_deg(&result.rotation, &rot_gt);
+        let t_err = translation_error(&result.translation, &t_gt);
+        assert!(rot_err < 0.2, "rotation error with outliers: {rot_err} deg");
+        assert!(
+            t_err < 5e-3,
+            "translation error with outliers: {} mm",
+            t_err * 1e3
+        );
+        Ok(())
+    }
+
+    /// Weak geometry must be visible in `observability`, because nothing else shows it.
+    ///
+    /// Guards a measured failure: on a near-degenerate view the tracker reported a perfect
+    /// inlier fraction and a sub-millimetre residual while publishing ~3x the true motion,
+    /// sliding along the surface. Residual and inlier fraction are blind to it — the pose moves
+    /// through a direction the geometry does not penalise — so the caller needs the conditioning
+    /// of the normal equations to refuse such a pose.
+    #[test]
+    fn observability_exposes_weak_geometry() -> Result<(), Box<dyn std::error::Error>> {
+        let intr = test_intrinsics();
+        // A wall with one small bump. The plane alone leaves three DoF free; the bump pins them,
+        // but only just — the near-degenerate regime, not the exactly-singular one the guard
+        // already rejects. (Two planes at any angle stay rank-deficient along their intersection,
+        // so a "shallow wedge" is the wrong shape for this test.)
+        let weak = Scene {
+            planes: vec![Plane {
+                normal: [0.0, 0.0, 1.0],
+                d: 2.0,
+            }],
+            spheres: vec![Sphere {
+                center: [0.0, 0.0, 1.9],
+                radius: 0.06,
+            }],
+        };
+        let slide = [0.02, 0.0, 0.0]; // along the surface: little residual to pay
+
+        let mut measured: Vec<(f64, f64, f64)> = Vec::new();
+        for scene in [weak, Scene::corner_and_sphere()] {
+            let src = RgbdPyramid::from_depth_mm(
+                &render_depth_mm(&scene, &intr, &IDENTITY_ROT, &[0.0; 3]),
+                &intr,
+                3,
+            )?;
+            let tgt = RgbdPyramid::from_depth_mm(
+                &render_depth_mm(&scene, &intr, &IDENTITY_ROT, &slide),
+                &intr,
+                3,
+            )?;
+            let r = icp_projective_plane(
+                &src,
+                &tgt,
+                IDENTITY_ROT,
+                [0.0; 3],
+                IcpPlaneCriteria::default(),
+            )?;
+            measured.push((r.observability, r.inlier_fraction, r.rmse));
+        }
+        let (weak_obs, weak_inl, weak_rmse) = measured[0];
+        let (rich_obs, rich_inl, _) = measured[1];
+
+        // Measured: 6.4e-7 on the weak scene against 8.8e-2 on the rich one — five orders of
+        // magnitude at nearly identical association counts, so the margin is geometry, not scale.
+        assert!(
+            weak_obs < 1e-4 && rich_obs > 1e-3,
+            "observability must separate the two geometries: weak {weak_obs:.3e}, rich {rich_obs:.3e}"
+        );
+        // The trap this field exists for: on the weak scene the numbers a caller would otherwise
+        // trust are not merely acceptable, they are BETTER than on the well-conditioned one.
+        assert!(
+            weak_inl >= rich_inl && weak_rmse < 0.001,
+            "expected the deceptive regime: weak inliers {weak_inl} (rich {rich_inl}), \
+             weak rmse {weak_rmse}"
+        );
+        Ok(())
+    }
+
+    /// Conditioning must not move with the number of correspondences.
+    ///
+    /// This is why the field is a ratio and not a pivot magnitude. Pivots of `J^T W J` accumulate
+    /// over correspondences, so an absolute floor tracks image resolution and scene depth rather
+    /// than geometry: a gate tuned on one scene silently never fires on a denser or nearer one.
+    /// Same geometry at half resolution — a quarter of the correspondences — must report the same
+    /// conditioning.
+    /// A rotation prior must not flatter the conditioning it is reported alongside.
+    ///
+    /// Measured regression: with a prior active, a frame whose translation was unobservable saw
+    /// its reported translation conditioning rise 14x — over the gate that had correctly held it
+    /// — while the published pose stayed wrong by 3.5x. The blocks are coupled through
+    /// elimination, so lifting rotation lifts translation's effective pivots. Conditioning is
+    /// therefore measured on the data-only equations while the solve uses the augmented ones.
+    #[test]
+    fn rotation_prior_does_not_inflate_reported_conditioning(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let intr = test_intrinsics();
+        // Roll-degenerate: rotation unobservable, translation pinned by the sphere.
+        let scene = Scene {
+            planes: vec![Plane {
+                normal: [0.0, 0.0, 1.0],
+                d: 2.5,
+            }],
+            spheres: vec![Sphere {
+                center: [0.0, 0.0, 1.8],
+                radius: 0.55,
+            }],
+        };
+        let true_rot = axis_angle_to_rotation_matrix(&[0.0, 0.0, 1.0], 3.0_f64.to_radians())?;
+        let src = RgbdPyramid::from_depth_mm(
+            &render_depth_mm(&scene, &intr, &IDENTITY_ROT, &[0.0; 3]),
+            &intr,
+            3,
+        )?;
+        let tgt = RgbdPyramid::from_depth_mm(
+            &render_depth_mm(&scene, &intr, &true_rot, &[0.01, 0.0, 0.0]),
+            &intr,
+            3,
+        )?;
+        let (prior_gt, _) = gt_target_source(&true_rot, &[0.01, 0.0, 0.0]);
+
+        let with = icp_projective_plane(
+            &src,
+            &tgt,
+            IDENTITY_ROT,
+            [0.0; 3],
+            IcpPlaneCriteria {
+                rotation_prior: Some(RotationPrior {
+                    rotation: prior_gt,
+                    sigma_rad: 0.1_f64.to_radians(),
+                }),
+                ..Default::default()
+            },
+        )?;
+
+        // The prior rescues the solve — without it the guard rejects this scene outright — but
+        // the rotation it rescued must still be REPORTED as unobservable, because it is.
+        assert!(
+            with.rotation_conditioning < 1e-3,
+            "prior inflated reported rotation conditioning to {:.3e}; the geometry did not change",
+            with.rotation_conditioning
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn conditioning_is_scale_free() -> Result<(), Box<dyn std::error::Error>> {
+        let scene = Scene::corner_and_sphere();
+        let full = test_intrinsics();
+        let half = DepthIntrinsics {
+            fx: full.fx / 2.0,
+            fy: full.fy / 2.0,
+            cx: (full.cx + 0.5) / 2.0 - 0.5,
+            cy: (full.cy + 0.5) / 2.0 - 0.5,
+            width: full.width / 2,
+            height: full.height / 2,
+        };
+        let slide = [0.02, 0.0, 0.0];
+
+        let mut solved = Vec::new();
+        for intr in [&full, &half] {
+            let src = RgbdPyramid::from_depth_mm(
+                &render_depth_mm(&scene, intr, &IDENTITY_ROT, &[0.0; 3]),
+                intr,
+                2,
+            )?;
+            let tgt = RgbdPyramid::from_depth_mm(
+                &render_depth_mm(&scene, intr, &IDENTITY_ROT, &slide),
+                intr,
+                2,
+            )?;
+            let r = icp_projective_plane(
+                &src,
+                &tgt,
+                IDENTITY_ROT,
+                [0.0; 3],
+                IcpPlaneCriteria::default(),
+            )?;
+            solved.push(r);
+        }
+        let (a, b) = (&solved[0], &solved[1]);
+        assert!(
+            b.num_associated * 3 < a.num_associated,
+            "half resolution should associate far fewer pixels: {} vs {}",
+            b.num_associated,
+            a.num_associated
+        );
+        for (name, lo, hi) in [
+            ("rotation", a.rotation_conditioning, b.rotation_conditioning),
+            (
+                "translation",
+                a.translation_conditioning,
+                b.translation_conditioning,
+            ),
+        ] {
+            let ratio = lo.max(hi) / lo.min(hi).max(f64::MIN_POSITIVE);
+            assert!(
+                ratio < 10.0,
+                "{name} conditioning moved with correspondence count: {lo:.3e} vs {hi:.3e}"
+            );
+        }
+        Ok(())
+    }
+
+    /// The rotation prior must rescue weak geometry WITHOUT damaging good geometry, and it must
+    /// survive a prior that is itself wrong — a real gyro carries bias, noise and, on hardware
+    /// with no IMU extrinsics, a fixed misalignment. A prior fed the exact answer proves nothing.
+    #[test]
+    fn rotation_prior_rescues_weak_geometry_without_harming_good(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let intr = test_intrinsics();
+        // Rotation-weak, translation-strong: a sphere centred on the optical axis in front of a
+        // fronto-parallel wall. Both are invariant under ROLL, so rotation about the viewing axis
+        // is unobservable, while the sphere's normals span every direction and pin all three
+        // translations. This isolates the mode the prior exists for — a scene that starves
+        // translation as well would be beyond any rotation prior's reach.
+        let weak = Scene {
+            planes: vec![Plane {
+                normal: [0.0, 0.0, 1.0],
+                d: 2.5,
+            }],
+            spheres: vec![Sphere {
+                center: [0.0, 0.0, 1.8],
+                radius: 0.55,
+            }],
+        };
+        let rich = Scene::corner_and_sphere();
+        // Roll about the viewing axis — the unobservable direction on the weak scene.
+        let true_rot = axis_angle_to_rotation_matrix(&[0.0, 0.0, 1.0], 3.0_f64.to_radians())?;
+        let true_t = [0.01, 0.0, 0.0];
+
+        // The prior is deliberately WRONG by 0.15 deg — well beyond a MEMS gyro's error over one
+        // frame, so passing here means it tolerates worse than reality.
+        let prior_err_deg: f64 = 0.15;
+        let prior_rot = mat3_mul(
+            &axis_angle_to_rotation_matrix(&[0.3, 0.6, 0.74], prior_err_deg.to_radians())?,
+            &true_rot,
+        );
+
+        let mut summary = Vec::new();
+        for scene in [&weak, &rich] {
+            let src = RgbdPyramid::from_depth_mm(
+                &render_depth_mm(scene, &intr, &IDENTITY_ROT, &[0.0; 3]),
+                &intr,
+                3,
+            )?;
+            let tgt = RgbdPyramid::from_depth_mm(
+                &render_depth_mm(scene, &intr, &true_rot, &true_t),
+                &intr,
+                3,
+            )?;
+            let (rot_gt, _) = gt_target_source(&true_rot, &true_t);
+
+            let solve = |prior: Option<RotationPrior>| {
+                let mut c = IcpPlaneCriteria {
+                    rotation_prior: prior,
+                    ..Default::default()
+                };
+                c.iters_per_level = vec![10, 7, 5];
+                icp_projective_plane(&src, &tgt, IDENTITY_ROT, [0.0; 3], c)
+            };
+            let (prior_gt, _) = gt_target_source(&prior_rot, &true_t);
+            // Without the prior the weak scene is rejected outright by the degeneracy guard —
+            // rotation is not merely poorly determined, it is unconstrained. Record that as an
+            // infinite error so the two cases compare on one scale.
+            let without = solve(None)
+                .map(|r| rotation_error_deg(&r.rotation, &rot_gt))
+                .unwrap_or(f64::INFINITY);
+            let with = solve(Some(RotationPrior {
+                rotation: prior_gt,
+                sigma_rad: prior_err_deg.to_radians(),
+            }))
+            .map(|r| rotation_error_deg(&r.rotation, &rot_gt))
+            .unwrap_or(f64::INFINITY);
+            summary.push((without, with));
+        }
+        let (weak_without, weak_with) = summary[0];
+        let (rich_without, rich_with) = summary[1];
+
+        // Weak geometry: the prior must take over, landing near its own accuracy rather than the
+        // solve's. Anything close to `prior_err_deg` means the constraint is carrying rotation.
+        assert!(
+            weak_without > 0.5 && weak_with < 0.3,
+            "prior failed to rescue weak rotation: {weak_without} deg without, {weak_with:.3} with"
+        );
+        // Good geometry: the prior is wrong by 0.15 deg and must NOT drag the solve toward it.
+        // Regularise, never override.
+        assert!(
+            rich_with < rich_without.max(0.05) * 3.0,
+            "prior degraded well-conditioned geometry: {rich_without:.4} deg without, {rich_with:.4} with"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_single_plane_is_degenerate() -> Result<(), Box<dyn std::error::Error>> {
+        let intr = test_intrinsics();
+        // one fronto-parallel plane: in-plane translation and in-plane rotation
+        // are unobservable for point-to-plane ICP
+        let scene = Scene {
+            planes: vec![Plane {
+                normal: [0.0, 0.0, 1.0],
+                d: 2.0,
+            }],
+            spheres: vec![],
+        };
+        let depth = render_depth_mm(&scene, &intr, &IDENTITY_ROT, &[0.0; 3]);
+        let pyr = RgbdPyramid::from_depth_mm(&depth, &intr, 3)?;
+
+        let result = icp_projective_plane(
+            &pyr,
+            &pyr,
+            IDENTITY_ROT,
+            [0.0; 3],
+            IcpPlaneCriteria::default(),
+        );
+        assert!(
+            matches!(result, Err(RgbdIcpError::SingularNormalEquations)),
+            "single plane must be rejected as degenerate, got {result:?}"
+        );
+        Ok(())
+    }
+}

--- a/crates/kornia-3d/src/registration/mod.rs
+++ b/crates/kornia-3d/src/registration/mod.rs
@@ -3,4 +3,13 @@
 mod icp_vanilla;
 pub use icp_vanilla::*;
 
+mod icp;
+pub use icp::*;
+
+mod rgbd;
+pub use rgbd::*;
+
+#[cfg(test)]
+pub(crate) mod synth;
+
 mod ops;

--- a/crates/kornia-3d/src/registration/rgbd.rs
+++ b/crates/kornia-3d/src/registration/rgbd.rs
@@ -1,0 +1,601 @@
+//! Depth-image (RGBD) geometry: vertex maps, normal maps and depth pyramids.
+//!
+//! Conventions used throughout this module (and the projective ICP built on it):
+//!
+//! * Camera model: OpenCV pinhole, +Z forward, +X right, +Y down.
+//! * Depth images: `u16` in millimetres, row-major, `0` = invalid (no measurement).
+//! * Vertex maps: `[f32; 3]` camera-frame points in metres, `[0, 0, 0]` = invalid
+//!   (a valid vertex always has `z > 0`).
+//! * Normal maps: unit `[f32; 3]` oriented towards the camera (`n · v < 0`),
+//!   `[0, 0, 0]` = invalid.
+
+/// Errors produced by the RGBD depth-geometry and projective ICP routines.
+#[derive(Debug, thiserror::Error)]
+pub enum RgbdIcpError {
+    /// The depth buffer length does not match the intrinsics dimensions.
+    #[error("depth buffer has {got} pixels, expected {width}x{height}={expected}")]
+    InvalidDepthSize {
+        /// Image width in pixels.
+        width: usize,
+        /// Image height in pixels.
+        height: usize,
+        /// Expected number of pixels (`width * height`).
+        expected: usize,
+        /// Actual buffer length.
+        got: usize,
+    },
+    /// The vertex map length does not match the given dimensions.
+    #[error("vertex map has {got} entries, expected {width}x{height}={expected}")]
+    InvalidVertexMapSize {
+        /// Image width in pixels.
+        width: usize,
+        /// Image height in pixels.
+        height: usize,
+        /// Expected number of entries (`width * height`).
+        expected: usize,
+        /// Actual buffer length.
+        got: usize,
+    },
+    /// A pyramid was requested with zero levels.
+    #[error("pyramid needs at least 1 level, got {0}")]
+    InvalidNumLevels(usize),
+    /// The image becomes too small to process at the requested pyramid level.
+    #[error("image is {width}x{height} at pyramid level {level}; need at least 3x3")]
+    ImageTooSmall {
+        /// Pyramid level at which the image became too small (0 = finest).
+        level: usize,
+        /// Image width at that level.
+        width: usize,
+        /// Image height at that level.
+        height: usize,
+    },
+    /// The point-to-plane normal equations are (near-)singular: the observed
+    /// geometry does not constrain all six pose DoF (e.g. a single plane /
+    /// blank wall).
+    #[error("point-to-plane normal equations are singular (degenerate geometry)")]
+    SingularNormalEquations,
+    /// Too few correspondences survived projective association and gating to
+    /// constrain a pose — low overlap or a bad initial guess, as opposed to
+    /// degenerate geometry ([`SingularNormalEquations`](Self::SingularNormalEquations)).
+    /// Recovery differs (re-initialize / widen gates vs hold pose), so the two
+    /// causes are distinct variants.
+    #[error("only {0} correspondences survived gating; need at least 6")]
+    TooFewCorrespondences(usize),
+}
+
+/// Pinhole intrinsics of a depth image (OpenCV convention, +Z forward).
+///
+/// Pixel centers sit at integer coordinates, i.e. pixel `(u, v)` covers the
+/// continuous range `[u - 0.5, u + 0.5) x [v - 0.5, v + 0.5)`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DepthIntrinsics {
+    /// Focal length in pixels along x.
+    pub fx: f64,
+    /// Focal length in pixels along y.
+    pub fy: f64,
+    /// Principal point x in pixels.
+    pub cx: f64,
+    /// Principal point y in pixels.
+    pub cy: f64,
+    /// Image width in pixels.
+    pub width: usize,
+    /// Image height in pixels.
+    pub height: usize,
+}
+
+impl DepthIntrinsics {
+    /// Back-project pixel `(u, v)` at depth `z` metres into a camera-frame point.
+    pub fn unproject(&self, u: f64, v: f64, z: f64) -> [f64; 3] {
+        [(u - self.cx) * z / self.fx, (v - self.cy) * z / self.fy, z]
+    }
+
+    /// Project a camera-frame point to continuous pixel coordinates `[u, v]`.
+    ///
+    /// Returns `None` for points at or behind the camera (`z <= 0`).
+    pub fn project(&self, point: &[f64; 3]) -> Option<[f64; 2]> {
+        if point[2] <= 0.0 {
+            return None;
+        }
+        Some([
+            self.fx * point[0] / point[2] + self.cx,
+            self.fy * point[1] / point[2] + self.cy,
+        ])
+    }
+
+    /// Intrinsics of the half-resolution image produced by [`downsample_depth_half`].
+    ///
+    /// With pixel centers at integer coordinates, the continuous coordinates of
+    /// the two grids relate as `u_full = 2 * u_half + 0.5` (a half-res pixel
+    /// covers a 2x2 full-res block whose center lies at `2u + 0.5`). Substituting
+    /// into the projection equation gives `fx' = fx / 2` and
+    /// `cx' = (cx + 0.5) / 2 - 0.5` (likewise for y). Dimensions floor-halve.
+    pub fn half(&self) -> DepthIntrinsics {
+        DepthIntrinsics {
+            fx: self.fx / 2.0,
+            fy: self.fy / 2.0,
+            cx: (self.cx + 0.5) / 2.0 - 0.5,
+            cy: (self.cy + 0.5) / 2.0 - 0.5,
+            width: self.width / 2,
+            height: self.height / 2,
+        }
+    }
+}
+
+/// Returns true if a vertex-map entry is a valid measurement (`z > 0`).
+#[inline]
+pub fn is_valid_vertex(v: &[f32; 3]) -> bool {
+    v[2] > 0.0
+}
+
+/// Returns true if a normal-map entry is valid (non-zero).
+#[inline]
+pub fn is_valid_normal(n: &[f32; 3]) -> bool {
+    n[0] != 0.0 || n[1] != 0.0 || n[2] != 0.0
+}
+
+/// Back-project a `u16` millimetre depth image into a camera-frame vertex map in metres.
+///
+/// Invalid depth (`0`) maps to `[0, 0, 0]`. `out` is resized to `width * height`.
+pub fn depth_to_vertex_map(
+    depth_mm: &[u16],
+    intr: &DepthIntrinsics,
+    out: &mut Vec<[f32; 3]>,
+) -> Result<(), RgbdIcpError> {
+    let expected = intr.width * intr.height;
+    if depth_mm.len() != expected {
+        return Err(RgbdIcpError::InvalidDepthSize {
+            width: intr.width,
+            height: intr.height,
+            expected,
+            got: depth_mm.len(),
+        });
+    }
+
+    out.clear();
+    out.resize(expected, [0.0; 3]);
+
+    for v in 0..intr.height {
+        let row = &depth_mm[v * intr.width..(v + 1) * intr.width];
+        let out_row = &mut out[v * intr.width..(v + 1) * intr.width];
+        for (u, (&d, out_px)) in row.iter().zip(out_row.iter_mut()).enumerate() {
+            if d == 0 {
+                continue;
+            }
+            let z = d as f64 * 1e-3;
+            let p = intr.unproject(u as f64, v as f64, z);
+            *out_px = [p[0] as f32, p[1] as f32, p[2] as f32];
+        }
+    }
+
+    Ok(())
+}
+
+/// Compute a normal map from a vertex map via the cross product of central differences.
+///
+/// For each interior pixel with a valid center and four valid neighbors, the
+/// normal is `normalize((v[u+1] - v[u-1]) x (v[v+1] - v[v-1]))`, flipped to face
+/// the camera (`n · vertex < 0`). Border pixels and pixels with any invalid
+/// neighbor get `[0, 0, 0]`. `out` is resized to `width * height`.
+pub fn vertex_map_to_normal_map(
+    vertices: &[[f32; 3]],
+    width: usize,
+    height: usize,
+    out: &mut Vec<[f32; 3]>,
+) -> Result<(), RgbdIcpError> {
+    let expected = width * height;
+    if vertices.len() != expected {
+        return Err(RgbdIcpError::InvalidVertexMapSize {
+            width,
+            height,
+            expected,
+            got: vertices.len(),
+        });
+    }
+
+    out.clear();
+    out.resize(expected, [0.0; 3]);
+
+    if width < 3 || height < 3 {
+        return Ok(());
+    }
+
+    for y in 1..height - 1 {
+        for x in 1..width - 1 {
+            let idx = y * width + x;
+            let center = &vertices[idx];
+            let left = &vertices[idx - 1];
+            let right = &vertices[idx + 1];
+            let up = &vertices[idx - width];
+            let down = &vertices[idx + width];
+            if !is_valid_vertex(center)
+                || !is_valid_vertex(left)
+                || !is_valid_vertex(right)
+                || !is_valid_vertex(up)
+                || !is_valid_vertex(down)
+            {
+                continue;
+            }
+
+            let du = [right[0] - left[0], right[1] - left[1], right[2] - left[2]];
+            let dv = [down[0] - up[0], down[1] - up[1], down[2] - up[2]];
+            let mut n = [
+                du[1] * dv[2] - du[2] * dv[1],
+                du[2] * dv[0] - du[0] * dv[2],
+                du[0] * dv[1] - du[1] * dv[0],
+            ];
+
+            let norm = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt();
+            if norm < 1e-12 {
+                continue;
+            }
+
+            // orient towards the camera: the view ray is the vertex itself
+            let flip = if n[0] * center[0] + n[1] * center[1] + n[2] * center[2] > 0.0 {
+                -1.0
+            } else {
+                1.0
+            };
+            n = [flip * n[0] / norm, flip * n[1] / norm, flip * n[2] / norm];
+            out[idx] = n;
+        }
+    }
+
+    Ok(())
+}
+
+/// Maximum in-block depth spread that is still averaged together when
+/// downsampling; values further than this from the block median are treated as
+/// belonging to a different surface (depth discontinuity) and excluded.
+const DOWNSAMPLE_JUMP_MM: i32 = 50;
+
+/// Downsample a `u16` millimetre depth image by 2x, validity- and discontinuity-aware.
+///
+/// Each output pixel covers a 2x2 input block: invalid (`0`) samples are
+/// ignored, the lower median of the valid samples is taken as pivot, and only
+/// samples within [`DOWNSAMPLE_JUMP_MM`] of the pivot are averaged. This never
+/// averages across depth discontinuities and never fills holes: a fully
+/// invalid block stays `0`. `out` is resized to `(width / 2) * (height / 2)`
+/// (floor; a trailing odd row/column is dropped).
+pub fn downsample_depth_half(
+    depth_mm: &[u16],
+    width: usize,
+    height: usize,
+    out: &mut Vec<u16>,
+) -> Result<(), RgbdIcpError> {
+    let expected = width * height;
+    if depth_mm.len() != expected {
+        return Err(RgbdIcpError::InvalidDepthSize {
+            width,
+            height,
+            expected,
+            got: depth_mm.len(),
+        });
+    }
+
+    let half_w = width / 2;
+    let half_h = height / 2;
+    out.clear();
+    out.resize(half_w * half_h, 0);
+
+    for y in 0..half_h {
+        let row0 = &depth_mm[2 * y * width..];
+        let row1 = &depth_mm[(2 * y + 1) * width..];
+        for x in 0..half_w {
+            let block = [row0[2 * x], row0[2 * x + 1], row1[2 * x], row1[2 * x + 1]];
+            let mut valid = [0u16; 4];
+            let mut n = 0;
+            for &d in &block {
+                if d != 0 {
+                    valid[n] = d;
+                    n += 1;
+                }
+            }
+            if n == 0 {
+                continue;
+            }
+            valid[..n].sort_unstable();
+            // lower median: always an actual sample, so it cannot itself
+            // straddle a discontinuity
+            let pivot = valid[(n - 1) / 2] as i32;
+            let mut sum = 0u32;
+            let mut count = 0u32;
+            for &d in &valid[..n] {
+                if (d as i32 - pivot).abs() <= DOWNSAMPLE_JUMP_MM {
+                    sum += d as u32;
+                    count += 1;
+                }
+            }
+            out[y * half_w + x] = ((sum + count / 2) / count) as u16;
+        }
+    }
+
+    Ok(())
+}
+
+/// One resolution level of an [`RgbdPyramid`]: intrinsics plus vertex and normal maps.
+#[derive(Debug, Clone)]
+pub struct RgbdLevel {
+    /// Intrinsics at this level's resolution.
+    pub intrinsics: DepthIntrinsics,
+    /// Camera-frame vertex map in metres, `[0, 0, 0]` = invalid.
+    pub vertices: Vec<[f32; 3]>,
+    /// Unit normal map oriented towards the camera, `[0, 0, 0]` = invalid.
+    pub normals: Vec<[f32; 3]>,
+}
+
+/// Coarse-to-fine pyramid of vertex/normal maps built from a single depth image.
+///
+/// `levels[0]` is the finest (input) resolution; each subsequent level halves
+/// the resolution via [`downsample_depth_half`] and [`DepthIntrinsics::half`].
+#[derive(Debug, Clone)]
+pub struct RgbdPyramid {
+    /// Pyramid levels, finest first.
+    pub levels: Vec<RgbdLevel>,
+}
+
+impl RgbdPyramid {
+    /// Build a pyramid with `num_levels` levels from a `u16` millimetre depth image.
+    pub fn from_depth_mm(
+        depth_mm: &[u16],
+        intr: &DepthIntrinsics,
+        num_levels: usize,
+    ) -> Result<Self, RgbdIcpError> {
+        if num_levels == 0 {
+            return Err(RgbdIcpError::InvalidNumLevels(num_levels));
+        }
+
+        let mut levels = Vec::with_capacity(num_levels);
+        // level 0 reads `depth_mm` directly (no copy — this sits on per-frame hot paths);
+        // `owned` holds the downsampled buffer from level 1 on.
+        let mut owned: Vec<u16> = Vec::new();
+        let mut level_intr = intr.clone();
+
+        for level in 0..num_levels {
+            if level > 0 {
+                let mut half = Vec::new();
+                let cur: &[u16] = if level == 1 { depth_mm } else { &owned };
+                downsample_depth_half(cur, level_intr.width, level_intr.height, &mut half)?;
+                owned = half;
+                level_intr = level_intr.half();
+            }
+            if level_intr.width < 3 || level_intr.height < 3 {
+                return Err(RgbdIcpError::ImageTooSmall {
+                    level,
+                    width: level_intr.width,
+                    height: level_intr.height,
+                });
+            }
+            let depth: &[u16] = if level == 0 { depth_mm } else { &owned };
+            let mut vertices = Vec::new();
+            depth_to_vertex_map(depth, &level_intr, &mut vertices)?;
+            let mut normals = Vec::new();
+            vertex_map_to_normal_map(&vertices, level_intr.width, level_intr.height, &mut normals)?;
+            levels.push(RgbdLevel {
+                intrinsics: level_intr.clone(),
+                vertices,
+                normals,
+            });
+        }
+
+        Ok(Self { levels })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::synth::{render_depth_mm, render_vertex_map, Scene};
+    use super::*;
+
+    const IDENTITY_ROT: [[f64; 3]; 3] = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]];
+
+    fn test_intrinsics() -> DepthIntrinsics {
+        DepthIntrinsics {
+            fx: 200.0,
+            fy: 200.0,
+            cx: 159.5,
+            cy: 89.5,
+            width: 320,
+            height: 180,
+        }
+    }
+
+    #[test]
+    fn test_vertex_map_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+        let intr = test_intrinsics();
+        let depth = render_depth_mm(&Scene::corner_and_sphere(), &intr, &IDENTITY_ROT, &[0.0; 3]);
+
+        let mut verts = Vec::new();
+        depth_to_vertex_map(&depth, &intr, &mut verts)?;
+
+        let mut checked = 0;
+        for v in 0..intr.height {
+            for u in 0..intr.width {
+                let idx = v * intr.width + u;
+                let d = depth[idx];
+                let p = verts[idx];
+                if d == 0 {
+                    assert_eq!(p, [0.0; 3], "invalid depth must give [0,0,0] at ({u},{v})");
+                    continue;
+                }
+                assert!(is_valid_vertex(&p));
+                // z is the depth in metres
+                assert!((p[2] as f64 - d as f64 * 1e-3).abs() < 1e-6);
+                // project(unproject(u, v, z)) == (u, v)
+                let uv = intr
+                    .project(&[p[0] as f64, p[1] as f64, p[2] as f64])
+                    .ok_or("valid vertex must project")?;
+                assert!(
+                    (uv[0] - u as f64).abs() < 1e-3 && (uv[1] - v as f64).abs() < 1e-3,
+                    "round trip failed at ({u},{v}): got ({}, {})",
+                    uv[0],
+                    uv[1]
+                );
+                checked += 1;
+            }
+        }
+        assert!(
+            checked > 10_000,
+            "scene should cover most pixels: {checked}"
+        );
+
+        // pure f64 unproject/project round trip on a hand-picked point
+        let p = intr.unproject(37.25, 101.75, 1.234);
+        let uv = intr.project(&p).ok_or("must project")?;
+        assert!((uv[0] - 37.25).abs() < 1e-12 && (uv[1] - 101.75).abs() < 1e-12);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_tilted_plane_normals_within_one_degree() -> Result<(), Box<dyn std::error::Error>> {
+        let intr = test_intrinsics();
+        // plane tilted 20 degrees about the x-axis, ~1.5 m in front of the camera
+        let (s, c) = (20.0f64).to_radians().sin_cos();
+        let scene = Scene {
+            planes: vec![super::super::synth::Plane {
+                normal: [0.0, s, c],
+                d: 1.5,
+            }],
+            spheres: vec![],
+        };
+        // camera-facing ground-truth normal (n_z < 0)
+        let n_gt = [0.0, -s, -c];
+
+        // exact (float) vertex map, so the test isolates the cross-product math
+        // from u16 millimetre quantization
+        let verts = render_vertex_map(&scene, &intr, &IDENTITY_ROT, &[0.0; 3]);
+        let mut normals = Vec::new();
+        vertex_map_to_normal_map(&verts, intr.width, intr.height, &mut normals)?;
+
+        let max_angle_rad = 1.0f64.to_radians();
+        let mut checked = 0;
+        for (idx, n) in normals.iter().enumerate() {
+            if !is_valid_normal(n) {
+                continue;
+            }
+            let dot = (n[0] as f64 * n_gt[0] + n[1] as f64 * n_gt[1] + n[2] as f64 * n_gt[2])
+                .clamp(-1.0, 1.0);
+            let angle = dot.acos();
+            assert!(
+                angle < max_angle_rad,
+                "normal at pixel {idx} off by {} deg",
+                angle.to_degrees()
+            );
+            checked += 1;
+        }
+        // all interior pixels see the plane
+        assert_eq!(checked, (intr.width - 2) * (intr.height - 2));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_downsample_holes_and_discontinuities() -> Result<(), Box<dyn std::error::Error>> {
+        // 8x8: left half at 1000 mm, right half at 2000 mm, one hole block,
+        // one block with a single valid sample
+        let (w, h) = (8usize, 8usize);
+        let mut depth = vec![0u16; w * h];
+        for y in 0..h {
+            for x in 0..w {
+                depth[y * w + x] = if x < 4 { 1000 } else { 2000 };
+            }
+        }
+        // fully invalid 2x2 block at output (0, 0)
+        depth[0] = 0;
+        depth[1] = 0;
+        depth[w] = 0;
+        depth[w + 1] = 0;
+        // single valid sample in block at output (1, 1): keep only (2, 2)
+        depth[2 * w + 3] = 0;
+        depth[3 * w + 2] = 0;
+        depth[3 * w + 3] = 0;
+        // 3-valid block at output (0, 2) (covers input x 4..6, y 0..2)
+        // straddling the discontinuity: one foreground sample, two background
+        depth[w + 4] = 0;
+        depth[4] = 1000; // foreground intruding into the background side
+        depth[5] = 2000;
+        depth[w + 5] = 2000;
+
+        let mut half = Vec::new();
+        downsample_depth_half(&depth, w, h, &mut half)?;
+        let hw = w / 2;
+
+        // hole block stays invalid — holes never get filled
+        assert_eq!(half[0], 0);
+        // single valid sample passes through unchanged
+        assert_eq!(half[hw + 1], 1000);
+        // uniform blocks average exactly
+        assert_eq!(half[2 * hw], 1000);
+        assert_eq!(half[2 * hw + 3], 2000);
+        // mixed 1000/2000 block must side with the median surface, never smear
+        let mixed = half[2];
+        assert_eq!(
+            mixed, 2000,
+            "block with samples [1000, 2000, 2000] must resolve to the median surface"
+        );
+        // no output pixel anywhere may be an average across the 1 m jump
+        for &d in &half {
+            assert!(
+                d == 0 || (d as i32 - 1500).abs() > 400,
+                "smeared depth {d} across discontinuity"
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_pyramid_levels_and_intrinsics() -> Result<(), Box<dyn std::error::Error>> {
+        let intr = test_intrinsics();
+        let mut depth =
+            render_depth_mm(&Scene::corner_and_sphere(), &intr, &IDENTITY_ROT, &[0.0; 3]);
+        // punch a 4x4 hole so coarser levels must keep it invalid
+        for y in 60..64 {
+            for x in 100..104 {
+                depth[y * intr.width + x] = 0;
+            }
+        }
+
+        let pyr = RgbdPyramid::from_depth_mm(&depth, &intr, 3)?;
+        assert_eq!(pyr.levels.len(), 3);
+
+        let mut expected = intr.clone();
+        for (i, level) in pyr.levels.iter().enumerate() {
+            if i > 0 {
+                expected = expected.half();
+            }
+            assert_eq!(level.intrinsics, expected, "intrinsics at level {i}");
+            let n = level.intrinsics.width * level.intrinsics.height;
+            assert_eq!(level.vertices.len(), n);
+            assert_eq!(level.normals.len(), n);
+            assert!(
+                level.vertices.iter().filter(|v| is_valid_vertex(v)).count() > n / 2,
+                "level {i} should be mostly valid"
+            );
+        }
+        assert_eq!(pyr.levels[1].intrinsics.width, 160);
+        assert_eq!(pyr.levels[1].intrinsics.height, 90);
+        assert_eq!(pyr.levels[2].intrinsics.width, 80);
+        assert_eq!(pyr.levels[2].intrinsics.height, 45);
+        // cx convention: cx' = (cx + 0.5) / 2 - 0.5
+        assert!((pyr.levels[1].intrinsics.cx - ((159.5 + 0.5) / 2.0 - 0.5)).abs() < 1e-12);
+        assert!((pyr.levels[1].intrinsics.fx - 100.0).abs() < 1e-12);
+
+        // the hole survives downsampling: level-1 block covering the hole center
+        // must be invalid (holes propagate, they are never filled)
+        let l1 = &pyr.levels[1];
+        assert_eq!(l1.vertices[31 * l1.intrinsics.width + 51][2], 0.0);
+
+        // errors
+        assert!(matches!(
+            RgbdPyramid::from_depth_mm(&depth, &intr, 0),
+            Err(RgbdIcpError::InvalidNumLevels(0))
+        ));
+        assert!(matches!(
+            RgbdPyramid::from_depth_mm(&depth, &intr, 8),
+            Err(RgbdIcpError::ImageTooSmall { .. })
+        ));
+
+        Ok(())
+    }
+}

--- a/crates/kornia-3d/src/registration/synth.rs
+++ b/crates/kornia-3d/src/registration/synth.rs
@@ -1,0 +1,176 @@
+//! Synthetic analytic depth renderer for registration tests.
+//!
+//! Raycasts a scene of (infinite) planes and spheres from a posed pinhole
+//! camera, producing either a `u16` millimetre depth image or an exact `f32`
+//! vertex map. Shared by the `rgbd` and `icp` test suites.
+//!
+//! Conventions match [`super::rgbd`]: OpenCV pinhole, +Z forward, camera pose
+//! given as `T_world_cam` (camera-to-world), depth is z-depth in millimetres.
+
+use super::rgbd::DepthIntrinsics;
+
+/// Infinite plane `normal . p = d` in world coordinates.
+pub(crate) struct Plane {
+    /// Unit plane normal.
+    pub normal: [f64; 3],
+    /// Signed distance so that `normal . p = d` on the plane.
+    pub d: f64,
+}
+
+/// Sphere in world coordinates.
+pub(crate) struct Sphere {
+    /// Center of the sphere.
+    pub center: [f64; 3],
+    /// Radius of the sphere.
+    pub radius: f64,
+}
+
+/// A raycastable test scene.
+pub(crate) struct Scene {
+    /// Infinite planes.
+    pub planes: Vec<Plane>,
+    /// Spheres.
+    pub spheres: Vec<Sphere>,
+}
+
+/// Near clip: hits closer than this are ignored.
+const NEAR_M: f64 = 0.05;
+
+impl Scene {
+    /// Concave corner of three orthogonal planes plus a sphere, all in front of
+    /// a camera at the origin looking down +Z.
+    ///
+    /// Three mutually orthogonal planes constrain all six DoF for
+    /// point-to-plane ICP (a single plane is degenerate); the sphere adds
+    /// curvature. Designed for the 320x180 / fx=200 test intrinsics.
+    pub fn corner_and_sphere() -> Self {
+        Scene {
+            planes: vec![
+                Plane {
+                    normal: [0.0, 0.0, 1.0],
+                    d: 2.0,
+                },
+                Plane {
+                    normal: [1.0, 0.0, 0.0],
+                    d: 0.8,
+                },
+                Plane {
+                    normal: [0.0, 1.0, 0.0],
+                    d: 0.6,
+                },
+            ],
+            spheres: vec![Sphere {
+                center: [-0.2, -0.15, 1.2],
+                radius: 0.3,
+            }],
+        }
+    }
+
+    /// Closest hit along ray `origin + t * dir`, returned as the parameter `t`.
+    fn raycast(&self, origin: &[f64; 3], dir: &[f64; 3]) -> Option<f64> {
+        let mut best: Option<f64> = None;
+        let mut consider = |t: f64| {
+            if t > NEAR_M && best.is_none_or(|b| t < b) {
+                best = Some(t);
+            }
+        };
+
+        for plane in &self.planes {
+            let denom = dot(&plane.normal, dir);
+            if denom.abs() < 1e-12 {
+                continue;
+            }
+            consider((plane.d - dot(&plane.normal, origin)) / denom);
+        }
+
+        for sphere in &self.spheres {
+            let oc = [
+                origin[0] - sphere.center[0],
+                origin[1] - sphere.center[1],
+                origin[2] - sphere.center[2],
+            ];
+            let a = dot(dir, dir);
+            let b = dot(&oc, dir);
+            let c = dot(&oc, &oc) - sphere.radius * sphere.radius;
+            let disc = b * b - a * c;
+            if disc < 0.0 {
+                continue;
+            }
+            let sqrt_disc = disc.sqrt();
+            consider((-b - sqrt_disc) / a);
+            consider((-b + sqrt_disc) / a);
+        }
+
+        best
+    }
+}
+
+fn dot(a: &[f64; 3], b: &[f64; 3]) -> f64 {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+}
+
+/// Z-depth (in metres) of the closest surface at pixel `(u, v)`, or `None`.
+///
+/// The camera ray direction is scaled so its camera-frame z component is 1,
+/// making the ray parameter equal to the z-depth.
+fn raycast_pixel(
+    scene: &Scene,
+    intr: &DepthIntrinsics,
+    rot_world_cam: &[[f64; 3]; 3],
+    t_world_cam: &[f64; 3],
+    u: usize,
+    v: usize,
+) -> Option<f64> {
+    let dir_cam = [
+        (u as f64 - intr.cx) / intr.fx,
+        (v as f64 - intr.cy) / intr.fy,
+        1.0,
+    ];
+    let dir_world = [
+        dot(&rot_world_cam[0], &dir_cam),
+        dot(&rot_world_cam[1], &dir_cam),
+        dot(&rot_world_cam[2], &dir_cam),
+    ];
+    scene.raycast(t_world_cam, &dir_world)
+}
+
+/// Render a `u16` millimetre depth image (0 = miss) from pose `T_world_cam`.
+pub(crate) fn render_depth_mm(
+    scene: &Scene,
+    intr: &DepthIntrinsics,
+    rot_world_cam: &[[f64; 3]; 3],
+    t_world_cam: &[f64; 3],
+) -> Vec<u16> {
+    let mut depth = vec![0u16; intr.width * intr.height];
+    for v in 0..intr.height {
+        for u in 0..intr.width {
+            if let Some(z) = raycast_pixel(scene, intr, rot_world_cam, t_world_cam, u, v) {
+                let mm = (z * 1000.0).round();
+                if mm >= 1.0 && mm <= u16::MAX as f64 {
+                    depth[v * intr.width + u] = mm as u16;
+                }
+            }
+        }
+    }
+    depth
+}
+
+/// Render an exact `f32` camera-frame vertex map (no millimetre quantization),
+/// `[0, 0, 0]` = miss. Same conventions as [`super::rgbd::depth_to_vertex_map`].
+pub(crate) fn render_vertex_map(
+    scene: &Scene,
+    intr: &DepthIntrinsics,
+    rot_world_cam: &[[f64; 3]; 3],
+    t_world_cam: &[f64; 3],
+) -> Vec<[f32; 3]> {
+    let mut verts = vec![[0.0f32; 3]; intr.width * intr.height];
+    for v in 0..intr.height {
+        for u in 0..intr.width {
+            if let Some(z) = raycast_pixel(scene, intr, rot_world_cam, t_world_cam, u, v) {
+                let p = intr.unproject(u as f64, v as f64, z);
+                verts[v * intr.width + u] = [p[0] as f32, p[1] as f32, p[2] as f32];
+            }
+        }
+    }
+    verts
+}


### PR DESCRIPTION
`registration` has vanilla point-to-point ICP. This adds the point-to-plane variant and the RGB-D odometry pipeline built on it. Both have been running in anger for handheld odometry on a Jetson Orin, at roughly **25 ms per solve on CPU**.

## Why point-to-plane

Point-to-point minimises the distance between corresponded points, which resists the tangential motion that indoor scans are full of: two views of the same wall are related by a slide the metric fights. Point-to-plane minimises distance along the target normal instead, letting surfaces slide over each other, so plane-dominated scenes converge in far fewer iterations.

## What's here

| file | |
|---|---|
| `registration/icp.rs` | the solver — normal estimation, correspondence rejection, Huber weighting, a 6x6 Cholesky on the normal equations, and an optional rotation prior contributing `1/sigma^2` to the rotation block alone |
| `registration/rgbd.rs` | depth-image front end: unproject, pyramid, per-level solve |
| `registration/synth.rs` | test-only synthetic scenes shared by both modules' tests |
| `examples/icp_bench.rs` | benchmark |
| `examples/icp_debug_pair.rs` | single-pair probe for debugging a bad alignment |

Additive alongside `icp_vanilla`; nothing existing changes behaviour.

## Tests

13 new (9 in `icp.rs`, 4 in `rgbd.rs`), on synthetic scenes with known ground-truth transforms. `cargo test -p kornia-3d` passes 215 + 14; clippy and rustfmt clean. **No new dependencies.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)