### PR TITLE
feat(calib): factorise the reduced camera system sparsely by default in SfM

### DIFF
--- a/crates/kornia-calib/src/sfm.rs
+++ b/crates/kornia-calib/src/sfm.rs
@@ -1104,6 +1104,7 @@ fn global_ba(
             } else {
                 0.0
             },
+            sparse_reduced_system: config.sparse_reduced_system,
             ..Default::default()
         },
         up_priors(poses, a0, config).as_deref(),
@@ -3293,6 +3294,50 @@ mod tests {
             "a DROPPED point keeps every observation, so triangulate_new can rebuild it later"
         );
         assert_eq!(depths[0].len(), 4);
+    }
+
+    /// The sparse reduced system must change the COST of the solve, never its answer.
+    ///
+    /// It is a different storage and factorisation of the same matrix, so anything that makes the
+    /// two disagree is a bug in the sparse assembly rather than a tuning choice — which is why this
+    /// asserts equality of the reconstruction and not merely similar quality. `kornia-3d` pins the
+    /// lower triangle as bit-identical at the matrix level; this pins the end-to-end result a
+    /// caller of [`reconstruct`] actually receives.
+    #[test]
+    fn sparse_reduced_system_does_not_change_the_reconstruction() {
+        let (cams, _gt, tracks) = walkthrough(40, 300, 0.4);
+        let solve = |sparse: bool| {
+            let config = ReconstructionConfig {
+                max_iterations: 20,
+                sparse_reduced_system: sparse,
+                ..ReconstructionConfig::new(0.0)
+            };
+            reconstruct_inner(&cams, &[], &tracks, &config, None, true, true).expect("recon")
+        };
+        let (sp, de) = (solve(true), solve(false));
+
+        assert_eq!(sp.points.len(), de.points.len(), "point count diverged");
+        assert_eq!(
+            sp.views.iter().filter(|v| v.is_some()).count(),
+            de.views.iter().filter(|v| v.is_some()).count(),
+            "registration diverged"
+        );
+        assert!(
+            (sp.reproj_rmse_px - de.reproj_rmse_px).abs() < 1e-6,
+            "rmse diverged: sparse {} vs dense {}",
+            sp.reproj_rmse_px,
+            de.reproj_rmse_px
+        );
+        let worst = sp
+            .points
+            .iter()
+            .zip(&de.points)
+            .map(|(a, b)| {
+                let d = a.position - b.position;
+                (d.x * d.x + d.y * d.y + d.z * d.z).sqrt()
+            })
+            .fold(0.0f64, f64::max);
+        assert!(worst < 1e-9, "point positions diverged by {worst}");
     }
 
     /// A forward walk: `n_views` cameras marching along their own optical axis toward a shell of

--- a/crates/kornia-calib/src/types.rs
+++ b/crates/kornia-calib/src/types.rs
@@ -150,6 +150,27 @@ pub struct ReconstructionConfig {
     /// whole reconstruction in a way no reprojection residual reveals. The fit is reported on
     /// [`Reconstruction::camera_correction`] and a second BA re-settles the geometry against it.
     pub refine_intrinsics: bool,
+    /// Factorise bundle adjustment's reduced camera system SPARSELY. **`true` by default**, which
+    /// is right for anything this entry point reconstructs.
+    ///
+    /// The reduced system is `6P x 6P`, and two cameras occupy a nonzero 6x6 block only if they
+    /// share a point. On a walkthrough, cameras a few hundred frames apart share nothing, so the
+    /// dense path pays `O(dim^2)` memory and `O(dim^3)` factorisation for structure that is not
+    /// there. Measured on a sequential synthetic, 10 LM iterations, same cost to 5 significant
+    /// figures and the same iteration count either way:
+    ///
+    /// | views | dense | sparse |
+    /// |---|---|---|
+    /// | 100 | 0.11 s | 0.02 s |
+    /// | 300 | 1.20 s | 0.08 s |
+    /// | 600 | 8.34 s | **0.13 s** |
+    ///
+    /// The gap widens with camera count — dense grows roughly cubically, sparse roughly linearly —
+    /// and sparse was never slower, down to 8 views. Turn it OFF only for a genuine RIG, where
+    /// every camera sees the same subject, the block pattern really is dense, and the sparse
+    /// bookkeeping is overhead with nothing to save. [`crate::CalibConfig`]'s rig path is
+    /// unaffected: this flag only reaches [`crate::reconstruct`].
+    pub sparse_reduced_system: bool,
     /// Called after each view is registered, as `(registered_so_far, total_views)`. `None` by
     /// default.
     pub progress: Option<std::sync::Arc<dyn Fn(usize, usize) + Send + Sync>>,
@@ -175,6 +196,7 @@ impl ReconstructionConfig {
             motion_prior_sigma: 0.0,
             min_registration_inliers: 30,
             refine_intrinsics: false,
+            sparse_reduced_system: true,
             progress: None,
         }
     }


### PR DESCRIPTION
The sparse reduced camera system landed in #1105 and **`reconstruct` has never used it.** `sfm.rs` builds its `BaParams` with `..Default::default()`, and that default is `false` — correct for a rig, and exactly wrong for the long sequential capture the sparse path was written for.

The reduced system is `6P × 6P`, and two cameras occupy a nonzero 6×6 block only if they share a point. On a walkthrough, cameras a few hundred frames apart share nothing, so the dense path pays `O(dim²)` memory and `O(dim³)` factorisation for structure that isn't there. At 900 keyframes that's a dense **5400×5400** matrix, ~233 MB, ~5×10¹⁰ flops per iteration.

## Measured

Sequential synthetic, 10 LM iterations, **identical cost to 5 significant figures and identical iteration counts**:

| views | dense | sparse | |
|---|---|---|---|
| 100 | 0.11 s | 0.02 s | 5.5× |
| 300 | 1.20 s | 0.08 s | 15× |
| 600 | 8.34 s | **0.13 s** | **64×** |

The gap widens with camera count — dense grows roughly cubically, sparse roughly linearly. Sparse was **never slower at any size measured, down to 8 views**.

## Exposed, not hardcoded

`ReconstructionConfig::sparse_reduced_system`, defaulting to `true`, documented with the measurement above and with the one case for turning it off: a genuine rig, where every camera sees the same subject, the block pattern really is dense, and the sparse bookkeeping saves nothing.

`CalibConfig`'s rig path is untouched, and so is `BaParams::default()` — this changes what `reconstruct` asks for, not what the solver defaults to.

## Tests

`sparse_reduced_system_does_not_change_the_reconstruction` pins the end-to-end result a caller receives: same points to 1e-9, same rmse to 1e-6, same registration count. It asserts *equality*, not comparable quality, because this is a different storage of the same matrix — anything that makes them disagree is a bug in the sparse assembly, not a tuning trade.

`kornia-3d` already pins the lower triangle as bit-identical at the matrix level. The other 40 tests in this crate previously exercised the dense path and are unchanged, which is itself the regression evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)