### PR TITLE
perf(imgproc): register-tile the SIFT vertical blur and warp-aggregate descriptor atomics

### DIFF
--- a/.github/workflows/rust_lint.yml
+++ b/.github/workflows/rust_lint.yml
@@ -69,7 +69,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@stable
+      # Pinned to match the toolchain pixi provides for the `Clippy` job above
+      # (`rust = ">=1.76"` currently resolves to 1.96). Tracking `stable` meant a
+      # compiler release could introduce a lint and fail this job on every open
+      # PR without any source change - Rust 1.98's `chunks_exact_to_as_chunks`
+      # did exactly that. Bump this deliberately, together with pixi's rust pin.
+      - uses: dtolnay/rust-toolchain@1.96.0
         with:
           components: clippy
 

--- a/crates/kornia-imgproc/Cargo.toml
+++ b/crates/kornia-imgproc/Cargo.toml
@@ -46,6 +46,11 @@ required-features = ["cuda"]
 
 [[bench]]
 harness = false
+name = "bench_cuda_sift"
+required-features = ["cuda"]
+
+[[bench]]
+harness = false
 name = "bench_sift_instr"
 
 [[bench]]

--- a/crates/kornia-imgproc/benches/bench_cuda_sift.rs
+++ b/crates/kornia-imgproc/benches/bench_cuda_sift.rs
@@ -1,0 +1,137 @@
+use std::time::Instant;
+
+use argh::FromArgs;
+use cudarc::driver::CudaContext;
+use kornia_image::{Image, ImageSize};
+use kornia_imgproc::cuda::sift::{FirstOctave, SiftCuda, SiftCudaConfig};
+
+/// Benchmark unified memory against explicit device copies for SIFT.
+#[derive(FromArgs)]
+struct Args {
+    /// CUDA device ordinal (default 0)
+    #[argh(option, default = "0")]
+    device: usize,
+
+    /// timed iterations per case (default 10)
+    #[argh(option, default = "10")]
+    iters: usize,
+
+    /// untimed warmup iterations per case (default 3)
+    #[argh(option, default = "3")]
+    warmup: usize,
+
+    /// accepted and ignored: `cargo bench` passes `--bench` to the harness
+    #[argh(switch)]
+    #[allow(dead_code)]
+    bench: bool,
+}
+
+const SIZES: &[(&str, usize, usize)] = &[
+    ("VGA    640x480", 640, 480),
+    ("HD    1280x720", 1280, 720),
+    ("FHD  1920x1080", 1920, 1080),
+];
+
+fn timed<F>(warmup: usize, iters: usize, mut f: F) -> Result<f64, Box<dyn std::error::Error>>
+where
+    F: FnMut() -> Result<(), Box<dyn std::error::Error>>,
+{
+    for _ in 0..warmup {
+        f()?;
+    }
+    let start = Instant::now();
+    for _ in 0..iters {
+        f()?;
+    }
+    Ok(start.elapsed().as_secs_f64() * 1e3 / iters as f64)
+}
+
+fn fill_ramp(buf: &mut [f32]) {
+    let inv = 255.0 / buf.len() as f32;
+    for (i, px) in buf.iter_mut().enumerate() {
+        *px = i as f32 * inv;
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Args = argh::from_env();
+
+    let ctx = CudaContext::new(args.device)?;
+    let stream = ctx.default_stream();
+
+    let integrated =
+        ctx.attribute(cudarc::driver::sys::CUdevice_attribute::CU_DEVICE_ATTRIBUTE_INTEGRATED)?;
+    let cc_major = ctx.attribute(
+        cudarc::driver::sys::CUdevice_attribute::CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR,
+    )?;
+    let cc_minor = ctx.attribute(
+        cudarc::driver::sys::CUdevice_attribute::CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR,
+    )?;
+
+    println!("device {}: sm_{cc_major}{cc_minor}", args.device);
+    println!(
+        "integrated: {} ({})",
+        integrated,
+        if integrated == 1 {
+            "shared physical memory — copies are redundant"
+        } else {
+            "discrete — copies cross PCIe"
+        }
+    );
+    println!("iters: {} (warmup {})\n", args.iters, args.warmup);
+
+    println!("── per frame, end-to-end SIFT detect_and_compute() ───────────");
+    println!(
+        "{:<16} {:>11} {:>11} {:>9}",
+        "size", "explicit ms", "unified ms", "speedup"
+    );
+    println!("{}", "-".repeat(52));
+
+    for &(label, w, h) in SIZES {
+        let size = ImageSize {
+            width: w,
+            height: h,
+        };
+
+        let cfg = SiftCudaConfig::default();
+        let mut plan_explicit = SiftCuda::new(
+            &ctx,
+            &stream,
+            w,
+            h,
+            cfg,
+            FirstOctave::Native, // fo=0
+            4,                   // 4 octaves
+        )?;
+        plan_explicit.set_fast_descriptor(true);
+
+        let mut plan_unified = SiftCuda::new(&ctx, &stream, w, h, cfg, FirstOctave::Native, 4)?;
+        plan_unified.set_fast_descriptor(true);
+
+        // Explicit: host frame, uploaded, compute. (D2H for descriptors is avoided in python API, so we just measure compute + H2D).
+        let explicit_ms = timed(args.warmup, args.iters, || {
+            let mut host = Image::<f32, 1>::from_size_val(size, 0.0)?;
+            fill_ramp(host.as_slice_mut());
+
+            let device = host.to_cuda(&stream)?;
+            let feats = plan_explicit.detect_and_compute(&ctx, &stream, &device)?;
+            std::hint::black_box(&feats);
+            Ok(())
+        })?;
+
+        // Unified: write into unified memory, compute directly.
+        let unified_ms = timed(args.warmup, args.iters, || {
+            let mut u_src = Image::<f32, 1>::zeros_cuda_unified(size, &stream)?;
+            fill_ramp(u_src.as_slice_mut());
+
+            let feats = plan_unified.detect_and_compute(&ctx, &stream, &u_src)?;
+            std::hint::black_box(&feats);
+            Ok(())
+        })?;
+
+        let speedup = explicit_ms / unified_ms;
+        println!("{label:<16} {explicit_ms:>11.3} {unified_ms:>11.3} {speedup:>8.2}x");
+    }
+
+    Ok(())
+}

--- a/crates/kornia-imgproc/benches/bench_opencv_sift.py
+++ b/crates/kornia-imgproc/benches/bench_opencv_sift.py
@@ -5,55 +5,55 @@ import kornia_rs
 
 def bench_opencv_vs_kornia(image_size=(1080, 1920), iters=100, warmup=10):
     print(f"Benchmarking SIFT detectAndCompute on {image_size[1]}x{image_size[0]} image")
-    
+
     # Generate a random uint8 image
     img = np.random.randint(0, 256, (image_size[0], image_size[1]), dtype=np.uint8)
-    
+
     # 1. OpenCV SIFT
     sift_cv = cv2.SIFT_create()
-    
+
     # Warmup OpenCV
     for _ in range(warmup):
         _ = sift_cv.detectAndCompute(img, None)
-        
+
     start_cv = time.perf_counter()
     for _ in range(iters):
         _ = sift_cv.detectAndCompute(img, None)
     cv_time = (time.perf_counter() - start_cv) * 1000 / iters
-    
+
     print(f"OpenCV SIFT: {cv_time:.2f} ms/frame")
-    
+
     # 2. Kornia-RS Host SIFT
     sift_kr = kornia_rs.imgproc.Sift()
     img_f32 = img.astype(np.float32).reshape(image_size[0], image_size[1], 1)
-    
+
     # Warmup Kornia Host
     for _ in range(warmup):
         _ = sift_kr.detect_and_compute(img_f32)
-        
+
     start_kr = time.perf_counter()
     for _ in range(iters):
         _ = sift_kr.detect_and_compute(img_f32)
     kr_time = (time.perf_counter() - start_kr) * 1000 / iters
-    
+
     print(f"Kornia-RS Host SIFT: {kr_time:.2f} ms/frame")
-    
+
     # 3. Kornia-RS CUDA SIFT (Explicit Copies)
     try:
         stream = kornia_rs.cuda.Stream.default()
         sift_cuda = kornia_rs.imgproc.Sift()
-        
+
         # Warmup Kornia CUDA (Explicit)
         for _ in range(warmup):
             img_cuda = kornia_rs.image.Image.from_numpy(img_f32).to_cuda(stream)
             _ = sift_cuda.detect_and_compute(img_cuda)
-            
+
         start_cuda = time.perf_counter()
         for _ in range(iters):
             img_cuda = kornia_rs.image.Image.from_numpy(img_f32).to_cuda(stream)
             _ = sift_cuda.detect_and_compute(img_cuda)
         cuda_time = (time.perf_counter() - start_cuda) * 1000 / iters
-        
+
         print(f"Kornia-RS CUDA (Explicit) SIFT: {cuda_time:.2f} ms/frame")
     except AttributeError:
         print("CUDA not available for Kornia-RS.")

--- a/crates/kornia-imgproc/benches/bench_opencv_sift.py
+++ b/crates/kornia-imgproc/benches/bench_opencv_sift.py
@@ -1,0 +1,66 @@
+import time
+import cv2
+import numpy as np
+import kornia_rs
+
+def bench_opencv_vs_kornia(image_size=(1080, 1920), iters=100, warmup=10):
+    print(f"Benchmarking SIFT detectAndCompute on {image_size[1]}x{image_size[0]} image")
+    
+    # Generate a random uint8 image
+    img = np.random.randint(0, 256, (image_size[0], image_size[1]), dtype=np.uint8)
+    
+    # 1. OpenCV SIFT
+    sift_cv = cv2.SIFT_create()
+    
+    # Warmup OpenCV
+    for _ in range(warmup):
+        _ = sift_cv.detectAndCompute(img, None)
+        
+    start_cv = time.perf_counter()
+    for _ in range(iters):
+        _ = sift_cv.detectAndCompute(img, None)
+    cv_time = (time.perf_counter() - start_cv) * 1000 / iters
+    
+    print(f"OpenCV SIFT: {cv_time:.2f} ms/frame")
+    
+    # 2. Kornia-RS Host SIFT
+    sift_kr = kornia_rs.imgproc.Sift()
+    img_f32 = img.astype(np.float32).reshape(image_size[0], image_size[1], 1)
+    
+    # Warmup Kornia Host
+    for _ in range(warmup):
+        _ = sift_kr.detect_and_compute(img_f32)
+        
+    start_kr = time.perf_counter()
+    for _ in range(iters):
+        _ = sift_kr.detect_and_compute(img_f32)
+    kr_time = (time.perf_counter() - start_kr) * 1000 / iters
+    
+    print(f"Kornia-RS Host SIFT: {kr_time:.2f} ms/frame")
+    
+    # 3. Kornia-RS CUDA SIFT (Explicit Copies)
+    try:
+        stream = kornia_rs.cuda.Stream.default()
+        sift_cuda = kornia_rs.imgproc.Sift()
+        
+        # Warmup Kornia CUDA (Explicit)
+        for _ in range(warmup):
+            img_cuda = kornia_rs.image.Image.from_numpy(img_f32).to_cuda(stream)
+            _ = sift_cuda.detect_and_compute(img_cuda)
+            
+        start_cuda = time.perf_counter()
+        for _ in range(iters):
+            img_cuda = kornia_rs.image.Image.from_numpy(img_f32).to_cuda(stream)
+            _ = sift_cuda.detect_and_compute(img_cuda)
+        cuda_time = (time.perf_counter() - start_cuda) * 1000 / iters
+        
+        print(f"Kornia-RS CUDA (Explicit) SIFT: {cuda_time:.2f} ms/frame")
+    except AttributeError:
+        print("CUDA not available for Kornia-RS.")
+
+if __name__ == "__main__":
+    bench_opencv_vs_kornia((480, 640), iters=50)
+    print("---")
+    bench_opencv_vs_kornia((720, 1280), iters=20)
+    print("---")
+    bench_opencv_vs_kornia((1080, 1920), iters=10)

--- a/crates/kornia-imgproc/benchmarks.md
+++ b/crates/kornia-imgproc/benchmarks.md
@@ -581,3 +581,57 @@ Same hardware/methodology as the sweep above (GTX 1650, 30 warmup, 100 timed ite
 | ycc_from_rgb (f32) | n/a | 3840×2160 | — | — | — | — | — | — | — |
 | bgr_from_rgb (u8) | n/a | 1920×1080 | — | — | — | — | — | — | — |
 | bgr_from_rgb (u8) | n/a | 3840×2160 | — | — | — | — | — | — | — |
+
+---
+
+## SIFT `detect_and_compute` — unified memory vs explicit copies — 2026-08-21
+
+Measures whether writing the source frame straight into unified memory
+(`Image::zeros_cuda_unified`) beats an explicit `to_cuda` upload for the
+end-to-end SIFT pipeline.
+
+```sh
+cargo bench --bench bench_cuda_sift --features cuda -- --iters 30 --warmup 10
+```
+
+### Desktop — NVIDIA GeForce GTX 1650 (discrete, sm_75)
+
+| Resolution | Explicit copies (ms) | Unified memory (ms) | Unified speedup |
+| --- | ---: | ---: | ---: |
+| VGA 640×480 | 2.451 | 5.114 | 0.48x |
+| HD 1280×720 | 8.086 | 13.715 | 0.59x |
+| FHD 1920×1080 | 19.902 | 25.013 | 0.80x |
+
+On a discrete GPU unified memory is a pageable buffer: every first touch from
+the device is a PCIe page fault, so it loses to a single batched H2D copy.
+
+### Embedded — NVIDIA Jetson Orin Nano (integrated)
+
+| Resolution | Explicit copies (ms) | Unified memory (ms) | Unified speedup |
+| --- | ---: | ---: | ---: |
+| VGA 640×480 | 4.865 | 4.301 | 1.13x |
+| HD 1280×720 | OOM | OOM | n/a |
+
+Jetson shares physical DRAM between CPU and GPU, so unified memory removes a
+real copy and wins at VGA. HD and above exhaust memory under the current
+allocation pattern — the pyramid and unified source are live simultaneously —
+so unified memory is **not** yet a general win on Jetson.
+
+## SIFT — OpenCV vs kornia-rs (Python API) — 2026-08-20
+
+`cv2.SIFT_create().detectAndCompute` against the kornia-rs Python bindings on
+random `uint8` images.
+
+```sh
+python crates/kornia-imgproc/benches/bench_opencv_sift.py
+```
+
+| Resolution | OpenCV SIFT (CPU) | kornia-rs host (CPU) | kornia-rs CUDA (explicit) |
+| --- | ---: | ---: | ---: |
+| VGA 640×480 | 64.11 ms | 210.98 ms | 12.51 ms |
+| HD 1280×720 | 242.21 ms | 591.92 ms | 34.11 ms |
+| FHD 1920×1080 | 527.19 ms | 1266.48 ms | 77.15 ms |
+
+The CUDA path is 5.1x–6.8x faster than OpenCV's CPU SIFT end to end, transfers
+included. The host path is slower than OpenCV on x86 — OpenCV's CPU SIFT is
+IPP/TBB-accelerated and the kornia-rs CPU SIFT is not yet vectorized.

--- a/crates/kornia-imgproc/src/cuda/sift/descriptor.rs
+++ b/crates/kornia-imgproc/src/cuda/sift/descriptor.rs
@@ -408,6 +408,46 @@ fn descriptor_block_src(threads: usize) -> String {
 __device__ __forceinline__ int cv_round_d(float v) {{ return __float2int_rn(v); }}
 __device__ __forceinline__ int cv_floor_d(float v) {{ return (int)floorf(v); }}
 
+// Warp-aggregated shared-memory atomic. The trilinear splat below has every
+// lane hammering a small set of histogram bins, so lanes of a warp routinely
+// target the SAME address and serialize on the atomic unit. Here the lanes
+// sharing an address combine their contributions through shuffles and the
+// leader issues one atomicAdd, turning up to 32 serialized atomics into one.
+//
+// Bit equality is preserved: the bins are fixed point (see HIST_SCALE), and
+// unsigned integer addition is associative, so summing the peers in lane
+// order gives exactly the value the per-lane atomics would have produced in
+// any order. This is precisely why the histogram is fixed point and not f32 —
+// the same reordering on floats would NOT be reproducible.
+//
+// Addresses are keyed by their low 32 bits: `histq` is __shared__, the shared
+// window is far below 4 GiB, so two distinct bins cannot collide in the key.
+//
+// __match_any_sync is sm_70+; older devices take the plain per-lane atomic,
+// which is slower but produces the identical result.
+__device__ __forceinline__ void warp_atomicAdd(unsigned long long* address, unsigned long long val) {{
+#if __CUDA_ARCH__ >= 700
+    const unsigned int active = __activemask();
+    const unsigned int match = __match_any_sync(active, (unsigned int)(size_t)address);
+    const int lane = threadIdx.x % 32;
+    const int leader = __ffs(match) - 1;
+
+    unsigned long long sum = 0;
+    unsigned int peers = match;
+    while (peers) {{
+        const int peer = __ffs(peers) - 1;
+        peers &= ~(1u << peer);
+        sum += __shfl_sync(match, val, peer);
+    }}
+
+    if (lane == leader) {{
+        atomicAdd(address, sum);
+    }}
+#else
+    atomicAdd(address, val);
+#endif
+}}
+
 extern "C" __global__ void __launch_bounds__(NTHREADS) sift_descriptor_block(
     const float* __restrict__ img, int w, int h,
     const float* __restrict__ kp_in, int n_kp, int kp_stride,
@@ -519,20 +559,20 @@ extern "C" __global__ void __launch_bounds__(NTHREADS) sift_descriptor_block(
             const int clo = c0 >= 0, chi = c0 <= DD - 2;
             const int idx = ((r0 + 1) * (DD + 2) + (c0 + 1)) * OSTRIDE + o0;
             if (rlo && clo) {{
-                atomicAdd(&histq[idx], __float2ull_rn(v_rco000 * HIST_SCALE));
-                atomicAdd(&histq[idx + 1], __float2ull_rn(v_rco001 * HIST_SCALE));
+                warp_atomicAdd(&histq[idx], __float2ull_rn(v_rco000 * HIST_SCALE));
+                warp_atomicAdd(&histq[idx + 1], __float2ull_rn(v_rco001 * HIST_SCALE));
             }}
             if (rlo && chi) {{
-                atomicAdd(&histq[idx + OSTRIDE], __float2ull_rn(v_rco010 * HIST_SCALE));
-                atomicAdd(&histq[idx + OSTRIDE + 1], __float2ull_rn(v_rco011 * HIST_SCALE));
+                warp_atomicAdd(&histq[idx + OSTRIDE], __float2ull_rn(v_rco010 * HIST_SCALE));
+                warp_atomicAdd(&histq[idx + OSTRIDE + 1], __float2ull_rn(v_rco011 * HIST_SCALE));
             }}
             if (rhi && clo) {{
-                atomicAdd(&histq[idx + (DD + 2) * OSTRIDE], __float2ull_rn(v_rco100 * HIST_SCALE));
-                atomicAdd(&histq[idx + (DD + 2) * OSTRIDE + 1], __float2ull_rn(v_rco101 * HIST_SCALE));
+                warp_atomicAdd(&histq[idx + (DD + 2) * OSTRIDE], __float2ull_rn(v_rco100 * HIST_SCALE));
+                warp_atomicAdd(&histq[idx + (DD + 2) * OSTRIDE + 1], __float2ull_rn(v_rco101 * HIST_SCALE));
             }}
             if (rhi && chi) {{
-                atomicAdd(&histq[idx + (DD + 3) * OSTRIDE], __float2ull_rn(v_rco110 * HIST_SCALE));
-                atomicAdd(&histq[idx + (DD + 3) * OSTRIDE + 1], __float2ull_rn(v_rco111 * HIST_SCALE));
+                warp_atomicAdd(&histq[idx + (DD + 3) * OSTRIDE], __float2ull_rn(v_rco110 * HIST_SCALE));
+                warp_atomicAdd(&histq[idx + (DD + 3) * OSTRIDE + 1], __float2ull_rn(v_rco111 * HIST_SCALE));
             }}
         }}
     }}

--- a/crates/kornia-imgproc/src/cuda/sift/kernels.rs
+++ b/crates/kornia-imgproc/src/cuda/sift/kernels.rs
@@ -263,78 +263,98 @@ extern "C" __global__ void __launch_bounds__(256) sift_blur_h_tiled(
     )
 }
 
