### PR TITLE
feat(kornia-3d): expose StereoRectifier's remap tables

### DIFF
--- a/crates/kornia-3d/src/stereo/rectify.rs
+++ b/crates/kornia-3d/src/stereo/rectify.rs
@@ -191,6 +191,20 @@ impl StereoRectifier {
         }
     }
 
+    /// The per-pixel source coordinates for the LEFT rectified view: one `[x, y]` f32 pair per
+    /// output pixel, row-major `width * height`. This is the table [`rectify_left`](Self::rectify_left)
+    /// samples through — exposed so an external sampler (e.g. a CUDA remap kernel, which takes
+    /// the same map split into x/y planes) can consume the exact same geometry instead of
+    /// re-deriving it.
+    pub fn left_map(&self) -> &[[f32; 2]] {
+        &self.left_map
+    }
+
+    /// The RIGHT view's map; see [`left_map`](Self::left_map).
+    pub fn right_map(&self) -> &[[f32; 2]] {
+        &self.right_map
+    }
+
     /// Metric baseline between the cameras.
     pub fn baseline(&self) -> f64 {
         self.baseline

--- a/crates/kornia-3d/src/stereo/rectify.rs
+++ b/crates/kornia-3d/src/stereo/rectify.rs
@@ -196,6 +196,11 @@ impl StereoRectifier {
     /// samples through — exposed so an external sampler (e.g. a CUDA remap kernel, which takes
     /// the same map split into x/y planes) can consume the exact same geometry instead of
     /// re-deriving it.
+    ///
+    /// The maps carry geometry only; BORDER POLICY belongs to the sampler. Coordinates in the
+    /// one-pixel band `(w-1, w)` / `(h-1, h)` are skipped (left black) by the CPU sampler here
+    /// but clamp-and-sample in kornia-imgproc's CUDA remap, so rectified border pixels may
+    /// differ between samplers consuming the same map.
     pub fn left_map(&self) -> &[[f32; 2]] {
         &self.left_map
     }


### PR DESCRIPTION
## Summary

`StereoRectifier::{left_map, right_map}` accessors: the per-pixel source-coordinate tables that `rectify_left`/`rectify_right` sample through, one `[x, y]` f32 pair per output pixel.

## Why

A consumer that wants to run the sampling elsewhere — specifically `kornia-imgproc`'s `launch_remap_bilinear_u8_cuda`, which takes exactly this map split into x/y planes — currently has no way to reach the tables and would have to re-derive the undistort+rectify math (the drift-prone part). With the accessors, CUDA rectification is: upload the two maps once, per-frame launch the existing u8 remap kernel with identical geometry to the CPU path.

First consumer: OAK stereo rectification in the flux-xlerobot source task on Jetson Orin.

## Test plan

- `cargo test -p kornia-3d` (223 + 14 green)
- No behavior change — accessors only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)