### PR TITLE
feat(kornia-3d): StereoRectifier rectifies through remap_u8 on CPU and CUDA

### DIFF
--- a/.github/workflows/rust_lint.yml
+++ b/.github/workflows/rust_lint.yml
@@ -86,6 +86,7 @@ jobs:
           cargo clippy --tests -p kornia-tensor --features cuda -- -D warnings
           cargo clippy --tests -p kornia-image --features cuda -- -D warnings
           cargo clippy --tests -p kornia-imgproc --features cuda -- -D warnings
+          cargo clippy --tests -p kornia-3d --features cuda -- -D warnings
 
   cross-platform-check-macos:
     name: Check - macOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ changes early: `cargo add kornia-imgproc@0.1.15-rc.1` or `pip install --pre korn
 
 ## [Unreleased]
 
+**Stereo rectification runs on CUDA, byte-exact with the CPU path.**
+`StereoRectifier` now resamples through the residency-dispatched `remap_u8`, and
+`StereoRectifier::to_cuda(&stream)` returns a `CudaStereoRectifier` that keeps
+both eyes' maps (and reusable scratch) device-resident — `rectify_*_device` for
+zero-copy device frames, `rectify_*_into` for host-byte driver loops. The two
+backends produce identical bytes by kornia-imgproc's tested CPU↔CUDA contract,
+so demoting to CPU on a CUDA failure is lossless. Border semantics changed
+deliberately with the unification: source coordinates in the `[w-1, w)` band now
+clamp-sample the edge texel (previously black), and blending is Q10 fixed point.
+
+**Breaking:** `StereoRectifier::rectify_left/right` are now into-style —
+`(&self, src, &mut dst) -> Result<(), StereoError>` — matching every imgproc op;
+`left_map()/right_map()` became `left_maps()/right_maps()` returning the x/y
+planes `remap_u8` consumes directly.
+
 ## [0.1.15-rc.5] — 2026-07-19 (pre-release)
 
 **Connected components 3-5x faster on CPU, ~2x on GPU.** The CPU path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ changes early: `cargo add kornia-imgproc@0.1.15-rc.1` or `pip install --pre korn
 **Stereo rectification runs on CUDA, byte-exact with the CPU path.**
 `StereoRectifier` now resamples through the residency-dispatched `remap_u8`, and
 `StereoRectifier::to_cuda(&stream)` returns a `CudaStereoRectifier` that keeps