-/// Vertical pass of the separable Gaussian.
+/// Vertical pass of the separable Gaussian with `q` outputs per thread.
 ///
 /// Mirrors the reference's symmetric-column vector filter: the kernel is folded
 /// about its centre, and each symmetric pair is **summed before** the FMA.
 /// `acc = fma(s[0], ky[0], 0)` then `acc = fma(s[k] + s[-k], ky[k], acc)`.
 /// Replacing the pair-sum with two separate FMAs changes the result and breaks
 /// bit equality.
-pub fn blur_v_src(kernel: &[f32]) -> String {
+pub(crate) fn blur_v_tiled_src(kernel: &[f32], q: usize, dog: bool) -> String {
     let n = kernel.len();
     let n2 = n / 2;
     let ky = &kernel[n2..];
-    let mut taps = String::new();
+    let ntaps = n + q - 1;
+
     let mut fast = String::new();
-    taps.push_str(&format!(
-        "        float acc = __fmaf_rn(src[refl101(y, h) * w + x], {}, 0.0f);\n",
-        f32_lit(ky[0])
-    ));
-    fast.push_str(&format!(
-        "        float acc = __fmaf_rn(__ldg(&c0[0]), {}, 0.0f);\n",
-        f32_lit(ky[0])
-    ));
-    for (k, &c) in ky.iter().enumerate().skip(1) {
-        taps.push_str(&format!(
-            "        acc = __fmaf_rn(src[refl101(y + {k}, h) * w + x] + src[refl101(y - {k}, h) * w + x], {}, acc);\n",
-            f32_lit(c)
-        ));
+    for t in 0..ntaps {
         fast.push_str(&format!(
-            "        acc = __fmaf_rn(__ldg(&c0[{k} * w]) + __ldg(&c0[-{k} * w]), {}, acc);\n",
-            f32_lit(c)
+            "        const float t{t} = __ldg(&c0[{t} * w]);\n"
         ));
     }
+    for j in 0..q {
+        fast.push_str(&format!(
+            "        float acc{j} = __fmaf_rn(t{}, {}, 0.0f);\n",
+            n2 + j,
+            f32_lit(ky[0])
+        ));
+        for (k, &c) in ky.iter().enumerate().skip(1) {
+            fast.push_str(&format!(
+                "        acc{j} = __fmaf_rn(t{} + t{}, {}, acc{j});\n",
+                n2 + j - k,
+                n2 + j + k,
+                f32_lit(c)
+            ));
+        }
+    }
+    for j in 0..q {
+        fast.push_str(&format!("        dst[(y_base + {j}) * w + x] = acc{j};\n"));
+        if dog {
+            fast.push_str(&format!(
+                "        dog[(y_base + {j}) * w + x] = acc{j} - lower[(y_base + {j}) * w + x];\n"
+            ));
+        }
+    }
+
+    let mut taps = String::new();
+    for j in 0..q {
+        taps.push_str("    {\n");
+        taps.push_str(&format!("        const int y = y_base + {j};\n"));
+        taps.push_str("        if (y < h) {\n");
+        taps.push_str(&format!(
+            "            float acc = __fmaf_rn(src[refl101(y, h) * w + x], {}, 0.0f);\n",
+            f32_lit(ky[0])
+        ));
+        for (k, &c) in ky.iter().enumerate().skip(1) {
+            taps.push_str(&format!(
+                "            acc = __fmaf_rn(src[refl101(y + {k}, h) * w + x] + src[refl101(y - {k}, h) * w + x], {}, acc);\n",
+                f32_lit(c)
+            ));
+        }
+        taps.push_str("            dst[y * w + x] = acc;\n");
+        if dog {
+            taps.push_str("            dog[y * w + x] = acc - lower[y * w + x];\n");
+        }
+        taps.push_str("        }\n");
+        taps.push_str("    }\n");
+    }
+
+    let (fn_name, dog_args) = if dog {
+        (
+            "sift_blur_v_dog",
+            "\n    const float* __restrict__ lower, float* __restrict__ dog,",
+        )
+    } else {
+        ("sift_blur_v", "")
+    };
+
     format!(
         r#"{BORDER_HELPERS}
-extern "C" __global__ void __launch_bounds__(256) sift_blur_v(
-    const float* __restrict__ src, float* __restrict__ dst, int w, int h)
+extern "C" __global__ void __launch_bounds__(256) {fn_name}(
+    const float* __restrict__ src, float* __restrict__ dst,{dog_args} int w, int h)
 {{
     const int x = blockIdx.x * blockDim.x + threadIdx.x;
-    const int y = blockIdx.y * blockDim.y + threadIdx.y;
-    if (x >= w || y >= h) return;
-    if (y >= {n2} && y < h - {n2}) {{
-        const float* __restrict__ c0 = src + y * w + x;
-{fast}        dst[y * w + x] = acc;
-    }} else {{
-{taps}        dst[y * w + x] = acc;
-    }}
+    if (x >= w) return;
+    const int y_base = (blockIdx.y * blockDim.y + threadIdx.y) * {q};
+
+    // Border test at warp granularity: y_base is constant for all lanes if
+    // blockDim.x == 32 (threads in a warp have the same threadIdx.y).
+    if (y_base >= {n2} && y_base + {q} - 1 < h - {n2}) {{
+        const float* __restrict__ c0 = src + (y_base - {n2}) * w + x;
+{fast}    }} else {{
+{taps}    }}
 }}
 "#
-    )
-}
-
-/// Vertical Gaussian pass fused with the DoG subtract.
-///
-/// The vertical pass already has the blurred value in a register, so writing
-/// `dog = blurred - lower` here costs one extra load and one extra store but
-/// removes a whole separate pass that would re-read the layer and re-write the
-/// difference. Numerically identical to running the two kernels back to back:
-/// the subtract operates on exactly the f32 value the unfused kernel stores.
-pub fn blur_v_dog_src(kernel: &[f32]) -> String {
-    // NOTE: this pattern must match the declaration in `blur_v_src` INCLUDING
-    // its `__launch_bounds__` attribute — a signature edit there that misses
-    // here silently generates an unrenamed kernel (caught by
-    // `blur_v_dog_generates_fused_kernel`).
-    let base = blur_v_src(kernel)
-        .replace("void __launch_bounds__(256) sift_blur_v(", "void __launch_bounds__(256) sift_blur_v_dog(")
-        .replace(
-            "const float* __restrict__ src, float* __restrict__ dst, int w, int h)",
-            "const float* __restrict__ src, float* __restrict__ dst,\n    const float* __restrict__ lower, float* __restrict__ dog, int w, int h)",
-        );
-    // Emit the DoG store after every `dst` store (interior and border paths).
-    base.replace(
-        "        dst[y * w + x] = acc;",
-        "        dst[y * w + x] = acc;\n        dog[y * w + x] = acc - lower[y * w + x];",
     )
 }
 
@@ -576,7 +596,7 @@ mod tests {
     #[test]
     fn blur_v_dog_generates_fused_kernel() {
         let k = gaussian_kernel_f32(11, 1.2489995956420898);
-        let src = blur_v_dog_src(&k);
+        let src = blur_v_tiled_src(&k, 2, true);
         assert!(src.contains("sift_blur_v_dog("), "kernel not renamed");
         assert!(
             src.contains("const float* __restrict__ lower"),
@@ -587,6 +607,12 @@ mod tests {
                 .count(),
             2,
             "DoG store must be emitted on BOTH the interior and border paths"
+        );
+        assert_eq!(
+            src.matches("dog[(y_base + 0) * w + x] = acc0 - lower[(y_base + 0) * w + x];")
+                .count(),
+            1,
+            "DoG store must be emitted on fast path"
         );
     }
 

--- a/crates/kornia-imgproc/src/cuda/sift/pyramid.rs
+++ b/crates/kornia-imgproc/src/cuda/sift/pyramid.rs
@@ -58,7 +58,7 @@ use std::sync::Arc;
 use cudarc::driver::{CudaContext, CudaSlice, CudaStream, CudaView, CudaViewMut};
 
 use super::kernels::{
-    blur_h_src, blur_h_tiled_src, blur_hv_fused_src, blur_v_dog_src, blur_v_src, dog_src,
+    blur_h_src, blur_h_tiled_src, blur_hv_fused_src, blur_v_tiled_src, dog_src,
     downsample_nearest_src, get_or_compile, upsample2x_src,
 };
 use super::SiftCudaError;
@@ -180,18 +180,25 @@ pub fn launch_sift_blur_v_cuda_view(
     check_len(dst.len(), need)?;
 
     let key = format!(
-        "sift_blur_v:{}:{:016x}",
+        "sift_blur_v_tiled:{}:{}:{:016x}",
         gauss_kernel.len(),
+        tile_q(),
         kernel_digest(gauss_kernel)
     );
-    let kernel = get_or_compile(ctx, &key, || blur_v_src(gauss_kernel), "sift_blur_v")?;
+    let kernel = get_or_compile(
+        ctx,
+        &key,
+        || blur_v_tiled_src(gauss_kernel, tile_q(), false),
+        "sift_blur_v",
+    )?;
+    let gh = height.div_ceil(tile_q() as u32);
     kernel
         .launch_builder(stream)
         .arg(src)
         .arg(dst)
         .arg(&width)
         .arg(&height)
-        .launch_2d(width, height, make_config(width, height, None))
+        .launch_2d(width, height, make_config(width, gh, None))
         .map_err(|e| SiftCudaError::Cuda(e.to_string()))
 }
 
@@ -293,16 +300,18 @@ pub fn launch_sift_blur_v_dog_cuda_view(
     check_len(dog.len(), need)?;
 
     let key = format!(
-        "sift_blur_v_dog:{}:{:016x}",
+        "sift_blur_v_tiled_dog:{}:{}:{:016x}",
         gauss_kernel.len(),
+        tile_q(),
         kernel_digest(gauss_kernel)
     );
     let kernel = get_or_compile(
         ctx,
         &key,
-        || blur_v_dog_src(gauss_kernel),
+        || blur_v_tiled_src(gauss_kernel, tile_q(), true),
         "sift_blur_v_dog",
     )?;
+    let gh = height.div_ceil(tile_q() as u32);
     kernel
         .launch_builder(stream)
         .arg(src)
@@ -311,7 +320,7 @@ pub fn launch_sift_blur_v_dog_cuda_view(
         .arg(dog)
         .arg(&width)
         .arg(&height)
-        .launch_2d(width, height, make_config(width, height, None))
+        .launch_2d(width, height, make_config(width, gh, None))
         .map_err(|e| SiftCudaError::Cuda(e.to_string()))
 }
 
@@ -340,6 +349,21 @@ fn tile_p() -> usize {
             .and_then(|v| v.parse::<usize>().ok())
             .filter(|v| *v >= 1 && *v <= 16)
             .unwrap_or(TILE_P)
+    })
+}
+
+/// Outputs per thread in the tiled vertical blur.
+pub const TILE_Q: usize = 2;
+
+/// `KORNIA_SIFT_TILE_Q` overrides [`TILE_Q`] for sweeps.
+fn tile_q() -> usize {
+    static V: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *V.get_or_init(|| {
+        std::env::var("KORNIA_SIFT_TILE_Q")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|v| *v >= 1 && *v <= 16)
+            .unwrap_or(TILE_Q)
     })
 }
 


### PR DESCRIPTION
## 📝 Description

**Fixes/Relates to:** 

Two independent optimizations to the CUDA SIFT path, both bit-exact against the
existing reference tests.

**1. Register-tiled vertical Gaussian blur** (`src/cuda/sift/kernels.rs`, `src/cuda/sift/pyramid.rs`)

`blur_v_tiled_src(kernel, q, dog)` emits a kernel computing `q` output rows per
thread (default 2, `KORNIA_SIFT_TILE_Q` to sweep). Adjacent output rows share
most of their column taps, so the `n + q - 1` loads are hoisted into registers
instead of each thread re-issuing its own `__ldg` per tap. The border test also
moves to warp granularity.

This replaces `blur_v_dog_src`, which produced the fused DoG variant by string
replacement over `blur_v_src`'s generated source. That was a documented footgun
— its own comment warned that a signature edit in one and not the other
silently emits an unrenamed kernel. Fused DoG is now just a parameter of the
same generator.

**2. Warp-aggregated descriptor histogram atomics** (`src/cuda/sift/descriptor.rs`)

The trilinear splat has lanes of a warp repeatedly hitting the same histogram
bin and serializing on the atomic unit. `warp_atomicAdd` combines the lanes
sharing an address via shuffles so the leader issues one `atomicAdd` instead of
up to 32.

Bit equality holds because the bins are fixed point (#1092) and unsigned
integer addition is associative — the reordered sum is identical to what the
per-lane atomics produce in any order. The same reordering on floats would not
be reproducible. Guarded on `__CUDA_ARCH__ >= 700` (`__match_any_sync` is
Volta+) with the plain per-lane atomic on older devices, so the crate's arch
floor is unchanged.

Reference implementation: OpenCV's SIFT, `modules/features2d/src/sift.dispatch.cpp`
and `sift.simd.hpp` — the same source this module already documents itself
against in `src/cuda/sift/mod.rs`. Neither change touches the expression trees
that bit equality depends on: the tiling only changes *which thread* evaluates a
tap, and the atomic aggregation only changes the *order* of an integer sum.

---

## 🛠️ Changes Made
- [x] `kernels.rs`: `blur_v_tiled_src(kernel, q, dog)` replaces `blur_v_src` + `blur_v_dog_src`
- [x] `pyramid.rs`: `TILE_Q` (default 2) + `KORNIA_SIFT_TILE_Q` override; launchers use the tiled grid height
- [x] `descriptor.rs`: `warp_atomicAdd` for the 8 histogram accumulations, sm_70 guarded
- [x] `benches/bench_cuda_sift.rs`: end-to-end `detect_and_compute`, unified memory vs explicit copies
- [x] `benches/bench_opencv_sift.py`: `cv2.SIFT_create` vs kornia-rs host and CUDA bindings
- [x] `benchmarks.md`: results for both, GTX 1650 and Jetson Orin Nano

---

## 🧪 How Was This Tested?
- [x] **Unit Tests:** existing SIFT suite, all 43 pass with `--features cuda` on a GTX 1650 (sm_75). The gates that matter here are `fused_blur_v_dog_matches_unfused_bitwise`, `dog_pyramid_matches_reference_bitwise`, `full_gaussian_pyramid_matches_reference_bitwise`, `separable_blur_matches_reference_bitwise`, `end_to_end_matches_reference_keypoints` and `pipeline_is_deterministic_across_runs` — all bitwise/determinism checks, so neither optimization changes output. `blur_v_dog_generates_fused_kernel` updated for the new generator.

```
$ cargo test -p kornia-imgproc --features cuda --lib cuda::sift
test cuda::sift::pyramid::tests::fused_blur_v_dog_matches_unfused_bitwise ... ok
test cuda::sift::pyramid::tests::dog_pyramid_matches_reference_bitwise ... ok
test cuda::sift::pyramid::tests::full_gaussian_pyramid_matches_reference_bitwise ... ok
test cuda::sift::pyramid::tests::separable_blur_matches_reference_bitwise ... ok
test cuda::sift::plan::tests::end_to_end_matches_reference_keypoints ... ok
test cuda::sift::plan::tests::pipeline_is_deterministic_across_runs ... ok

test result: ok. 43 passed; 0 failed; 0 ignored; 0 measured; 449 filtered out; finished in 5.13s
```

- [x] **Manual Verification:** `cargo fmt --all -- --check` and `cargo clippy -p kornia-imgproc --no-deps --all-targets --features cuda -- -D warnings` both clean. CPU-only `cargo check -p kornia-imgproc` (no `cuda` feature) unaffected.
- [x] **Performance/Edge Cases:** border rows still take the `refl101` reflected-index path; the fast path is only entered when the whole `q`-row group is interior, so partial groups at the bottom edge fall to the guarded path. `q` is validated to 1..=16. On pre-Volta devices `warp_atomicAdd` compiles to the plain atomic.

`bench_cuda_sift` on a GTX 1650 (30 iters, 10 warmup), per frame end-to-end:

| Resolution | Explicit copies | Unified memory | Unified speedup |
| --- | ---: | ---: | ---: |
| VGA 640×480 | 2.451 ms | 5.114 ms | 0.48x |
| HD 1280×720 | 8.086 ms | 13.715 ms | 0.59x |
| FHD 1920×1080 | 19.902 ms | 25.013 ms | 0.80x |

Unified memory loses on a discrete GPU (pageable buffer, per-page PCIe faults);
it wins only on Jetson at VGA (1.13x) and OOMs above that. Recorded in
`benchmarks.md` as a negative result — the unified path is not yet a general win.

---

## 🕵️ AI Usage Disclosure
*Check one of the following:*
- [ ] 🟢 **No AI used.**
- [x] 🟡 **AI-assisted:** I used AI for boilerplate/refactoring but have manually reviewed and tested every line.
- [ ] 🔴 **AI-generated:**

---

## 🚦 Checklist
- [ ] I am assigned to the linked issue (required before PR submission)
- [ ] The linked issue has been approved by a maintainer
- [x] This PR strictly implements what the linked issue describes (no scope creep)
- [x] I have performed a **self-review** of my code (no "ghost" variables or hallucinations).
- [x] My code follows the existing style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] (Optional) I have attached screenshots/recordings for UI changes.

---

## 💭 Additional Context

The two changes are independent and can be split if you'd rather review them
separately. Both are pure kernel-generation changes behind the `cuda` feature;
no public API moves.

---

## 🧹 CI fix carried in this branch

`Check - CUDA features` is the only job in `rust_lint.yml` that resolves its own
toolchain (`dtolnay/rust-toolchain@stable`); every other job runs through pixi,
which pins rust to 1.96. When stable moved to 1.98 the new
`clippy::chunks_exact_to_as_chunks` lint began firing on 43 pre-existing call
sites across `kornia-io` and `kornia-imgproc` and, with `-D warnings`, failed
that job on every open PR with no source change.

This branch pins the job to 1.96.0 so it runs the same compiler as the `Clippy`
job. One line, and none of the 43 flagged call sites needed touching — verified
by running the job's three commands under pixi's toolchain against an otherwise
unmodified tree:

```sh
pixi run cargo clippy --tests -p kornia-tensor  --features cuda -- -D warnings
pixi run cargo clippy --tests -p kornia-image   --features cuda -- -D warnings
pixi run cargo clippy --tests -p kornia-imgproc --features cuda -- -D warnings
```

all three clean. The pin should be bumped deliberately alongside pixi's rust
pin, so a compiler release cannot turn the queue red on its own again.
