### PR TITLE
fix(optim): make LM step tolerance configurable per solve

### DIFF
--- a/crates/kornia-3d/src/pnp/mod.rs
+++ b/crates/kornia-3d/src/pnp/mod.rs
@@ -19,7 +19,7 @@ pub use epnp::{EPnP, EPnPParams};
 use kornia_algebra::{Mat3AF32, Vec2F32, Vec3AF32};
 use kornia_imgproc::calibration::distortion::PolynomialDistortion;
 pub use ransac::{solve_pnp_ransac, PnPRansacError, PnPRansacResult, RansacParams};
-pub use refine::{refine_pose_lm, LMRefineParams};
+pub use refine::{refine_pose_lm, refine_pose_lm_with_step_tolerance, LMRefineParams};
 use thiserror::Error;
 
 /// Error types for PnP solvers.

--- a/crates/kornia-3d/src/pnp/refine.rs
+++ b/crates/kornia-3d/src/pnp/refine.rs
@@ -368,6 +368,43 @@ fn build_robust_loss(params: &LMRefineParams) -> Result<Option<Arc<dyn RobustLos
 /// # Returns
 ///
 /// Refined `PnPResult` with updated rotation, translation, and convergence info.
+///
+/// # Errors
+///
+/// Returns a [`PnPError`] if the correspondence counts differ, fewer than three
+/// correspondences are provided, the robust loss is invalid, or optimization
+/// fails.
+///
+/// # Example
+///
+/// ```no_run
+/// use kornia_3d::pnp::{refine_pose_lm, LMRefineParams, PnPError};
+/// use kornia_algebra::{Mat3AF32, Vec2F32, Vec3AF32};
+///
+/// # fn main() -> Result<(), PnPError> {
+/// let points_world = [
+///     Vec3AF32::new(0.0, 0.0, 0.0),
+///     Vec3AF32::new(1.0, 0.0, 0.0),
+///     Vec3AF32::new(0.0, 1.0, 0.0),
+/// ];
+/// let points_image = [
+///     Vec2F32::new(0.0, 0.0),
+///     Vec2F32::new(1.0 / 3.0, 0.0),
+///     Vec2F32::new(0.0, 1.0 / 3.0),
+/// ];
+/// let result = refine_pose_lm(
+///     &points_world,
+///     &points_image,
+///     &Mat3AF32::IDENTITY,
+///     &Mat3AF32::IDENTITY,
+///     &Vec3AF32::new(0.0, 0.0, 3.0),
+///     None,
+///     &LMRefineParams::default(),
+/// )?;
+/// assert!(result.reproj_rmse.is_some());
+/// # Ok(())
+/// # }
+/// ```
 pub fn refine_pose_lm(
     points_world: &[Vec3AF32],
     points_image: &[Vec2F32],
@@ -376,6 +413,115 @@ pub fn refine_pose_lm(
     initial_translation: &Vec3AF32,
     distortion: Option<&PolynomialDistortion>,
     params: &LMRefineParams,
+) -> Result<PnPResult, PnPError> {
+    refine_pose_lm_impl(
+        points_world,
+        points_image,
+        k,
+        initial_rotation,
+        initial_translation,
+        distortion,
+        params,
+        None,
+    )
+}
+
+/// Refine a PnP pose estimate with a caller-supplied LM step tolerance.
+///
+/// A proposed step whose Euclidean norm is smaller than `step_tolerance`
+/// terminates optimization before the step is applied. Use [`refine_pose_lm`]
+/// when the optimizer's default `1e-12` tolerance is appropriate.
+/// Keeping the tolerance as a per-call argument leaves [`LMRefineParams`]
+/// unchanged, so downstream exhaustive struct literals remain source-compatible.
+///
+/// # Arguments
+///
+/// * `points_world` - 3D points in world coordinates.
+/// * `points_image` - Corresponding 2D points in image coordinates.
+/// * `k` - Camera intrinsic matrix.
+/// * `initial_rotation` - Initial rotation estimate.
+/// * `initial_translation` - Initial translation estimate.
+/// * `distortion` - Optional camera distortion model.
+/// * `params` - LM refinement parameters.
+/// * `step_tolerance` - Minimum step norm that will be applied.
+///
+/// # Returns
+///
+/// Refined [`PnPResult`] with updated rotation, translation, and convergence
+/// information.
+///
+/// # Errors
+///
+/// Returns a [`PnPError`] if the correspondence counts differ, fewer than three
+/// correspondences are provided, the robust loss is invalid, or optimization
+/// fails.
+///
+/// # Example
+///
+/// ```no_run
+/// use kornia_3d::pnp::{
+///     refine_pose_lm_with_step_tolerance, LMRefineParams, PnPError,
+/// };
+/// use kornia_algebra::{Mat3AF32, Vec2F32, Vec3AF32};
+///
+/// # fn main() -> Result<(), PnPError> {
+/// let points_world = [
+///     Vec3AF32::new(0.0, 0.0, 0.0),
+///     Vec3AF32::new(1.0, 0.0, 0.0),
+///     Vec3AF32::new(0.0, 1.0, 0.0),
+/// ];
+/// let points_image = [
+///     Vec2F32::new(0.0, 0.0),
+///     Vec2F32::new(1.0 / 3.0, 0.0),
+///     Vec2F32::new(0.0, 1.0 / 3.0),
+/// ];
+/// let result = refine_pose_lm_with_step_tolerance(
+///     &points_world,
+///     &points_image,
+///     &Mat3AF32::IDENTITY,
+///     &Mat3AF32::IDENTITY,
+///     &Vec3AF32::new(0.0, 0.0, 3.0),
+///     None,
+///     &LMRefineParams::default(),
+///     1e-12,
+/// )?;
+/// assert!(result.reproj_rmse.is_some());
+/// # Ok(())
+/// # }
+/// ```
+#[allow(clippy::too_many_arguments)]
+pub fn refine_pose_lm_with_step_tolerance(
+    points_world: &[Vec3AF32],
+    points_image: &[Vec2F32],
+    k: &Mat3AF32,
+    initial_rotation: &Mat3AF32,
+    initial_translation: &Vec3AF32,
+    distortion: Option<&PolynomialDistortion>,
+    params: &LMRefineParams,
+    step_tolerance: f32,
+) -> Result<PnPResult, PnPError> {
+    refine_pose_lm_impl(
+        points_world,
+        points_image,
+        k,
+        initial_rotation,
+        initial_translation,
+        distortion,
+        params,
+        Some(step_tolerance),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn refine_pose_lm_impl(
+    points_world: &[Vec3AF32],
+    points_image: &[Vec2F32],
+    k: &Mat3AF32,
+    initial_rotation: &Mat3AF32,
+    initial_translation: &Vec3AF32,
+    distortion: Option<&PolynomialDistortion>,
+    params: &LMRefineParams,
+    step_tolerance: Option<f32>,
 ) -> Result<PnPResult, PnPError> {
     let n = points_world.len();
     if n != points_image.len() {
@@ -432,9 +578,15 @@ pub fn refine_pose_lm(
         gradient_tolerance: params.gradient_tolerance,
     };
 
-    let result = optimizer
-        .optimize(&mut problem)
-        .map_err(|e| PnPError::SvdFailed(format!("Optimization failed: {}", e)))?;
+    // Keep the original entry point tied to the optimizer's canonical default;
+    // only the additive API supplies a per-solve override.
+    let result = match step_tolerance {
+        Some(step_tolerance) => {
+            optimizer.optimize_with_step_tolerance(&mut problem, step_tolerance)
+        }
+        None => optimizer.optimize(&mut problem),
+    }
+    .map_err(|e| PnPError::SvdFailed(format!("Optimization failed: {}", e)))?;
 
     // Extract refined pose
     let pose_values = problem
@@ -637,6 +789,65 @@ mod tests {
         assert!(result.num_iterations.is_some());
         assert!(result.reproj_rmse.unwrap().is_finite());
         assert!(result.num_iterations.unwrap() > 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_refine_pose_lm_step_tolerance_is_configurable() -> Result<(), PnPError> {
+        let points_world = [
+            Vec3AF32::new(0.0315, 0.03333, -0.10409),
+            Vec3AF32::new(-0.0315, 0.03333, -0.10409),
+            Vec3AF32::new(0.0, -0.00102, -0.12977),
+            Vec3AF32::new(0.02646, -0.03167, -0.1053),
+            Vec3AF32::new(-0.02646, -0.031667, -0.1053),
+            Vec3AF32::new(0.0, 0.04515, -0.11033),
+        ];
+        let points_image = [
+            Vec2F32::new(722.96466, 502.0828),
+            Vec2F32::new(669.88837, 498.61877),
+            Vec2F32::new(707.0025, 478.48975),
+            Vec2F32::new(728.05634, 447.56918),
+            Vec2F32::new(682.6069, 443.91776),
+            Vec2F32::new(696.4414, 511.96442),
+        ];
+        let k = k_default();
+        let initial_rotation = Mat3AF32::IDENTITY;
+        let initial_translation = Vec3AF32::new(0.0, 0.0, 1.0);
+        let params = LMRefineParams {
+            max_iterations: 1,
+            cost_tolerance: 0.0,
+            gradient_tolerance: 0.0,
+            ..LMRefineParams::default()
+        };
+
+        let strict = refine_pose_lm_with_step_tolerance(
+            &points_world,
+            &points_image,
+            &k,
+            &initial_rotation,
+            &initial_translation,
+            None,
+            &params,
+            0.0,
+        )?;
+        // A zero cutoff allows the single configured iteration to run.
+        assert_eq!(strict.num_iterations, Some(1));
+        assert_eq!(strict.converged, Some(false));
+
+        let loose = refine_pose_lm_with_step_tolerance(
+            &points_world,
+            &points_image,
+            &k,
+            &initial_rotation,
+            &initial_translation,
+            None,
+            &params,
+            1e6,
+        )?;
+        // A loose cutoff terminates before the first step is applied.
+        assert_eq!(loose.num_iterations, Some(0));
+        assert_eq!(loose.converged, Some(true));
 
         Ok(())
     }

--- a/crates/kornia-3d/src/pnp/refine.rs
+++ b/crates/kornia-3d/src/pnp/refine.rs
@@ -443,7 +443,7 @@ pub fn refine_pose_lm(
 /// * `initial_translation` - Initial translation estimate.
 /// * `distortion` - Optional camera distortion model.
 /// * `params` - LM refinement parameters.
-/// * `step_tolerance` - Minimum step norm that will be applied.
+/// * `step_tolerance` - Finite, non-negative minimum step norm that will be applied.
 ///
 /// # Returns
 ///
@@ -452,9 +452,9 @@ pub fn refine_pose_lm(
 ///
 /// # Errors
 ///
-/// Returns a [`PnPError`] if the correspondence counts differ, fewer than three
-/// correspondences are provided, the robust loss is invalid, or optimization
-/// fails.
+/// Returns a [`PnPError`] if `step_tolerance` is negative or non-finite, the
+/// correspondence counts differ, fewer than three correspondences are provided,
+/// the robust loss is invalid, or optimization fails.
 ///
 /// # Example
 ///
@@ -848,6 +848,22 @@ mod tests {
         // A loose cutoff terminates before the first step is applied.
         assert_eq!(loose.num_iterations, Some(0));
         assert_eq!(loose.converged, Some(true));
+
+        let invalid = refine_pose_lm_with_step_tolerance(
+            &points_world,
+            &points_image,
+            &k,
+            &initial_rotation,
+            &initial_translation,
+            None,
+            &params,
+            f32::NAN,
+        );
+        assert!(matches!(
+            invalid,
+            Err(PnPError::SvdFailed(message))
+                if message.contains("Step tolerance must be finite and non-negative")
+        ));
 
         Ok(())
     }

--- a/crates/kornia-algebra/src/optim/solvers/levenberg_marquardt.rs
+++ b/crates/kornia-algebra/src/optim/solvers/levenberg_marquardt.rs
@@ -72,6 +72,8 @@ pub enum TerminationReason {
 /// [`Self::optimize_with_callback_and_step_tolerance`]. It is intentionally not
 /// stored as another public field: callers can construct this configuration
 /// with exhaustive struct literals, and adding a field would break that source.
+/// The existing optimization entry points use `1e-12`, preserving the step
+/// convergence behavior from before the shared threshold was loosened.
 ///
 /// # Example
 ///
@@ -137,10 +139,12 @@ pub struct OptimizerState {
 
 impl LevenbergMarquardt {
     // Keep the threshold out of this exhaustively constructible public struct so
-    // downstream struct literals remain source-compatible.
-    const DEFAULT_STEP_TOLERANCE: f32 = 1e-6;
+    // downstream struct literals remain source-compatible. The 1e-12 value
+    // restores the historical default; callers that need earlier termination can
+    // opt into a larger threshold per solve.
+    const DEFAULT_STEP_TOLERANCE: f32 = 1e-12;
 
-    /// Optimizes a nonlinear least-squares problem with the default step tolerance.
+    /// Optimizes a nonlinear least-squares problem with a `1e-12` step tolerance.
     ///
     /// # Arguments
     ///
@@ -177,7 +181,7 @@ impl LevenbergMarquardt {
         self.optimize_with_step_tolerance(problem, Self::DEFAULT_STEP_TOLERANCE)
     }
 
-    /// Optimizes a problem with the default step tolerance and an iteration callback.
+    /// Optimizes a problem with a `1e-12` step tolerance and an iteration callback.
     ///
     /// The callback is invoked before the first iteration and after each attempted
     /// step. Returning `false` stops optimization with
@@ -691,6 +695,21 @@ mod tests {
         );
         assert_eq!(loose_result.iterations, 0);
         assert_eq!(loose_problem.get_variables()["x"].values[0], 0.0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_default_step_tolerance_restores_small_step_behavior() -> Result<(), OptimizerError> {
+        // A 1e-6 default would incorrectly terminate before applying this roughly
+        // 5e-7 step. The historical 1e-12 default must let the iteration proceed.
+        let optimizer = single_iteration_optimizer();
+        let mut problem = small_step_problem()?;
+        let result = optimizer.optimize(&mut problem)?;
+
+        assert_eq!(result.termination_reason, TerminationReason::MaxIterations);
+        assert_eq!(result.iterations, 1);
+        assert!(problem.get_variables()["x"].values[0] > 0.0);
 
         Ok(())
     }

--- a/crates/kornia-algebra/src/optim/solvers/levenberg_marquardt.rs
+++ b/crates/kornia-algebra/src/optim/solvers/levenberg_marquardt.rs
@@ -66,6 +66,37 @@ pub enum TerminationReason {
 }
 
 /// Levenberg-Marquardt optimizer configuration.
+///
+/// Step tolerance is configured per optimization call through
+/// [`Self::optimize_with_step_tolerance`] or
+/// [`Self::optimize_with_callback_and_step_tolerance`]. It is intentionally not
+/// stored as another public field: callers can construct this configuration
+/// with exhaustive struct literals, and adding a field would break that source.
+///
+/// # Example
+///
+/// ```rust
+/// use kornia_algebra::optim::{
+///     LevenbergMarquardt, OptimizerError, PriorFactor, Problem, Variable,
+/// };
+///
+/// # fn main() -> Result<(), OptimizerError> {
+/// let optimizer = LevenbergMarquardt {
+///     lambda_init: 1e-3,
+///     lambda_max: 1e10,
+///     lambda_factor: 10.0,
+///     max_iterations: 50,
+///     cost_tolerance: 1e-6,
+///     gradient_tolerance: 1e-6,
+/// };
+/// let mut problem = Problem::new();
+/// problem.add_variable(Variable::euclidean("x", 1), vec![0.0])?;
+/// problem.add_factor(Box::new(PriorFactor::new(vec![1.0])), vec!["x".into()])?;
+///
+/// optimizer.optimize_with_step_tolerance(&mut problem, 1e-12)?;
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Debug, Clone)]
 pub struct LevenbergMarquardt {
     /// Initial damping parameter
@@ -105,16 +136,209 @@ pub struct OptimizerState {
 }
 
 impl LevenbergMarquardt {
-    /// Minimum step norm threshold. Steps smaller than this are considered zero.
-    const STEP_SIZE_TOLERANCE: f32 = 1e-6;
+    // Keep the threshold out of this exhaustively constructible public struct so
+    // downstream struct literals remain source-compatible.
+    const DEFAULT_STEP_TOLERANCE: f32 = 1e-6;
 
+    /// Optimizes a nonlinear least-squares problem with the default step tolerance.
+    ///
+    /// # Arguments
+    ///
+    /// * `problem` - Problem whose variables will be updated in place.
+    ///
+    /// # Returns
+    ///
+    /// The final cost, iteration count, and termination reason.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`OptimizerError`] if the problem is empty or invalid, factor
+    /// evaluation fails, the damped system cannot be solved, or a parameter update
+    /// fails.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use kornia_algebra::optim::{
+    ///     LevenbergMarquardt, OptimizerError, PriorFactor, Problem, Variable,
+    /// };
+    ///
+    /// # fn main() -> Result<(), OptimizerError> {
+    /// let mut problem = Problem::new();
+    /// problem.add_variable(Variable::euclidean("x", 1), vec![0.0])?;
+    /// problem.add_factor(Box::new(PriorFactor::new(vec![2.0])), vec!["x".into()])?;
+    ///
+    /// let result = LevenbergMarquardt::default().optimize(&mut problem)?;
+    /// assert!(result.iterations > 0);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn optimize(&self, problem: &mut Problem) -> Result<OptimizerResult, OptimizerError> {
-        self.optimize_with_callback(problem, |_problem, _state| true)
+        self.optimize_with_step_tolerance(problem, Self::DEFAULT_STEP_TOLERANCE)
     }
 
+    /// Optimizes a problem with the default step tolerance and an iteration callback.
+    ///
+    /// The callback is invoked before the first iteration and after each attempted
+    /// step. Returning `false` stops optimization with
+    /// [`TerminationReason::Interrupted`].
+    ///
+    /// # Arguments
+    ///
+    /// * `problem` - Problem whose variables will be updated in place.
+    /// * `callback` - Function that receives the current problem and optimizer state.
+    ///
+    /// # Returns
+    ///
+    /// The final cost, iteration count, and termination reason.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`OptimizerError`] if the problem is empty or invalid, factor
+    /// evaluation fails, the damped system cannot be solved, or a parameter update
+    /// fails.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use kornia_algebra::optim::{
+    ///     LevenbergMarquardt, OptimizerError, PriorFactor, Problem, Variable,
+    /// };
+    ///
+    /// # fn main() -> Result<(), OptimizerError> {
+    /// let mut problem = Problem::new();
+    /// problem.add_variable(Variable::euclidean("x", 1), vec![0.0])?;
+    /// problem.add_factor(Box::new(PriorFactor::new(vec![2.0])), vec!["x".into()])?;
+    ///
+    /// let mut callback_count = 0;
+    /// LevenbergMarquardt::default().optimize_with_callback(
+    ///     &mut problem,
+    ///     |_problem, _state| {
+    ///         callback_count += 1;
+    ///         true
+    ///     },
+    /// )?;
+    /// assert!(callback_count > 0);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn optimize_with_callback<F>(
         &self,
         problem: &mut Problem,
+        callback: F,
+    ) -> Result<OptimizerResult, OptimizerError>
+    where
+        F: FnMut(&Problem, &OptimizerState) -> bool,
+    {
+        self.optimize_with_callback_and_step_tolerance(
+            problem,
+            Self::DEFAULT_STEP_TOLERANCE,
+            callback,
+        )
+    }
+
+    /// Optimizes a problem with a caller-supplied step tolerance.
+    ///
+    /// A proposed step whose Euclidean norm is smaller than `step_tolerance`
+    /// terminates optimization with [`TerminationReason::CostConverged`] before
+    /// the step is applied.
+    ///
+    /// # Arguments
+    ///
+    /// * `problem` - Problem whose variables will be updated in place.
+    /// * `step_tolerance` - Minimum step norm that will be applied.
+    ///
+    /// # Returns
+    ///
+    /// The final cost, iteration count, and termination reason.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`OptimizerError`] if the problem is empty or invalid, factor
+    /// evaluation fails, the damped system cannot be solved, or a parameter update
+    /// fails.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use kornia_algebra::optim::{
+    ///     LevenbergMarquardt, OptimizerError, PriorFactor, Problem, Variable,
+    /// };
+    ///
+    /// # fn main() -> Result<(), OptimizerError> {
+    /// let mut problem = Problem::new();
+    /// problem.add_variable(Variable::euclidean("x", 1), vec![0.0])?;
+    /// problem.add_factor(Box::new(PriorFactor::new(vec![2.0])), vec!["x".into()])?;
+    ///
+    /// LevenbergMarquardt::default()
+    ///     .optimize_with_step_tolerance(&mut problem, 1e-12)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn optimize_with_step_tolerance(
+        &self,
+        problem: &mut Problem,
+        step_tolerance: f32,
+    ) -> Result<OptimizerResult, OptimizerError> {
+        self.optimize_with_callback_and_step_tolerance(
+            problem,
+            step_tolerance,
+            |_problem, _state| true,
+        )
+    }
+
+    /// Optimizes a problem with a caller-supplied step tolerance and callback.
+    ///
+    /// A proposed step whose Euclidean norm is smaller than `step_tolerance`
+    /// terminates optimization with [`TerminationReason::CostConverged`] before
+    /// the step is applied. Returning `false` from `callback` stops optimization
+    /// with [`TerminationReason::Interrupted`].
+    ///
+    /// # Arguments
+    ///
+    /// * `problem` - Problem whose variables will be updated in place.
+    /// * `step_tolerance` - Minimum step norm that will be applied.
+    /// * `callback` - Function that receives the current problem and optimizer state.
+    ///
+    /// # Returns
+    ///
+    /// The final cost, iteration count, and termination reason.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`OptimizerError`] if the problem is empty or invalid, factor
+    /// evaluation fails, the damped system cannot be solved, or a parameter update
+    /// fails.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use kornia_algebra::optim::{
+    ///     LevenbergMarquardt, OptimizerError, PriorFactor, Problem, Variable,
+    /// };
+    ///
+    /// # fn main() -> Result<(), OptimizerError> {
+    /// let mut problem = Problem::new();
+    /// problem.add_variable(Variable::euclidean("x", 1), vec![0.0])?;
+    /// problem.add_factor(Box::new(PriorFactor::new(vec![2.0])), vec!["x".into()])?;
+    ///
+    /// let mut callback_count = 0;
+    /// LevenbergMarquardt::default().optimize_with_callback_and_step_tolerance(
+    ///     &mut problem,
+    ///     1e-12,
+    ///     |_problem, _state| {
+    ///         callback_count += 1;
+    ///         true
+    ///     },
+    /// )?;
+    /// assert!(callback_count > 0);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn optimize_with_callback_and_step_tolerance<F>(
+        &self,
+        problem: &mut Problem,
+        step_tolerance: f32,
         mut callback: F,
     ) -> Result<OptimizerResult, OptimizerError>
     where
@@ -191,7 +415,7 @@ impl LevenbergMarquardt {
 
             // Compute step size
             let step_norm = delta.norm();
-            if step_norm < Self::STEP_SIZE_TOLERANCE {
+            if step_norm < step_tolerance {
                 // Step is essentially zero, consider converged
                 return Ok(OptimizerResult {
                     final_cost: current_cost,
@@ -354,6 +578,25 @@ mod tests {
     use super::*;
     use crate::optim::{PriorFactor, Problem, Variable};
 
+    fn small_step_problem() -> Result<Problem, OptimizerError> {
+        let mut problem = Problem::new();
+        problem.add_variable(Variable::euclidean("x", 1), vec![0.0])?;
+        problem.add_factor(
+            Box::new(PriorFactor::new(vec![5e-7])),
+            vec!["x".to_string()],
+        )?;
+        Ok(problem)
+    }
+
+    fn single_iteration_optimizer() -> LevenbergMarquardt {
+        LevenbergMarquardt {
+            max_iterations: 1,
+            cost_tolerance: 0.0,
+            gradient_tolerance: 0.0,
+            ..LevenbergMarquardt::default()
+        }
+    }
+
     #[test]
     fn test_simple_1d_optimization() {
         // Minimize (x - 5)^2
@@ -422,5 +665,33 @@ mod tests {
         assert_eq!(optimizer.lambda_max, 1e10);
         assert_eq!(optimizer.lambda_factor, 10.0);
         assert_eq!(optimizer.max_iterations, 50);
+    }
+
+    #[test]
+    fn test_step_tolerance_is_configurable() -> Result<(), OptimizerError> {
+        // The first LM step is about 5e-7, between the two thresholds. This
+        // isolates step convergence from the disabled cost and gradient checks.
+        let optimizer = single_iteration_optimizer();
+        let mut strict_problem = small_step_problem()?;
+        let strict_result = optimizer.optimize_with_step_tolerance(&mut strict_problem, 1e-12)?;
+
+        assert_eq!(
+            strict_result.termination_reason,
+            TerminationReason::MaxIterations
+        );
+        assert_eq!(strict_result.iterations, 1);
+        assert!(strict_problem.get_variables()["x"].values[0] > 0.0);
+
+        let mut loose_problem = small_step_problem()?;
+        let loose_result = optimizer.optimize_with_step_tolerance(&mut loose_problem, 1e-6)?;
+
+        assert_eq!(
+            loose_result.termination_reason,
+            TerminationReason::CostConverged
+        );
+        assert_eq!(loose_result.iterations, 0);
+        assert_eq!(loose_problem.get_variables()["x"].values[0], 0.0);
+
+        Ok(())
     }
 }

--- a/crates/kornia-algebra/src/optim/solvers/levenberg_marquardt.rs
+++ b/crates/kornia-algebra/src/optim/solvers/levenberg_marquardt.rs
@@ -183,9 +183,9 @@ impl LevenbergMarquardt {
 
     /// Optimizes a problem with a `1e-12` step tolerance and an iteration callback.
     ///
-    /// The callback is invoked before the first iteration and after each attempted
-    /// step. Returning `false` stops optimization with
-    /// [`TerminationReason::Interrupted`].
+    /// The callback is invoked before the first iteration and after each accepted
+    /// or rejected step that does not terminate optimization. Returning `false`
+    /// stops optimization with [`TerminationReason::Interrupted`].
     ///
     /// # Arguments
     ///
@@ -250,7 +250,7 @@ impl LevenbergMarquardt {
     /// # Arguments
     ///
     /// * `problem` - Problem whose variables will be updated in place.
-    /// * `step_tolerance` - Minimum step norm that will be applied.
+    /// * `step_tolerance` - Finite, non-negative minimum step norm that will be applied.
     ///
     /// # Returns
     ///
@@ -258,9 +258,9 @@ impl LevenbergMarquardt {
     ///
     /// # Errors
     ///
-    /// Returns an [`OptimizerError`] if the problem is empty or invalid, factor
-    /// evaluation fails, the damped system cannot be solved, or a parameter update
-    /// fails.
+    /// Returns an [`OptimizerError`] if `step_tolerance` is negative or non-finite,
+    /// the problem is empty or invalid, factor evaluation fails, the damped system
+    /// cannot be solved, or a parameter update fails.
     ///
     /// # Example
     ///
@@ -295,13 +295,15 @@ impl LevenbergMarquardt {
     ///
     /// A proposed step whose Euclidean norm is smaller than `step_tolerance`
     /// terminates optimization with [`TerminationReason::CostConverged`] before
-    /// the step is applied. Returning `false` from `callback` stops optimization
-    /// with [`TerminationReason::Interrupted`].
+    /// the step is applied. The callback is invoked before the first iteration and
+    /// after each accepted or rejected step that does not terminate optimization.
+    /// Returning `false` from `callback` stops optimization with
+    /// [`TerminationReason::Interrupted`].
     ///
     /// # Arguments
     ///
     /// * `problem` - Problem whose variables will be updated in place.
-    /// * `step_tolerance` - Minimum step norm that will be applied.
+    /// * `step_tolerance` - Finite, non-negative minimum step norm that will be applied.
     /// * `callback` - Function that receives the current problem and optimizer state.
     ///
     /// # Returns
@@ -310,9 +312,9 @@ impl LevenbergMarquardt {
     ///
     /// # Errors
     ///
-    /// Returns an [`OptimizerError`] if the problem is empty or invalid, factor
-    /// evaluation fails, the damped system cannot be solved, or a parameter update
-    /// fails.
+    /// Returns an [`OptimizerError`] if `step_tolerance` is negative or non-finite,
+    /// the problem is empty or invalid, factor evaluation fails, the damped system
+    /// cannot be solved, or a parameter update fails.
     ///
     /// # Example
     ///
@@ -348,6 +350,12 @@ impl LevenbergMarquardt {
     where
         F: FnMut(&Problem, &OptimizerState) -> bool,
     {
+        if !step_tolerance.is_finite() || step_tolerance < 0.0 {
+            return Err(OptimizerError::NumericalInstability(format!(
+                "Step tolerance must be finite and non-negative, got {step_tolerance}"
+            )));
+        }
+
         let variables = problem.get_variables();
         let factors = problem.get_factors();
 
@@ -695,6 +703,26 @@ mod tests {
         );
         assert_eq!(loose_result.iterations, 0);
         assert_eq!(loose_problem.get_variables()["x"].values[0], 0.0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_step_tolerance_rejects_invalid_values() -> Result<(), OptimizerError> {
+        let optimizer = single_iteration_optimizer();
+
+        for step_tolerance in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY, -1.0] {
+            let mut problem = small_step_problem()?;
+            let error = optimizer
+                .optimize_with_step_tolerance(&mut problem, step_tolerance)
+                .expect_err("invalid step tolerance should fail");
+
+            assert!(matches!(
+                error,
+                OptimizerError::NumericalInstability(message)
+                    if message.contains("Step tolerance must be finite and non-negative")
+            ));
+        }
 
         Ok(())
     }


### PR DESCRIPTION
## 📝 Description

Fixes #1118

#1111 changed the shared Levenberg–Marquardt step cutoff from `1e-12` to `1e-6`, affecting BA, PGO, calibration, and PnP. This PR restores `1e-12` for existing callers and adds per-solve overrides. Additive methods are used instead of public struct fields, preserving exhaustive downstream literals.

Use case: retain precise convergence globally while allowing one LM or PnP solve to select a different cutoff.

## 🛠️ Changes Made

- [x] Add per-solve APIs in `levenberg_marquardt.rs`.
- [x] Add and re-export `refine_pose_lm_with_step_tolerance`.
- [x] Add default and configurable-tolerance regression tests and rustdoc.

## 🧪 How Was This Tested?

```text
$ cargo test -p kornia-algebra
test result: ok. 287 passed; 0 failed
doc-tests: 12 passed; 0 failed

$ cargo test -p kornia-3d --lib pnp::
test result: ok. 28 passed; 0 failed

$ cargo test --doc -p kornia-3d pnp::refine
test result: ok. 2 passed; 0 failed
```

- [x] Scoped Clippy with `-D warnings`, rustfmt, and diff checks passed.
- [x] Tests cover both applying a small step and stopping before a loose-threshold step.

## 🕵️ AI Usage Disclosure

- [ ] 🟢 **No AI used.**
- [x] 🟡 **AI-assisted:** I used AI while implementing this change and personally reviewed, tested, understand, and can explain every line.
- [ ] 🔴 **AI-generated.**

## 🚦 Checklist

- [ ] Assigned to #1118
- [ ] Approved by a maintainer
- [x] Issue-scoped and self-reviewed
- [x] Follows project style and documentation requirements
- [x] Includes regression tests
- [ ] Screenshots (not applicable)

## 💭 Additional Context

Draft pending assignment and approval.

References: the existing `pose/lm_pose.rs` `step_tol` configuration and Ceres Solver's [`parameter_tolerance`](https://ceres-solver.readthedocs.io/latest/nnls_solving.html#_CPPv4N5ceres6Solver7Options19parameter_toleranceE).