-both eyes' maps (and reusable scratch) device-resident — `rectify_*_device` for
-zero-copy device frames, `rectify_*_into` for host-byte driver loops. The two
+both eyes' maps device-resident and rectifies device frames zero-copy via
+`rectify_left_device`/`rectify_right_device`. The two
 backends produce identical bytes by kornia-imgproc's tested CPU↔CUDA contract,
 so demoting to CPU on a CUDA failure is lossless. Border semantics changed
 deliberately with the unification: source coordinates in the `[w-1, w)` band now

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7785,6 +7785,7 @@ dependencies = [
  "approx",
  "bincode 2.0.1",
  "criterion 0.8.2",
+ "cudarc 0.19.8",
  "faer 0.24.4",
  "kiddo",
  "kornia-algebra",

--- a/crates/kornia-3d/Cargo.toml
+++ b/crates/kornia-3d/Cargo.toml
@@ -32,7 +32,14 @@ kiddo = { workspace = true }
 kornia-algebra = { workspace = true }
 kornia-image = { workspace = true }
 kornia-imgproc = { workspace = true }
-cudarc = { workspace = true, optional = true }
+cudarc = { version = "0.19.0", default-features = false, features = [
+  "cuda-version-from-build-system",
+  "driver",
+  "fallback-dynamic-loading",
+  "fallback-latest",
+  "nvrtc",
+  "std",
+], optional = true }
 log = { workspace = true }
 nalgebra = { workspace = true }
 rand = { workspace = true }

--- a/crates/kornia-3d/Cargo.toml
+++ b/crates/kornia-3d/Cargo.toml
@@ -21,14 +21,7 @@ name = "bench_twoview"
 
 [dependencies]
 bincode = { workspace = true }
-cudarc = { version = "0.19.0", default-features = false, features = [
-  "cuda-version-from-build-system",
-  "driver",
-  "fallback-dynamic-loading",
-  "fallback-latest",
-  "nvrtc",
-  "std",
-], optional = true }
+cudarc = { workspace = true, optional = true }
 faer = { workspace = true }
 kiddo = { workspace = true }
 kornia-algebra = { workspace = true }

--- a/crates/kornia-3d/Cargo.toml
+++ b/crates/kornia-3d/Cargo.toml
@@ -19,19 +19,8 @@ name = "bench_linalg"
 harness = false
 name = "bench_twoview"
 
-[features]
-# CUDA-resident rectification: uploads the remap tables once and serves device frames through
-# kornia-imgproc's residency-dispatched remap (byte-exact with the CPU path by its tested
-# contract). cudarc appears only for the stream type in `to_cuda`'s signature.
-cuda = ["dep:cudarc", "kornia-imgproc/cuda", "kornia-image/cuda"]
-
 [dependencies]
 bincode = { workspace = true }
-faer = { workspace = true }
-kiddo = { workspace = true }
-kornia-algebra = { workspace = true }
-kornia-image = { workspace = true }
-kornia-imgproc = { workspace = true }
 cudarc = { version = "0.19.0", default-features = false, features = [
   "cuda-version-from-build-system",
   "driver",
@@ -40,6 +29,11 @@ cudarc = { version = "0.19.0", default-features = false, features = [
   "nvrtc",
   "std",
 ], optional = true }
+faer = { workspace = true }
+kiddo = { workspace = true }
+kornia-algebra = { workspace = true }
+kornia-image = { workspace = true }
+kornia-imgproc = { workspace = true }
 log = { workspace = true }
 nalgebra = { workspace = true }
 rand = { workspace = true }
@@ -52,3 +46,9 @@ approx = { workspace = true }
 criterion = { workspace = true }
 kornia-io = { workspace = true }
 kornia-tensor = { workspace = true }
+
+[features]
+# CUDA-resident rectification: uploads the remap tables once and serves device frames through
+# kornia-imgproc's residency-dispatched remap (byte-exact with the CPU path by its tested
+# contract). cudarc appears only for the stream type in `to_cuda`'s signature.
+cuda = ["dep:cudarc", "kornia-image/cuda", "kornia-imgproc/cuda"]

--- a/crates/kornia-3d/Cargo.toml
+++ b/crates/kornia-3d/Cargo.toml
@@ -19,6 +19,12 @@ name = "bench_linalg"
 harness = false
 name = "bench_twoview"
 
+[features]
+# CUDA-resident rectification: uploads the remap tables once and serves device frames through
+# kornia-imgproc's residency-dispatched remap (byte-exact with the CPU path by its tested
+# contract). cudarc appears only for the stream type in `to_cuda`'s signature.
+cuda = ["dep:cudarc", "kornia-imgproc/cuda", "kornia-image/cuda"]
+
 [dependencies]
 bincode = { workspace = true }
 faer = { workspace = true }
@@ -26,6 +32,7 @@ kiddo = { workspace = true }
 kornia-algebra = { workspace = true }
 kornia-image = { workspace = true }
 kornia-imgproc = { workspace = true }
+cudarc = { workspace = true, optional = true }
 log = { workspace = true }
 nalgebra = { workspace = true }
 rand = { workspace = true }

--- a/crates/kornia-3d/src/stereo/mod.rs
+++ b/crates/kornia-3d/src/stereo/mod.rs
@@ -3,3 +3,6 @@
 mod rectify;
 
 pub use rectify::{CameraCalib, StereoError, StereoRectifier};
+
+#[cfg(feature = "cuda")]
+pub use rectify::CudaStereoRectifier;

--- a/crates/kornia-3d/src/stereo/rectify.rs
+++ b/crates/kornia-3d/src/stereo/rectify.rs
@@ -49,18 +49,6 @@ pub enum StereoError {
         expected: (usize, usize),
     },
 
-    /// A host byte buffer's length does not match the rectifier's pixel count. The same
-    /// caller mistake as [`ImageSizeMismatch`](Self::ImageSizeMismatch), for the raw-slice
-    /// entry points — kept typed so a demote-to-CPU policy can classify it as a caller bug,
-    /// not a CUDA failure.
-    #[error("raw buffer holds {got} bytes, rectifier expects {expected} (width * height)")]
-    RawLengthMismatch {
-        /// Provided buffer length in bytes.
-        got: usize,
-        /// Expected length, the rectifier's `width * height`.
-        expected: usize,
-    },
-
     /// Failed to build the rectified image from the remapped buffer.
     #[error(transparent)]
     Image(#[from] ImageError),
@@ -308,11 +296,15 @@ mod cuda {
     impl StereoRectifier {
         /// Uploads both eyes' map planes and warms the kernel, returning a rectifier that serves
         /// DEVICE-resident work. Explicit — no hidden H2D on first frame — and the warm-up runs a
-        /// full rectify so nvrtc/compile/launch failures surface HERE, where a caller's CPU
-        /// fallback can catch them, not on frame one with the fallback already forfeited.
+        /// full rectify so nvrtc compile failures surface HERE, where a caller's CPU fallback
+        /// can catch them, not on frame one with the fallback already forfeited.
         ///
-        /// The stream is only borrowed for the uploads; it is also retained for the host
-        /// convenience methods. No context is created — the application owns that.
+        /// Everything — map uploads and the warm-up launch — is ENQUEUED on `stream`; this
+        /// method does not synchronize, per the crate convention that synchronization belongs
+        /// to the caller. Work issued later on this same stream is ordered after the uploads
+        /// automatically; before touching the rectifier from a DIFFERENT stream of the same
+        /// device, synchronize this one first, or the kernels may race the map uploads.
+        /// No context is created — the application owns that.
         pub fn to_cuda(
             &self,
             stream: &Arc<cudarc::driver::CudaStream>,
@@ -321,30 +313,25 @@ mod cuda {
                 width: self.geom.width,
                 height: self.geom.height,
             };
-            let mut dev = CudaStereoRectifier {
+            let dev = CudaStereoRectifier {
                 geom: self.geom,
                 left_map_x: self.left_map_x.to_cuda(stream)?,
                 left_map_y: self.left_map_y.to_cuda(stream)?,
                 right_map_x: self.right_map_x.to_cuda(stream)?,
                 right_map_y: self.right_map_y.to_cuda(stream)?,
-                scratch_in: Image::zeros_cuda(size, stream)?,
-                scratch_out: Image::zeros_cuda(size, stream)?,
                 stream: stream.clone(),
             };
-            // Warm-up on the retained device scratch: compiles the kernel through the cache and
-            // proves a launch works, with no host round-trip. The synchronize is also load-bearing
-            // for correctness — it fences the four async map uploads above, so the maps are
-            // quiescent for every later call.
+            // Warm-up on throwaway device buffers: compiles the kernel through the cache (a
+            // host-side nvrtc step, so failures surface synchronously) and enqueues one launch.
+            let warm_src: Image<u8, 1> = Image::zeros_cuda(size, stream)?;
+            let mut warm_dst = Image::zeros_cuda(size, stream)?;
             remap_u8(
-                &dev.scratch_in,
-                &mut dev.scratch_out,
+                &warm_src,
+                &mut warm_dst,
                 &dev.left_map_x,
                 &dev.left_map_y,
                 InterpolationMode::Bilinear,
             )?;
-            stream
-                .synchronize()
-                .map_err(|e| ImageError::Cuda(format!("warm-up sync: {e}")))?;
             Ok(dev)
         }
     }
@@ -361,8 +348,6 @@ mod cuda {
         left_map_y: Image<f32, 1>,
         right_map_x: Image<f32, 1>,
         right_map_y: Image<f32, 1>,
-        scratch_in: Image<u8, 1>,
-        scratch_out: Image<u8, 1>,
         stream: Arc<cudarc::driver::CudaStream>,
     }
 
@@ -401,65 +386,6 @@ mod cuda {
                 &self.right_map_y,
                 InterpolationMode::Bilinear,
             )?;
-            Ok(())
-        }
-
-        /// Host-bytes convenience for the driver loop: H2D into retained scratch, kernel, blocking
-        /// D2H into `out` (resized once). No per-frame allocation.
-        pub fn rectify_left_into(
-            &mut self,
-            raw: &[u8],
-            out: &mut Vec<u8>,
-        ) -> Result<(), StereoError> {
-            self.host_roundtrip(raw, out, true)
-        }
-
-        /// See [`rectify_left_into`](Self::rectify_left_into).
-        pub fn rectify_right_into(
-            &mut self,
-            raw: &[u8],
-            out: &mut Vec<u8>,
-        ) -> Result<(), StereoError> {
-            self.host_roundtrip(raw, out, false)
-        }
-
-        fn host_roundtrip(
-            &mut self,
-            raw: &[u8],
-            out: &mut Vec<u8>,
-            left: bool,
-        ) -> Result<(), StereoError> {
-            let n = self.geom.width * self.geom.height;
-            if raw.len() != n {
-                return Err(StereoError::RawLengthMismatch {
-                    got: raw.len(),
-                    expected: n,
-                });
-            }
-            {
-                let slice = self
-                    .scratch_in
-                    .as_cudaslice_mut()
-                    .ok_or_else(|| ImageError::Cuda("scratch lost device residency".into()))?;
-                self.stream
-                    .memcpy_htod(raw, slice)
-                    .map_err(|e| ImageError::Cuda(format!("h2d: {e}")))?;
-            }
-            let (mx, my) = if left {
-                (&self.left_map_x, &self.left_map_y)
-            } else {
-                (&self.right_map_x, &self.right_map_y)
-            };
-            remap_u8(
-                &self.scratch_in,
-                &mut self.scratch_out,
-                mx,
-                my,
-                InterpolationMode::Bilinear,
-            )?;
-            out.resize(n, 0);
-            // Blocking: syncs the stream, so the bytes are final when this returns.
-            self.scratch_out.to_host_into(out)?;
             Ok(())
         }
 
@@ -871,11 +797,17 @@ mod tests {
 
         let ctx = CudaContext::new(0)?;
         let stream = ctx.default_stream();
-        let mut dev = rect.to_cuda(&stream)?;
-        let mut gpu_l = Vec::new();
-        let mut gpu_r = Vec::new();
-        dev.rectify_left_into(&raw, &mut gpu_l)?;
-        dev.rectify_right_into(&raw, &mut gpu_r)?;
+        let dev = rect.to_cuda(&stream)?;
+        let src_dev = img.to_cuda(&stream)?;
+        let mut dst_l = Image::zeros_cuda(size, &stream)?;
+        let mut dst_r = Image::zeros_cuda(size, &stream)?;
+        dev.rectify_left_device(&src_dev, &mut dst_l)?;
+        dev.rectify_right_device(&src_dev, &mut dst_r)?;
+        // to_host_into synchronizes the images' stream, so the bytes are final on return.
+        let mut gpu_l = vec![0u8; w * h];
+        let mut gpu_r = vec![0u8; w * h];
+        dst_l.to_host_into(&mut gpu_l)?;
+        dst_r.to_host_into(&mut gpu_r)?;
 
         assert_eq!(cpu_l.as_slice(), gpu_l.as_slice(), "left bytes diverge");
         assert_eq!(cpu_r.as_slice(), gpu_r.as_slice(), "right bytes diverge");

--- a/crates/kornia-3d/src/stereo/rectify.rs
+++ b/crates/kornia-3d/src/stereo/rectify.rs
@@ -40,13 +40,25 @@ pub enum StereoError {
     )]
     DegenerateBaseline(f64),
 
-    /// An input image's resolution does not match the rectifier's.
-    #[error("input image {got:?} does not match rectifier resolution {expected:?}")]
+    /// An image operand's resolution does not match the rectifier's.
+    #[error("image {got:?} does not match rectifier resolution {expected:?}")]
     ImageSizeMismatch {
-        /// Provided image resolution `(width, height)`.
+        /// Offending image resolution `(width, height)` — source or destination.
         got: (usize, usize),
         /// Rectifier resolution `(width, height)`.
         expected: (usize, usize),
+    },
+
+    /// A host byte buffer's length does not match the rectifier's pixel count. The same
+    /// caller mistake as [`ImageSizeMismatch`](Self::ImageSizeMismatch), for the raw-slice
+    /// entry points — kept typed so a demote-to-CPU policy can classify it as a caller bug,
+    /// not a CUDA failure.
+    #[error("raw buffer holds {got} bytes, rectifier expects {expected} (width * height)")]
+    RawLengthMismatch {
+        /// Provided buffer length in bytes.
+        got: usize,
+        /// Expected length, the rectifier's `width * height`.
+        expected: usize,
     },
 
     /// Failed to build the rectified image from the remapped buffer.
@@ -54,8 +66,10 @@ pub enum StereoError {
     Image(#[from] ImageError),
 }
 
-/// Precomputed stereo rectification for a fixed camera pair and resolution.
-pub struct StereoRectifier {
+/// Geometry of the rectified rig, shared verbatim by the CPU and CUDA rectifiers so the
+/// two cannot drift.
+#[derive(Clone, Copy)]
+struct RectifiedGeometry {
     width: usize,
     height: usize,
     /// Common rectified focal length (fx = fy).
@@ -67,6 +81,26 @@ pub struct StereoRectifier {
     baseline: f64,
     /// Rotation mapping raw left-camera coordinates into the rectified frame.
     rect_left: Mat3F64,
+}
+
+impl RectifiedGeometry {
+    fn rectified_camera(&self) -> PinholeCamera {
+        PinholeCamera {
+            fx: self.f,
+            fy: self.f,
+            cx: self.cx,
+            cy: self.cy,
+            k1: 0.0,
+            k2: 0.0,
+            p1: 0.0,
+            p2: 0.0,
+        }
+    }
+}
+
+/// Precomputed stereo rectification for a fixed camera pair and resolution.
+pub struct StereoRectifier {
+    geom: RectifiedGeometry,
     /// Per-output-pixel source coordinate in the raw left image (`[u, v]`).
     left_map_x: Image<f32, 1>,
     left_map_y: Image<f32, 1>,
@@ -162,13 +196,15 @@ impl StereoRectifier {
         let (right_map_x, right_map_y) = build_map(width, height, f, cx, cy, &rect_r, right)?;
 
         Ok(Self {
-            width,
-            height,
-            f,
-            cx,
-            cy,
-            baseline: nt,
-            rect_left: rect_l,
+            geom: RectifiedGeometry {
+                width,
+                height,
+                f,
+                cx,
+                cy,
+                baseline: nt,
+                rect_left: rect_l,
+            },
             left_map_x,
             left_map_y,
             right_map_x,
@@ -180,21 +216,12 @@ impl StereoRectifier {
     /// (`p_rect = R · p_left_raw`). Lets callers re-express raw-frame
     /// extrinsics (e.g. a camera-IMU `T_BS`) for the rectified virtual camera.
     pub fn left_rectifying_rotation(&self) -> Mat3F64 {
-        self.rect_left
+        self.geom.rect_left
     }
 
     /// Rectified pinhole camera (shared by both views; zero distortion).
     pub fn rectified_camera(&self) -> PinholeCamera {
-        PinholeCamera {
-            fx: self.f,
-            fy: self.f,
-            cx: self.cx,
-            cy: self.cy,
-            k1: 0.0,
-            k2: 0.0,
-            p1: 0.0,
-            p2: 0.0,
-        }
+        self.geom.rectified_camera()
     }
 
     /// The LEFT view's undistort+rectify map as `(x, y)` planes, one f32 per output pixel,
@@ -212,12 +239,12 @@ impl StereoRectifier {
 
     /// Metric baseline between the cameras.
     pub fn baseline(&self) -> f64 {
-        self.baseline
+        self.geom.baseline
     }
 
     /// `bf = focal * baseline`, the constant in `depth = bf / disparity`.
     pub fn bf(&self) -> f64 {
-        self.f * self.baseline
+        self.geom.f * self.geom.baseline
     }
 
     /// Rectifies a raw left image into `dst` — into-style like every imgproc op, so the
@@ -254,11 +281,11 @@ impl StereoRectifier {
         map_x: &Image<f32, 1>,
         map_y: &Image<f32, 1>,
     ) -> Result<(), StereoError> {
-        for img in [&*src, dst] {
-            if (img.width(), img.height()) != (self.width, self.height) {
+        for img in [src, dst] {
+            if (img.width(), img.height()) != (self.geom.width, self.geom.height) {
                 return Err(StereoError::ImageSizeMismatch {
                     got: (img.width(), img.height()),
-                    expected: (self.width, self.height),
+                    expected: (self.geom.width, self.geom.height),
                 });
             }
         }
@@ -291,17 +318,11 @@ mod cuda {
             stream: &Arc<cudarc::driver::CudaStream>,
         ) -> Result<CudaStereoRectifier, StereoError> {
             let size = ImageSize {
-                width: self.width,
-                height: self.height,
+                width: self.geom.width,
+                height: self.geom.height,
             };
             let mut dev = CudaStereoRectifier {
-                width: self.width,
-                height: self.height,
-                f: self.f,
-                cx: self.cx,
-                cy: self.cy,
-                baseline: self.baseline,
-                rect_left: self.rect_left,
+                geom: self.geom,
                 left_map_x: self.left_map_x.to_cuda(stream)?,
                 left_map_y: self.left_map_y.to_cuda(stream)?,
                 right_map_x: self.right_map_x.to_cuda(stream)?,
@@ -310,10 +331,20 @@ mod cuda {
                 scratch_out: Image::zeros_cuda(size, stream)?,
                 stream: stream.clone(),
             };
-            // Warm-up: compiles the kernel through the cache and proves a launch works.
-            let mut sink = vec![0u8; self.width * self.height];
-            let zeros = vec![0u8; self.width * self.height];
-            dev.rectify_left_into(&zeros, &mut sink)?;
+            // Warm-up on the retained device scratch: compiles the kernel through the cache and
+            // proves a launch works, with no host round-trip. The synchronize is also load-bearing
+            // for correctness — it fences the four async map uploads above, so the maps are
+            // quiescent for every later call.
+            remap_u8(
+                &dev.scratch_in,
+                &mut dev.scratch_out,
+                &dev.left_map_x,
+                &dev.left_map_y,
+                InterpolationMode::Bilinear,
+            )?;
+            stream
+                .synchronize()
+                .map_err(|e| ImageError::Cuda(format!("warm-up sync: {e}")))?;
             Ok(dev)
         }
     }
@@ -325,13 +356,7 @@ mod cuda {
     /// Mid-run CUDA errors return typed errors and leave the stream state suspect; the demote-to-CPU
     /// policy belongs to the caller (safe precisely because the bytes match).
     pub struct CudaStereoRectifier {
-        width: usize,
-        height: usize,
-        f: f64,
-        cx: f64,
-        cy: f64,
-        baseline: f64,
-        rect_left: Mat3F64,
+        geom: RectifiedGeometry,
         left_map_x: Image<f32, 1>,
         left_map_y: Image<f32, 1>,
         right_map_x: Image<f32, 1>,
@@ -345,7 +370,7 @@ mod cuda {
         /// Rectify a DEVICE-resident left frame into a device-resident destination. Zero copies;
         /// work is enqueued on the images' stream and the caller synchronizes before reading.
         pub fn rectify_left_device(
-            &mut self,
+            &self,
             src: &Image<u8, 1>,
             dst: &mut Image<u8, 1>,
         ) -> Result<(), StereoError> {
@@ -363,7 +388,7 @@ mod cuda {
 
         /// See [`rectify_left_device`](Self::rectify_left_device).
         pub fn rectify_right_device(
-            &mut self,
+            &self,
             src: &Image<u8, 1>,
             dst: &mut Image<u8, 1>,
         ) -> Result<(), StereoError> {
@@ -404,11 +429,12 @@ mod cuda {
             out: &mut Vec<u8>,
             left: bool,
         ) -> Result<(), StereoError> {
-            let n = self.width * self.height;
+            let n = self.geom.width * self.geom.height;
             if raw.len() != n {
-                return Err(
-                    ImageError::InvalidImageSize(raw.len(), 1, self.width, self.height).into(),
-                );
+                return Err(StereoError::RawLengthMismatch {
+                    got: raw.len(),
+                    expected: n,
+                });
             }
             {
                 let slice = self
@@ -438,52 +464,47 @@ mod cuda {
         }
 
         fn check(&self, img: &Image<u8, 1>) -> Result<(), StereoError> {
-            if (img.width(), img.height()) != (self.width, self.height) {
+            if (img.width(), img.height()) != (self.geom.width, self.geom.height) {
                 return Err(StereoError::ImageSizeMismatch {
                     got: (img.width(), img.height()),
-                    expected: (self.width, self.height),
+                    expected: (self.geom.width, self.geom.height),
                 });
             }
-            // Fail HERE with a clear message rather than deeper in the dispatch: the _device
-            // methods are device-only by contract. Cross-DEVICE mismatches are still caught
-            // by remap_u8's own stream/device checks.
-            if img.as_cudaslice().is_none() {
+            // Fail HERE with a typed error: the _device methods are device-only by contract,
+            // and nothing downstream compares the MAPS' device to the image's — on a multi-GPU
+            // host a cross-device frame would launch with foreign map pointers (illegal memory
+            // access), not a typed error.
+            let Some(stream) = img.cuda_stream() else {
                 return Err(ImageError::Cuda(
                     "rectify_*_device needs a device-resident image (use to_cuda/zeros_cuda)"
                         .into(),
                 )
                 .into());
+            };
+            if stream.context().ordinal() != self.stream.context().ordinal() {
+                return Err(ImageError::DeviceMismatch.into());
             }
             Ok(())
         }
 
         /// Rectified pinhole camera (shared by both views; zero distortion).
         pub fn rectified_camera(&self) -> PinholeCamera {
-            PinholeCamera {
-                fx: self.f,
-                fy: self.f,
-                cx: self.cx,
-                cy: self.cy,
-                k1: 0.0,
-                k2: 0.0,
-                p1: 0.0,
-                p2: 0.0,
-            }
+            self.geom.rectified_camera()
         }
 
         /// Metric baseline between the cameras.
         pub fn baseline(&self) -> f64 {
-            self.baseline
+            self.geom.baseline
         }
 
         /// `bf = focal * baseline`, the constant in `depth = bf / disparity`.
         pub fn bf(&self) -> f64 {
-            self.f * self.baseline
+            self.geom.f * self.geom.baseline
         }
 
         /// See [`StereoRectifier::left_rectifying_rotation`].
         pub fn left_rectifying_rotation(&self) -> Mat3F64 {
-            self.rect_left
+            self.geom.rect_left
         }
     }
 }
@@ -528,10 +549,7 @@ fn build_map(
         }
     }
     let size = ImageSize { width, height };
-    Ok((
-        Image::from_size_slice(size, &map_x)?,
-        Image::from_size_slice(size, &map_y)?,
-    ))
+    Ok((Image::new(size, map_x)?, Image::new(size, map_y)?))
 }
 
 fn component(v: &Vec3F64, idx: usize) -> f64 {

--- a/crates/kornia-3d/src/stereo/rectify.rs
+++ b/crates/kornia-3d/src/stereo/rectify.rs
@@ -49,7 +49,8 @@ pub enum StereoError {
         expected: (usize, usize),
     },
 
-    /// Failed to build the rectified image from the remapped buffer.
+    /// An underlying image or CUDA operation failed (allocation, upload, residency, or
+    /// resampling).
     #[error(transparent)]
     Image(#[from] ImageError),
 }
@@ -78,11 +79,12 @@ impl RectifiedGeometry {
             fy: self.f,
             cx: self.cx,
             cy: self.cy,
-            k1: 0.0,
-            k2: 0.0,
-            p1: 0.0,
-            p2: 0.0,
+            ..PinholeCamera::IDENTITY
         }
+    }
+
+    fn bf(&self) -> f64 {
+        self.f * self.baseline
     }
 }
 
@@ -232,7 +234,7 @@ impl StereoRectifier {
 
     /// `bf = focal * baseline`, the constant in `depth = bf / disparity`.
     pub fn bf(&self) -> f64 {
-        self.geom.f * self.geom.baseline
+        self.geom.bf()
     }
 
     /// Rectifies a raw left image into `dst` — into-style like every imgproc op, so the
@@ -321,17 +323,12 @@ mod cuda {
                 right_map_y: self.right_map_y.to_cuda(stream)?,
                 stream: stream.clone(),
             };
-            // Warm-up on throwaway device buffers: compiles the kernel through the cache (a
-            // host-side nvrtc step, so failures surface synchronously) and enqueues one launch.
+            // Warm-up on throwaway device buffers, through the REAL entry point so it compiles
+            // the exact kernel later calls launch (a host-side nvrtc step — failures surface
+            // synchronously) and exercises the same residency checks.
             let warm_src: Image<u8, 1> = Image::zeros_cuda(size, stream)?;
             let mut warm_dst = Image::zeros_cuda(size, stream)?;
-            remap_u8(
-                &warm_src,
-                &mut warm_dst,
-                &dev.left_map_x,
-                &dev.left_map_y,
-                InterpolationMode::Bilinear,
-            )?;
+            dev.rectify_left_device(&warm_src, &mut warm_dst)?;
             Ok(dev)
         }
     }
@@ -359,16 +356,7 @@ mod cuda {
             src: &Image<u8, 1>,
             dst: &mut Image<u8, 1>,
         ) -> Result<(), StereoError> {
-            self.check(src)?;
-            self.check(dst)?;
-            remap_u8(
-                src,
-                dst,
-                &self.left_map_x,
-                &self.left_map_y,
-                InterpolationMode::Bilinear,
-            )?;
-            Ok(())
+            self.remap_device(src, dst, &self.left_map_x, &self.left_map_y)
         }
 
         /// See [`rectify_left_device`](Self::rectify_left_device).
@@ -377,15 +365,20 @@ mod cuda {
             src: &Image<u8, 1>,
             dst: &mut Image<u8, 1>,
         ) -> Result<(), StereoError> {
+            self.remap_device(src, dst, &self.right_map_x, &self.right_map_y)
+        }
+
+        /// The device twin of [`StereoRectifier::remap`]: checks, then one `remap_u8` call.
+        fn remap_device(
+            &self,
+            src: &Image<u8, 1>,
+            dst: &mut Image<u8, 1>,
+            map_x: &Image<f32, 1>,
+            map_y: &Image<f32, 1>,
+        ) -> Result<(), StereoError> {
             self.check(src)?;
             self.check(dst)?;
-            remap_u8(
-                src,
-                dst,
-                &self.right_map_x,
-                &self.right_map_y,
-                InterpolationMode::Bilinear,
-            )?;
+            remap_u8(src, dst, map_x, map_y, InterpolationMode::Bilinear)?;
             Ok(())
         }
 
@@ -425,7 +418,7 @@ mod cuda {
 
         /// `bf = focal * baseline`, the constant in `depth = bf / disparity`.
         pub fn bf(&self) -> f64 {
-            self.geom.f * self.geom.baseline
+            self.geom.bf()
         }
 
         /// See [`StereoRectifier::left_rectifying_rotation`].

--- a/crates/kornia-3d/src/stereo/rectify.rs
+++ b/crates/kornia-3d/src/stereo/rectify.rs
@@ -17,8 +17,6 @@ use kornia_algebra::{Mat3F64, Vec3F64, SO3F64};
 use kornia_image::{Image, ImageError, ImageSize};
 use kornia_imgproc::interpolation::{remap_u8, InterpolationMode};
 
-#[cfg(feature = "cuda")]
-use std::sync::Arc;
 use kornia_imgproc::calibration::distortion::{distort_point_polynomial, PolynomialDistortion};
 use kornia_imgproc::calibration::CameraIntrinsic;
 
@@ -222,22 +220,27 @@ impl StereoRectifier {
         self.f * self.baseline
     }
 
-    /// Rectifies a raw left image.
+    /// Rectifies a raw left image into `dst` — into-style like every imgproc op, so the
+    /// output's size and residency are the caller's stated intent, not an allocation policy.
     ///
     /// # Errors
-    /// [`StereoError::ImageSizeMismatch`] if `img`'s resolution differs from
-    /// the rectifier's.
-    pub fn rectify_left(&self, img: &Image<u8, 1>) -> Result<Image<u8, 1>, StereoError> {
-        self.remap(img, &self.left_map_x, &self.left_map_y)
+    /// [`StereoError::ImageSizeMismatch`] if `src` or `dst` resolution differs from the
+    /// rectifier's.
+    pub fn rectify_left(
+        &self,
+        src: &Image<u8, 1>,
+        dst: &mut Image<u8, 1>,
+    ) -> Result<(), StereoError> {
+        self.remap(src, dst, &self.left_map_x, &self.left_map_y)
     }
 
-    /// Rectifies a raw right image.
-    ///
-    /// # Errors
-    /// [`StereoError::ImageSizeMismatch`] if `img`'s resolution differs from
-    /// the rectifier's.
-    pub fn rectify_right(&self, img: &Image<u8, 1>) -> Result<Image<u8, 1>, StereoError> {
-        self.remap(img, &self.right_map_x, &self.right_map_y)
+    /// Rectifies a raw right image into `dst`; see [`rectify_left`](Self::rectify_left).
+    pub fn rectify_right(
+        &self,
+        src: &Image<u8, 1>,
+        dst: &mut Image<u8, 1>,
+    ) -> Result<(), StereoError> {
+        self.remap(src, dst, &self.right_map_x, &self.right_map_y)
     }
 
     /// One sampler for every backend: [`remap_u8`], whose CPU and CUDA paths are byte-exact
@@ -246,220 +249,242 @@ impl StereoRectifier {
     /// black), and blending is Q10 fixed point.
     fn remap(
         &self,
-        img: &Image<u8, 1>,
+        src: &Image<u8, 1>,
+        dst: &mut Image<u8, 1>,
         map_x: &Image<f32, 1>,
         map_y: &Image<f32, 1>,
-    ) -> Result<Image<u8, 1>, StereoError> {
-        if (img.width(), img.height()) != (self.width, self.height) {
-            return Err(StereoError::ImageSizeMismatch {
-                got: (img.width(), img.height()),
-                expected: (self.width, self.height),
-            });
+    ) -> Result<(), StereoError> {
+        for img in [&*src, dst] {
+            if (img.width(), img.height()) != (self.width, self.height) {
+                return Err(StereoError::ImageSizeMismatch {
+                    got: (img.width(), img.height()),
+                    expected: (self.width, self.height),
+                });
+            }
         }
-        let mut out = Image::from_size_val(
-            ImageSize {
+        remap_u8(src, dst, map_x, map_y, InterpolationMode::Bilinear)?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "cuda")]
+pub use cuda::CudaStereoRectifier;
+
+/// The CUDA-resident half, in its own module so the `std::sync::Arc` / cudarc imports exist
+/// only when the feature does.
+#[cfg(feature = "cuda")]
+mod cuda {
+    use std::sync::Arc;
+
+    use super::*;
+
+    impl StereoRectifier {
+        /// Uploads both eyes' map planes and warms the kernel, returning a rectifier that serves
+        /// DEVICE-resident work. Explicit — no hidden H2D on first frame — and the warm-up runs a
+        /// full rectify so nvrtc/compile/launch failures surface HERE, where a caller's CPU
+        /// fallback can catch them, not on frame one with the fallback already forfeited.
+        ///
+        /// The stream is only borrowed for the uploads; it is also retained for the host
+        /// convenience methods. No context is created — the application owns that.
+        pub fn to_cuda(
+            &self,
+            stream: &Arc<cudarc::driver::CudaStream>,
+        ) -> Result<CudaStereoRectifier, StereoError> {
+            let size = ImageSize {
                 width: self.width,
                 height: self.height,
-            },
-            0u8,
-        )?;
-        remap_u8(img, &mut out, map_x, map_y, InterpolationMode::Bilinear)?;
-        Ok(out)
+            };
+            let mut dev = CudaStereoRectifier {
+                width: self.width,
+                height: self.height,
+                f: self.f,
+                cx: self.cx,
+                cy: self.cy,
+                baseline: self.baseline,
+                rect_left: self.rect_left,
+                left_map_x: self.left_map_x.to_cuda(stream)?,
+                left_map_y: self.left_map_y.to_cuda(stream)?,
+                right_map_x: self.right_map_x.to_cuda(stream)?,
+                right_map_y: self.right_map_y.to_cuda(stream)?,
+                scratch_in: Image::zeros_cuda(size, stream)?,
+                scratch_out: Image::zeros_cuda(size, stream)?,
+                stream: stream.clone(),
+            };
+            // Warm-up: compiles the kernel through the cache and proves a launch works.
+            let mut sink = vec![0u8; self.width * self.height];
+            let zeros = vec![0u8; self.width * self.height];
+            dev.rectify_left_into(&zeros, &mut sink)?;
+            Ok(dev)
+        }
     }
-}
 
-#[cfg(feature = "cuda")]
-impl StereoRectifier {
-    /// Uploads both eyes' map planes and warms the kernel, returning a rectifier that serves
-    /// DEVICE-resident work. Explicit — no hidden H2D on first frame — and the warm-up runs a
-    /// full rectify so nvrtc/compile/launch failures surface HERE, where a caller's CPU
-    /// fallback can catch them, not on frame one with the fallback already forfeited.
+    /// [`StereoRectifier`]'s maps, device-resident, rectifying through the SAME
+    /// residency-dispatched [`remap_u8`] as the CPU path — the two produce identical bytes by
+    /// kornia-imgproc's tested CPU↔CUDA contract.
     ///
-    /// The stream is only borrowed for the uploads; it is also retained for the host
-    /// convenience methods. No context is created — the application owns that.
-    pub fn to_cuda(
-        &self,
-        stream: &Arc<cudarc::driver::CudaStream>,
-    ) -> Result<CudaStereoRectifier, StereoError> {
-        let size = ImageSize {
-            width: self.width,
-            height: self.height,
-        };
-        let mut dev = CudaStereoRectifier {
-            width: self.width,
-            height: self.height,
-            f: self.f,
-            cx: self.cx,
-            cy: self.cy,
-            baseline: self.baseline,
-            rect_left: self.rect_left,
-            left_map_x: self.left_map_x.to_cuda(stream)?,
-            left_map_y: self.left_map_y.to_cuda(stream)?,
-            right_map_x: self.right_map_x.to_cuda(stream)?,
-            right_map_y: self.right_map_y.to_cuda(stream)?,
-            scratch_in: Image::zeros_cuda(size, stream)?,
-            scratch_out: Image::zeros_cuda(size, stream)?,
-            stream: stream.clone(),
-        };
-        // Warm-up: compiles the kernel through the cache and proves a launch works.
-        let mut sink = vec![0u8; self.width * self.height];
-        let zeros = vec![0u8; self.width * self.height];
-        dev.rectify_left_into(&zeros, &mut sink)?;
-        Ok(dev)
-    }
-}
-
-/// [`StereoRectifier`]'s maps, device-resident, rectifying through the SAME
-/// residency-dispatched [`remap_u8`] as the CPU path — the two produce identical bytes by
-/// kornia-imgproc's tested CPU↔CUDA contract.
-///
-/// Mid-run CUDA errors return typed errors and leave the stream state suspect; the demote-to-CPU
-/// policy belongs to the caller (safe precisely because the bytes match).
-#[cfg(feature = "cuda")]
-pub struct CudaStereoRectifier {
-    width: usize,
-    height: usize,
-    f: f64,
-    cx: f64,
-    cy: f64,
-    baseline: f64,
-    rect_left: Mat3F64,
-    left_map_x: Image<f32, 1>,
-    left_map_y: Image<f32, 1>,
-    right_map_x: Image<f32, 1>,
-    right_map_y: Image<f32, 1>,
-    scratch_in: Image<u8, 1>,
-    scratch_out: Image<u8, 1>,
-    stream: Arc<cudarc::driver::CudaStream>,
-}
-
-#[cfg(feature = "cuda")]
-impl CudaStereoRectifier {
-    /// Rectify a DEVICE-resident left frame into a device-resident destination. Zero copies;
-    /// work is enqueued on the images' stream and the caller synchronizes before reading.
-    pub fn rectify_left_device(
-        &mut self,
-        src: &Image<u8, 1>,
-        dst: &mut Image<u8, 1>,
-    ) -> Result<(), StereoError> {
-        self.check(src)?;
-        self.check(dst)?;
-        remap_u8(
-            src,
-            dst,
-            &self.left_map_x,
-            &self.left_map_y,
-            InterpolationMode::Bilinear,
-        )?;
-        Ok(())
+    /// Mid-run CUDA errors return typed errors and leave the stream state suspect; the demote-to-CPU
+    /// policy belongs to the caller (safe precisely because the bytes match).
+    pub struct CudaStereoRectifier {
+        width: usize,
+        height: usize,
+        f: f64,
+        cx: f64,
+        cy: f64,
+        baseline: f64,
+        rect_left: Mat3F64,
+        left_map_x: Image<f32, 1>,
+        left_map_y: Image<f32, 1>,
+        right_map_x: Image<f32, 1>,
+        right_map_y: Image<f32, 1>,
+        scratch_in: Image<u8, 1>,
+        scratch_out: Image<u8, 1>,
+        stream: Arc<cudarc::driver::CudaStream>,
     }
 
-    /// See [`rectify_left_device`](Self::rectify_left_device).
-    pub fn rectify_right_device(
-        &mut self,
-        src: &Image<u8, 1>,
-        dst: &mut Image<u8, 1>,
-    ) -> Result<(), StereoError> {
-        self.check(src)?;
-        self.check(dst)?;
-        remap_u8(
-            src,
-            dst,
-            &self.right_map_x,
-            &self.right_map_y,
-            InterpolationMode::Bilinear,
-        )?;
-        Ok(())
-    }
-
-    /// Host-bytes convenience for the driver loop: H2D into retained scratch, kernel, blocking
-    /// D2H into `out` (resized once). No per-frame allocation.
-    pub fn rectify_left_into(&mut self, raw: &[u8], out: &mut Vec<u8>) -> Result<(), StereoError> {
-        self.host_roundtrip(raw, out, true)
-    }
-
-    /// See [`rectify_left_into`](Self::rectify_left_into).
-    pub fn rectify_right_into(&mut self, raw: &[u8], out: &mut Vec<u8>) -> Result<(), StereoError> {
-        self.host_roundtrip(raw, out, false)
-    }
-
-    fn host_roundtrip(
-        &mut self,
-        raw: &[u8],
-        out: &mut Vec<u8>,
-        left: bool,
-    ) -> Result<(), StereoError> {
-        let n = self.width * self.height;
-        if raw.len() != n {
-            return Err(StereoError::ImageSizeMismatch {
-                got: (raw.len(), 1),
-                expected: (self.width, self.height),
-            });
+    impl CudaStereoRectifier {
+        /// Rectify a DEVICE-resident left frame into a device-resident destination. Zero copies;
+        /// work is enqueued on the images' stream and the caller synchronizes before reading.
+        pub fn rectify_left_device(
+            &mut self,
+            src: &Image<u8, 1>,
+            dst: &mut Image<u8, 1>,
+        ) -> Result<(), StereoError> {
+            self.check(src)?;
+            self.check(dst)?;
+            remap_u8(
+                src,
+                dst,
+                &self.left_map_x,
+                &self.left_map_y,
+                InterpolationMode::Bilinear,
+            )?;
+            Ok(())
         }
-        {
-            let slice = self
-                .scratch_in
-                .as_cudaslice_mut()
-                .ok_or_else(|| ImageError::Cuda("scratch lost device residency".into()))?;
-            self.stream
-                .memcpy_htod(raw, slice)
-                .map_err(|e| ImageError::Cuda(format!("h2d: {e}")))?;
+
+        /// See [`rectify_left_device`](Self::rectify_left_device).
+        pub fn rectify_right_device(
+            &mut self,
+            src: &Image<u8, 1>,
+            dst: &mut Image<u8, 1>,
+        ) -> Result<(), StereoError> {
+            self.check(src)?;
+            self.check(dst)?;
+            remap_u8(
+                src,
+                dst,
+                &self.right_map_x,
+                &self.right_map_y,
+                InterpolationMode::Bilinear,
+            )?;
+            Ok(())
         }
-        let (mx, my) = if left {
-            (&self.left_map_x, &self.left_map_y)
-        } else {
-            (&self.right_map_x, &self.right_map_y)
-        };
-        remap_u8(
-            &self.scratch_in,
-            &mut self.scratch_out,
-            mx,
-            my,
-            InterpolationMode::Bilinear,
-        )?;
-        out.resize(n, 0);
-        // Blocking: syncs the stream, so the bytes are final when this returns.
-        self.scratch_out.to_host_into(out)?;
-        Ok(())
-    }
 
-    fn check(&self, img: &Image<u8, 1>) -> Result<(), StereoError> {
-        if (img.width(), img.height()) != (self.width, self.height) {
-            return Err(StereoError::ImageSizeMismatch {
-                got: (img.width(), img.height()),
-                expected: (self.width, self.height),
-            });
+        /// Host-bytes convenience for the driver loop: H2D into retained scratch, kernel, blocking
+        /// D2H into `out` (resized once). No per-frame allocation.
+        pub fn rectify_left_into(
+            &mut self,
+            raw: &[u8],
+            out: &mut Vec<u8>,
+        ) -> Result<(), StereoError> {
+            self.host_roundtrip(raw, out, true)
         }
-        Ok(())
-    }
 
-    /// Rectified pinhole camera (shared by both views; zero distortion).
-    pub fn rectified_camera(&self) -> PinholeCamera {
-        PinholeCamera {
-            fx: self.f,
-            fy: self.f,
-            cx: self.cx,
-            cy: self.cy,
-            k1: 0.0,
-            k2: 0.0,
-            p1: 0.0,
-            p2: 0.0,
+        /// See [`rectify_left_into`](Self::rectify_left_into).
+        pub fn rectify_right_into(
+            &mut self,
+            raw: &[u8],
+            out: &mut Vec<u8>,
+        ) -> Result<(), StereoError> {
+            self.host_roundtrip(raw, out, false)
         }
-    }
 
-    /// Metric baseline between the cameras.
-    pub fn baseline(&self) -> f64 {
-        self.baseline
-    }
+        fn host_roundtrip(
+            &mut self,
+            raw: &[u8],
+            out: &mut Vec<u8>,
+            left: bool,
+        ) -> Result<(), StereoError> {
+            let n = self.width * self.height;
+            if raw.len() != n {
+                return Err(
+                    ImageError::InvalidImageSize(raw.len(), 1, self.width, self.height).into(),
+                );
+            }
+            {
+                let slice = self
+                    .scratch_in
+                    .as_cudaslice_mut()
+                    .ok_or_else(|| ImageError::Cuda("scratch lost device residency".into()))?;
+                self.stream
+                    .memcpy_htod(raw, slice)
+                    .map_err(|e| ImageError::Cuda(format!("h2d: {e}")))?;
+            }
+            let (mx, my) = if left {
+                (&self.left_map_x, &self.left_map_y)
+            } else {
+                (&self.right_map_x, &self.right_map_y)
+            };
+            remap_u8(
+                &self.scratch_in,
+                &mut self.scratch_out,
+                mx,
+                my,
+                InterpolationMode::Bilinear,
+            )?;
+            out.resize(n, 0);
+            // Blocking: syncs the stream, so the bytes are final when this returns.
+            self.scratch_out.to_host_into(out)?;
+            Ok(())
+        }
 
-    /// `bf = focal * baseline`, the constant in `depth = bf / disparity`.
-    pub fn bf(&self) -> f64 {
-        self.f * self.baseline
-    }
+        fn check(&self, img: &Image<u8, 1>) -> Result<(), StereoError> {
+            if (img.width(), img.height()) != (self.width, self.height) {
+                return Err(StereoError::ImageSizeMismatch {
+                    got: (img.width(), img.height()),
+                    expected: (self.width, self.height),
+                });
+            }
+            // Fail HERE with a clear message rather than deeper in the dispatch: the _device
+            // methods are device-only by contract. Cross-DEVICE mismatches are still caught
+            // by remap_u8's own stream/device checks.
+            if img.as_cudaslice().is_none() {
+                return Err(ImageError::Cuda(
+                    "rectify_*_device needs a device-resident image (use to_cuda/zeros_cuda)"
+                        .into(),
+                )
+                .into());
+            }
+            Ok(())
+        }
 
-    /// See [`StereoRectifier::left_rectifying_rotation`].
-    pub fn left_rectifying_rotation(&self) -> Mat3F64 {
-        self.rect_left
+        /// Rectified pinhole camera (shared by both views; zero distortion).
+        pub fn rectified_camera(&self) -> PinholeCamera {
+            PinholeCamera {
+                fx: self.f,
+                fy: self.f,
+                cx: self.cx,
+                cy: self.cy,
+                k1: 0.0,
+                k2: 0.0,
+                p1: 0.0,
+                p2: 0.0,
+            }
+        }
+
+        /// Metric baseline between the cameras.
+        pub fn baseline(&self) -> f64 {
+            self.baseline
+        }
+
+        /// `bf = focal * baseline`, the constant in `depth = bf / disparity`.
+        pub fn bf(&self) -> f64 {
+            self.f * self.baseline
+        }
+
+        /// See [`StereoRectifier::left_rectifying_rotation`].
+        pub fn left_rectifying_rotation(&self) -> Mat3F64 {
+            self.rect_left
+        }
     }
 }
 
@@ -508,7 +533,6 @@ fn build_map(
         Image::from_size_slice(size, &map_y)?,
     ))
 }
-
 
 fn component(v: &Vec3F64, idx: usize) -> f64 {
     if idx == 0 {
@@ -644,10 +668,16 @@ mod tests {
             // Stamp each raw view and rectify.
             let img_l = dot_image(w, h, ul.round() as usize, vl.round() as usize)?;
             let img_r = dot_image(w, h, ur.round() as usize, vr.round() as usize)?;
-            let (_, cvl) =
-                centroid(&rect.rectify_left(&img_l)?).expect("left dot survives rectify");
-            let (_, cvr) =
-                centroid(&rect.rectify_right(&img_r)?).expect("right dot survives rectify");
+            let (_, cvl) = {
+                let mut out = Image::from_size_val(img_l.size(), 0u8)?;
+                rect.rectify_left(&img_l, &mut out)?;
+                centroid(&out).expect("left dot survives rectify")
+            };
+            let (_, cvr) = {
+                let mut out = Image::from_size_val(img_r.size(), 0u8)?;
+                rect.rectify_right(&img_r, &mut out)?;
+                centroid(&out).expect("right dot survives rectify")
+            };
 
             assert!(
                 (cvl - cvr).abs() < 2.0,
@@ -694,8 +724,9 @@ mod tests {
             Vec3F64::new(-0.1, 0.0, 0.0),
         )?;
         let wrong = dot_image(320, 240, 10, 10)?;
+        let mut out = Image::from_size_val(wrong.size(), 0u8)?;
         assert!(matches!(
-            rect.rectify_left(&wrong),
+            rect.rectify_left(&wrong, &mut out),
             Err(StereoError::ImageSizeMismatch { .. })
         ));
         Ok(())
@@ -804,9 +835,21 @@ mod tests {
                 (x & 0xFF) as u8
             })
             .collect();
-        let img = Image::from_size_slice(ImageSize { width: w, height: h }, &raw)?;
-        let cpu_l = rect.rectify_left(&img)?;
-        let cpu_r = rect.rectify_right(&img)?;
+        let img = Image::from_size_slice(
+            ImageSize {
+                width: w,
+                height: h,
+            },
+            &raw,
+        )?;
+        let size = ImageSize {
+            width: w,
+            height: h,
+        };
+        let mut cpu_l = Image::from_size_val(size, 0u8)?;
+        let mut cpu_r = Image::from_size_val(size, 0u8)?;
+        rect.rectify_left(&img, &mut cpu_l)?;
+        rect.rectify_right(&img, &mut cpu_r)?;
 
         let ctx = CudaContext::new(0)?;
         let stream = ctx.default_stream();

--- a/crates/kornia-3d/src/stereo/rectify.rs
+++ b/crates/kornia-3d/src/stereo/rectify.rs
@@ -15,6 +15,10 @@
 use crate::camera::PinholeCamera;
 use kornia_algebra::{Mat3F64, Vec3F64, SO3F64};
 use kornia_image::{Image, ImageError, ImageSize};
+use kornia_imgproc::interpolation::{remap_u8, InterpolationMode};
+
+#[cfg(feature = "cuda")]
+use std::sync::Arc;
 use kornia_imgproc::calibration::distortion::{distort_point_polynomial, PolynomialDistortion};
 use kornia_imgproc::calibration::CameraIntrinsic;
 
@@ -66,9 +70,11 @@ pub struct StereoRectifier {
     /// Rotation mapping raw left-camera coordinates into the rectified frame.
     rect_left: Mat3F64,
     /// Per-output-pixel source coordinate in the raw left image (`[u, v]`).
-    left_map: Vec<[f32; 2]>,
+    left_map_x: Image<f32, 1>,
+    left_map_y: Image<f32, 1>,
     /// Per-output-pixel source coordinate in the raw right image.
-    right_map: Vec<[f32; 2]>,
+    right_map_x: Image<f32, 1>,
+    right_map_y: Image<f32, 1>,
 }
 
 /// Per-camera calibration for rectification: intrinsics + Brown-Conrady
@@ -154,8 +160,8 @@ impl StereoRectifier {
         let cx = (width as f64 - 1.0) * 0.5;
         let cy = (height as f64 - 1.0) * 0.5;
 
-        let left_map = build_map(width, height, f, cx, cy, &rect_l, left);
-        let right_map = build_map(width, height, f, cx, cy, &rect_r, right);
+        let (left_map_x, left_map_y) = build_map(width, height, f, cx, cy, &rect_l, left)?;
+        let (right_map_x, right_map_y) = build_map(width, height, f, cx, cy, &rect_r, right)?;
 
         Ok(Self {
             width,
@@ -165,8 +171,10 @@ impl StereoRectifier {
             cy,
             baseline: nt,
             rect_left: rect_l,
-            left_map,
-            right_map,
+            left_map_x,
+            left_map_y,
+            right_map_x,
+            right_map_y,
         })
     }
 
@@ -191,23 +199,17 @@ impl StereoRectifier {
         }
     }
 
-    /// The per-pixel source coordinates for the LEFT rectified view: one `[x, y]` f32 pair per
-    /// output pixel, row-major `width * height`. This is the table [`rectify_left`](Self::rectify_left)
-    /// samples through — exposed so an external sampler (e.g. a CUDA remap kernel, which takes
-    /// the same map split into x/y planes) can consume the exact same geometry instead of
-    /// re-deriving it.
-    ///
-    /// The maps carry geometry only; BORDER POLICY belongs to the sampler. Coordinates in the
-    /// one-pixel band `(w-1, w)` / `(h-1, h)` are skipped (left black) by the CPU sampler here
-    /// but clamp-and-sample in kornia-imgproc's CUDA remap, so rectified border pixels may
-    /// differ between samplers consuming the same map.
-    pub fn left_map(&self) -> &[[f32; 2]] {
-        &self.left_map
+    /// The LEFT view's undistort+rectify map as `(x, y)` planes, one f32 per output pixel,
+    /// row-major `width * height` — exactly the operands [`remap_u8`] takes, on either backend.
+    /// [`rectify_left`](Self::rectify_left) samples through this same table, so an external
+    /// consumer sees identical geometry AND identical border/rounding semantics.
+    pub fn left_maps(&self) -> (&Image<f32, 1>, &Image<f32, 1>) {
+        (&self.left_map_x, &self.left_map_y)
     }
 
-    /// The RIGHT view's map; see [`left_map`](Self::left_map).
-    pub fn right_map(&self) -> &[[f32; 2]] {
-        &self.right_map
+    /// The RIGHT view's map planes; see [`left_maps`](Self::left_maps).
+    pub fn right_maps(&self) -> (&Image<f32, 1>, &Image<f32, 1>) {
+        (&self.right_map_x, &self.right_map_y)
     }
 
     /// Metric baseline between the cameras.
@@ -226,7 +228,7 @@ impl StereoRectifier {
     /// [`StereoError::ImageSizeMismatch`] if `img`'s resolution differs from
     /// the rectifier's.
     pub fn rectify_left(&self, img: &Image<u8, 1>) -> Result<Image<u8, 1>, StereoError> {
-        self.remap(img, &self.left_map)
+        self.remap(img, &self.left_map_x, &self.left_map_y)
     }
 
     /// Rectifies a raw right image.
@@ -235,33 +237,229 @@ impl StereoRectifier {
     /// [`StereoError::ImageSizeMismatch`] if `img`'s resolution differs from
     /// the rectifier's.
     pub fn rectify_right(&self, img: &Image<u8, 1>) -> Result<Image<u8, 1>, StereoError> {
-        self.remap(img, &self.right_map)
+        self.remap(img, &self.right_map_x, &self.right_map_y)
     }
 
-    fn remap(&self, img: &Image<u8, 1>, map: &[[f32; 2]]) -> Result<Image<u8, 1>, StereoError> {
+    /// One sampler for every backend: [`remap_u8`], whose CPU and CUDA paths are byte-exact
+    /// by tested contract. Border semantics are therefore remap_u8's — coordinates in the
+    /// `[w-1, w)` band clamp-sample the edge texel (the previous private sampler left them
+    /// black), and blending is Q10 fixed point.
+    fn remap(
+        &self,
+        img: &Image<u8, 1>,
+        map_x: &Image<f32, 1>,
+        map_y: &Image<f32, 1>,
+    ) -> Result<Image<u8, 1>, StereoError> {
         if (img.width(), img.height()) != (self.width, self.height) {
             return Err(StereoError::ImageSizeMismatch {
                 got: (img.width(), img.height()),
                 expected: (self.width, self.height),
             });
         }
-        let src = img.as_slice();
-        let (sw, sh) = (img.width(), img.height());
-        // `out` starts black; only pixels whose source lands inside the raw
-        // image get written, so out-of-frame borders stay black.
-        let mut out = vec![0u8; self.width * self.height];
-        for (dst, &[fx, fy]) in out.iter_mut().zip(map.iter()) {
-            if let Some(v) = sample_bilinear(src, sw, sh, fx, fy) {
-                *dst = v;
-            }
-        }
-        Ok(Image::from_size_slice(
+        let mut out = Image::from_size_val(
             ImageSize {
                 width: self.width,
                 height: self.height,
             },
-            &out,
-        )?)
+            0u8,
+        )?;
+        remap_u8(img, &mut out, map_x, map_y, InterpolationMode::Bilinear)?;
+        Ok(out)
+    }
+}
+
+#[cfg(feature = "cuda")]
+impl StereoRectifier {
+    /// Uploads both eyes' map planes and warms the kernel, returning a rectifier that serves
+    /// DEVICE-resident work. Explicit — no hidden H2D on first frame — and the warm-up runs a
+    /// full rectify so nvrtc/compile/launch failures surface HERE, where a caller's CPU
+    /// fallback can catch them, not on frame one with the fallback already forfeited.
+    ///
+    /// The stream is only borrowed for the uploads; it is also retained for the host
+    /// convenience methods. No context is created — the application owns that.
+    pub fn to_cuda(
+        &self,
+        stream: &Arc<cudarc::driver::CudaStream>,
+    ) -> Result<CudaStereoRectifier, StereoError> {
+        let size = ImageSize {
+            width: self.width,
+            height: self.height,
+        };
+        let mut dev = CudaStereoRectifier {
+            width: self.width,
+            height: self.height,
+            f: self.f,
+            cx: self.cx,
+            cy: self.cy,
+            baseline: self.baseline,
+            rect_left: self.rect_left,
+            left_map_x: self.left_map_x.to_cuda(stream)?,
+            left_map_y: self.left_map_y.to_cuda(stream)?,
+            right_map_x: self.right_map_x.to_cuda(stream)?,
+            right_map_y: self.right_map_y.to_cuda(stream)?,
+            scratch_in: Image::zeros_cuda(size, stream)?,
+            scratch_out: Image::zeros_cuda(size, stream)?,
+            stream: stream.clone(),
+        };
+        // Warm-up: compiles the kernel through the cache and proves a launch works.
+        let mut sink = vec![0u8; self.width * self.height];
+        let zeros = vec![0u8; self.width * self.height];
+        dev.rectify_left_into(&zeros, &mut sink)?;
+        Ok(dev)
+    }
+}
+
+/// [`StereoRectifier`]'s maps, device-resident, rectifying through the SAME
+/// residency-dispatched [`remap_u8`] as the CPU path — the two produce identical bytes by
+/// kornia-imgproc's tested CPU↔CUDA contract.
+///
+/// Mid-run CUDA errors return typed errors and leave the stream state suspect; the demote-to-CPU
+/// policy belongs to the caller (safe precisely because the bytes match).
+#[cfg(feature = "cuda")]
+pub struct CudaStereoRectifier {
+    width: usize,
+    height: usize,
+    f: f64,
+    cx: f64,
+    cy: f64,
+    baseline: f64,
+    rect_left: Mat3F64,
+    left_map_x: Image<f32, 1>,
+    left_map_y: Image<f32, 1>,
+    right_map_x: Image<f32, 1>,
+    right_map_y: Image<f32, 1>,
+    scratch_in: Image<u8, 1>,
+    scratch_out: Image<u8, 1>,
+    stream: Arc<cudarc::driver::CudaStream>,
+}
+
+#[cfg(feature = "cuda")]
+impl CudaStereoRectifier {
+    /// Rectify a DEVICE-resident left frame into a device-resident destination. Zero copies;
+    /// work is enqueued on the images' stream and the caller synchronizes before reading.
+    pub fn rectify_left_device(
+        &mut self,
+        src: &Image<u8, 1>,
+        dst: &mut Image<u8, 1>,
+    ) -> Result<(), StereoError> {
+        self.check(src)?;
+        self.check(dst)?;
+        remap_u8(
+            src,
+            dst,
+            &self.left_map_x,
+            &self.left_map_y,
+            InterpolationMode::Bilinear,
+        )?;
+        Ok(())
+    }
+
+    /// See [`rectify_left_device`](Self::rectify_left_device).
+    pub fn rectify_right_device(
+        &mut self,
+        src: &Image<u8, 1>,
+        dst: &mut Image<u8, 1>,
+    ) -> Result<(), StereoError> {
+        self.check(src)?;
+        self.check(dst)?;
+        remap_u8(
+            src,
+            dst,
+            &self.right_map_x,
+            &self.right_map_y,
+            InterpolationMode::Bilinear,
+        )?;
+        Ok(())
+    }
+
+    /// Host-bytes convenience for the driver loop: H2D into retained scratch, kernel, blocking
+    /// D2H into `out` (resized once). No per-frame allocation.
+    pub fn rectify_left_into(&mut self, raw: &[u8], out: &mut Vec<u8>) -> Result<(), StereoError> {
+        self.host_roundtrip(raw, out, true)
+    }
+
+    /// See [`rectify_left_into`](Self::rectify_left_into).
+    pub fn rectify_right_into(&mut self, raw: &[u8], out: &mut Vec<u8>) -> Result<(), StereoError> {
+        self.host_roundtrip(raw, out, false)
+    }
+
+    fn host_roundtrip(
+        &mut self,
+        raw: &[u8],
+        out: &mut Vec<u8>,
+        left: bool,
+    ) -> Result<(), StereoError> {
+        let n = self.width * self.height;
+        if raw.len() != n {
+            return Err(StereoError::ImageSizeMismatch {
+                got: (raw.len(), 1),
+                expected: (self.width, self.height),
+            });
+        }
+        {
+            let slice = self
+                .scratch_in
+                .as_cudaslice_mut()
+                .ok_or_else(|| ImageError::Cuda("scratch lost device residency".into()))?;
+            self.stream
+                .memcpy_htod(raw, slice)
+                .map_err(|e| ImageError::Cuda(format!("h2d: {e}")))?;
+        }
+        let (mx, my) = if left {
+            (&self.left_map_x, &self.left_map_y)
+        } else {
+            (&self.right_map_x, &self.right_map_y)
+        };
+        remap_u8(
+            &self.scratch_in,
+            &mut self.scratch_out,
+            mx,
+            my,
+            InterpolationMode::Bilinear,
+        )?;
+        out.resize(n, 0);
+        // Blocking: syncs the stream, so the bytes are final when this returns.
+        self.scratch_out.to_host_into(out)?;
+        Ok(())
+    }
+
+    fn check(&self, img: &Image<u8, 1>) -> Result<(), StereoError> {
+        if (img.width(), img.height()) != (self.width, self.height) {
+            return Err(StereoError::ImageSizeMismatch {
+                got: (img.width(), img.height()),
+                expected: (self.width, self.height),
+            });
+        }
+        Ok(())
+    }
+
+    /// Rectified pinhole camera (shared by both views; zero distortion).
+    pub fn rectified_camera(&self) -> PinholeCamera {
+        PinholeCamera {
+            fx: self.f,
+            fy: self.f,
+            cx: self.cx,
+            cy: self.cy,
+            k1: 0.0,
+            k2: 0.0,
+            p1: 0.0,
+            p2: 0.0,
+        }
+    }
+
+    /// Metric baseline between the cameras.
+    pub fn baseline(&self) -> f64 {
+        self.baseline
+    }
+
+    /// `bf = focal * baseline`, the constant in `depth = bf / disparity`.
+    pub fn bf(&self) -> f64 {
+        self.f * self.baseline
+    }
+
+    /// See [`StereoRectifier::left_rectifying_rotation`].
+    pub fn left_rectifying_rotation(&self) -> Mat3F64 {
+        self.rect_left
     }
 }
 
@@ -275,7 +473,7 @@ fn build_map(
     cy: f64,
     rect: &Mat3F64,
     cam: &CameraCalib,
-) -> Vec<[f32; 2]> {
+) -> Result<(Image<f32, 1>, Image<f32, 1>), ImageError> {
     let rect_t = rect.transpose(); // rectified-normalized -> camera-normalized
     let intrinsic = CameraIntrinsic {
         fx: cam.fx,
@@ -285,7 +483,8 @@ fn build_map(
     };
     let distortion = cam.distortion;
 
-    let mut map = vec![[0.0f32; 2]; width * height];
+    let mut map_x = vec![0.0f32; width * height];
+    let mut map_y = vec![0.0f32; width * height];
     for v in 0..height {
         for u in 0..width {
             // Inverse rectified projection -> normalized rectified coords.
@@ -299,37 +498,17 @@ fn build_map(
             let px = cam.fx * xn + cam.cx;
             let py = cam.fy * yn + cam.cy;
             let (du, dv) = distort_point_polynomial(px, py, &intrinsic, &distortion);
-            map[v * width + u] = [du as f32, dv as f32];
+            map_x[v * width + u] = du as f32;
+            map_y[v * width + u] = dv as f32;
         }
     }
-    map
+    let size = ImageSize { width, height };
+    Ok((
+        Image::from_size_slice(size, &map_x)?,
+        Image::from_size_slice(size, &map_y)?,
+    ))
 }
 
-/// Samples the source image at `(fx, fy)` with bilinear interpolation.
-/// Returns `None` when the coordinate is non-finite or outside the image, so
-/// the caller decides how to fill those (out-of-frame) rectified pixels.
-fn sample_bilinear(src: &[u8], w: usize, h: usize, fx: f32, fy: f32) -> Option<u8> {
-    if !fx.is_finite() || !fy.is_finite() || fx < 0.0 || fy < 0.0 {
-        return None;
-    }
-    let (wf, hf) = (w as f32, h as f32);
-    if fx > wf - 1.0 || fy > hf - 1.0 {
-        return None;
-    }
-    let x0 = fx.floor() as usize;
-    let y0 = fy.floor() as usize;
-    let x1 = (x0 + 1).min(w - 1);
-    let y1 = (y0 + 1).min(h - 1);
-    let ax = fx - x0 as f32;
-    let ay = fy - y0 as f32;
-    let p00 = src[y0 * w + x0] as f32;
-    let p01 = src[y0 * w + x1] as f32;
-    let p10 = src[y1 * w + x0] as f32;
-    let p11 = src[y1 * w + x1] as f32;
-    let top = p00 + (p01 - p00) * ax;
-    let bot = p10 + (p11 - p10) * ax;
-    Some((top + (bot - top) * ay).round().clamp(0.0, 255.0) as u8)
-}
 
 fn component(v: &Vec3F64, idx: usize) -> f64 {
     if idx == 0 {
@@ -593,7 +772,52 @@ mod tests {
             rect.baseline()
         );
         assert!(rect.bf() > 0.0);
-        assert_eq!(rect.left_map.len(), 752 * 480);
+        let (mx, my) = rect.left_maps();
+        assert_eq!(mx.as_slice().len(), 752 * 480);
+        assert_eq!(my.as_slice().len(), 752 * 480);
+        Ok(())
+    }
+
+    /// CPU and CUDA rectification must produce IDENTICAL bytes: both are remap_u8, whose
+    /// backends are byte-exact by kornia-imgproc's tested contract. Requires a CUDA device.
+    #[test]
+    #[cfg(feature = "cuda")]
+    fn cuda_rectify_matches_cpu_byte_exact() -> Result<(), Box<dyn std::error::Error>> {
+        use cudarc::driver::CudaContext;
+        // Same MH01-style rig as the baseline test: distorted 752x480 pair.
+        let left = calib(367.215, 248.375);
+        let right = calib(379.999, 255.238);
+        let rect = StereoRectifier::from_calib(
+            &left,
+            &right,
+            Mat3F64::IDENTITY,
+            Vec3F64::new(-0.11, 0.0, 0.0),
+        )?;
+        let (w, h) = (752usize, 480usize);
+        // Deterministic pseudo-random frame.
+        let mut x = 0x9E3779B97F4A7C15u64;
+        let raw: Vec<u8> = (0..w * h)
+            .map(|_| {
+                x ^= x << 13;
+                x ^= x >> 7;
+                x ^= x << 17;
+                (x & 0xFF) as u8
+            })
+            .collect();
+        let img = Image::from_size_slice(ImageSize { width: w, height: h }, &raw)?;
+        let cpu_l = rect.rectify_left(&img)?;
+        let cpu_r = rect.rectify_right(&img)?;
+
+        let ctx = CudaContext::new(0)?;
+        let stream = ctx.default_stream();
+        let mut dev = rect.to_cuda(&stream)?;
+        let mut gpu_l = Vec::new();
+        let mut gpu_r = Vec::new();
+        dev.rectify_left_into(&raw, &mut gpu_l)?;
+        dev.rectify_right_into(&raw, &mut gpu_r)?;
+
+        assert_eq!(cpu_l.as_slice(), gpu_l.as_slice(), "left bytes diverge");
+        assert_eq!(cpu_r.as_slice(), gpu_r.as_slice(), "right bytes diverge");
         Ok(())
     }
 }

--- a/crates/kornia/Cargo.toml
+++ b/crates/kornia/Cargo.toml
@@ -28,7 +28,7 @@ arrow = ["kornia-image/arrow"]
 bincode = ["kornia-tensor/bincode"]
 # CI-compatible feature bundle (everything except cuda/mkl which need special hardware)
 ci = ["arrow", "bincode", "gstreamer", "serde", "turbojpeg", "v4l"]
-cuda = ["kornia-vlm/cuda", "kornia-3d/cuda"]
+cuda = ["kornia-3d/cuda", "kornia-vlm/cuda"]
 gstreamer = ["kornia-io/gstreamer"]
 serde = ["kornia-tensor/serde"]
 turbojpeg = ["kornia-io/turbojpeg"]

--- a/crates/kornia/Cargo.toml
+++ b/crates/kornia/Cargo.toml
@@ -28,7 +28,7 @@ arrow = ["kornia-image/arrow"]
 bincode = ["kornia-tensor/bincode"]
 # CI-compatible feature bundle (everything except cuda/mkl which need special hardware)
 ci = ["arrow", "bincode", "gstreamer", "serde", "turbojpeg", "v4l"]
-cuda = ["kornia-vlm/cuda"]
+cuda = ["kornia-vlm/cuda", "kornia-3d/cuda"]
 gstreamer = ["kornia-io/gstreamer"]
 serde = ["kornia-tensor/serde"]
 turbojpeg = ["kornia-io/turbojpeg"]


### PR DESCRIPTION
## Summary

`StereoRectifier` now has one sampler for every backend: `rectify_left/right` route through kornia-imgproc's residency-dispatched `remap_u8` (CPU↔CUDA byte-exact by its tested contract), and a new `cuda` feature adds `to_cuda(&stream) → CudaStereoRectifier` with device-resident maps.

Design (from a three-agent design review):
- **Dispatch stays in `remap_u8`** — kornia-3d holds maps in both residencies and forwards; zero kernel/launch/unsafe code in this crate.
- **Maps stored planar** (`Image<f32,1>` x/y pairs) — what every consumer actually wants; the #1125 interleaved accessors become `left_maps()/right_maps()`.
- **Warm-up in `to_cuda`**: kernels compile lazily via nvrtc, so without a warm-up a broken CUDA stack passes construction and fails on frame 1 with the caller's CPU fallback already forfeited. The constructor runs one full rectify.
- **`_device` primitives + `_into` conveniences**: zero-copy async for device-resident pipelines; H2D/D2H with retained scratch (no per-frame allocation) for host-bytes drivers.
- **No implicit anything**: no context creation, no lazy uploads, typed errors on mid-run failures — demote-to-CPU policy belongs to the caller, and is now SAFE because the bytes match.

## Behaviour change (deliberate)

Rectified bytes shift: the `[w-1, w)` border band (formerly black) now clamp-samples, and blending is Q10 fixed point (±1 LSB anywhere). In exchange **CPU and CUDA rectification are identical**, so live-GPU and replay-CPU pipelines produce the same pixels — previously they could not.

## Tests

- All existing kornia-3d tests green with the remap_u8 CPU path (row-alignment, MH01 baseline, size mismatch).
- New `cuda_rectify_matches_cpu_byte_exact` — passes on Jetson Orin (Vulkan/CUDA 8.7).
- Default build stays cudarc-free; feature is additive.

First consumer: flux-xlerobot's OAK source deletes its hand-rolled 107-line CudaRectifier (13.7× measured on Orin, 4.09→0.30 ms/eye).

🤖 Generated with [Claude Code](https://claude.com/claude-code)